### PR TITLE
Adding googletest

### DIFF
--- a/pennylane_lightning/tests/conftest.py
+++ b/pennylane_lightning/tests/conftest.py
@@ -1,0 +1,126 @@
+# Copyright 2020 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Pytest configuration file for PennyLane-Lightning test suite.
+"""
+import os
+
+import pytest
+import numpy as np
+
+import pennylane as qml
+
+# defaults
+TOL = 1e-3
+
+
+@pytest.fixture(scope="session")
+def tol():
+    """Numerical tolerance for equality tests."""
+    return float(os.environ.get("TOL", TOL))
+
+@pytest.fixture(scope="session")
+def tf_tol():
+    """Numerical tolerance for equality tests."""
+    return float(os.environ.get("TF_TOL", TF_TOL))
+
+@pytest.fixture(scope="session", params=[1, 2])
+def n_layers(request):
+    """Number of layers."""
+    return request.param
+
+
+@pytest.fixture(scope="session", params=[2, 3])
+def n_subsystems(request):
+    """Number of qubits or qumodes."""
+    return request.param
+
+
+@pytest.fixture(scope="session")
+def qubit_device(n_subsystems):
+    return qml.device('lightning.qubit', wires=n_subsystems)
+
+
+@pytest.fixture(scope="function")
+def qubit_device_1_wire():
+    return qml.device('lightning.qubit', wires=1)
+
+
+@pytest.fixture(scope="function")
+def qubit_device_2_wires():
+    return qml.device('lightning.qubit', wires=2)
+
+
+@pytest.fixture(scope="function")
+def qubit_device_3_wires():
+    return qml.device('lightning.qubit', wires=3)
+
+
+@pytest.fixture(scope="session")
+def gaussian_device(n_subsystems):
+    """Number of qubits or modes."""
+    return DummyDevice(wires=n_subsystems)
+
+@pytest.fixture(scope="session")
+def gaussian_dummy():
+    """Number of qubits or modes."""
+    return DummyDevice
+
+@pytest.fixture(scope="session")
+def gaussian_device_2_wires():
+    """A 2-mode Gaussian device."""
+    return DummyDevice(wires=2)
+
+
+@pytest.fixture(scope="session")
+def gaussian_device_4modes():
+    """A 4 mode Gaussian device."""
+    return DummyDevice(wires=4)
+
+
+@pytest.fixture()
+def skip_if_no_torch_support(torch_support):
+    if not torch_support:
+        pytest.skip("Skipped, no torch support")
+
+
+@pytest.fixture()
+def skip_if_no_tf_support(tf_support):
+    if not tf_support:
+        pytest.skip("Skipped, no tf support")
+
+
+@pytest.fixture(scope="module",
+                params=[1, 2, 3])
+def seed(request):
+    """Different seeds."""
+    return request.param
+
+
+@pytest.fixture(scope="function")
+def mock_device(monkeypatch):
+    """A mock instance of the abstract Device class"""
+
+    with monkeypatch.context() as m:
+        dev = qml.Device
+        m.setattr(dev, '__abstractmethods__', frozenset())
+        m.setattr(dev, 'short_name', 'mock_device')
+        m.setattr(dev, 'capabilities', lambda cls: {"model": "qubit"})
+        yield qml.Device(wires=2)
+
+@pytest.fixture
+def tear_down_hermitian():
+    yield None
+    qml.Hermitian._eigs = {}
+

--- a/pennylane_lightning/tests/test_apply.py
+++ b/pennylane_lightning/tests/test_apply.py
@@ -1,0 +1,305 @@
+import pytest
+
+import numpy as np
+import pennylane as qml
+from scipy.linalg import block_diag
+
+from pennylane_qiskit import AerDevice, BasicAerDevice
+
+from conftest import U, U2, A
+
+np.random.seed(42)
+
+
+# global variables and rotations
+I = np.identity(2)
+X = np.array([[0, 1], [1, 0]])
+Y = np.array([[0, -1j], [1j, 0]])
+Z = np.array([[1, 0], [0, -1]])
+H = np.array([[1, 1], [1, -1]]) / np.sqrt(2)
+S = np.diag([1, 1j])
+T = np.diag([1, np.exp(1j * np.pi / 4)])
+SWAP = np.array([[1, 0, 0, 0], [0, 0, 1, 0], [0, 1, 0, 0], [0, 0, 0, 1]])
+CNOT = np.array([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0]])
+CZ = np.diag([1, 1, 1, -1])
+toffoli = np.diag([1 for i in range(8)])
+toffoli[6:8, 6:8] = np.array([[0, 1], [1, 0]])
+CSWAP = block_diag(I, I, SWAP)
+
+
+phase_shift = lambda phi: np.array([[1, 0], [0, np.exp(1j * phi)]])
+rx = lambda theta: np.cos(theta / 2) * I + 1j * np.sin(-theta / 2) * X
+ry = lambda theta: np.cos(theta / 2) * I + 1j * np.sin(-theta / 2) * Y
+rz = lambda theta: np.cos(theta / 2) * I + 1j * np.sin(-theta / 2) * Z
+rot = lambda a, b, c: rz(c) @ (ry(b) @ rz(a))
+crz = lambda theta: np.array(
+    [
+        [1, 0, 0, 0],
+        [0, 1, 0, 0],
+        [0, 0, np.exp(-1j * theta / 2), 0],
+        [0, 0, 0, np.exp(1j * theta / 2)],
+    ]
+)
+
+
+single_qubit_operations = [
+    qml.PauliX,
+    qml.PauliY,
+    qml.PauliZ,
+    qml.Hadamard,
+    qml.S,
+    qml.T
+]
+
+single_qubit_operations_param = [qml.PhaseShift, qml.RX, qml.RY, qml.RZ]
+two_qubit = [qml.CNOT, qml.SWAP, qml.CZ]
+two_qubit_param = [qml.CRZ]
+three_qubit = [qml.Toffoli, qml.CSWAP]
+
+@pytest.mark.parametrize("analytic", [True])
+@pytest.mark.parametrize("shots", [8192])
+@pytest.mark.usefixtures("skip_unitary")
+class TestAnalyticApply:
+    """Test application of PennyLane operations with analytic attribute set to True."""
+
+    def test_qubit_state_vector(self, init_state, device, tol):
+        """Test that the QubitStateVector operation produces the expected
+        result with the apply method."""
+        dev = device(1)
+        state = init_state(1)
+
+        dev.apply([qml.QubitStateVector(state, wires=[0])])
+
+        res = np.abs(dev.state) ** 2
+        expected = np.abs(state) ** 2
+        assert np.allclose(res, expected, **tol)
+
+    @pytest.mark.parametrize("operation", single_qubit_operations)
+    def test_single_qubit_operations_no_parameters(self, init_state, device, operation, tol):
+        """Test that single qubit operations that take no parameters work fine
+        with the apply method."""
+        dev = device(1)
+        state = init_state(1)
+        applied_operation = operation(wires=[0])
+
+        dev.apply([qml.QubitStateVector(state, wires=[0]), applied_operation])
+
+        res = np.abs(dev.state) ** 2
+        expected = np.abs(applied_operation.matrix @ state) ** 2
+        assert np.allclose(res, expected, **tol)
+
+    @pytest.mark.parametrize("theta", [0.5432, -0.232])
+    @pytest.mark.parametrize("operation", single_qubit_operations_param)
+    def test_single_qubit_operations_parameters(self, init_state, device, operation, theta, tol):
+        """Test that single qubit parametrized operations work fine with the
+        apply method."""
+        dev = device(1)
+        state = init_state(1)
+        applied_operation = operation(theta, wires=[0])
+
+        dev.apply([qml.QubitStateVector(state, wires=[0]), applied_operation])
+
+        res = np.abs(dev.state) ** 2
+        expected = np.abs(applied_operation.matrix @ state) ** 2
+        assert np.allclose(res, expected, **tol)
+
+    @pytest.mark.parametrize("operation", two_qubit)
+    def test_two_qubit_operations_no_parameters(self, init_state, device, operation, tol):
+        """Test that two qubit operations that take no parameters work fine
+        with the apply method."""
+        dev = device(2)
+        state = init_state(2)
+        wires = [0, 1]
+
+        applied_operation = operation(wires=wires)
+
+        dev.apply([qml.QubitStateVector(state, wires=wires), applied_operation])
+
+        res = np.abs(dev.state) ** 2
+        expected = np.abs(applied_operation.matrix @ state) ** 2
+        assert np.allclose(res, expected, **tol)
+
+    @pytest.mark.parametrize("theta", [0.5432, -0.232])
+    @pytest.mark.parametrize("operation", two_qubit_param)
+    def test_two_qubit_operations_parameters(self, init_state, device, operation, theta, tol):
+        """Test that two qubit parametrized operations work fine with the
+        apply method."""
+        dev = device(2)
+        state = init_state(2)
+        wires = [0, 1]
+        applied_operation = operation(theta, wires=wires)
+
+        dev.apply([qml.QubitStateVector(state, wires=wires), applied_operation])
+
+        res = np.abs(dev.state) ** 2
+        expected = np.abs(applied_operation.matrix @ state) ** 2
+        assert np.allclose(res, expected, **tol)
+
+    @pytest.mark.parametrize("operation", three_qubit)
+    def test_three_qubit_operations_no_parameters(self, init_state, device, operation, tol):
+        """Test that three qubit operations that take no parameters work fine
+        with the apply method."""
+        dev = device(3)
+        state = init_state(3)
+        applied_operation = operation(wires=[0, 1, 2])
+
+        dev.apply([qml.QubitStateVector(state, wires=[0, 1, 2]), applied_operation])
+
+        res = np.abs(dev.state) ** 2
+        expected = np.abs(applied_operation.matrix @ state) ** 2
+        assert np.allclose(res, expected, **tol)
+
+@pytest.mark.parametrize("analytic", [True])
+@pytest.mark.parametrize("shots", [8192])
+@pytest.mark.usefixtures("run_only_for_unitary")
+class TestStateApplyUnitarySimulator:
+    """Test application of PennyLane operations to the unitary simulator."""
+
+    def test_invalid_qubit(self, init_state, device):
+        """Test that an exception is raised if the
+        unitary matrix is applied on a unitary simulator."""
+        dev = device(1)
+        state = init_state(1)
+
+        with pytest.raises(qml.QuantumFunctionError, match="The QubitStateVector operation is not supported on the unitary simulator backend"):
+            dev.apply([qml.QubitStateVector(state, wires=[0])])
+
+@pytest.mark.parametrize("shots", [8192])
+@pytest.mark.parametrize("analytic", [False])
+@pytest.mark.usefixtures("skip_unitary")
+class TestNonAnalyticApply:
+    """Test application of PennyLane operations with the analytic attribute set to False."""
+
+    def test_qubit_state_vector(self, init_state, device, tol):
+        """Test that the QubitStateVector operation produces the expected
+        result with the apply method."""
+        dev = device(1)
+        state = init_state(1)
+        wires = [0]
+
+        dev.apply([qml.QubitStateVector(state, wires=wires)])
+        dev._samples = dev.generate_samples()
+
+        res = np.fromiter(dev.probability(), dtype=np.float64)
+        expected = np.abs(state) ** 2
+        assert np.allclose(res, expected, **tol)
+
+    def test_invalid_qubit_state_vector(self, device):
+        """Test that an exception is raised if the state
+        vector is the wrong size"""
+        dev = device(2)
+        state = np.array([0, 123.432])
+        wires = [0, 1]
+
+        with pytest.raises(ValueError, match=r"State vector must be of length 2\*\*wires"):
+            dev.apply([qml.QubitStateVector(state, wires=wires)])
+
+    @pytest.mark.parametrize("mat", [U, U2])
+    def test_qubit_unitary(self, init_state, device, mat, tol):
+        """Test that the QubitUnitary operation produces the expected result
+        with the apply method."""
+        N = int(np.log2(len(mat)))
+        dev = device(N)
+        state = init_state(N)
+        wires = list(range(N))
+
+        dev.apply([qml.QubitStateVector(state, wires=wires), qml.QubitUnitary(mat, wires=wires)])
+        dev._samples = dev.generate_samples()
+
+        res = np.fromiter(dev.probability(), dtype=np.float64)
+        expected = np.abs(mat @ state) ** 2
+        assert np.allclose(res, expected, **tol)
+
+    def test_invalid_qubit_unitary(self, device):
+        """Test that an exception is raised if the
+        unitary matrix is the wrong size"""
+        dev = device(2)
+        state = np.array([[0, 123.432], [-0.432, 023.4]])
+
+        with pytest.raises(ValueError, match=r"Unitary matrix must be of shape"):
+            dev.apply([qml.QubitUnitary(state, wires=[0, 1])])
+
+    @pytest.mark.parametrize("operation", single_qubit_operations)
+    def test_single_qubit_operations_no_parameters(self, init_state, device, operation, tol):
+        """Test that single qubit operations that take no parameters work fine
+        with the apply method."""
+        dev = device(1)
+        state = init_state(1)
+        wires = [0]
+        applied_operation = operation(wires=wires)
+
+        dev.apply([qml.QubitStateVector(state, wires=wires), applied_operation])
+        dev._samples = dev.generate_samples()
+
+        res = np.fromiter(dev.probability(), dtype=np.float64)
+        expected = np.abs(applied_operation.matrix @ state) ** 2
+        assert np.allclose(res, expected, **tol)
+
+    @pytest.mark.parametrize("theta", [0.5432, -0.232])
+    @pytest.mark.parametrize("operation", single_qubit_operations_param)
+    def test_single_qubit_operations_parameters(self, init_state, device, operation, theta, tol):
+        """Test that single qubit parametrized operations work fine with the
+        apply method."""
+        dev = device(1)
+        state = init_state(1)
+        wires = [0]
+        applied_operation = operation(theta, wires=wires)
+
+        dev.apply([qml.QubitStateVector(state, wires=wires), applied_operation])
+        dev._samples = dev.generate_samples()
+
+        res = np.fromiter(dev.probability(), dtype=np.float64)
+        expected = np.abs(applied_operation.matrix @ state) ** 2
+        assert np.allclose(res, expected, **tol)
+
+    @pytest.mark.parametrize("operation", two_qubit)
+    def test_two_qubit_no_parameters(self, init_state, device, operation, tol):
+        """Test that two qubit operations that take no parameters work fine
+        with the apply method."""
+        dev = device(2)
+        state = init_state(2)
+        wires = [0, 1]
+
+        applied_operation = operation(wires=wires)
+
+        dev.apply([qml.QubitStateVector(state, wires=wires), applied_operation])
+        dev._samples = dev.generate_samples()
+
+        res = np.fromiter(dev.probability(), dtype=np.float64)
+        expected = np.abs(applied_operation.matrix @ state) ** 2
+        assert np.allclose(res, expected, **tol)
+
+    @pytest.mark.parametrize("theta", [0.5432, -0.232])
+    @pytest.mark.parametrize("operation", two_qubit_param)
+    def test_two_qubit_operations_parameters(self, init_state, device, operation, theta, tol):
+        """Test that two qubit parametrized operations work fine with the
+        apply method."""
+        dev = device(2)
+        state = init_state(2)
+        wires = [0, 1]
+
+        applied_operation = operation(theta, wires=wires)
+
+        dev.apply([qml.QubitStateVector(state, wires=wires), applied_operation])
+        dev._samples = dev.generate_samples()
+
+        res = np.fromiter(dev.probability(), dtype=np.float64)
+        expected = np.abs(applied_operation.matrix @ state) ** 2
+        assert np.allclose(res, expected, **tol)
+
+    @pytest.mark.parametrize("operation", three_qubit)
+    def test_three_qubit_no_parameters(self, init_state, device, operation, tol):
+        """Test that three qubit operations that take no parameters work fine
+        with the apply method."""
+        dev = device(3)
+        state = init_state(3)
+        applied_operation = operation(wires=[0, 1, 2])
+        wires = [0, 1, 2]
+
+        dev.apply([qml.QubitStateVector(state, wires=wires), applied_operation])
+        dev._samples = dev.generate_samples()
+
+        res = np.fromiter(dev.probability(), dtype=np.float64)
+        expected = np.abs(applied_operation.matrix @ state) ** 2
+        assert np.allclose(res, expected, **tol)
+

--- a/pennylane_lightning/tests/test_converter.py
+++ b/pennylane_lightning/tests/test_converter.py
@@ -1,0 +1,1007 @@
+import math
+import sys
+
+import pytest
+from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister
+from qiskit import extensions as ex
+from qiskit.circuit import Parameter
+from qiskit.exceptions import QiskitError
+from qiskit.quantum_info.operators import Operator
+
+import pennylane as qml
+from pennylane import numpy as np
+from pennylane_qiskit.converter import load, load_qasm, load_qasm_from_file, map_wires
+
+
+THETA = np.linspace(0.11, 3, 5)
+PHI = np.linspace(0.32, 3, 5)
+VARPHI = np.linspace(0.02, 3, 5)
+
+
+class TestConverter:
+    """Tests the converter function that allows converting QuantumCircuit objects
+     to Pennylane templates."""
+
+    def test_quantum_circuit_init_by_specifying_rotation_in_circuit(self, recorder):
+        """Tests the load method for a QuantumCircuit initialized using separately defined
+         quantum and classical registers."""
+
+        angle = 0.5
+
+        qr = QuantumRegister(1)
+        cr = ClassicalRegister(1)
+
+        qc = QuantumCircuit(qr, cr)
+        qc.rz(angle, [0])
+
+        quantum_circuit = load(qc)
+
+        with recorder:
+            quantum_circuit()
+
+        assert len(recorder.queue) == 1
+        assert recorder.queue[0].name == 'RZ'
+        assert recorder.queue[0].params == [angle]
+        assert recorder.queue[0].wires == [0]
+
+    def test_quantum_circuit_by_passing_parameters(self, recorder):
+        """Tests the load method for a QuantumCircuit initialized by passing the number
+        of registers required."""
+
+        theta = Parameter('θ')
+        angle = 0.5
+
+        qc = QuantumCircuit(3, 1)
+        qc.rz(theta, [0])
+
+        quantum_circuit = load(qc)
+
+        with recorder:
+            quantum_circuit(params={theta: angle})
+
+        assert len(recorder.queue) == 1
+        assert recorder.queue[0].name == 'RZ'
+        assert recorder.queue[0].params == [angle]
+        assert recorder.queue[0].wires == [0]
+
+    def test_loaded_quantum_circuit_and_further_pennylane_operations(self, recorder):
+        """Tests that a loaded quantum circuit can be used around other PennyLane
+        templates in a circuit."""
+
+        theta = Parameter('θ')
+        angle = 0.5
+
+        qc = QuantumCircuit(3, 1)
+        qc.rz(theta, [0])
+
+        quantum_circuit = load(qc)
+
+        with recorder:
+            qml.PauliZ(0)
+            quantum_circuit(params={theta: angle})
+            qml.Hadamard(0)
+
+        assert len(recorder.queue) == 3
+        assert recorder.queue[0].name == 'PauliZ'
+        assert recorder.queue[0].params == []
+        assert recorder.queue[0].wires == [0]
+        assert recorder.queue[1].name == 'RZ'
+        assert recorder.queue[1].params == [angle]
+        assert recorder.queue[1].wires == [0]
+        assert recorder.queue[2].name == 'Hadamard'
+        assert recorder.queue[2].params == []
+        assert recorder.queue[2].wires == [0]
+
+    def test_quantum_circuit_with_multiple_parameters(self, recorder):
+        """Tests loading a circuit with multiple parameters."""
+
+        angle1 = 0.5
+        angle2 = 0.3
+
+        phi = Parameter('φ')
+        theta = Parameter('θ')
+
+        qc = QuantumCircuit(3, 1)
+        qc.rx(phi, 1)
+        qc.rz(theta, 0)
+
+        quantum_circuit = load(qc)
+
+        with recorder:
+            quantum_circuit(params={phi: angle1, theta: angle2})
+
+        assert len(recorder.queue) == 2
+        assert recorder.queue[0].name == 'RX'
+        assert recorder.queue[0].params == [angle1]
+        assert recorder.queue[0].wires == [1]
+        assert recorder.queue[1].name == 'RZ'
+        assert recorder.queue[1].params == [angle2]
+        assert recorder.queue[1].wires == [0]
+
+    def test_quantum_circuit_with_gate_requiring_multiple_parameters(self, recorder):
+        """Tests loading a circuit containing a gate that requires
+        multiple parameters."""
+
+        angle1 = 0.5
+        angle2 = 0.3
+        angle3 = 0.1
+
+        phi = Parameter('φ')
+        lam = Parameter('λ')
+        theta = Parameter('θ')
+
+        qc = QuantumCircuit(3, 1)
+        qc.u3(phi, lam, theta, [0])
+
+        quantum_circuit = load(qc)
+
+        with recorder:
+            quantum_circuit(params={phi: angle1, lam: angle2, theta: angle3})
+
+        assert recorder.queue[0].name == 'U3'
+        assert len(recorder.queue[0].params) == 3
+        assert recorder.queue[0].params == [0.5, 0.3, 0.1]
+        assert recorder.queue[0].wires == [0]
+
+    def test_quantum_circuit_loaded_multiple_times_with_different_arguments(self, recorder):
+        """Tests that a loaded quantum circuit can be called multiple times with
+        different arguments."""
+
+        theta = Parameter('θ')
+        angle1 = 0.5
+        angle2 = -0.5
+        angle3 = 0
+
+        qc = QuantumCircuit(3, 1)
+        qc.rz(theta, [0])
+
+        quantum_circuit = load(qc)
+
+        with recorder:
+            quantum_circuit(params={theta: angle1})
+            quantum_circuit(params={theta: angle2})
+            quantum_circuit(params={theta: angle3})
+
+        assert len(recorder.queue) == 3
+        assert recorder.queue[0].name == 'RZ'
+        assert recorder.queue[0].params == [angle1]
+        assert recorder.queue[0].wires == [0]
+        assert recorder.queue[1].name == 'RZ'
+        assert recorder.queue[1].params == [angle2]
+        assert recorder.queue[1].wires == [0]
+        assert recorder.queue[2].name == 'RZ'
+        assert recorder.queue[2].params == [angle3]
+        assert recorder.queue[2].wires == [0]
+
+    def test_quantum_circuit_with_bound_parameters(self, recorder):
+        """Tests loading a quantum circuit that already had bound parameters."""
+
+        theta = Parameter('θ')
+
+        qc = QuantumCircuit(3, 1)
+        qc.rz(theta, [0])
+        qc_1 = qc.bind_parameters({theta: 0.5})
+
+        quantum_circuit = load(qc_1)
+
+        with recorder:
+            quantum_circuit()
+
+        assert len(recorder.queue) == 1
+        assert recorder.queue[0].name == 'RZ'
+        assert recorder.queue[0].params == [0.5]
+        assert recorder.queue[0].wires == [0]
+
+    def test_pass_parameters_to_bind(self, recorder):
+        """Tests parameter binding by passing parameters when loading a quantum circuit."""
+
+        theta = Parameter('θ')
+
+        qc = QuantumCircuit(3, 1)
+        qc.rz(theta, [0])
+
+        quantum_circuit = load(qc)
+
+        with recorder:
+            quantum_circuit(params={theta: 0.5})
+
+        assert len(recorder.queue) == 1
+        assert recorder.queue[0].name == 'RZ'
+        assert recorder.queue[0].params == [0.5]
+        assert recorder.queue[0].wires == [0]
+
+    def test_parameter_was_not_bound(self, recorder):
+        """Tests that loading raises an error when parameters were not bound."""
+
+        theta = Parameter('θ')
+
+        qc = QuantumCircuit(3, 1)
+        qc.rz(theta, [0])
+
+        quantum_circuit = load(qc)
+
+        with pytest.raises(ValueError, match='The parameter {} was not bound correctly.'.format(theta)):
+            with recorder:
+                quantum_circuit(params={})
+
+    def test_invalid_parameter_expression(self, recorder):
+        """Tests that an operation with multiple parameters raises an error."""
+
+        theta = Parameter('θ')
+        phi = Parameter('φ')
+
+        qc = QuantumCircuit(3, 1)
+        qc.rz(theta*phi, [0])
+
+        quantum_circuit = load(qc)
+
+        with pytest.raises(ValueError, match='PennyLane does not support expressions'):
+            with recorder:
+                quantum_circuit(params={theta: qml.variable.Variable(0), phi: qml.variable.Variable(1)})
+
+    def test_extra_parameters_were_passed(self, recorder):
+        """Tests that loading raises an error when extra parameters were
+        passed."""
+
+        theta = Parameter('θ')
+        phi = Parameter('φ')
+
+        qc = QuantumCircuit(3, 1)
+
+        quantum_circuit = load(qc)
+
+        with pytest.raises(QiskitError):
+            with recorder:
+                quantum_circuit(params={theta: 0.5, phi: 0.3})
+
+    @pytest.mark.parametrize("qiskit_operation, pennylane_name", [(QuantumCircuit.crx, "CRX"), (QuantumCircuit.crz, "CRZ"), (QuantumCircuit.cry, "CRY")])
+    def test_controlled_rotations(self, qiskit_operation, pennylane_name, recorder):
+        """Tests loading a circuit with two qubit controlled rotations (except
+        for CRY)."""
+
+        q2 = QuantumRegister(2)
+        qc = QuantumCircuit(q2)
+
+        qiskit_operation(qc, 0.5, q2[0], q2[1])
+
+
+        quantum_circuit = load(qc)
+
+        with recorder:
+            quantum_circuit()
+
+        assert len(recorder.queue) == 1
+        assert recorder.queue[0].name == pennylane_name
+        assert recorder.queue[0].params == [0.5]
+        assert recorder.queue[0].wires == [0, 1]
+
+    def test_one_qubit_operations_supported_by_pennylane(self, recorder):
+        """Tests loading a circuit with the one-qubit operations supported by PennyLane."""
+
+        single_wire = [0]
+
+        qc = QuantumCircuit(1, 1)
+        qc.x(single_wire)
+        qc.y(single_wire)
+        qc.z(single_wire)
+        qc.h(single_wire)
+        qc.s(single_wire)
+        qc.t(single_wire)
+
+        quantum_circuit = load(qc)
+        with recorder:
+            quantum_circuit()
+
+        assert len(recorder.queue) == 6
+
+        assert recorder.queue[0].name == 'PauliX'
+        assert recorder.queue[0].params == []
+        assert recorder.queue[0].wires == single_wire
+
+        assert recorder.queue[1].name == 'PauliY'
+        assert recorder.queue[1].params == []
+        assert recorder.queue[1].wires == single_wire
+
+        assert recorder.queue[2].name == 'PauliZ'
+        assert recorder.queue[2].params == []
+        assert recorder.queue[2].wires == single_wire
+
+        assert recorder.queue[3].name == 'Hadamard'
+        assert recorder.queue[3].params == []
+        assert recorder.queue[3].wires == single_wire
+
+        assert recorder.queue[4].name == 'S'
+        assert recorder.queue[4].params == []
+        assert recorder.queue[4].wires == single_wire
+
+        assert recorder.queue[5].name == 'T'
+        assert recorder.queue[5].params == []
+        assert recorder.queue[5].wires == single_wire
+
+    def test_one_qubit_parametrized_operations_supported_by_pennylane(self, recorder):
+        """Tests loading a circuit with the one-qubit parametrized operations supported by PennyLane."""
+
+        single_wire = [0]
+        angle = 0.3333
+
+        phi = 0.3
+        lam = 0.4
+        theta = 0.2
+
+        q_reg = QuantumRegister(1)
+        qc = QuantumCircuit(q_reg)
+
+        qc.u1(angle, single_wire)
+        qc.rx(angle, single_wire)
+        qc.ry(angle, single_wire)
+        qc.rz(angle, single_wire)
+        qc.u2(phi, lam, [0])
+        qc.u3(phi, lam, theta, [0])
+
+        quantum_circuit = load(qc)
+        with recorder:
+            quantum_circuit()
+
+        assert recorder.queue[0].name == 'PhaseShift'
+        assert recorder.queue[0].params == [angle]
+        assert recorder.queue[0].wires == single_wire
+
+        assert recorder.queue[1].name == 'RX'
+        assert recorder.queue[1].params == [angle]
+        assert recorder.queue[1].wires == single_wire
+
+        assert recorder.queue[2].name == 'RY'
+        assert recorder.queue[2].params == [angle]
+        assert recorder.queue[2].wires == single_wire
+
+        assert recorder.queue[3].name == 'RZ'
+        assert recorder.queue[3].params == [angle]
+        assert recorder.queue[3].wires == single_wire
+
+        assert recorder.queue[4].name == 'U2'
+        assert len(recorder.queue[4].params) == 2
+        assert recorder.queue[4].params == [0.3, 0.4]
+        assert recorder.queue[4].wires == [0]
+
+        assert recorder.queue[5].name == 'U3'
+        assert len(recorder.queue[5].params) == 3
+        assert recorder.queue[5].params == [0.3, 0.4, 0.2]
+        assert recorder.queue[5].wires == [0]
+
+    def test_two_qubit_operations_supported_by_pennylane(self, recorder):
+        """Tests loading a circuit with the two-qubit operations supported by PennyLane."""
+
+        two_wires = [0, 1]
+
+        qc = QuantumCircuit(2, 1)
+
+        unitary_op = [[1, 0, 0, 0],
+                     [0, 0, 1j, 0],
+                     [0, 1j, 0, 0],
+                     [0, 0, 0, 1]]
+        iswap_op = Operator(unitary_op)
+
+
+        qc.cx(*two_wires)
+        qc.cz(*two_wires)
+        qc.swap(*two_wires)
+        qc.unitary(iswap_op, [0, 1], label='iswap')
+
+        quantum_circuit = load(qc)
+        with recorder:
+            quantum_circuit()
+
+        assert len(recorder.queue) == 4
+
+        assert recorder.queue[0].name == 'CNOT'
+        assert recorder.queue[0].params == []
+        assert recorder.queue[0].wires == two_wires
+
+        assert recorder.queue[1].name == 'CZ'
+        assert recorder.queue[1].params == []
+        assert recorder.queue[1].wires == two_wires
+
+        assert recorder.queue[2].name == 'SWAP'
+        assert recorder.queue[2].params == []
+        assert recorder.queue[2].wires == two_wires
+
+        assert recorder.queue[3].name == 'QubitUnitary'
+        assert len(recorder.queue[3].params) == 1
+        assert np.array_equal(recorder.queue[3].params[0], np.array(unitary_op))
+        assert recorder.queue[3].wires == two_wires
+
+    def test_two_qubit_parametrized_operations_supported_by_pennylane(self, recorder):
+        """Tests loading a circuit with the two-qubit parametrized operations supported by PennyLane."""
+
+        two_wires = [0, 1]
+        angle = 0.3333
+
+        qc = QuantumCircuit(2, 1)
+
+        qc.crz(angle, *two_wires)
+
+        quantum_circuit = load(qc)
+        with recorder:
+            quantum_circuit()
+
+        assert len(recorder.queue) == 1
+
+        assert recorder.queue[0].name == 'CRZ'
+        assert recorder.queue[0].params == [angle]
+        assert recorder.queue[0].wires == two_wires
+
+    def test_three_qubit_operations_supported_by_pennylane(self, recorder):
+        """Tests loading a circuit with the three-qubit operations supported by PennyLane."""
+
+        three_wires = [0, 1, 2]
+
+        qc = QuantumCircuit(3, 1)
+        qc.cswap(*three_wires)
+        qc.ccx(*three_wires)
+        quantum_circuit = load(qc)
+
+        with recorder:
+            quantum_circuit()
+
+        assert recorder.queue[0].name == 'CSWAP'
+        assert recorder.queue[0].params == []
+        assert recorder.queue[0].wires == three_wires
+
+        assert recorder.queue[1].name == 'Toffoli'
+        assert len(recorder.queue[1].params) == 0
+        assert recorder.queue[1].wires == three_wires
+
+    def test_wires_two_different_quantum_registers(self, recorder):
+        """Tests loading a circuit with the three-qubit operations supported by PennyLane."""
+
+        three_wires = [0, 1, 2]
+
+        qr1 = QuantumRegister(2)
+        qr2 = QuantumRegister(1)
+
+        qc = QuantumCircuit(qr1, qr2)
+
+        qc.cswap(*three_wires)
+
+        quantum_circuit = load(qc)
+        with recorder:
+            quantum_circuit()
+
+        assert recorder.queue[0].name == 'CSWAP'
+        assert recorder.queue[0].params == []
+        assert recorder.queue[0].wires == three_wires
+
+    def test_wires_quantum_circuit_init_with_two_different_quantum_registers(self, recorder):
+        """Tests that the wires is correct even if the quantum circuit was initiliazed with two
+        separate quantum registers."""
+
+        three_wires = [0, 1, 2]
+
+        qr1 = QuantumRegister(2)
+        qr2 = QuantumRegister(1)
+
+        qc = QuantumCircuit(qr1, qr2)
+
+        qc.cswap(*three_wires)
+
+        quantum_circuit = load(qc)
+        with recorder:
+            quantum_circuit(wires=three_wires)
+
+        assert recorder.queue[0].name == 'CSWAP'
+        assert recorder.queue[0].params == []
+        assert recorder.queue[0].wires == three_wires
+
+    def test_wires_pass_different_wires_than_for_circuit(self, recorder):
+        """Tests that custom wires can be passed to the loaded template."""
+
+        three_wires = [4, 7, 1]
+
+        qr1 = QuantumRegister(2)
+        qr2 = QuantumRegister(1)
+
+        qc = QuantumCircuit(qr1, qr2)
+
+        qc.cswap(*[0, 1, 2])
+
+        quantum_circuit = load(qc)
+        with recorder:
+            quantum_circuit(wires=three_wires)
+
+        assert recorder.queue[0].name == 'CSWAP'
+        assert recorder.queue[0].params == []
+        assert recorder.queue[0].wires == three_wires
+
+    def test_operations_sdg_and_tdg(self, recorder):
+        """Tests loading a circuit with the operations Sdg and Tdg gates."""
+
+        qc = QuantumCircuit(3, 1)
+
+        qc.sdg([0])
+        qc.tdg([0])
+
+        quantum_circuit = load(qc)
+        with recorder:
+            quantum_circuit()
+
+        assert recorder.queue[0].name == 'S.inv'
+        assert len(recorder.queue[0].params) == 0
+        assert recorder.queue[0].wires == [0]
+
+        assert recorder.queue[1].name == 'T.inv'
+        assert len(recorder.queue[1].params) == 0
+        assert recorder.queue[1].wires == [0]
+
+    def test_operation_transformed_into_qubit_unitary(self, recorder):
+        """Tests loading a circuit with operations that can be converted,
+         but not natively supported by PennyLane."""
+
+        qc = QuantumCircuit(3, 1)
+
+        qc.ch([0], [1])
+
+        quantum_circuit = load(qc)
+        with recorder:
+            quantum_circuit()
+
+        assert recorder.queue[0].name == 'QubitUnitary'
+        assert len(recorder.queue[0].params) == 1
+        assert np.array_equal(recorder.queue[0].params[0], ex.CHGate().to_matrix())
+        assert recorder.queue[0].wires == [0, 1]
+
+    def test_quantum_circuit_error_by_passing_wrong_parameters(self, recorder):
+        """Tests the load method for a QuantumCircuit raises a QiskitError,
+        if the wrong type of arguments were passed."""
+
+        theta = Parameter('θ')
+        angle = 'some_string_instead_of_an_angle'
+
+        qc = QuantumCircuit(3, 1)
+        qc.rz(theta, [0])
+
+        quantum_circuit = load(qc)
+
+        with pytest.raises(QiskitError):
+            with recorder:
+                quantum_circuit(params={theta: angle})
+
+    def test_quantum_circuit_error_by_calling_wrong_parameters(self, recorder):
+        """Tests that the load method for a QuantumCircuit raises a TypeError,
+        if the wrong type of arguments were passed."""
+
+        angle = 'some_string_instead_of_an_angle'
+
+        qc = QuantumCircuit(3, 1)
+        qc.rz(angle, [0])
+
+        quantum_circuit = load(qc)
+
+        with pytest.raises(TypeError, match="parameter expected, got <class 'str'>"):
+            with recorder:
+                quantum_circuit()
+
+    def test_quantum_circuit_error_passing_parameters_not_required(self, recorder):
+        """Tests the load method raises a QiskitError if arguments
+        that are not required were passed."""
+
+        theta = Parameter('θ')
+        angle = 0.5
+
+        qc = QuantumCircuit(3, 1)
+        qc.z([0])
+
+        quantum_circuit = load(qc)
+
+        with pytest.raises(QiskitError):
+            with recorder:
+                quantum_circuit(params={theta: angle})
+
+    def test_quantum_circuit_error_parameter_not_bound(self, recorder):
+        """Tests the load method for a QuantumCircuit raises a ValueError,
+        if one of the parameters was not bound correctly."""
+
+        theta = Parameter('θ')
+
+        qc = QuantumCircuit(3, 1)
+        qc.rz(theta, [0])
+
+        quantum_circuit = load(qc)
+
+        with pytest.raises(ValueError, match="The parameter {} was not bound correctly.".format(theta)):
+            with recorder:
+                quantum_circuit()
+
+    def test_quantum_circuit_error_not_qiskit_circuit_passed(self, recorder):
+        """Tests the load method raises a ValueError, if something
+        that is not a QuanctumCircuit was passed."""
+
+        qc = qml.PauliZ(0)
+
+        quantum_circuit = load(qc)
+
+        with pytest.raises(ValueError):
+            with recorder:
+                quantum_circuit()
+
+    def test_wires_error_too_few_wires_specified(self, recorder):
+        """Tests that an error is raised when too few wires were specified."""
+
+        only_two_wires = [0, 1]
+        three_wires_for_the_operation = [0, 1, 2]
+
+        qr1 = QuantumRegister(2)
+        qr2 = QuantumRegister(1)
+
+        qc = QuantumCircuit(qr1, qr2)
+
+        qc.cswap(*three_wires_for_the_operation)
+
+        quantum_circuit = load(qc)
+
+        with pytest.raises(qml.QuantumFunctionError, match='The specified number of wires - {} - does not match the'
+                                                           ' number of wires the loaded quantum circuit acts on.'.
+                format(len(only_two_wires))):
+            with recorder:
+                quantum_circuit(wires=only_two_wires)
+
+    def test_wires_error_too_many_wires_specified(self, recorder):
+        """Tests that an error is raised when too many wires were specified."""
+
+        more_than_three_wires = [4, 13, 123, 321]
+        three_wires_for_the_operation = [0, 1, 2]
+
+        qr1 = QuantumRegister(2)
+        qr2 = QuantumRegister(1)
+
+        qc = QuantumCircuit(qr1, qr2)
+
+        qc.cswap(*three_wires_for_the_operation)
+
+        quantum_circuit = load(qc)
+
+        with pytest.raises(qml.QuantumFunctionError, match="The specified number of wires - {} - does not match the"
+                                                           " number of wires the loaded quantum circuit acts on.".
+                format(len(more_than_three_wires))):
+            with recorder:
+                quantum_circuit(wires=more_than_three_wires)
+
+
+class TestConverterUtils:
+    """Tests the utility functions used by the converter function."""
+
+    def test_map_wires(self, recorder):
+        """Tests the map_wires function for wires of a quantum circuit."""
+
+        wires = [0]
+        qc = QuantumCircuit(1)
+        qc_wires = [(q.register.name, q.index) for q in qc.qubits]
+
+        assert map_wires(qc_wires, wires) == {0: ('q', 0)}
+
+    def test_map_wires_instantiate_quantum_circuit_with_registers(self, recorder):
+        """Tests the map_wires function for wires of a quantum circuit instantiated
+        using quantum registers."""
+
+        wires = [0, 1, 2]
+        qr1 = QuantumRegister(1)
+        qr2 = QuantumRegister(1)
+        qr3 = QuantumRegister(1)
+        qc = QuantumCircuit(qr1, qr2, qr3)
+        qc_wires = [(q.register.name, q.index) for q in qc.qubits]
+
+        mapped_wires = map_wires(qc_wires, wires)
+
+        assert len(mapped_wires) == len(wires)
+        assert list(mapped_wires.keys()) == wires
+        for q in qc.qubits:
+            assert (q.register.name, q.index) in mapped_wires.values()
+
+    def test_map_wires_provided_non_standard_order(self, recorder):
+        """Tests the map_wires function for wires of non-standard order."""
+
+        wires = [1, 2, 0]
+        qc = QuantumCircuit(3)
+        qc_wires = [(q.register.name, q.index) for q in qc.qubits]
+
+        mapped_wires = map_wires(qc_wires, wires)
+
+        assert len(mapped_wires) == len(wires)
+        assert set(mapped_wires.keys()) == set(wires)
+        for q in qc.qubits:
+            assert (q.register.name, q.index) in mapped_wires.values()
+        assert mapped_wires[0][1] == 2
+        assert mapped_wires[1][1] == 0
+        assert mapped_wires[2][1] == 1
+
+    def test_map_wires_exception_mismatch_in_number_of_wires(self, recorder):
+        """Tests that the map_wires function raises an exception if there is a mismatch between
+        wires."""
+
+        wires = [0, 1, 2]
+        qc = QuantumCircuit(1)
+        qc_wires = [(q.register.name, q.index) for q in qc.qubits]
+
+        with pytest.raises(qml.QuantumFunctionError, match='The specified number of wires - {} - does not match '
+                                                           'the number of wires the loaded quantum circuit acts on.'
+                .format(len(wires))):
+            map_wires(wires, qc_wires)
+
+
+class TestConverterWarnings:
+    """Tests that the converter.load function emits warnings."""
+
+    def test_barrier_not_supported(self, recorder):
+        """Tests that a warning is raised if an unsupported instruction was reached."""
+        qc = QuantumCircuit(3, 1)
+        qc.barrier()
+
+        quantum_circuit = load(qc)
+
+        with pytest.warns(UserWarning) as record:
+            with recorder:
+                quantum_circuit(params={})
+
+        # check that only one warning was raised
+        assert len(record) == 1
+        # check that the message matches
+        assert record[0].message.args[0] == "pennylane_qiskit.converter: The Barrier instruction is not supported by" \
+                                            " PennyLane, and has not been added to the template."
+
+
+class TestConverterQasm:
+    """Tests that the converter.load function allows conversion from qasm."""
+
+    qft_qasm = 'OPENQASM 2.0;' \
+               'include "qelib1.inc";' \
+               'qreg q[4];' \
+               'creg c[4];' \
+               'x q[0]; ' \
+               'x q[2];' \
+               'barrier q;' \
+               'h q[0];' \
+               'cu1(pi/2) q[1],q[0];' \
+               'h q[1];' \
+               'cu1(pi/4) q[2],q[0];' \
+               'cu1(pi/2) q[2],q[1];' \
+               'h q[2];' \
+               'cu1(pi/8) q[3],q[0];' \
+               'cu1(pi/4) q[3],q[1];' \
+               'cu1(pi/2) q[3],q[2];' \
+               'h q[3];' \
+               'measure q -> c;'
+
+    @pytest.mark.skipif(sys.version_info < (3, 6), reason="tmpdir fixture requires Python >=3.6")
+    def test_qasm_from_file(self, tmpdir, recorder):
+        """Tests that a QuantumCircuit object is deserialized from a qasm file."""
+        qft_qasm = tmpdir.join("qft.qasm")
+
+        with open(qft_qasm, "w") as f:
+            f.write(TestConverterQasm.qft_qasm)
+
+        quantum_circuit = load_qasm_from_file(qft_qasm)
+
+        with pytest.warns(UserWarning) as record:
+            with recorder:
+                quantum_circuit()
+
+        assert len(recorder.queue) == 6
+
+        assert recorder.queue[0].name == 'PauliX'
+        assert recorder.queue[0].params == []
+        assert recorder.queue[0].wires == [0]
+
+        assert recorder.queue[1].name == 'PauliX'
+        assert recorder.queue[1].params == []
+        assert recorder.queue[1].wires == [2]
+
+        assert recorder.queue[2].name == 'Hadamard'
+        assert recorder.queue[2].params == []
+        assert recorder.queue[2].wires == [0]
+
+        assert recorder.queue[3].name == 'Hadamard'
+        assert recorder.queue[3].params == []
+        assert recorder.queue[3].wires == [1]
+
+        assert recorder.queue[4].name == 'Hadamard'
+        assert recorder.queue[4].params == []
+        assert recorder.queue[4].wires == [2]
+
+        assert recorder.queue[5].name == 'Hadamard'
+        assert recorder.queue[5].params == []
+        assert recorder.queue[5].wires == [3]
+
+        assert len(record) == 11
+        # check that the message matches
+        assert record[0].message.args[0] == "pennylane_qiskit.converter: The {} instruction is not supported by" \
+                                            " PennyLane, and has not been added to the template."\
+            .format('Barrier')
+        assert record[1].message.args[0] == "pennylane_qiskit.converter: The {} instruction is not supported by" \
+                                            " PennyLane, and has not been added to the template."\
+            .format('CU1Gate')
+        assert record[7].message.args[0] == "pennylane_qiskit.converter: The {} instruction is not supported by" \
+                                            " PennyLane, and has not been added to the template."\
+            .format('Measure')
+
+    def test_qasm_file_not_found_error(self):
+        """Tests that an error is propagated, when a non-existing file is specified for parsing."""
+        qft_qasm = 'some_qasm_file.qasm'
+
+        with pytest.raises(FileNotFoundError):
+            load_qasm_from_file(qft_qasm)
+
+    def test_qasm_(self, recorder):
+        """Tests that a QuantumCircuit object is deserialized from a qasm string."""
+        qasm_string = 'include "qelib1.inc";' \
+                      'qreg q[4];' \
+                      'creg c[4];' \
+                      'x q[0];' \
+                      'cx q[2],q[0];'\
+                      'measure q -> c;'
+
+        quantum_circuit = load_qasm(qasm_string)
+
+        with pytest.warns(UserWarning) as record:
+            with recorder:
+                quantum_circuit(params={})
+
+        assert len(recorder.queue) == 2
+
+        assert recorder.queue[0].name == 'PauliX'
+        assert recorder.queue[0].params == []
+        assert recorder.queue[0].wires == [0]
+
+        assert recorder.queue[1].name == 'CNOT'
+        assert recorder.queue[1].params == []
+        assert recorder.queue[1].wires == [2, 0]
+
+
+class TestConverterIntegration:
+
+    def test_use_loaded_circuit_in_qnode(self, qubit_device_2_wires):
+        """Tests loading a converted template in a QNode."""
+
+        angle = 0.5
+
+        qc = QuantumCircuit(2)
+        qc.rz(angle, [0])
+
+        quantum_circuit = load(qc)
+
+        @qml.qnode(qubit_device_2_wires)
+        def circuit_loaded_qiskit_circuit():
+            quantum_circuit()
+            return qml.expval(qml.PauliZ(0))
+
+        @qml.qnode(qubit_device_2_wires)
+        def circuit_native_pennylane():
+            qml.RZ(angle, wires=0)
+            return qml.expval(qml.PauliZ(0))
+
+        assert circuit_loaded_qiskit_circuit() == circuit_native_pennylane()
+
+    def test_load_circuit_inside_of_qnode(self, qubit_device_2_wires):
+        """Tests loading a QuantumCircuit inside of the QNode circuit
+        definition."""
+
+        theta = Parameter('θ')
+        angle = 0.5
+
+        qc = QuantumCircuit(2)
+        qc.rz(theta, [0])
+
+        @qml.qnode(qubit_device_2_wires)
+        def circuit_loaded_qiskit_circuit():
+            load(qc)({theta: angle})
+            return qml.expval(qml.PauliZ(0))
+
+        @qml.qnode(qubit_device_2_wires)
+        def circuit_native_pennylane():
+            qml.RZ(angle, wires=0)
+            return qml.expval(qml.PauliZ(0))
+
+        assert circuit_loaded_qiskit_circuit() == \
+               circuit_native_pennylane()
+
+    def test_passing_parameter_into_qnode(self, qubit_device_2_wires):
+        """Tests passing a circuit parameter into the QNode."""
+
+        theta = Parameter('θ')
+        rotation_angle = 0.5
+
+        qc = QuantumCircuit(2)
+        qc.rz(theta, [0])
+
+        @qml.qnode(qubit_device_2_wires)
+        def circuit_loaded_qiskit_circuit(angle):
+            load(qc)({theta: angle})
+            return qml.expval(qml.PauliZ(0))
+
+        @qml.qnode(qubit_device_2_wires)
+        def circuit_native_pennylane(angle):
+            qml.RZ(angle, wires=0)
+            return qml.expval(qml.PauliZ(0))
+
+        assert circuit_loaded_qiskit_circuit(rotation_angle) == \
+               circuit_native_pennylane(rotation_angle)
+
+    def test_one_parameter_in_qc_one_passed_into_qnode(self, qubit_device_2_wires):
+        """Tests passing a parameter by pre-defining it and then
+         passing another to the QNode."""
+
+        theta = Parameter('θ')
+        phi = Parameter('φ')
+        rotation_angle1 = 0.5
+        rotation_angle2 = 0.3
+
+        qc = QuantumCircuit(2)
+        qc.rz(theta, [0])
+        qc.rx(phi, [0])
+
+        @qml.qnode(qubit_device_2_wires)
+        def circuit_loaded_qiskit_circuit(angle):
+            load(qc)({theta: angle, phi: rotation_angle2})
+            return qml.expval(qml.PauliZ(0))
+
+        @qml.qnode(qubit_device_2_wires)
+        def circuit_native_pennylane(angle):
+            qml.RZ(angle, wires=0)
+            qml.RX(rotation_angle2, wires=0)
+            return qml.expval(qml.PauliZ(0))
+
+        assert circuit_loaded_qiskit_circuit(rotation_angle1) == \
+               circuit_native_pennylane(rotation_angle1)
+
+    def test_initialize_with_qubit_state_vector(self, qubit_device_single_wire):
+        """Tests the QuantumCircuit.initialize method in a QNode."""
+
+        prob_amplitudes = [1/np.sqrt(2), 1/np.sqrt(2)]
+
+        qreg = QuantumRegister(2)
+        qc = QuantumCircuit(qreg)
+        qc.initialize(prob_amplitudes, [qreg[0]])
+
+        @qml.qnode(qubit_device_single_wire)
+        def circuit_loaded_qiskit_circuit():
+            load(qc)()
+            return qml.expval(qml.PauliZ(0))
+
+        @qml.qnode(qubit_device_single_wire)
+        def circuit_native_pennylane():
+            qml.QubitStateVector(np.array(prob_amplitudes), wires=[0])
+            return qml.expval(qml.PauliZ(0))
+
+        assert circuit_loaded_qiskit_circuit() == circuit_native_pennylane()
+
+    @pytest.mark.parametrize("analytic", [True])
+    @pytest.mark.parametrize("theta,phi,varphi", list(zip(THETA, PHI, VARPHI)))
+    def test_gradient(self, theta, phi, varphi, analytic, tol):
+        """Test that the gradient works correctly"""
+        qc = QuantumCircuit(3)
+        qiskit_params = [Parameter("param_{}".format(i)) for i in range(3)]
+
+        qc.rx(qiskit_params[0], 0)
+        qc.rx(qiskit_params[1], 1)
+        qc.rx(qiskit_params[2], 2)
+        qc.cx(0, 1)
+        qc.cx(1, 2)
+
+        # convert to a PennyLane circuit
+        qc_pl = qml.from_qiskit(qc)
+
+        dev = qml.device("default.qubit", wires=3, analytic=analytic)
+
+        @qml.qnode(dev)
+        def circuit(params):
+            qiskit_param_mapping = dict(map(list, zip(qiskit_params, params)))
+            qc_pl(qiskit_param_mapping)
+            return qml.expval(qml.PauliX(0) @ qml.PauliY(2))
+
+        dcircuit = qml.grad(circuit, 0)
+        res = dcircuit([theta, phi, varphi])
+        expected = [
+            np.cos(theta) * np.sin(phi) * np.sin(varphi),
+            np.sin(theta) * np.cos(phi) * np.sin(varphi),
+            np.sin(theta) * np.sin(phi) * np.cos(varphi)
+        ]
+
+        assert np.allclose(res, expected, **tol)

--- a/pennylane_lightning/tests/test_expval.py
+++ b/pennylane_lightning/tests/test_expval.py
@@ -1,0 +1,380 @@
+import pytest
+
+import numpy as np
+import pennylane as qml
+
+from conftest import U, U2, A
+
+
+np.random.seed(42)
+
+THETA = np.linspace(0.11, 1, 3)
+PHI = np.linspace(0.32, 1, 3)
+VARPHI = np.linspace(0.02, 1, 3)
+
+
+@pytest.mark.parametrize("theta, phi", list(zip(THETA, PHI)))
+@pytest.mark.parametrize("analytic", [True, False])
+@pytest.mark.parametrize("shots", [8192])
+@pytest.mark.usefixtures("skip_unitary")
+class TestExpval:
+    """Test expectation values"""
+
+    def test_identity_expectation(self, theta, phi, device, shots, tol):
+        """Test that identity expectation value (i.e. the trace) is 1"""
+        dev = device(2)
+
+        O1 = qml.Identity(wires=[0])
+        O2 = qml.Identity(wires=[1])
+
+        dev.apply(
+            [
+                qml.RX(theta, wires=[0]),
+                qml.RX(phi, wires=[1]),
+                qml.CNOT(wires=[0, 1])
+            ],
+            rotations=[*O1.diagonalizing_gates(), *O2.diagonalizing_gates()]
+        )
+
+        dev._samples = dev.generate_samples()
+
+        res = np.array([dev.expval(O1), dev.expval(O2)])
+        assert np.allclose(res, np.array([1, 1]), **tol)
+
+    def test_pauliz_expectation(self, theta, phi, device, shots, tol):
+        """Test that PauliZ expectation value is correct"""
+        dev = device(2)
+        O1 = qml.PauliZ(wires=[0])
+        O2 = qml.PauliZ(wires=[1])
+
+        dev.apply(
+            [
+                qml.RX(theta, wires=[0]),
+                qml.RX(phi, wires=[1]),
+                qml.CNOT(wires=[0, 1])
+            ],
+            rotations=[*O1.diagonalizing_gates(), *O2.diagonalizing_gates()]
+        )
+
+        dev._samples = dev.generate_samples()
+
+        res = np.array([dev.expval(O1), dev.expval(O2)])
+        assert np.allclose(res, np.array([np.cos(theta), np.cos(theta) * np.cos(phi)]), **tol)
+
+    def test_paulix_expectation(self, theta, phi, device, shots, tol):
+        """Test that PauliX expectation value is correct"""
+        dev = device(2)
+        O1 = qml.PauliX(wires=[0])
+        O2 = qml.PauliX(wires=[1])
+
+        dev.apply(
+            [
+                qml.RY(theta, wires=[0]),
+                qml.RY(phi, wires=[1]),
+                qml.CNOT(wires=[0, 1])
+            ],
+            rotations=[*O1.diagonalizing_gates(), *O2.diagonalizing_gates()]
+        )
+
+        dev._samples = dev.generate_samples()
+
+        res = np.array([dev.expval(O1), dev.expval(O2)])
+        assert np.allclose(res, np.array([np.sin(theta) * np.sin(phi), np.sin(phi)]), **tol)
+
+    def test_pauliy_expectation(self, theta, phi, device, shots, tol):
+        """Test that PauliY expectation value is correct"""
+        dev = device(2)
+        O1 = qml.PauliY(wires=[0])
+        O2 = qml.PauliY(wires=[1])
+
+        dev.apply(
+            [
+                qml.RX(theta, wires=[0]),
+                qml.RX(phi, wires=[1]),
+                qml.CNOT(wires=[0, 1])
+            ],
+            rotations=[*O1.diagonalizing_gates(), *O2.diagonalizing_gates()]
+        )
+
+        dev._samples = dev.generate_samples()
+
+        res = np.array([dev.expval(O1), dev.expval(O2)])
+        assert np.allclose(res, np.array([0, -np.cos(theta) * np.sin(phi)]), **tol)
+
+    def test_hadamard_expectation(self, theta, phi, device, shots, tol):
+        """Test that Hadamard expectation value is correct"""
+        dev = device(2)
+        O1 = qml.Hadamard(wires=[0])
+        O2 = qml.Hadamard(wires=[1])
+
+        dev.apply(
+            [
+                qml.RY(theta, wires=[0]),
+                qml.RY(phi, wires=[1]),
+                qml.CNOT(wires=[0, 1])
+            ],
+            rotations=[*O1.diagonalizing_gates(), *O2.diagonalizing_gates()]
+        )
+
+        dev._samples = dev.generate_samples()
+
+        res = np.array([dev.expval(O1), dev.expval(O2)])
+        expected = np.array(
+            [np.sin(theta) * np.sin(phi) + np.cos(theta), np.cos(theta) * np.cos(phi) + np.sin(phi)]
+        ) / np.sqrt(2)
+        assert np.allclose(res, expected, **tol)
+
+    def test_hermitian_expectation(self, theta, phi, device, shots, tol):
+        """Test that arbitrary Hermitian expectation values are correct"""
+        dev = device(2)
+        O1 = qml.Hermitian(A, wires=[0])
+        O2 = qml.Hermitian(A, wires=[1])
+
+        dev.apply(
+            [
+                qml.RY(theta, wires=[0]),
+                qml.RY(phi, wires=[1]),
+                qml.CNOT(wires=[0, 1])
+            ],
+            rotations=[*O1.diagonalizing_gates(), *O2.diagonalizing_gates()]
+        )
+        dev._samples = dev.generate_samples()
+
+        res = np.array([dev.expval(O1), dev.expval(O2)])
+
+        a = A[0, 0]
+        re_b = A[0, 1].real
+        d = A[1, 1]
+        ev1 = ((a - d) * np.cos(theta) + 2 * re_b * np.sin(theta) * np.sin(phi) + a + d) / 2
+        ev2 = ((a - d) * np.cos(theta) * np.cos(phi) + 2 * re_b * np.sin(phi) + a + d) / 2
+        expected = np.array([ev1, ev2])
+
+        assert np.allclose(res, expected, **tol)
+
+    def test_multi_qubit_hermitian_expectation(self, theta, phi, device, shots, tol):
+        """Test that arbitrary multi-qubit Hermitian expectation values are
+        correct"""
+        dev = device(2)
+
+        A = np.array(
+            [
+                [-6, 2 + 1j, -3, -5 + 2j],
+                [2 - 1j, 0, 2 - 1j, -5 + 4j],
+                [-3, 2 + 1j, 0, -4 + 3j],
+                [-5 - 2j, -5 - 4j, -4 - 3j, -6],
+            ]
+        )
+        O1 = qml.Hermitian(A, wires=[0, 1])
+
+        dev.apply(
+            [
+                qml.RY(theta, wires=[0]),
+                qml.RY(phi, wires=[1]),
+                qml.CNOT(wires=[0, 1])
+            ],
+            rotations=[*O1.diagonalizing_gates()]
+        )
+        dev._samples = dev.generate_samples()
+
+        res = np.array([dev.expval(O1)])
+
+        # below is the analytic expectation value for this circuit with arbitrary
+        # Hermitian observable A
+        expected = 0.5 * (
+            6 * np.cos(theta) * np.sin(phi)
+            - np.sin(theta) * (8 * np.sin(phi) + 7 * np.cos(phi) + 3)
+            - 2 * np.sin(phi)
+            - 6 * np.cos(phi)
+            - 6
+        )
+
+        assert np.allclose(res, expected, **tol)
+
+
+@pytest.mark.parametrize("theta,phi,varphi", list(zip(THETA, PHI, VARPHI)))
+@pytest.mark.parametrize("analytic", [True, False])
+@pytest.mark.parametrize("shots", [8192])
+class TestTensorExpval:
+    """Test tensor expectation values"""
+
+    def test_paulix_pauliy(self, theta, phi, varphi, device, shots, tol):
+        """Test that a tensor product involving PauliX and PauliY works
+        correctly"""
+        dev = device(3)
+        obs = qml.PauliX(0) @ qml.PauliY(2)
+
+        dev.apply(
+            [
+                qml.RX(theta, wires=[0]),
+                qml.RX(phi, wires=[1]),
+                qml.RX(varphi, wires=[2]),
+                qml.CNOT(wires=[0, 1]),
+                qml.CNOT(wires=[1, 2])
+            ],
+            rotations=obs.diagonalizing_gates()
+        )
+
+        dev._samples = dev.generate_samples()
+        res = dev.expval(obs)
+
+        expected = np.sin(theta) * np.sin(phi) * np.sin(varphi)
+
+        assert np.allclose(res, expected, **tol)
+
+    def test_pauliz_identity(self, theta, phi, varphi, device, shots, tol):
+        """Test that a tensor product involving PauliZ and Identity works
+        correctly"""
+        dev = device(3)
+        obs = qml.PauliZ(0) @ qml.Identity(1) @ qml.PauliZ(2)
+
+        dev.apply(
+            [
+                qml.RX(theta, wires=[0]),
+                qml.RX(phi, wires=[1]),
+                qml.RX(varphi, wires=[2]),
+                qml.CNOT(wires=[0, 1]),
+                qml.CNOT(wires=[1, 2])
+            ],
+            rotations=obs.diagonalizing_gates()
+        )
+
+        dev._samples = dev.generate_samples()
+        res = dev.expval(obs)
+
+        expected = np.cos(varphi)*np.cos(phi)
+
+        assert np.allclose(res, expected, **tol)
+
+    def test_pauliz_hadamard_pauliy(self, theta, phi, varphi, device, shots, tol):
+        """Test that a tensor product involving PauliZ and PauliY and hadamard
+        works correctly"""
+        dev = device(3)
+        obs = qml.PauliZ(0) @ qml.Hadamard(1) @ qml.PauliY(2)
+
+        dev.apply(
+            [
+                qml.RX(theta, wires=[0]),
+                qml.RX(phi, wires=[1]),
+                qml.RX(varphi, wires=[2]),
+                qml.CNOT(wires=[0, 1]),
+                qml.CNOT(wires=[1, 2])
+            ],
+            rotations=obs.diagonalizing_gates()
+        )
+
+        dev._samples = dev.generate_samples()
+        res = dev.expval(obs)
+        expected = -(np.cos(varphi) * np.sin(phi) + np.sin(varphi) * np.cos(theta)) / np.sqrt(2)
+
+        assert np.allclose(res, expected, **tol)
+
+    def test_hermitian(self, theta, phi, varphi, device, shots, tol):
+        """Test that a tensor product involving qml.Hermitian works
+        correctly"""
+        dev = device(3)
+        A = np.array(
+            [
+                [-6, 2 + 1j, -3, -5 + 2j],
+                [2 - 1j, 0, 2 - 1j, -5 + 4j],
+                [-3, 2 + 1j, 0, -4 + 3j],
+                [-5 - 2j, -5 - 4j, -4 - 3j, -6],
+            ]
+        )
+
+        obs = qml.PauliZ(0) @ qml.Hermitian(A, wires=[1, 2])
+
+        dev.apply(
+            [
+                qml.RX(theta, wires=[0]),
+                qml.RX(phi, wires=[1]),
+                qml.RX(varphi, wires=[2]),
+                qml.CNOT(wires=[0, 1]),
+                qml.CNOT(wires=[1, 2])
+            ],
+            rotations=obs.diagonalizing_gates()
+        )
+
+        dev._samples = dev.generate_samples()
+        res = dev.expval(obs)
+        expected = 0.5 * (
+            -6 * np.cos(theta) * (np.cos(varphi) + 1)
+            - 2 * np.sin(varphi) * (np.cos(theta) + np.sin(phi) - 2 * np.cos(phi))
+            + 3 * np.cos(varphi) * np.sin(phi)
+            + np.sin(phi)
+        )
+
+        assert np.allclose(res, expected, **tol)
+
+    def test_hermitian_hermitian(self, theta, phi, varphi, device, shots, tol):
+        """Test that a tensor product involving two Hermitian matrices works
+        correctly"""
+        dev = device(3)
+        A1 = np.array([[1, 2],
+                       [2, 4]])
+
+        A2 = np.array(
+            [
+                [-6, 2 + 1j, -3, -5 + 2j],
+                [2 - 1j, 0, 2 - 1j, -5 + 4j],
+                [-3, 2 + 1j, 0, -4 + 3j],
+                [-5 - 2j, -5 - 4j, -4 - 3j, -6],
+            ]
+        )
+        obs = qml.Hermitian(A1, wires=[0]) @ qml.Hermitian(A2, wires=[1, 2])
+
+        dev.apply(
+            [
+                qml.RX(theta, wires=[0]),
+                qml.RX(phi, wires=[1]),
+                qml.RX(varphi, wires=[2]),
+                qml.CNOT(wires=[0, 1]),
+                qml.CNOT(wires=[1, 2])
+            ],
+            rotations=obs.diagonalizing_gates()
+        )
+
+        dev._samples = dev.generate_samples()
+        res = dev.expval(obs)
+        expected = 0.25 * (
+            -30
+            + 4 * np.cos(phi) * np.sin(theta)
+            + 3 * np.cos(varphi) * (-10 + 4 * np.cos(phi) * np.sin(theta) - 3 * np.sin(phi))
+            - 3 * np.sin(phi)
+            - 2 * (5 + np.cos(phi) * (6 + 4 * np.sin(theta)) + (-3 + 8 * np.sin(theta)) * np.sin(phi))
+            * np.sin(varphi)
+            + np.cos(theta)
+            * (
+                18
+                + 5 * np.sin(phi)
+                + 3 * np.cos(varphi) * (6 + 5 * np.sin(phi))
+                + 2 * (3 + 10 * np.cos(phi) - 5 * np.sin(phi)) * np.sin(varphi)
+            )
+        )
+
+        assert np.allclose(res, expected, **tol)
+
+    def test_hermitian_identity_expectation(self, theta, phi, varphi, device, shots, tol):
+        """Test that a tensor product involving an Hermitian matrix and the
+        identity works correctly"""
+        dev = device(2)
+
+        obs = qml.Hermitian(A, wires=[0]) @ qml.Identity(1)
+
+        dev.apply(
+            [
+                qml.RY(theta, wires=[0]),
+                qml.RY(phi, wires=[1]),
+                qml.CNOT(wires=[0, 1]),
+            ],
+            rotations=obs.diagonalizing_gates()
+        )
+
+        dev._samples = dev.generate_samples()
+        res = dev.expval(obs)
+
+        a = A[0, 0]
+        re_b = A[0, 1].real
+        d = A[1, 1]
+        expected = ((a - d) * np.cos(theta) + 2 * re_b * np.sin(theta) * np.sin(phi) + a + d) / 2
+
+        assert np.allclose(res, expected, **tol)

--- a/pennylane_lightning/tests/test_integration.py
+++ b/pennylane_lightning/tests/test_integration.py
@@ -1,0 +1,335 @@
+import sys
+
+import numpy as np
+import pennylane as qml
+import pytest
+import qiskit
+
+from pennylane_qiskit import AerDevice, BasicAerDevice
+
+from conftest import state_backends
+
+pldevices = [("qiskit.aer", qiskit.Aer), ("qiskit.basicaer", qiskit.BasicAer)]
+
+
+class TestDeviceIntegration:
+    """Test the devices work correctly from the PennyLane frontend."""
+
+    @pytest.mark.parametrize("d", pldevices)
+    def test_load_device(self, d, backend):
+        """Test that the qiskit device loads correctly"""
+        dev = qml.device(d[0], wires=2, backend=backend, shots=1024)
+        assert dev.num_wires == 2
+        assert dev.shots == 1024
+        assert dev.short_name == d[0]
+        assert dev.provider == d[1]
+
+    def test_incorrect_backend(self):
+        """Test that exception is raised if name is incorrect"""
+        with pytest.raises(ValueError, match="Backend 'none' does not exist"):
+            qml.device("qiskit.aer", wires=2, backend="none")
+
+    def test_incorrect_backend_wires(self):
+        """Test that exception is raised if number of wires is too large"""
+        with pytest.raises(ValueError, match=r"Backend 'statevector\_simulator' supports maximum"):
+            qml.device("qiskit.aer", wires=100, backend="statevector_simulator")
+
+    def test_args(self):
+        """Test that the device requires correct arguments"""
+        with pytest.raises(TypeError, match="missing 1 required positional argument"):
+            qml.device("qiskit.aer")
+
+        with pytest.raises(qml.DeviceError, match="specified number of shots needs to be at least 1"):
+            qml.device("qiskit.aer", backend="qasm_simulator", wires=1, shots=0)
+
+    @pytest.mark.parametrize("d", pldevices)
+    @pytest.mark.parametrize("analytic", [True, False])
+    @pytest.mark.parametrize("shots", [8192])
+    def test_one_qubit_circuit(self, shots, analytic, d, backend, tol):
+        """Test that devices provide correct result for a simple circuit"""
+        if backend not in state_backends and analytic:
+            pytest.skip("Hardware simulators do not support analytic mode")
+
+        dev = qml.device(d[0], wires=1, backend=backend, shots=shots, analytic=analytic)
+
+        a = 0.543
+        b = 0.123
+        c = 0.987
+
+        @qml.qnode(dev)
+        def circuit(x, y, z):
+            """Reference QNode"""
+            qml.BasisState(np.array([1]), wires=0)
+            qml.Hadamard(wires=0)
+            qml.Rot(x, y, z, wires=0)
+            return qml.expval(qml.PauliZ(0))
+
+        assert np.allclose(circuit(a, b, c), np.cos(a) * np.sin(b), **tol)
+
+    @pytest.mark.parametrize("d", pldevices)
+    @pytest.mark.parametrize("analytic", [False])
+    @pytest.mark.parametrize("shots", [8192])
+    def test_one_qubit_circuit(self, shots, analytic, d, backend, tol):
+        """Integration test for the Basisstate and Rot operations for when analytic
+        is False"""
+        dev = qml.device(d[0], wires=1, backend=backend, shots=shots, analytic=analytic)
+
+        a = 0
+        b = 0
+        c = np.pi
+        expected = 1
+
+        @qml.qnode(dev)
+        def circuit(x, y, z):
+            """Reference QNode"""
+            qml.BasisState(np.array([0]), wires=0)
+            qml.Rot(x, y, z, wires=0)
+            return qml.expval(qml.PauliZ(0))
+
+        assert np.allclose(circuit(a, b, c), expected, **tol)
+
+    def test_gradient_for_tensor_product(self):
+        """Test that the gradient of a circuit containing a tensor product is
+        computed without any errors."""
+        n_qubits = 2
+        depth = 2
+
+        def ansatz(weights):
+            weights = weights.reshape(depth, n_qubits)
+            qml.RX(weights[0][0], wires=[0])
+            qml.RZ(weights[0][1], wires=[0])
+            qml.RX(weights[1][0], wires=[0])
+            qml.RZ(weights[1][1], wires=[0])
+            return qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
+
+        dev_qsk = qml.device(
+                    "qiskit.aer",
+                    wires=n_qubits,
+                    shots=1000,
+                    backend="qasm_simulator",
+                )
+
+        weights = np.random.random((depth, n_qubits)).flatten()
+
+        # Want to get expectation value and gradient
+        exp_sampled = qml.QNode(ansatz, dev_qsk, diff_method="parameter-shift")
+        grad_shift = qml.grad(exp_sampled, argnum=0)
+        exp_sampled(weights)
+        grad_shift(weights)
+
+class TestKeywordArguments:
+    """Test keyword argument logic is correct"""
+
+    @pytest.mark.parametrize("d", pldevices)
+    def test_compile_backend(self, d):
+        """Test that the compile backend argument is properly
+        extracted"""
+        dev = qml.device(d[0], wires=2, compile_backend="test value")
+        assert dev.compile_backend == "test value"
+
+    def test_noise_model(self):
+        """Test that the noise model argument is properly
+        extracted if the backend supports it"""
+        dev = qml.device("qiskit.aer", wires=2, noise_model="test value")
+        assert dev.run_args["noise_model"] == "test value"
+
+    def test_invalid_noise_model(self):
+        """Test that the noise model argument causes an exception to be raised
+        if the backend does not support it"""
+        with pytest.raises(ValueError, match="does not support noisy simulations"):
+            dev = qml.device("qiskit.basicaer", wires=2, noise_model="test value")
+
+    @pytest.mark.parametrize("d", pldevices)
+    def test_overflow_backend_options(self, d):
+        """Test all overflow backend options are extracted"""
+        dev = qml.device(d[0], wires=2, k1="v1", k2="v2")
+        assert dev.run_args["backend_options"]["k1"] == "v1"
+        assert dev.run_args["backend_options"]["k2"] == "v2"
+
+
+class TestLoadIntegration:
+    """Integration tests for the PennyLane load function. This test ensures that the PennyLane-Qiskit
+    specific load functions integrate properly with the PennyLane-Qiskit plugin."""
+
+    hadamard_qasm = 'OPENQASM 2.0;' \
+                    'include "qelib1.inc";' \
+                    'qreg q[1];' \
+                    'h q[0];'
+
+    def test_load_qiskit_circuit(self):
+        """Test that the default load function works correctly."""
+        theta = qiskit.circuit.Parameter('θ')
+
+        qc = qiskit.QuantumCircuit(2)
+        qc.rx(theta, 0)
+
+        my_template = qml.load(qc, format='qiskit')
+
+        dev = qml.device('default.qubit', wires=2)
+
+        angles = np.array([0.53896774, 0.79503606, 0.27826503, 0.])
+
+        @qml.qnode(dev)
+        def loaded_quantum_circuit(angle):
+            my_template({theta: angle})
+            return qml.expval(qml.PauliZ(0))
+
+        @qml.qnode(dev)
+        def quantum_circuit(angle):
+            qml.RX(angle, wires=[0])
+            return qml.expval(qml.PauliZ(0))
+
+        for x in angles:
+            assert np.allclose(loaded_quantum_circuit(x), quantum_circuit(x))
+
+    def test_load_from_qasm_string(self):
+        """Test that quantum circuits can be loaded from a qasm string."""
+
+        dev = qml.device('default.qubit', wires=2)
+
+        @qml.qnode(dev)
+        def loaded_quantum_circuit():
+            qml.from_qasm(TestLoadIntegration.hadamard_qasm)(wires=[0])
+            return qml.expval(qml.PauliZ(0))
+
+        @qml.qnode(dev)
+        def quantum_circuit():
+            qml.Hadamard(wires=[0])
+            return qml.expval(qml.PauliZ(0))
+
+        assert np.allclose(loaded_quantum_circuit(), quantum_circuit())
+
+    @pytest.mark.skipif(sys.version_info < (3, 6), reason="tmpdir fixture requires Python >=3.6")
+    def test_load_qasm_from_file(self, tmpdir):
+        """Test that quantum circuits can be loaded from a qasm file."""
+        apply_hadamard = tmpdir.join("hadamard.qasm")
+
+        with open(apply_hadamard, "w") as f:
+            f.write(TestLoadIntegration.hadamard_qasm)
+
+        hadamard = qml.from_qasm_file(apply_hadamard)
+
+        dev = qml.device('default.qubit', wires=2)
+
+        @qml.qnode(dev)
+        def loaded_quantum_circuit():
+            hadamard(wires=[0])
+            return qml.expval(qml.PauliZ(0))
+
+        @qml.qnode(dev)
+        def quantum_circuit():
+            qml.Hadamard(wires=[0])
+            return qml.expval(qml.PauliZ(0))
+
+        assert np.allclose(loaded_quantum_circuit(), quantum_circuit())
+
+
+class TestPLOperations:
+    """Integration tests for checking certain PennyLane specific operations."""
+
+    @pytest.mark.parametrize("shots", [1000])
+    @pytest.mark.parametrize("analytic", [True, False])
+    def test_rotation(self, init_state, state_vector_device, shots, analytic, tol):
+        """Test that the QubitStateVector and Rot operations are decomposed using a
+        Qiskit device with statevector backend"""
+
+        dev = state_vector_device(1)
+
+        if dev.backend_name == "unitary_simulator":
+            pytest.skip("Test only runs for backends that are not the unitary simulator.")
+
+        state = init_state(1)
+
+        a = 0.542
+        b = 1.3432
+        c = -0.654
+
+        I = np.eye(2)
+        Y = np.array([[0, -1j], [1j, 0]])  #: Pauli-Y matrix
+        Z = np.array([[1, 0], [0, -1]])  #: Pauli-Z matrix
+
+        def ry(theta):
+            return np.cos(theta / 2) * I + 1j * np.sin(-theta / 2) * Y
+
+        def rz(theta):
+            return np.cos(theta / 2) * I + 1j * np.sin(-theta / 2) * Z
+
+        @qml.qnode(dev)
+        def qubitstatevector_and_rot():
+            qml.QubitStateVector(state, wires=[0])
+            qml.Rot(a, b, c, wires=[0])
+            return qml.expval(qml.Identity(0))
+
+        qubitstatevector_and_rot()
+
+        assert np.allclose(np.abs(dev.state) ** 2, np.abs(rz(c) @ ry(b) @ rz(a) @ state) ** 2, **tol)
+
+    @pytest.mark.parametrize("shots", [1000])
+    @pytest.mark.parametrize("analytic", [True, False])
+    def test_basisstate(self, init_state, state_vector_device, shots, analytic, tol):
+        """Test that the Basisstate is decomposed using a Qiskit device with
+        statevector backend"""
+
+        dev = state_vector_device(2)
+        state = np.array([1, 0])
+
+        @qml.qnode(dev)
+        def basisstate():
+            qml.BasisState(state, wires=[0, 1])
+            return qml.expval(qml.Identity(0))
+
+        basisstate()
+
+        expected_state = np.zeros(2**dev.num_wires)
+        expected_state[2] = 1
+
+        assert np.allclose(np.abs(dev.state) ** 2, np.abs(expected_state) ** 2, **tol)
+
+    @pytest.mark.parametrize("shots", [1000])
+    @pytest.mark.parametrize("analytic", [True, False])
+    def test_basisstate_init_all_zero_states(self, init_state, state_vector_device, shots, analytic, tol):
+        """Test that the Basisstate that receives the all zero state is decomposed using
+        a Qiskit device with statevector backend"""
+
+        dev = state_vector_device(4)
+        state = np.array([0, 0, 0, 0])
+
+        @qml.qnode(dev)
+        def basisstate():
+            qml.BasisState(state, wires=[0, 1, 2, 3])
+            return qml.expval(qml.Identity(0))
+
+        basisstate()
+
+        expected_state = np.zeros(2**dev.num_wires)
+        expected_state[0] = 1
+
+        assert np.allclose(np.abs(dev.state) ** 2, np.abs(expected_state) ** 2, **tol)
+
+
+class TestInverses:
+    """Integration tests checking that the inverse of the operations are applied."""
+
+    def test_inverse_of_operation(self):
+        """Test that the inverse of operations works as expected
+        by comparing a simple circuit with default.qubit."""
+        dev = qml.device('default.qubit', wires=2)
+
+        dev2 = qml.device('qiskit.aer', backend='statevector_simulator', shots=5, wires=2, analytic=True)
+
+        angles = np.array([0.53896774, 0.79503606, 0.27826503, 0.])
+
+        @qml.qnode(dev)
+        def circuit_with_inverses(angle):
+            qml.Hadamard(0).inv()
+            qml.RX(angle, wires=0).inv()
+            return qml.expval(qml.PauliZ(0))
+
+        @qml.qnode(dev2)
+        def circuit_with_inverses_default_qubit(angle):
+            qml.Hadamard(0).inv()
+            qml.RX(angle, wires=0).inv()
+            return qml.expval(qml.PauliZ(0))
+
+        for x in angles:
+            assert np.allclose(circuit_with_inverses(x), circuit_with_inverses_default_qubit(x))

--- a/pennylane_lightning/tests/test_inverses.py
+++ b/pennylane_lightning/tests/test_inverses.py
@@ -1,0 +1,189 @@
+import pytest
+
+import pennylane as qml
+import math
+import cmath
+import numpy as np
+
+# defaults
+tol = 1e-5
+
+
+class TestInverses:
+    """Tests that the inverse of the operations are applied."""
+
+    # This test is ran against the state |0> with one Z expval
+    @pytest.mark.parametrize("name,expected_output", [
+        ("PauliX", -1),
+        ("PauliY", -1),
+        ("PauliZ", 1),
+        ("Hadamard", 0),
+        ("S", 1),
+        ("T", 1),
+    ])
+    def test_supported_gate_inverse_single_wire_no_parameters(self, name, expected_output):
+        """Tests the inverse of supported gates that act on a single wire that are not
+        parameterized"""
+
+        op = getattr(qml.ops, name)
+
+        dev = qml.device('qiskit.aer', backend='statevector_simulator', wires=2, analytic=True)
+
+        @qml.qnode(dev)
+        def circuit():
+            op(wires=0).inv()
+            return qml.expval(qml.PauliZ(0))
+
+        assert np.isclose(circuit(), expected_output, atol=tol, rtol=0)
+
+    # This test is ran against the state |Phi+> with two Z expvals
+    @pytest.mark.parametrize("name,expected_output", [
+        ("CNOT", [-1/2, 1]),
+        ("SWAP", [-1/2, -1/2]),
+        ("CZ", [-1/2, -1/2]),
+    ])
+    def test_supported_gate_inverse_two_wires_no_parameters(self, name, expected_output):
+        """Tests the inverse of supported gates that act on two wires that are not parameterized"""
+
+        op = getattr(qml.ops, name)
+
+        dev = qml.device('qiskit.aer', backend='statevector_simulator', wires=2, analytic=True)
+
+        assert dev.supports_operation(name)
+
+        @qml.qnode(dev)
+        def circuit():
+            qml.QubitStateVector(np.array([1/2, 0, 0, math.sqrt(3)/2]), wires=[0, 1])
+            op(wires=[0, 1]).inv()
+            return qml.expval(qml.PauliZ(0)), qml.expval(qml.PauliZ(1))
+
+        assert np.allclose(circuit(), expected_output, atol=tol, rtol=0)
+
+    @pytest.mark.parametrize("name,expected_output", [
+        ("CSWAP", [-1, -1, 1]),
+    ])
+    def test_supported_gate_inverse_three_wires_no_parameters(self, name, expected_output):
+        """Tests the inverse of supported gates that act on three wires that are not parameterized"""
+
+        op = getattr(qml.ops, name)
+
+        dev = qml.device('qiskit.aer', backend='statevector_simulator', wires=3, analytic=True)
+
+        assert dev.supports_operation(name)
+
+        @qml.qnode(dev)
+        def circuit():
+            qml.BasisState(np.array([1, 0, 1]), wires=[0, 1, 2])
+            op(wires=[0, 1, 2]).inv()
+            return qml.expval(qml.PauliZ(0)), qml.expval(qml.PauliZ(1)), qml.expval(qml.PauliZ(2))
+
+        assert np.allclose(circuit(), expected_output, atol=tol, rtol=0)
+
+    # This test is ran on the state |0> with one Z expvals
+    @pytest.mark.parametrize("name,par,expected_output", [
+        ("PhaseShift", [math.pi/2], 1),
+        ("PhaseShift", [-math.pi/4], 1),
+        ("RX", [math.pi/2], 0),
+        ("RX", [-math.pi/4], 1/math.sqrt(2)),
+        ("RY", [math.pi/2], 0),
+        ("RY", [-math.pi/4], 1/math.sqrt(2)),
+        ("RZ", [math.pi/2], 1),
+        ("RZ", [-math.pi/4], 1),
+        ("QubitUnitary", [np.array([[1j/math.sqrt(2), 1j/math.sqrt(2)], [1j/math.sqrt(2), -1j/math.sqrt(2)]])], 0),
+        ("QubitUnitary", [np.array([[-1j/math.sqrt(2), 1j/math.sqrt(2)], [1j/math.sqrt(2), 1j/math.sqrt(2)]])], 0),
+    ])
+    def test_supported_gate_inverse_single_wire_with_parameters(self, name, par, expected_output):
+        """Test the inverse of single gates with parameters"""
+
+        dev = qml.device('qiskit.aer', backend='statevector_simulator', wires=2, analytic=True)
+
+        op = getattr(qml.ops, name)
+
+        assert dev.supports_operation(name)
+
+        @qml.qnode(dev)
+        def circuit():
+            op(*np.negative(par), wires=0).inv()
+            return qml.expval(qml.PauliZ(0))
+
+        assert np.isclose(circuit(), expected_output, atol=tol, rtol=0)
+
+    # This test is ran against the state 1/2|00>+sqrt(3)/2|11> with two Z expvals
+    @pytest.mark.parametrize("name,par,expected_output", [
+        ("CRZ", [0], [-1/2, -1/2]),
+        ("CRZ", [-math.pi], [-1/2, -1/2]),
+        ("CRZ", [math.pi/2], [-1/2, -1/2]),
+        ("QubitUnitary", [np.array([[1, 0, 0, 0], [0, 1/math.sqrt(2), 1/math.sqrt(2), 0], [0, 1/math.sqrt(2), -1/math.sqrt(2), 0], [0, 0, 0, 1]])], [-1/2, -1/2]),
+        ("QubitUnitary", [np.array([[-1, 0, 0, 0], [0, 1/math.sqrt(2), 1/math.sqrt(2), 0], [0, 1/math.sqrt(2), -1/math.sqrt(2), 0], [0, 0, 0, -1]])], [-1/2, -1/2]),
+    ])
+    def test_supported_gate_inverse_two_wires_with_parameters(self, name, par, expected_output):
+        """Tests the inverse of supported gates that act on two wires that are parameterized"""
+
+        dev = qml.device('qiskit.aer', backend='statevector_simulator', wires=2, analytic=True)
+
+        op = getattr(qml.ops, name)
+
+        assert dev.supports_operation(name)
+
+        @qml.qnode(dev)
+        def circuit():
+            qml.QubitStateVector(np.array([1/2, 0, 0, math.sqrt(3)/2]), wires=[0, 1])
+            op(*np.negative(par), wires=[0, 1]).inv()
+            return qml.expval(qml.PauliZ(0)), qml.expval(qml.PauliZ(1))
+
+        assert np.allclose(circuit(), expected_output, atol=tol, rtol=0)
+
+    @pytest.mark.parametrize("name,par,expected_output", [
+        ("Rot", [math.pi/2, 0, 0], 1),
+        ("Rot", [0, math.pi/2, 0], 0),
+        ("Rot", [0, 0, math.pi/2], 1),
+        ("Rot", [math.pi/2, -math.pi/4, -math.pi/4], 1/math.sqrt(2)),
+        ("Rot", [-math.pi/4, math.pi/2, math.pi/4], 0),
+        ("Rot", [-math.pi/4, math.pi/4, math.pi/2], 1/math.sqrt(2)),
+    ])
+    def test_unsupported_gate_inverses(self, name, par, expected_output):
+        """Test the inverse of single gates with parameters"""
+
+        dev = qml.device('qiskit.aer', backend='statevector_simulator', wires=2, analytic=True)
+
+        op = getattr(qml.ops, name)
+
+        @qml.qnode(dev)
+        def circuit():
+            op(*np.negative(par), wires=0).inv()
+            return qml.expval(qml.PauliZ(0))
+
+        assert np.isclose(circuit(), expected_output, atol=tol, rtol=0)
+
+    @pytest.mark.parametrize("par", [np.pi/i for i in range(1, 5)])
+    def test_s_gate_inverses(self, par):
+        """Tests the inverse of the S gate"""
+
+        dev = qml.device('qiskit.aer', backend='statevector_simulator', wires=2, analytic=True)
+
+        expected_output = -0.5 * 1j * cmath.exp(-1j*par)*(-1 + cmath.exp(2j*par))
+
+        @qml.qnode(dev)
+        def circuit():
+            qml.Hadamard(0)
+            qml.RZ(par, wires=[0])
+            qml.S(wires=[0]).inv()
+            return qml.expval(qml.PauliX(0))
+
+        assert np.allclose(circuit(), expected_output, atol=tol, rtol=0)
+
+    @pytest.mark.parametrize("par", [np.pi/i for i in range(1, 5)])
+    def test_t_gate_inverses(self, par):
+        """Tests the inverse of the T gate"""
+
+        dev = qml.device('qiskit.aer', backend='statevector_simulator', wires=2, analytic=True)
+
+        expected_output = -math.sin(par) / math.sqrt(2)
+
+        @qml.qnode(dev)
+        def circuit():
+            qml.RX(par, wires=[0])
+            qml.T(wires=[0]).inv()
+            return qml.expval(qml.PauliX(0))
+
+        assert np.allclose(circuit(), expected_output, atol=tol, rtol=0)

--- a/pennylane_lightning/tests/test_lightning_qubit.py
+++ b/pennylane_lightning/tests/test_lightning_qubit.py
@@ -1,0 +1,1593 @@
+# Copyright 2018-2020 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Unit tests for the :mod:`pennylane.plugin.LightningQubit` device.
+"""
+import cmath
+# pylint: disable=protected-access,cell-var-from-loop
+import math
+
+import pytest
+import pennylane as qml
+from pennylane import numpy as np, DeviceError
+from pennylane.operation import Operation
+
+U = np.array(
+    [
+        [0.83645892 - 0.40533293j, -0.20215326 + 0.30850569j],
+        [-0.23889780 - 0.28101519j, -0.88031770 - 0.29832709j],
+    ]
+)
+
+
+U2 = np.array(
+    [
+        [
+            -0.07843244 - 3.57825948e-01j,
+            0.71447295 - 5.38069384e-02j,
+            0.20949966 + 6.59100734e-05j,
+            -0.50297381 + 2.35731613e-01j,
+        ],
+        [
+            -0.26626692 + 4.53837083e-01j,
+            0.27771991 - 2.40717436e-01j,
+            0.41228017 - 1.30198687e-01j,
+            0.01384490 - 6.33200028e-01j,
+        ],
+        [
+            -0.69254712 - 2.56963068e-02j,
+            -0.15484858 + 6.57298384e-02j,
+            -0.53082141 + 7.18073414e-02j,
+            -0.41060450 - 1.89462315e-01j,
+        ],
+        [
+            -0.09686189 - 3.15085273e-01j,
+            -0.53241387 - 1.99491763e-01j,
+            0.56928622 + 3.97704398e-01j,
+            -0.28671074 - 6.01574497e-02j,
+        ],
+    ]
+)
+
+
+U_toffoli = np.diag([1 for i in range(8)])
+U_toffoli[6:8, 6:8] = np.array([[0, 1], [1, 0]])
+
+U_swap = np.array([[1, 0, 0, 0], [0, 0, 1, 0], [0, 1, 0, 0], [0, 0, 0, 1]])
+
+U_cswap = np.array([[1, 0, 0, 0, 0, 0, 0, 0],
+                    [0, 1, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 1, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 1, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 1, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 1, 0],
+                    [0, 0, 0, 0, 0, 1, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0, 1]])
+
+
+H = np.array(
+    [[1.02789352, 1.61296440 - 0.3498192j], [1.61296440 + 0.3498192j, 1.23920938 + 0j]]
+)
+
+
+THETA = np.linspace(0.11, 1, 3)
+PHI = np.linspace(0.32, 1, 3)
+VARPHI = np.linspace(0.02, 1, 3)
+
+
+def prep_par(par, op):
+    "Convert par into a list of parameters that op expects."
+    if op.par_domain == "A":
+        return [np.diag([x, 1]) for x in par]
+    return par
+
+
+def include_inverses_with_test_data(test_data):
+    return test_data + [(item[0] + ".inv", item[1], item[2]) for item in test_data]
+
+
+class TestApply:
+    """Tests that operations and inverses of certain operations are applied correctly or that the proper
+    errors are raised.
+    """
+
+    test_data_no_parameters = [
+        (qml.PauliX, [1, 0], np.array([0, 1])),
+        (qml.PauliX, [1/math.sqrt(2), 1/math.sqrt(2)], [1/math.sqrt(2), 1/math.sqrt(2)]),
+        (qml.PauliY, [1, 0], [0, 1j]),
+        (qml.PauliY, [1/math.sqrt(2), 1/math.sqrt(2)], [-1j/math.sqrt(2), 1j/math.sqrt(2)]),
+        (qml.PauliZ, [1, 0], [1, 0]),
+        (qml.PauliZ, [1/math.sqrt(2), 1/math.sqrt(2)], [1/math.sqrt(2), -1/math.sqrt(2)]),
+        (qml.S, [1, 0], [1, 0]),
+        (qml.S, [1/math.sqrt(2), 1/math.sqrt(2)], [1/math.sqrt(2), 1j/math.sqrt(2)]),
+        (qml.T, [1, 0], [1, 0]),
+        (qml.T, [1 / math.sqrt(2), 1 / math.sqrt(2)], [1 / math.sqrt(2), np.exp(1j * np.pi / 4) / math.sqrt(2)]),
+        (qml.Hadamard, [1, 0], [1/math.sqrt(2), 1/math.sqrt(2)]),
+        (qml.Hadamard, [1/math.sqrt(2), -1/math.sqrt(2)], [0, 1]),
+    ]
+
+    test_data_no_parameters_inverses  = [
+        (qml.PauliX, [1, 0], np.array([0, 1])),
+        (qml.PauliX, [1/math.sqrt(2), 1/math.sqrt(2)], [1/math.sqrt(2), 1/math.sqrt(2)]),
+        (qml.PauliY, [1, 0], [0, 1j]),
+        (qml.PauliY, [1/math.sqrt(2), 1/math.sqrt(2)], [-1j/math.sqrt(2), 1j/math.sqrt(2)]),
+        (qml.PauliZ, [1, 0], [1, 0]),
+        (qml.PauliZ, [1/math.sqrt(2), 1/math.sqrt(2)], [1/math.sqrt(2), -1/math.sqrt(2)]),
+        (qml.S, [1, 0], [1, 0]),
+        (qml.S, [1/math.sqrt(2), 1/math.sqrt(2)], [1/math.sqrt(2), -1j/math.sqrt(2)]),
+        (qml.T, [1, 0], [1, 0]),
+        (qml.T, [1 / math.sqrt(2), 1 / math.sqrt(2)], [1 / math.sqrt(2), np.exp(-1j * np.pi / 4) / math.sqrt(2)]),
+        (qml.Hadamard, [1, 0], [1/math.sqrt(2), 1/math.sqrt(2)]),
+        (qml.Hadamard, [1/math.sqrt(2), -1/math.sqrt(2)], [0, 1]),
+    ]
+
+    @pytest.mark.parametrize("operation,input,expected_output", test_data_no_parameters)
+    def test_apply_operation_single_wire_no_parameters(self, qubit_device_1_wire, tol, operation, input, expected_output):
+        """Tests that applying an operation yields the expected output state for single wire
+           operations that have no parameters."""
+
+        qubit_device_1_wire._state = np.array(input)
+        qubit_device_1_wire.apply([operation(wires=[0])])
+
+        assert np.allclose(qubit_device_1_wire._state, np.array(expected_output), atol=tol, rtol=0)
+
+    @pytest.mark.parametrize("operation,input,expected_output", test_data_no_parameters_inverses)
+    def test_apply_operation_single_wire_no_parameters_inverse(self, qubit_device_1_wire, tol, operation, input, expected_output):
+        """Tests that applying an operation yields the expected output state for single wire
+           operations that have no parameters."""
+
+        qubit_device_1_wire._state = np.array(input)
+        qubit_device_1_wire.apply([operation(wires=[0]).inv()])
+
+        assert np.allclose(qubit_device_1_wire._state, np.array(expected_output), atol=tol, rtol=0)
+
+    test_data_two_wires_no_parameters = [
+        (qml.CNOT, [1, 0, 0, 0], [1, 0, 0, 0]),
+        (qml.CNOT, [0, 0, 1, 0], [0, 0, 0, 1]),
+        (qml.CNOT, [1 / math.sqrt(2), 0, 0, 1 / math.sqrt(2)], [1 / math.sqrt(2), 0, 1 / math.sqrt(2), 0]),
+        (qml.SWAP, [1, 0, 0, 0], [1, 0, 0, 0]),
+        (qml.SWAP, [0, 0, 1, 0], [0, 1, 0, 0]),
+        (qml.SWAP, [1 / math.sqrt(2), 0, -1 / math.sqrt(2), 0], [1 / math.sqrt(2), -1 / math.sqrt(2), 0, 0]),
+        (qml.CZ, [1, 0, 0, 0], [1, 0, 0, 0]),
+        (qml.CZ, [0, 0, 0, 1], [0, 0, 0, -1]),
+        (qml.CZ, [1 / math.sqrt(2), 0, 0, -1 / math.sqrt(2)], [1 / math.sqrt(2), 0, 0, 1 / math.sqrt(2)]),
+    ]
+
+    @pytest.mark.parametrize("operation,input,expected_output", test_data_two_wires_no_parameters)
+    def test_apply_operation_two_wires_no_parameters(self, qubit_device_2_wires, tol, operation, input, expected_output):
+        """Tests that applying an operation yields the expected output state for two wire
+           operations that have no parameters."""
+        qubit_device_2_wires._state = np.array(input).reshape(2 *[2])
+        qubit_device_2_wires.apply([operation(wires=[0, 1])])
+
+        assert np.allclose(qubit_device_2_wires.state, np.array(expected_output), atol=tol, rtol=0)
+
+    @pytest.mark.parametrize("operation,input,expected_output", test_data_two_wires_no_parameters)
+    def test_apply_operation_two_wires_no_parameters_inverse(self, qubit_device_2_wires, tol, operation, input, expected_output):
+        """Tests that applying an operation yields the expected output state for two wire
+           operations that have no parameters."""
+
+        qubit_device_2_wires._state = np.array(input).reshape(2 *[2])
+        qubit_device_2_wires.apply([operation(wires=[0, 1]).inv()])
+
+        assert np.allclose(qubit_device_2_wires.state, np.array(expected_output), atol=tol, rtol=0)
+
+    test_data_three_wires_no_parameters = [
+        (qml.CSWAP, [1, 0, 0, 0, 0, 0, 0, 0], [1, 0, 0, 0, 0, 0, 0, 0]),
+        (qml.CSWAP, [0, 0, 0, 0, 0, 1, 0, 0], [0, 0, 0, 0, 0, 0, 1, 0]),
+        (qml.CSWAP, [0, 0, 0, 0, 0, 0, 1, 0], [0, 0, 0, 0, 0, 1, 0, 0]),
+    ]
+
+    @pytest.mark.parametrize("operation,input,expected_output", test_data_three_wires_no_parameters)
+    def test_apply_operation_three_wires_no_parameters(self, qubit_device_3_wires, tol, operation, input, expected_output):
+        """Tests that applying an operation yields the expected output state for three wire
+           operations that have no parameters."""
+
+        qubit_device_3_wires._state = np.array(input).reshape(3 *[2])
+        qubit_device_3_wires.apply([operation(wires=[0, 1, 2])])
+
+        assert np.allclose(qubit_device_3_wires.state, np.array(expected_output), atol=tol, rtol=0)
+
+    @pytest.mark.parametrize("operation,input,expected_output", test_data_three_wires_no_parameters)
+    def test_apply_operation_three_wires_no_parameters_inverse(self, qubit_device_3_wires, tol, operation, input, expected_output):
+        """Tests that applying the inverse of an operation yields the expected output state for three wire
+           operations that have no parameters."""
+
+        qubit_device_3_wires._state = np.array(input).reshape(3 *[2])
+        qubit_device_3_wires.apply([operation(wires=[0, 1, 2]).inv()])
+
+        assert np.allclose(qubit_device_3_wires.state, np.array(expected_output), atol=tol, rtol=0)
+
+
+    @pytest.mark.parametrize("operation,expected_output,par", [
+        (qml.BasisState, [0, 0, 1, 0], [1, 0]),
+        (qml.BasisState, [0, 0, 1, 0], [1, 0]),
+        (qml.BasisState, [0, 0, 0, 1], [1, 1]),
+        (qml.QubitStateVector, [0, 0, 1, 0], [0, 0, 1, 0]),
+        (qml.QubitStateVector, [0, 0, 1, 0], [0, 0, 1, 0]),
+        (qml.QubitStateVector, [0, 0, 0, 1], [0, 0, 0, 1]),
+        (qml.QubitStateVector, [1/math.sqrt(3), 0, 1/math.sqrt(3), 1/math.sqrt(3)], [1/math.sqrt(3), 0, 1/math.sqrt(3), 1/math.sqrt(3)]),
+        (qml.QubitStateVector, [1/math.sqrt(3), 0, -1/math.sqrt(3), 1/math.sqrt(3)], [1/math.sqrt(3), 0, -1/math.sqrt(3), 1/math.sqrt(3)]),
+    ])
+    def test_apply_operation_state_preparation(self, qubit_device_2_wires, tol, operation, expected_output, par):
+        """Tests that applying an operation yields the expected output state for single wire
+           operations that have no parameters."""
+
+        par = np.array(par)
+        qubit_device_2_wires.reset()
+        qubit_device_2_wires.apply([operation(par, wires=[0, 1])])
+
+        assert np.allclose(qubit_device_2_wires.state, np.array(expected_output), atol=tol, rtol=0)
+
+    test_data_single_wire_with_parameters = [
+        (qml.PhaseShift, [1, 0], [1, 0], [math.pi / 2]),
+        (qml.PhaseShift, [0, 1], [0, 1j], [math.pi / 2]),
+        (qml.PhaseShift, [1 / math.sqrt(2), 1 / math.sqrt(2)], [1 / math.sqrt(2), 1 / 2 + 1j / 2], [math.pi / 4]),
+        (qml.RX, [1, 0], [1 / math.sqrt(2), -1j * 1 / math.sqrt(2)], [math.pi / 2]),
+        (qml.RX, [1, 0], [0, -1j], [math.pi]),
+        (qml.RX, [1 / math.sqrt(2), 1 / math.sqrt(2)], [1 / 2 - 1j / 2, 1 / 2 - 1j / 2], [math.pi / 2]),
+        (qml.RY, [1, 0], [1 / math.sqrt(2), 1 / math.sqrt(2)], [math.pi / 2]),
+        (qml.RY, [1, 0], [0, 1], [math.pi]),
+        (qml.RY, [1 / math.sqrt(2), 1 / math.sqrt(2)], [0, 1], [math.pi / 2]),
+        (qml.RZ, [1, 0], [1 / math.sqrt(2) - 1j / math.sqrt(2), 0], [math.pi / 2]),
+        (qml.RZ, [0, 1], [0, 1j], [math.pi]),
+        (qml.RZ, [1 / math.sqrt(2), 1 / math.sqrt(2)], [1 / 2 - 1j / 2, 1 / 2 + 1j / 2], [math.pi / 2]),
+        (qml.Rot, [1, 0], [1 / math.sqrt(2) - 1j / math.sqrt(2), 0], [math.pi / 2, 0, 0]),
+        (qml.Rot, [1, 0], [1 / math.sqrt(2), 1 / math.sqrt(2)], [0, math.pi / 2, 0]),
+        (qml.Rot, [1 / math.sqrt(2), 1 / math.sqrt(2)], [1 / 2 - 1j / 2, 1 / 2 + 1j / 2], [0, 0, math.pi / 2]),
+        (qml.Rot, [1, 0], [-1j / math.sqrt(2), -1 / math.sqrt(2)], [math.pi / 2, -math.pi / 2, math.pi / 2]),
+        (qml.Rot, [1 / math.sqrt(2), 1 / math.sqrt(2)], [1 / 2 + 1j / 2, -1 / 2 + 1j / 2],
+         [-math.pi / 2, math.pi, math.pi]),
+        (qml.QubitUnitary, [1, 0], [1j / math.sqrt(2), 1j / math.sqrt(2)],
+         [np.array([[1j / math.sqrt(2), 1j / math.sqrt(2)], [1j / math.sqrt(2), -1j / math.sqrt(2)]])]),
+        (qml.QubitUnitary, [0, 1], [1j / math.sqrt(2), -1j / math.sqrt(2)],
+         [np.array([[1j / math.sqrt(2), 1j / math.sqrt(2)], [1j / math.sqrt(2), -1j / math.sqrt(2)]])]),
+        (qml.QubitUnitary, [1 / math.sqrt(2), -1 / math.sqrt(2)], [0, 1j],
+         [np.array([[1j / math.sqrt(2), 1j / math.sqrt(2)], [1j / math.sqrt(2), -1j / math.sqrt(2)]])]),
+    ]
+
+    test_data_single_wire_with_parameters_inverses = [
+        (qml.PhaseShift, [1, 0], [1, 0], [math.pi / 2]),
+        (qml.PhaseShift, [0, 1], [0, -1j], [math.pi / 2]),
+        (qml.PhaseShift, [1 / math.sqrt(2), 1 / math.sqrt(2)],
+         [1 / math.sqrt(2), 1 / 2 - 1j / 2], [math.pi / 4]),
+        (qml.RX, [1, 0], [1 / math.sqrt(2), 1j * 1 / math.sqrt(2)], [math.pi / 2]),
+        (qml.RX, [1, 0], [0, 1j], [math.pi]),
+        (qml.RX, [1 / math.sqrt(2), 1 / math.sqrt(2)], [1 / 2 + 1j / 2, 1 / 2 + 1j / 2], [math.pi / 2]),
+        (qml.RY, [1, 0], [1 / math.sqrt(2), -1 / math.sqrt(2)], [math.pi / 2]),
+        (qml.RY, [1, 0], [0, -1], [math.pi]),
+        (qml.RY, [1 / math.sqrt(2), 1 / math.sqrt(2)], [1, 0], [math.pi / 2]),
+        (qml.RZ, [1, 0], [1 / math.sqrt(2) + 1j / math.sqrt(2), 0], [math.pi / 2]),
+        (qml.RZ, [0, 1], [0, -1j], [math.pi]),
+        (qml.RZ, [1 / math.sqrt(2), 1 / math.sqrt(2)],
+         [1 / 2 + 1/2*1j, 1 / 2 - 1/2*1j], [math.pi / 2]),
+    ]
+
+    @pytest.mark.parametrize("operation,input,expected_output,par", test_data_single_wire_with_parameters)
+    def test_apply_operation_single_wire_with_parameters(self, qubit_device_1_wire, tol, operation, input, expected_output, par):
+        """Tests that applying an operation yields the expected output state for single wire
+           operations that have parameters."""
+
+        #parameter = par[0]
+        qubit_device_1_wire._state = np.array(input)
+
+        qubit_device_1_wire.apply([operation(*par, wires=[0])])
+
+        assert np.allclose(qubit_device_1_wire.state, np.array(expected_output), atol=tol, rtol=0)
+
+    @pytest.mark.parametrize("operation,input,expected_output,par", test_data_single_wire_with_parameters_inverses)
+    def test_apply_operation_single_wire_with_parameters_inverse(self, qubit_device_1_wire, tol, operation, input, expected_output, par):
+        """Tests that applying the inverse of an operation yields the expected output state for single wire
+           operations that have parameters."""
+
+        qubit_device_1_wire._state = np.array(input)
+        qubit_device_1_wire.apply([operation(*par, wires=[0]).inv()])
+
+        assert np.allclose(qubit_device_1_wire._state, np.array(expected_output), atol=tol, rtol=0)
+
+    test_data_two_wires_with_parameters = [
+        (qml.CRX, [0, 1, 0, 0], [0, 1, 0, 0], [math.pi / 2]),
+        (qml.CRX, [0, 0, 0, 1], [0, 0, -1j, 0], [math.pi]),
+        (qml.CRX, [0, 1 / math.sqrt(2), 1 / math.sqrt(2), 0], [0, 1 / math.sqrt(2), 1 / 2, -1j / 2], [math.pi / 2]),
+        (qml.CRY, [0, 0, 0, 1], [0, 0, -1 / math.sqrt(2), 1 / math.sqrt(2)], [math.pi / 2]),
+        (qml.CRY, [0, 0, 0, 1], [0, 0, -1, 0], [math.pi]),
+        (qml.CRY, [1 / math.sqrt(2), 1 / math.sqrt(2), 0, 0], [1 / math.sqrt(2), 1 / math.sqrt(2), 0, 0], [math.pi / 2]),
+        (qml.CRZ, [0, 0, 0, 1], [0, 0, 0, 1 / math.sqrt(2) + 1j / math.sqrt(2)], [math.pi / 2]),
+        (qml.CRZ, [0, 0, 0, 1], [0, 0, 0, 1j], [math.pi]),
+        (qml.CRZ, [1 / math.sqrt(2), 1 / math.sqrt(2), 0, 0], [1 / math.sqrt(2), 1 / math.sqrt(2), 0, 0], [math.pi / 2]),
+        (qml.CRot, [0, 0, 0, 1], [0, 0, 0, 1 / math.sqrt(2) + 1j / math.sqrt(2)], [math.pi / 2, 0, 0]),
+        (qml.CRot, [0, 0, 0, 1], [0, 0, -1 / math.sqrt(2), 1 / math.sqrt(2)], [0, math.pi / 2, 0]),
+        (qml.CRot, [0, 0, 1 / math.sqrt(2), 1 / math.sqrt(2)], [0, 0, 1 / 2 - 1j / 2, 1 / 2 + 1j / 2],
+         [0, 0, math.pi / 2]),
+        (qml.CRot, [0, 0, 0, 1], [0, 0, 1 / math.sqrt(2), 1j / math.sqrt(2)], [math.pi / 2, -math.pi / 2, math.pi / 2]),
+        (qml.CRot, [0, 1 / math.sqrt(2), 1 / math.sqrt(2), 0], [0, 1 / math.sqrt(2), 0, -1 / 2 + 1j / 2],
+         [-math.pi / 2, math.pi, math.pi]),
+        (qml.QubitUnitary, [1, 0, 0, 0], [1, 0, 0, 0], [np.array(
+            [[1, 0, 0, 0], [0, 1 / math.sqrt(2), 1 / math.sqrt(2), 0], [0, 1 / math.sqrt(2), -1 / math.sqrt(2), 0],
+             [0, 0, 0, 1]])]),
+        (qml.QubitUnitary, [0, 1, 0, 0], [0, 1 / math.sqrt(2), 1 / math.sqrt(2), 0], [np.array(
+            [[1, 0, 0, 0], [0, 1 / math.sqrt(2), 1 / math.sqrt(2), 0], [0, 1 / math.sqrt(2), -1 / math.sqrt(2), 0],
+             [0, 0, 0, 1]])]),
+        (qml.QubitUnitary, [1 / 2, 1 / 2, -1 / 2, 1 / 2], [1 / 2, 0, 1 / math.sqrt(2), 1 / 2], [np.array(
+            [[1, 0, 0, 0], [0, 1 / math.sqrt(2), 1 / math.sqrt(2), 0], [0, 1 / math.sqrt(2), -1 / math.sqrt(2), 0],
+             [0, 0, 0, 1]])]),
+    ]
+
+    test_data_two_wires_with_parameters_inverses = [
+        (qml.CRX, [0, 1, 0, 0], [0, 1, 0, 0], [math.pi / 2]),
+        (qml.CRX, [0, 0, 0, 1], [0, 0, 1j, 0], [math.pi]),
+        (qml.CRX, [0, 1 / math.sqrt(2), 1 / math.sqrt(2), 0],
+         [0, 1 / math.sqrt(2), 1 / 2, 1j / 2], [math.pi / 2]),
+    ]
+
+    @pytest.mark.parametrize("operation,input,expected_output,par", test_data_two_wires_with_parameters)
+    def test_apply_operation_two_wires_with_parameters(self, qubit_device_2_wires, tol, operation, input, expected_output, par):
+        """Tests that applying an operation yields the expected output state for two wire
+           operations that have parameters."""
+
+        qubit_device_2_wires._state = np.array(input).reshape(2 *[2])
+        qubit_device_2_wires.apply([operation(*par, wires=[0, 1])])
+
+        assert np.allclose(qubit_device_2_wires.state, np.array(expected_output), atol=tol, rtol=0)
+
+    @pytest.mark.parametrize("operation,input,expected_output,par", test_data_two_wires_with_parameters_inverses)
+    def test_apply_operation_two_wires_with_parameters_inverse(self, qubit_device_2_wires, tol, operation, input, expected_output, par):
+        """Tests that applying the inverse of an operation yields the expected output state for two wire
+           operations that have parameters."""
+
+        qubit_device_2_wires._state = np.array(input).reshape(2 *[2])
+        qubit_device_2_wires.apply([operation(*par, wires=[0, 1]).inv()])
+
+        assert np.allclose(qubit_device_2_wires.state, np.array(expected_output), atol=tol, rtol=0)
+
+    def test_apply_errors_qubit_state_vector(self, qubit_device_2_wires):
+        """Test that apply fails for incorrect state preparation, and > 2 qubit gates"""
+        with pytest.raises(
+            ValueError,
+            match="Sum of amplitudes-squared does not equal one."
+        ):
+            qubit_device_2_wires.apply([qml.QubitStateVector(np.array([1, -1]), wires=[0])])
+
+        with pytest.raises(
+            ValueError,
+            match=r"State vector must be of length 2\*\*wires."
+        ):
+            p = np.array([1, 0, 1, 1, 0]) / np.sqrt(3)
+            qubit_device_2_wires.apply([qml.QubitStateVector(p, wires=[0, 1])])
+
+        with pytest.raises(
+            DeviceError,
+            match="Operation QubitStateVector cannot be used after other Operations have already been applied "
+        ):
+            qubit_device_2_wires.reset()
+            qubit_device_2_wires.apply([
+                qml.RZ(0.5, wires=[0]),
+                qml.QubitStateVector(np.array([0, 1, 0, 0]), wires=[0, 1])
+            ])
+
+    def test_apply_errors_basis_state(self, qubit_device_2_wires):
+        with pytest.raises(
+            ValueError,
+            match="BasisState parameter must consist of 0 or 1 integers."
+        ):
+            qubit_device_2_wires.apply([qml.BasisState(np.array([-0.2, 4.2]), wires=[0, 1])])
+
+        with pytest.raises(
+            ValueError,
+            match="BasisState parameter and wires must be of equal length."
+        ):
+            qubit_device_2_wires.apply([qml.BasisState(np.array([0, 1]), wires=[0])])
+
+        with pytest.raises(
+            DeviceError,
+            match="Operation BasisState cannot be used after other Operations have already been applied "
+        ):
+            qubit_device_2_wires.reset()
+            qubit_device_2_wires.apply([
+                qml.RZ(0.5, wires=[0]),
+                qml.BasisState(np.array([1, 1]), wires=[0, 1])
+            ])
+
+class TestExpval:
+    """Tests that expectation values are properly calculated or that the proper errors are raised."""
+
+    @pytest.mark.parametrize("operation,input,expected_output", [
+        (qml.PauliX, [1/math.sqrt(2), 1/math.sqrt(2)], 1),
+        (qml.PauliX, [1/math.sqrt(2), -1/math.sqrt(2)], -1),
+        (qml.PauliX, [1, 0], 0),
+        (qml.PauliY, [1/math.sqrt(2), 1j/math.sqrt(2)], 1),
+        (qml.PauliY, [1/math.sqrt(2), -1j/math.sqrt(2)], -1),
+        (qml.PauliY, [1, 0], 0),
+        (qml.PauliZ, [1, 0], 1),
+        (qml.PauliZ, [0, 1], -1),
+        (qml.PauliZ, [1/math.sqrt(2), 1/math.sqrt(2)], 0),
+        (qml.Hadamard, [1, 0], 1/math.sqrt(2)),
+        (qml.Hadamard, [0, 1], -1/math.sqrt(2)),
+        (qml.Hadamard, [1/math.sqrt(2), 1/math.sqrt(2)], 1/math.sqrt(2)),
+        (qml.Identity, [1, 0], 1),
+        (qml.Identity, [0, 1], 1),
+        (qml.Identity, [1/math.sqrt(2), -1/math.sqrt(2)], 1),
+    ])
+    def test_expval_single_wire_no_parameters(self, qubit_device_1_wire, tol, operation, input, expected_output):
+        """Tests that expectation values are properly calculated for single-wire observables without parameters."""
+
+        obs = operation(wires=[0])
+
+        qubit_device_1_wire.reset()
+        qubit_device_1_wire.apply(
+            [qml.QubitStateVector(np.array(input), wires=[0])],
+            obs.diagonalizing_gates()
+        )
+        res = qubit_device_1_wire.expval(obs)
+
+        assert np.isclose(res, expected_output, atol=tol, rtol=0)
+
+    @pytest.mark.parametrize("operation,input,expected_output,par", [
+        (qml.Hermitian, [1, 0], 1, [[1, 1j], [-1j, 1]]),
+        (qml.Hermitian, [0, 1], 1, [[1, 1j], [-1j, 1]]),
+        (qml.Hermitian, [1/math.sqrt(2), -1/math.sqrt(2)], 1, [[1, 1j], [-1j, 1]]),
+    ])
+    def test_expval_single_wire_with_parameters(self, qubit_device_1_wire, tol, operation, input, expected_output, par):
+        """Tests that expectation values are properly calculated for single-wire observables with parameters."""
+
+        obs = operation(np.array(par), wires=[0])
+
+        qubit_device_1_wire.reset()
+        qubit_device_1_wire.apply(
+            [qml.QubitStateVector(np.array(input), wires=[0])],
+            obs.diagonalizing_gates()
+        )
+        res = qubit_device_1_wire.expval(obs)
+
+        assert np.isclose(res, expected_output, atol=tol, rtol=0)
+
+    @pytest.mark.parametrize("operation,input,expected_output,par", [
+        (qml.Hermitian, [1/math.sqrt(3), 0, 1/math.sqrt(3), 1/math.sqrt(3)], 5/3, [[1, 1j, 0, 1], [-1j, 1, 0, 0], [0, 0, 1, -1j], [1, 0, 1j, 1]]),
+        (qml.Hermitian, [0, 0, 0, 1], 0, [[0, 1j, 0, 0], [-1j, 0, 0, 0], [0, 0, 0, -1j], [0, 0, 1j, 0]]),
+        (qml.Hermitian, [1/math.sqrt(2), 0, -1/math.sqrt(2), 0], 1, [[1, 1j, 0, 0], [-1j, 1, 0, 0], [0, 0, 1, -1j], [0, 0, 1j, 1]]),
+        (qml.Hermitian, [1/math.sqrt(3), -1/math.sqrt(3), 1/math.sqrt(6), 1/math.sqrt(6)], 1, [[1, 1j, 0, .5j], [-1j, 1, 0, 0], [0, 0, 1, -1j], [-.5j, 0, 1j, 1]]),
+        (qml.Hermitian, [1/math.sqrt(2), 0, 0, 1/math.sqrt(2)], 1, [[1, 0, 0, 0], [0, -1, 0, 0], [0, 0, -1, 0], [0, 0, 0, 1]]),
+        (qml.Hermitian, [0, 1/math.sqrt(2), -1/math.sqrt(2), 0], -1, [[1, 0, 0, 0], [0, -1, 0, 0], [0, 0, -1, 0], [0, 0, 0, 1]]),
+    ])
+    def test_expval_two_wires_with_parameters(self, qubit_device_2_wires, tol, operation, input, expected_output, par):
+        """Tests that expectation values are properly calculated for two-wire observables with parameters."""
+
+        obs = operation(np.array(par), wires=[0, 1])
+
+        qubit_device_2_wires.reset()
+        qubit_device_2_wires.apply(
+            [qml.QubitStateVector(np.array(input), wires=[0, 1])],
+            obs.diagonalizing_gates()
+        )
+        res = qubit_device_2_wires.expval(obs)
+
+        assert np.isclose(res, expected_output, atol=tol, rtol=0)
+
+    def test_expval_estimate(self):
+        """Test that the expectation value is not analytically calculated"""
+
+        dev = qml.device("lightning.qubit", wires=1, shots=3, analytic=False)
+
+        @qml.qnode(dev)
+        def circuit():
+            return qml.expval(qml.PauliX(0))
+
+        expval = circuit()
+
+        # With 3 samples we are guaranteed to see a difference between
+        # an estimated variance an an analytically calculated one
+        assert expval != 0.0
+
+class TestVar:
+    """Tests that variances are properly calculated."""
+
+    @pytest.mark.parametrize("operation,input,expected_output", [
+        (qml.PauliX, [1/math.sqrt(2), 1/math.sqrt(2)], 0),
+        (qml.PauliX, [1/math.sqrt(2), -1/math.sqrt(2)], 0),
+        (qml.PauliX, [1, 0], 1),
+        (qml.PauliY, [1/math.sqrt(2), 1j/math.sqrt(2)], 0),
+        (qml.PauliY, [1/math.sqrt(2), -1j/math.sqrt(2)], 0),
+        (qml.PauliY, [1, 0], 1),
+        (qml.PauliZ, [1, 0], 0),
+        (qml.PauliZ, [0, 1], 0),
+        (qml.PauliZ, [1/math.sqrt(2), 1/math.sqrt(2)], 1),
+        (qml.Hadamard, [1, 0], 1/2),
+        (qml.Hadamard, [0, 1], 1/2),
+        (qml.Hadamard, [1/math.sqrt(2), 1/math.sqrt(2)], 1/2),
+        (qml.Identity, [1, 0], 0),
+        (qml.Identity, [0, 1], 0),
+        (qml.Identity, [1/math.sqrt(2), -1/math.sqrt(2)], 0),
+
+    ])
+    def test_var_single_wire_no_parameters(self, qubit_device_1_wire, tol, operation, input, expected_output):
+        """Tests that variances are properly calculated for single-wire observables without parameters."""
+
+        obs = operation(wires=[0])
+
+        qubit_device_1_wire.reset()
+        qubit_device_1_wire.apply(
+            [qml.QubitStateVector(np.array(input), wires=[0])],
+            obs.diagonalizing_gates()
+        )
+        res = qubit_device_1_wire.var(obs)
+
+        assert np.isclose(res, expected_output, atol=tol, rtol=0)
+
+    @pytest.mark.parametrize("operation,input,expected_output,par", [
+        (qml.Hermitian, [1, 0], 1, [[1, 1j], [-1j, 1]]),
+        (qml.Hermitian, [0, 1], 1, [[1, 1j], [-1j, 1]]),
+        (qml.Hermitian, [1/math.sqrt(2), -1/math.sqrt(2)], 1, [[1, 1j], [-1j, 1]]),
+    ])
+    def test_var_single_wire_with_parameters(self, qubit_device_1_wire, tol, operation, input, expected_output, par):
+        """Tests that variances are properly calculated for single-wire observables with parameters."""
+
+        obs = operation(np.array(par), wires=[0])
+
+        qubit_device_1_wire.reset()
+        qubit_device_1_wire.apply(
+            [qml.QubitStateVector(np.array(input), wires=[0])],
+            obs.diagonalizing_gates()
+        )
+        res = qubit_device_1_wire.var(obs)
+
+        assert np.isclose(res, expected_output, atol=tol, rtol=0)
+
+    @pytest.mark.parametrize("operation,input,expected_output,par", [
+        (qml.Hermitian, [1/math.sqrt(3), 0, 1/math.sqrt(3), 1/math.sqrt(3)], 11/9, [[1, 1j, 0, 1], [-1j, 1, 0, 0], [0, 0, 1, -1j], [1, 0, 1j, 1]]),
+        (qml.Hermitian, [0, 0, 0, 1], 1, [[0, 1j, 0, 0], [-1j, 0, 0, 0], [0, 0, 0, -1j], [0, 0, 1j, 0]]),
+        (qml.Hermitian, [1/math.sqrt(2), 0, -1/math.sqrt(2), 0], 1, [[1, 1j, 0, 0], [-1j, 1, 0, 0], [0, 0, 1, -1j], [0, 0, 1j, 1]]),
+        (qml.Hermitian, [1/math.sqrt(2), 0, 0, 1/math.sqrt(2)], 0, [[1, 0, 0, 0], [0, -1, 0, 0], [0, 0, -1, 0], [0, 0, 0, 1]]),
+        (qml.Hermitian, [0, 1/math.sqrt(2), -1/math.sqrt(2), 0], 0, [[1, 0, 0, 0], [0, -1, 0, 0], [0, 0, -1, 0], [0, 0, 0, 1]]),
+    ])
+    def test_var_two_wires_with_parameters(self, qubit_device_2_wires, tol, operation, input, expected_output, par):
+        """Tests that variances are properly calculated for two-wire observables with parameters."""
+
+        obs = operation(np.array(par), wires=[0, 1])
+
+        qubit_device_2_wires.reset()
+        qubit_device_2_wires.apply(
+            [qml.QubitStateVector(np.array(input), wires=[0, 1])],
+            obs.diagonalizing_gates()
+        )
+        res = qubit_device_2_wires.var(obs)
+
+        assert np.isclose(res, expected_output, atol=tol, rtol=0)
+
+    def test_var_estimate(self):
+        """Test that the variance is not analytically calculated"""
+
+        dev = qml.device("lightning.qubit", wires=1, shots=3, analytic=False)
+
+        @qml.qnode(dev)
+        def circuit():
+            return qml.var(qml.PauliX(0))
+
+        var = circuit()
+
+        # With 3 samples we are guaranteed to see a difference between
+        # an estimated variance and an analytically calculated one
+        assert var != 1.0
+
+class TestSample:
+    """Tests that samples are properly calculated."""
+
+    def test_sample_dimensions(self, qubit_device_2_wires):
+        """Tests if the samples returned by the sample function have
+        the correct dimensions
+        """
+
+        # Explicitly resetting is necessary as the internal
+        # state is set to None in __init__ and only properly
+        # initialized during reset
+        qubit_device_2_wires.reset()
+
+        qubit_device_2_wires.apply(
+            [qml.RX(1.5708, wires=[0]), qml.RX(1.5708, wires=[1])]
+        )
+
+        qubit_device_2_wires.shots = 10
+        qubit_device_2_wires._wires_measured = {0}
+        qubit_device_2_wires._samples = qubit_device_2_wires.generate_samples()
+        s1 = qubit_device_2_wires.sample(qml.PauliZ(wires=[0]))
+        assert np.array_equal(s1.shape, (10,))
+
+        qubit_device_2_wires.reset()
+        qubit_device_2_wires.shots = 12
+        qubit_device_2_wires._wires_measured = {1}
+        qubit_device_2_wires._samples = qubit_device_2_wires.generate_samples()
+        s2 = qubit_device_2_wires.sample(qml.PauliZ(wires=[1]))
+        assert np.array_equal(s2.shape, (12,))
+
+        qubit_device_2_wires.reset()
+        qubit_device_2_wires.shots = 17
+        qubit_device_2_wires._wires_measured = {0, 1}
+        qubit_device_2_wires._samples = qubit_device_2_wires.generate_samples()
+        s3 = qubit_device_2_wires.sample(qml.PauliX(0) @ qml.PauliZ(1))
+        assert np.array_equal(s3.shape, (17,))
+
+    def test_sample_values(self, qubit_device_2_wires, tol):
+        """Tests if the samples returned by sample have
+        the correct values
+        """
+
+        # Explicitly resetting is necessary as the internal
+        # state is set to None in __init__ and only properly
+        # initialized during reset
+        qubit_device_2_wires.reset()
+
+        qubit_device_2_wires.apply([qml.RX(1.5708, wires=[0])])
+        qubit_device_2_wires._wires_measured = {0}
+        qubit_device_2_wires._samples = qubit_device_2_wires.generate_samples()
+
+        s1 = qubit_device_2_wires.sample(qml.PauliZ(0))
+
+        # s1 should only contain 1 and -1, which is guaranteed if
+        # they square to 1
+        assert np.allclose(s1**2, 1, atol=tol, rtol=0)
+
+class TestLightningQubitIntegration:
+    """Integration tests for lightning.qubit. This test ensures it integrates
+    properly with the PennyLane interface, in particular QNode."""
+
+    def test_load_default_qubit_device(self):
+        """Test that the default plugin loads correctly"""
+
+        dev = qml.device("lightning.qubit", wires=2)
+        assert dev.num_wires == 2
+        assert dev.shots == 1000
+        assert dev.analytic
+        assert dev.short_name == "lightning.qubit"
+
+    def test_args(self):
+        """Test that the plugin requires correct arguments"""
+
+        with pytest.raises(
+            TypeError, match="missing 1 required positional argument: 'wires'"
+        ):
+            qml.device("lightning.qubit")
+
+    def test_qubit_circuit(self, qubit_device_1_wire, tol):
+        """Test that the default qubit plugin provides correct result for a simple circuit"""
+
+        p = 0.543
+
+        @qml.qnode(qubit_device_1_wire)
+        def circuit(x):
+            qml.RX(x, wires=0)
+            return qml.expval(qml.PauliY(0))
+
+        expected = -np.sin(p)
+
+        assert np.isclose(circuit(p), expected, atol=tol, rtol=0)
+
+    def test_qubit_identity(self, qubit_device_1_wire, tol):
+        """Test that the default qubit plugin provides correct result for the Identity expectation"""
+
+        p = 0.543
+
+        @qml.qnode(qubit_device_1_wire)
+        def circuit(x):
+            """Test quantum function"""
+            qml.RX(x, wires=0)
+            return qml.expval(qml.Identity(0))
+
+        assert np.isclose(circuit(p), 1, atol=tol, rtol=0)
+
+    def test_nonzero_shots(self, tol):
+        """Test that the default qubit plugin provides correct result for high shot number"""
+
+        shots = 10 ** 5
+        dev = qml.device("lightning.qubit", wires=1)
+
+        p = 0.543
+
+        @qml.qnode(dev)
+        def circuit(x):
+            """Test quantum function"""
+            qml.RX(x, wires=0)
+            return qml.expval(qml.PauliY(0))
+
+        runs = []
+        for _ in range(100):
+            runs.append(circuit(p))
+
+        assert np.isclose(np.mean(runs), -np.sin(p), atol=tol, rtol=0)
+
+    @pytest.mark.parametrize("name,expected_output", [
+        ("PauliX", 1),
+        ("PauliY", 1),
+        ("S", -1),
+    ])
+    def test_inverse_circuit(self, qubit_device_1_wire, tol, name, expected_output):
+        """Tests the inverse of supported gates that act on a single wire and are not parameterized"""
+
+        op = getattr(qml.ops, name)
+
+        @qml.qnode(qubit_device_1_wire)
+        def circuit():
+            qml.BasisState(np.array([1]), wires=[0])
+            op(wires=0).inv()
+            return qml.expval(qml.PauliZ(0))
+
+        assert np.isclose(circuit(), expected_output, atol=tol, rtol=0)
+
+    @pytest.mark.parametrize("name,expected_output", [
+        ("PauliX", 1),
+        ("PauliY", 1),
+        ("S", -1),
+    ])
+    def test_inverse_circuit_calling_inv_multiple_times(self, qubit_device_1_wire, tol, name, expected_output):
+        """Tests that multiple calls to the inverse of an operation works"""
+
+        op = getattr(qml.ops, name)
+
+        @qml.qnode(qubit_device_1_wire)
+        def circuit():
+            qml.BasisState(np.array([1]), wires=[0])
+            op(wires=0).inv().inv().inv()
+            return qml.expval(qml.PauliZ(0))
+
+        assert np.isclose(circuit(), expected_output, atol=tol, rtol=0)
+
+    @pytest.mark.parametrize("name,expected_output,phi", [("RX", 1,
+                                                           multiplier * 0.5432) for multiplier in range(8)
+                                                          ])
+    def test_inverse_circuit_with_parameters(self, qubit_device_1_wire, tol, name, expected_output, phi):
+        """Tests the inverse of supported gates that act on a single wire and are parameterized"""
+
+        @qml.qnode(qubit_device_1_wire)
+        def circuit():
+            qml.RX(phi, wires=0)
+            qml.RX(phi, wires=0).inv()
+            return qml.expval(qml.PauliZ(0))
+
+        assert np.isclose(circuit(), expected_output, atol=tol, rtol=0)
+
+
+
+    @pytest.mark.parametrize("name,expected_output,phi", [("RX", 1,
+                                                           multiplier * 0.5432) for multiplier in range(8)
+                                                          ])
+    def test_inverse_circuit_with_parameters_expectation(self, qubit_device_1_wire, tol, name, expected_output, phi):
+        @qml.qnode(qubit_device_1_wire)
+        def circuit():
+            qml.RX(phi, wires=0)
+            qml.RX(phi, wires=0).inv()
+            return qml.expval(qml.PauliZ(0).inv())
+
+        assert np.isclose(circuit(), expected_output, atol=tol, rtol=0)
+
+    # This test is ran against the state |0> with one Z expval
+    @pytest.mark.parametrize("name,expected_output", [
+        ("PauliX", -1),
+        ("PauliY", -1),
+        ("PauliZ", 1),
+        ("Hadamard", 0),
+    ])
+    def test_supported_gate_single_wire_no_parameters(self, qubit_device_1_wire, tol, name, expected_output):
+        """Tests supported gates that act on a single wire that are not parameterized"""
+
+        op = getattr(qml.ops, name)
+
+        assert qubit_device_1_wire.supports_operation(name)
+
+        @qml.qnode(qubit_device_1_wire)
+        def circuit():
+            op(wires=0)
+            return qml.expval(qml.PauliZ(0))
+
+        assert np.isclose(circuit(), expected_output, atol=tol, rtol=0)
+
+    # This test is ran against the state |Phi+> with two Z expvals
+    @pytest.mark.parametrize("name,expected_output", [
+        ("CNOT", [-1/2, 1]),
+        ("SWAP", [-1/2, -1/2]),
+        ("CZ", [-1/2, -1/2]),
+    ])
+    def test_supported_gate_two_wires_no_parameters(self, qubit_device_2_wires, tol, name, expected_output):
+        """Tests supported gates that act on two wires that are not parameterized"""
+
+        op = getattr(qml.ops, name)
+
+        assert qubit_device_2_wires.supports_operation(name)
+
+        @qml.qnode(qubit_device_2_wires)
+        def circuit():
+            qml.QubitStateVector(np.array([1/2, 0, 0, math.sqrt(3)/2]), wires=[0, 1])
+            op(wires=[0, 1])
+            return qml.expval(qml.PauliZ(0)), qml.expval(qml.PauliZ(1))
+
+        assert np.allclose(circuit(), expected_output, atol=tol, rtol=0)
+
+    @pytest.mark.parametrize("name,expected_output", [
+        ("CSWAP", [-1, -1, 1]),
+    ])
+    def test_supported_gate_three_wires_no_parameters(self, qubit_device_3_wires, tol, name, expected_output):
+        """Tests supported gates that act on three wires that are not parameterized"""
+
+        op = getattr(qml.ops, name)
+
+        assert qubit_device_3_wires.supports_operation(name)
+
+        @qml.qnode(qubit_device_3_wires)
+        def circuit():
+            qml.BasisState(np.array([1, 0, 1]), wires=[0, 1, 2])
+            op(wires=[0, 1, 2])
+            return qml.expval(qml.PauliZ(0)), qml.expval(qml.PauliZ(1)), qml.expval(qml.PauliZ(2))
+
+        assert np.allclose(circuit(), expected_output, atol=tol, rtol=0)
+
+    # This test is ran with two Z expvals
+    @pytest.mark.parametrize("name,par,expected_output", [
+        ("BasisState", [0, 0], [1, 1]),
+        ("BasisState", [1, 0], [-1, 1]),
+        ("BasisState", [0, 1], [1, -1]),
+        ("QubitStateVector", [1, 0, 0, 0], [1, 1]),
+        ("QubitStateVector", [0, 0, 1, 0], [-1, 1]),
+        ("QubitStateVector", [0, 1, 0, 0], [1, -1]),
+    ])
+    def test_supported_state_preparation(self, qubit_device_2_wires, tol, name, par, expected_output):
+        """Tests supported state preparations"""
+
+        op = getattr(qml.ops, name)
+
+        assert qubit_device_2_wires.supports_operation(name)
+
+        @qml.qnode(qubit_device_2_wires)
+        def circuit():
+            op(np.array(par), wires=[0, 1])
+            return qml.expval(qml.PauliZ(0)), qml.expval(qml.PauliZ(1))
+
+        assert np.allclose(circuit(), expected_output, atol=tol, rtol=0)
+
+    # This test is ran with two Z expvals
+    @pytest.mark.parametrize("name,par,wires,expected_output", [
+        ("BasisState", [1, 1], [0, 1], [-1, -1]),
+        ("BasisState", [1], [0], [-1, 1]),
+        ("BasisState", [1], [1], [1, -1])
+    ])
+    def test_basis_state_2_qubit_subset(self, qubit_device_2_wires, tol, name, par, wires, expected_output):
+        """Tests qubit basis state preparation on subsets of qubits"""
+
+        op = getattr(qml.ops, name)
+
+        @qml.qnode(qubit_device_2_wires)
+        def circuit():
+            op(np.array(par), wires=wires)
+            return qml.expval(qml.PauliZ(0)), qml.expval(qml.PauliZ(1))
+
+        assert np.allclose(circuit(), expected_output, atol=tol, rtol=0)
+
+    # This test is run with two expvals
+    @pytest.mark.parametrize("name,par,wires,expected_output", [
+        ("QubitStateVector", [0, 1], [1], [1, -1]),
+        ("QubitStateVector", [0, 1], [0], [-1, 1]),
+        ("QubitStateVector", [1./np.sqrt(2), 1./np.sqrt(2)], [1], [1, 0]),
+        ("QubitStateVector", [1j/2., np.sqrt(3)/2.], [1], [1, -0.5]),
+        ("QubitStateVector", [(2-1j)/3., 2j/3.], [0], [1/9., 1])
+    ])
+    def test_state_vector_2_qubit_subset(self, qubit_device_2_wires, tol, name, par, wires, expected_output):
+        """Tests qubit state vector preparation on subsets of 2 qubits"""
+
+        op = getattr(qml.ops, name)
+
+        par = np.array(par)
+
+        @qml.qnode(qubit_device_2_wires)
+        def circuit():
+            op(par, wires=wires)
+            return qml.expval(qml.PauliZ(0)), qml.expval(qml.PauliZ(1))
+
+        assert np.allclose(circuit(), expected_output, atol=tol, rtol=0)
+
+    # This test is run with three expvals
+    @pytest.mark.parametrize("name,par,wires,expected_output", [
+        ("QubitStateVector", [1j/np.sqrt(10), (1-2j)/np.sqrt(10), 0, 0, 0, 2/np.sqrt(10), 0, 0],
+         [0, 1, 2], [1/5., 1., -4/5.]),
+        ("QubitStateVector", [1/np.sqrt(2), 0, 0, 1/np.sqrt(2)], [0, 2], [0., 1., 0.]),
+        ("QubitStateVector", [1 / np.sqrt(2), 0, 0, 1 / np.sqrt(2)], [0, 1], [0., 0., 1.]),
+        ("QubitStateVector", [0, 1, 0, 0, 0, 0, 0, 0], [2, 1, 0], [-1., 1., 1.]),
+        ("QubitStateVector", [0, 1j, 0, 0, 0, 0, 0, 0], [0, 2, 1], [1., -1., 1.]),
+        ("QubitStateVector", [0, 1/np.sqrt(2), 0, 1/np.sqrt(2)], [1, 0], [-1., 0., 1.]),
+        ("QubitStateVector", [0, 1 / np.sqrt(2), 0, 1 / np.sqrt(2)], [0, 1], [0., -1., 1.])
+    ])
+    def test_state_vector_3_qubit_subset(self, qubit_device_3_wires, tol, name, par, wires, expected_output):
+        """Tests qubit state vector preparation on subsets of 3 qubits"""
+
+        op = getattr(qml.ops, name)
+
+        par = np.array(par)
+
+        @qml.qnode(qubit_device_3_wires)
+        def circuit():
+            op(par, wires=wires)
+            return qml.expval(qml.PauliZ(0)), qml.expval(qml.PauliZ(1)), qml.expval(qml.PauliZ(2))
+
+        assert np.allclose(circuit(), expected_output, atol=tol, rtol=0)
+
+    # This test is ran on the state |0> with one Z expvals
+    @pytest.mark.parametrize("name,par,expected_output", [
+        ("PhaseShift", [math.pi/2], 1),
+        ("PhaseShift", [-math.pi/4], 1),
+        ("RX", [math.pi/2], 0),
+        ("RX", [-math.pi/4], 1/math.sqrt(2)),
+        ("RY", [math.pi/2], 0),
+        ("RY", [-math.pi/4], 1/math.sqrt(2)),
+        ("RZ", [math.pi/2], 1),
+        ("RZ", [-math.pi/4], 1),
+        ("Rot", [math.pi/2, 0, 0], 1),
+        ("Rot", [0, math.pi/2, 0], 0),
+        ("Rot", [0, 0, math.pi/2], 1),
+        ("Rot", [math.pi/2, -math.pi/4, -math.pi/4], 1/math.sqrt(2)),
+        ("Rot", [-math.pi/4, math.pi/2, math.pi/4], 0),
+        ("Rot", [-math.pi/4, math.pi/4, math.pi/2], 1/math.sqrt(2)),
+        ("QubitUnitary", [np.array([[1j/math.sqrt(2), 1j/math.sqrt(2)], [1j/math.sqrt(2), -1j/math.sqrt(2)]])], 0),
+        ("QubitUnitary", [np.array([[-1j/math.sqrt(2), 1j/math.sqrt(2)], [1j/math.sqrt(2), 1j/math.sqrt(2)]])], 0),
+    ])
+    def test_supported_gate_single_wire_with_parameters(self, qubit_device_1_wire, tol, name, par, expected_output):
+        """Tests supported gates that act on a single wire that are parameterized"""
+
+        op = getattr(qml.ops, name)
+
+        assert qubit_device_1_wire.supports_operation(name)
+
+        @qml.qnode(qubit_device_1_wire)
+        def circuit():
+            op(*par, wires=0)
+            return qml.expval(qml.PauliZ(0))
+
+        assert np.isclose(circuit(), expected_output, atol=tol, rtol=0)
+
+    # This test is ran against the state 1/2|00>+sqrt(3)/2|11> with two Z expvals
+    @pytest.mark.parametrize("name,par,expected_output", [
+        ("CRX", [0], [-1/2, -1/2]),
+        ("CRX", [-math.pi], [-1/2, 1]),
+        ("CRX", [math.pi/2], [-1/2, 1/4]),
+        ("CRY", [0], [-1/2, -1/2]),
+        ("CRY", [-math.pi], [-1/2, 1]),
+        ("CRY", [math.pi/2], [-1/2, 1/4]),
+        ("CRZ", [0], [-1/2, -1/2]),
+        ("CRZ", [-math.pi], [-1/2, -1/2]),
+        ("CRZ", [math.pi/2], [-1/2, -1/2]),
+        ("CRot", [math.pi/2, 0, 0], [-1/2, -1/2]),
+        ("CRot", [0, math.pi/2, 0], [-1/2, 1/4]),
+        ("CRot", [0, 0, math.pi/2], [-1/2, -1/2]),
+        ("CRot", [math.pi/2, 0, -math.pi], [-1/2, -1/2]),
+        ("CRot", [0, math.pi/2, -math.pi], [-1/2, 1/4]),
+        ("CRot", [-math.pi, 0, math.pi/2], [-1/2, -1/2]),
+        ("QubitUnitary", [np.array([[1, 0, 0, 0], [0, 1/math.sqrt(2), 1/math.sqrt(2), 0], [0, 1/math.sqrt(2), -1/math.sqrt(2), 0], [0, 0, 0, 1]])], [-1/2, -1/2]),
+        ("QubitUnitary", [np.array([[-1, 0, 0, 0], [0, 1/math.sqrt(2), 1/math.sqrt(2), 0], [0, 1/math.sqrt(2), -1/math.sqrt(2), 0], [0, 0, 0, -1]])], [-1/2, -1/2]),
+    ])
+    def test_supported_gate_two_wires_with_parameters(self, qubit_device_2_wires, tol, name, par, expected_output):
+        """Tests supported gates that act on two wires wires that are parameterized"""
+
+        op = getattr(qml.ops, name)
+
+        assert qubit_device_2_wires.supports_operation(name)
+
+        @qml.qnode(qubit_device_2_wires)
+        def circuit():
+            qml.QubitStateVector(np.array([1/2, 0, 0, math.sqrt(3)/2]), wires=[0, 1])
+            op(*par, wires=[0, 1])
+            return qml.expval(qml.PauliZ(0)), qml.expval(qml.PauliZ(1))
+
+        assert np.allclose(circuit(), expected_output, atol=tol, rtol=0)
+
+    @pytest.mark.parametrize("name,state,expected_output", [
+        ("PauliX", [1/math.sqrt(2), 1/math.sqrt(2)], 1),
+        ("PauliX", [1/math.sqrt(2), -1/math.sqrt(2)], -1),
+        ("PauliX", [1, 0], 0),
+        ("PauliY", [1/math.sqrt(2), 1j/math.sqrt(2)], 1),
+        ("PauliY", [1/math.sqrt(2), -1j/math.sqrt(2)], -1),
+        ("PauliY", [1, 0], 0),
+        ("PauliZ", [1, 0], 1),
+        ("PauliZ", [0, 1], -1),
+        ("PauliZ", [1/math.sqrt(2), 1/math.sqrt(2)], 0),
+        ("Hadamard", [1, 0], 1/math.sqrt(2)),
+        ("Hadamard", [0, 1], -1/math.sqrt(2)),
+        ("Hadamard", [1/math.sqrt(2), 1/math.sqrt(2)], 1/math.sqrt(2)),
+    ])
+    def test_supported_observable_single_wire_no_parameters(self, qubit_device_1_wire, tol, name, state, expected_output):
+        """Tests supported observables on single wires without parameters."""
+
+        obs = getattr(qml.ops, name)
+
+        assert qubit_device_1_wire.supports_observable(name)
+
+        @qml.qnode(qubit_device_1_wire)
+        def circuit():
+            qml.QubitStateVector(np.array(state), wires=[0])
+            return qml.expval(obs(wires=[0]))
+
+        assert np.isclose(circuit(), expected_output, atol=tol, rtol=0)
+
+    @pytest.mark.parametrize("name,state,expected_output,par", [
+        ("Identity", [1, 0], 1, []),
+        ("Identity", [0, 1], 1, []),
+        ("Identity", [1/math.sqrt(2), -1/math.sqrt(2)], 1, []),
+        ("Hermitian", [1, 0], 1, [np.array([[1, 1j], [-1j, 1]])]),
+        ("Hermitian", [0, 1], 1, [np.array([[1, 1j], [-1j, 1]])]),
+        ("Hermitian", [1/math.sqrt(2), -1/math.sqrt(2)], 1, [np.array([[1, 1j], [-1j, 1]])]),
+    ])
+    def test_supported_observable_single_wire_with_parameters(self, qubit_device_1_wire, tol, name, state, expected_output, par):
+        """Tests supported observables on single wires with parameters."""
+
+        obs = getattr(qml.ops, name)
+
+        assert qubit_device_1_wire.supports_observable(name)
+
+        @qml.qnode(qubit_device_1_wire)
+        def circuit():
+            qml.QubitStateVector(np.array(state), wires=[0])
+            return qml.expval(obs(*par, wires=[0]))
+
+        assert np.isclose(circuit(), expected_output, atol=tol, rtol=0)
+
+    @pytest.mark.parametrize("name,state,expected_output,par", [
+        ("Hermitian", [1/math.sqrt(3), 0, 1/math.sqrt(3), 1/math.sqrt(3)], 5/3, [np.array([[1, 1j, 0, 1], [-1j, 1, 0, 0], [0, 0, 1, -1j], [1, 0, 1j, 1]])]),
+        ("Hermitian", [0, 0, 0, 1], 0, [np.array([[0, 1j, 0, 0], [-1j, 0, 0, 0], [0, 0, 0, -1j], [0, 0, 1j, 0]])]),
+        ("Hermitian", [1/math.sqrt(2), 0, -1/math.sqrt(2), 0], 1, [np.array([[1, 1j, 0, 0], [-1j, 1, 0, 0], [0, 0, 1, -1j], [0, 0, 1j, 1]])]),
+        ("Hermitian", [1/math.sqrt(3), -1/math.sqrt(3), 1/math.sqrt(6), 1/math.sqrt(6)], 1, [np.array([[1, 1j, 0, .5j], [-1j, 1, 0, 0], [0, 0, 1, -1j], [-.5j, 0, 1j, 1]])]),
+        ("Hermitian", [1/math.sqrt(2), 0, 0, 1/math.sqrt(2)], 1, [np.array([[1, 0, 0, 0], [0, -1, 0, 0], [0, 0, -1, 0], [0, 0, 0, 1]])]),
+        ("Hermitian", [0, 1/math.sqrt(2), -1/math.sqrt(2), 0], -1, [np.array([[1, 0, 0, 0], [0, -1, 0, 0], [0, 0, -1, 0], [0, 0, 0, 1]])]),
+    ])
+    def test_supported_observable_two_wires_with_parameters(self, qubit_device_2_wires, tol, name, state, expected_output, par):
+        """Tests supported observables on two wires with parameters."""
+
+        obs = getattr(qml.ops, name)
+
+        assert qubit_device_2_wires.supports_observable(name)
+
+        @qml.qnode(qubit_device_2_wires)
+        def circuit():
+            qml.QubitStateVector(np.array(state), wires=[0, 1])
+            return qml.expval(obs(*par, wires=[0, 1]))
+
+        assert np.isclose(circuit(), expected_output, atol=tol, rtol=0)
+
+    def test_multi_samples_return_correlated_results(self):
+        """Tests if the samples returned by the sample function have
+        the correct dimensions
+        """
+
+        dev = qml.device('lightning.qubit', wires=2)
+
+        @qml.qnode(dev)
+        def circuit():
+            qml.Hadamard(0)
+            qml.CNOT(wires=[0, 1])
+            return qml.sample(qml.PauliZ(0)), qml.sample(qml.PauliZ(1))
+
+        outcomes = circuit()
+
+        assert np.array_equal(outcomes[0], outcomes[1])
+
+    @pytest.mark.parametrize("num_wires", [3, 4, 5, 6, 7, 8])
+    def test_multi_samples_return_correlated_results_more_wires_than_size_of_observable(self, num_wires):
+        """Tests if the samples returned by the sample function have
+        the correct dimensions
+        """
+
+        dev = qml.device('lightning.qubit', wires=num_wires)
+
+        @qml.qnode(dev)
+        def circuit():
+            qml.Hadamard(0)
+            qml.CNOT(wires=[0, 1])
+            return qml.sample(qml.PauliZ(0)), qml.sample(qml.PauliZ(1))
+
+        outcomes = circuit()
+
+        assert np.array_equal(outcomes[0], outcomes[1])
+
+@pytest.mark.parametrize("theta,phi,varphi", list(zip(THETA, PHI, VARPHI)))
+class TestTensorExpval:
+    """Test tensor expectation values"""
+
+    def test_paulix_pauliy(self, theta, phi, varphi, tol):
+        """Test that a tensor product involving PauliX and PauliY works correctly"""
+        dev = qml.device("lightning.qubit", wires=3)
+        dev.reset()
+
+        obs = qml.PauliX(0) @ qml.PauliY(2)
+
+        dev.apply(
+            [
+                qml.RX(theta, wires=[0]),
+                qml.RX(phi, wires=[1]),
+                qml.RX(varphi, wires=[2]),
+                qml.CNOT(wires=[0, 1]),
+                qml.CNOT(wires=[1, 2])
+            ],
+            obs.diagonalizing_gates()
+        )
+
+        res = dev.expval(obs)
+
+        expected = np.sin(theta) * np.sin(phi) * np.sin(varphi)
+
+        assert np.allclose(res, expected, atol=tol, rtol=0)
+
+    def test_pauliz_identity(self, theta, phi, varphi, tol):
+        """Test that a tensor product involving PauliZ and Identity works correctly"""
+        dev = qml.device("lightning.qubit", wires=3)
+        dev.reset()
+
+        obs = qml.PauliZ(0) @ qml.Identity(1) @ qml.PauliZ(2)
+
+        dev.apply(
+            [
+                qml.RX(theta, wires=[0]),
+                qml.RX(phi, wires=[1]),
+                qml.RX(varphi, wires=[2]),
+                qml.CNOT(wires=[0, 1]),
+                qml.CNOT(wires=[1, 2])
+            ],
+            obs.diagonalizing_gates()
+        )
+
+        res = dev.expval(obs)
+
+        expected = np.cos(varphi)*np.cos(phi)
+
+        assert np.allclose(res, expected, atol=tol, rtol=0)
+
+    def test_pauliz_hadamard(self, theta, phi, varphi, tol):
+        """Test that a tensor product involving PauliZ and PauliY and hadamard works correctly"""
+        dev = qml.device("lightning.qubit", wires=3)
+        obs = qml.PauliZ(0) @ qml.Hadamard(1) @ qml.PauliY(2)
+
+        dev.reset()
+        dev.apply(
+            [
+                qml.RX(theta, wires=[0]),
+                qml.RX(phi, wires=[1]),
+                qml.RX(varphi, wires=[2]),
+                qml.CNOT(wires=[0, 1]),
+                qml.CNOT(wires=[1, 2])
+            ],
+            obs.diagonalizing_gates()
+        )
+
+        res = dev.expval(obs)
+
+        expected = -(np.cos(varphi) * np.sin(phi) + np.sin(varphi) * np.cos(theta)) / np.sqrt(2)
+
+        assert np.allclose(res, expected, atol=tol, rtol=0)
+
+    def test_hermitian(self, theta, phi, varphi, tol):
+        """Test that a tensor product involving qml.Hermitian works correctly"""
+        dev = qml.device("lightning.qubit", wires=3)
+        dev.reset()
+
+        A = np.array(
+            [
+                [-6, 2 + 1j, -3, -5 + 2j],
+                [2 - 1j, 0, 2 - 1j, -5 + 4j],
+                [-3, 2 + 1j, 0, -4 + 3j],
+                [-5 - 2j, -5 - 4j, -4 - 3j, -6],
+            ]
+        )
+
+        obs = qml.PauliZ(0) @ qml.Hermitian(A, wires=[1, 2])
+
+        dev.apply(
+            [
+                qml.RX(theta, wires=[0]),
+                qml.RX(phi, wires=[1]),
+                qml.RX(varphi, wires=[2]),
+                qml.CNOT(wires=[0, 1]),
+                qml.CNOT(wires=[1, 2])
+            ],
+            obs.diagonalizing_gates()
+        )
+
+        res = dev.expval(obs)
+
+        expected = 0.5 * (
+            -6 * np.cos(theta) * (np.cos(varphi) + 1)
+            - 2 * np.sin(varphi) * (np.cos(theta) + np.sin(phi) - 2 * np.cos(phi))
+            + 3 * np.cos(varphi) * np.sin(phi)
+            + np.sin(phi)
+        )
+
+        assert np.allclose(res, expected, atol=tol, rtol=0)
+
+    def test_hermitian_hermitian(self, theta, phi, varphi, tol):
+        """Test that a tensor product involving two Hermitian matrices works correctly"""
+        dev = qml.device("lightning.qubit", wires=3)
+
+        A1 = np.array([[1, 2],
+                       [2, 4]])
+
+        A2 = np.array(
+            [
+                [-6, 2 + 1j, -3, -5 + 2j],
+                [2 - 1j, 0, 2 - 1j, -5 + 4j],
+                [-3, 2 + 1j, 0, -4 + 3j],
+                [-5 - 2j, -5 - 4j, -4 - 3j, -6],
+            ]
+        )
+
+        obs = qml.Hermitian(A1, wires=[0]) @ qml.Hermitian(A2, wires=[1, 2])
+
+        dev.apply(
+            [
+                qml.RX(theta, wires=[0]),
+                qml.RX(phi, wires=[1]),
+                qml.RX(varphi, wires=[2]),
+                qml.CNOT(wires=[0, 1]),
+                qml.CNOT(wires=[1, 2])
+            ],
+            obs.diagonalizing_gates()
+        )
+
+        res = dev.expval(obs)
+
+        expected = 0.25 * (
+            -30
+            + 4 * np.cos(phi) * np.sin(theta)
+            + 3 * np.cos(varphi) * (-10 + 4 * np.cos(phi) * np.sin(theta) - 3 * np.sin(phi))
+            - 3 * np.sin(phi)
+            - 2 * (5 + np.cos(phi) * (6 + 4 * np.sin(theta)) + (-3 + 8 * np.sin(theta)) * np.sin(phi))
+            * np.sin(varphi)
+            + np.cos(theta)
+            * (
+                18
+                + 5 * np.sin(phi)
+                + 3 * np.cos(varphi) * (6 + 5 * np.sin(phi))
+                + 2 * (3 + 10 * np.cos(phi) - 5 * np.sin(phi)) * np.sin(varphi)
+            )
+        )
+
+        assert np.allclose(res, expected, atol=tol, rtol=0)
+
+    def test_hermitian_identity_expectation(self, theta, phi, varphi, tol):
+        """Test that a tensor product involving an Hermitian matrix and the identity works correctly"""
+        dev = qml.device("lightning.qubit", wires=2)
+
+        A = np.array([[1.02789352, 1.61296440 - 0.3498192j], [1.61296440 + 0.3498192j, 1.23920938 + 0j]])
+
+        obs = qml.Hermitian(A, wires=[0]) @ qml.Identity(wires=[1])
+
+        dev.apply(
+            [
+                qml.RY(theta, wires=[0]),
+                qml.RY(phi, wires=[1]),
+                qml.CNOT(wires=[0, 1])
+            ],
+            obs.diagonalizing_gates()
+        )
+
+        res = dev.expval(obs)
+
+        a = A[0, 0]
+        re_b = A[0, 1].real
+        d = A[1, 1]
+        expected = ((a - d) * np.cos(theta) + 2 * re_b * np.sin(theta) * np.sin(phi) + a + d) / 2
+
+        assert np.allclose(res, expected, atol=tol, rtol=0)
+
+    def test_hermitian_two_wires_identity_expectation(self, theta, phi, varphi, tol):
+        """Test that a tensor product involving an Hermitian matrix for two wires and the identity works correctly"""
+        dev = qml.device("lightning.qubit", wires=3, analytic=True)
+
+        A = np.array([[1.02789352, 1.61296440 - 0.3498192j], [1.61296440 + 0.3498192j, 1.23920938 + 0j]])
+        Identity = np.array([[1, 0],[0, 1]])
+        H = np.kron(np.kron(Identity,Identity), A)
+        obs = qml.Hermitian(H, wires=[2, 1, 0])
+
+        dev.apply(
+            [
+                qml.RY(theta, wires=[0]),
+                qml.RY(phi, wires=[1]),
+                qml.CNOT(wires=[0, 1])
+            ],
+            obs.diagonalizing_gates()
+        )
+        res = dev.expval(obs)
+
+        a = A[0, 0]
+        re_b = A[0, 1].real
+        d = A[1, 1]
+
+        expected = ((a - d) * np.cos(theta) + 2 * re_b * np.sin(theta) * np.sin(phi) + a + d) / 2
+        assert np.allclose(res, expected, atol=tol, rtol=0)
+
+@pytest.mark.parametrize("theta, phi, varphi", list(zip(THETA, PHI, VARPHI)))
+class TestTensorVar:
+    """Tests for variance of tensor observables"""
+
+    def test_paulix_pauliy(self, theta, phi, varphi, tol):
+        """Test that a tensor product involving PauliX and PauliY works correctly"""
+        dev = qml.device("lightning.qubit", wires=3)
+
+        obs = qml.PauliX(0) @ qml.PauliY(2)
+
+        dev.apply(
+            [
+                qml.RX(theta, wires=[0]),
+                qml.RX(phi, wires=[1]),
+                qml.RX(varphi, wires=[2]),
+                qml.CNOT(wires=[0, 1]),
+                qml.CNOT(wires=[1, 2])
+            ],
+            obs.diagonalizing_gates()
+        )
+
+        res = dev.var(obs)
+
+        expected = (
+            8 * np.sin(theta) ** 2 * np.cos(2 * varphi) * np.sin(phi) ** 2
+            - np.cos(2 * (theta - phi))
+            - np.cos(2 * (theta + phi))
+            + 2 * np.cos(2 * theta)
+            + 2 * np.cos(2 * phi)
+            + 14
+        ) / 16
+
+        assert np.allclose(res, expected, atol=tol, rtol=0)
+
+    def test_pauliz_hadamard(self, theta, phi, varphi, tol):
+        """Test that a tensor product involving PauliZ and PauliY and hadamard works correctly"""
+        dev = qml.device("lightning.qubit", wires=3)
+        obs = qml.PauliZ(0) @ qml.Hadamard(1) @ qml.PauliY(2)
+
+        dev.reset()
+        dev.apply(
+            [
+                qml.RX(theta, wires=[0]),
+                qml.RX(phi, wires=[1]),
+                qml.RX(varphi, wires=[2]),
+                qml.CNOT(wires=[0, 1]),
+                qml.CNOT(wires=[1, 2])
+            ],
+            obs.diagonalizing_gates()
+        )
+
+        res = dev.var(obs)
+
+        expected = (
+            3
+            + np.cos(2 * phi) * np.cos(varphi) ** 2
+            - np.cos(2 * theta) * np.sin(varphi) ** 2
+            - 2 * np.cos(theta) * np.sin(phi) * np.sin(2 * varphi)
+        ) / 4
+
+        assert np.allclose(res, expected, atol=tol, rtol=0)
+
+    def test_hermitian(self, theta, phi, varphi, tol):
+        """Test that a tensor product involving qml.Hermitian works correctly"""
+        dev = qml.device("lightning.qubit", wires=3)
+
+        A = np.array(
+            [
+                [-6, 2 + 1j, -3, -5 + 2j],
+                [2 - 1j, 0, 2 - 1j, -5 + 4j],
+                [-3, 2 + 1j, 0, -4 + 3j],
+                [-5 - 2j, -5 - 4j, -4 - 3j, -6],
+            ]
+        )
+
+        obs = qml.PauliZ(0) @ qml.Hermitian(A, wires=[1, 2])
+
+        dev.apply(
+            [
+                qml.RX(theta, wires=[0]),
+                qml.RX(phi, wires=[1]),
+                qml.RX(varphi, wires=[2]),
+                qml.CNOT(wires=[0, 1]),
+                qml.CNOT(wires=[1, 2])
+            ],
+            obs.diagonalizing_gates()
+        )
+
+        res = dev.var(obs)
+
+        expected = (
+            1057
+            - np.cos(2 * phi)
+            + 12 * (27 + np.cos(2 * phi)) * np.cos(varphi)
+            - 2 * np.cos(2 * varphi) * np.sin(phi) * (16 * np.cos(phi) + 21 * np.sin(phi))
+            + 16 * np.sin(2 * phi)
+            - 8 * (-17 + np.cos(2 * phi) + 2 * np.sin(2 * phi)) * np.sin(varphi)
+            - 8 * np.cos(2 * theta) * (3 + 3 * np.cos(varphi) + np.sin(varphi)) ** 2
+            - 24 * np.cos(phi) * (np.cos(phi) + 2 * np.sin(phi)) * np.sin(2 * varphi)
+            - 8
+            * np.cos(theta)
+            * (
+                4
+                * np.cos(phi)
+                * (
+                    4
+                    + 8 * np.cos(varphi)
+                    + np.cos(2 * varphi)
+                    - (1 + 6 * np.cos(varphi)) * np.sin(varphi)
+                )
+                + np.sin(phi)
+                * (
+                    15
+                    + 8 * np.cos(varphi)
+                    - 11 * np.cos(2 * varphi)
+                    + 42 * np.sin(varphi)
+                    + 3 * np.sin(2 * varphi)
+                )
+            )
+        ) / 16
+
+        assert np.allclose(res, expected, atol=tol, rtol=0)
+
+@pytest.mark.parametrize("theta, phi, varphi", list(zip(THETA, PHI, VARPHI)))
+class TestTensorSample:
+    """Test tensor expectation values"""
+
+    def test_paulix_pauliy(self, theta, phi, varphi, monkeypatch, tol):
+        """Test that a tensor product involving PauliX and PauliY works correctly"""
+        dev = qml.device("lightning.qubit", wires=3, shots=10000)
+
+        obs = qml.PauliX(0) @ qml.PauliY(2)
+
+        dev.apply(
+            [
+                qml.RX(theta, wires=[0]),
+                qml.RX(phi, wires=[1]),
+                qml.RX(varphi, wires=[2]),
+                qml.CNOT(wires=[0, 1]),
+                qml.CNOT(wires=[1, 2])
+            ],
+            obs.diagonalizing_gates()
+        )
+
+        dev._wires_measured = {0, 1, 2}
+        dev._samples = dev.generate_samples()
+        dev.sample(obs)
+
+        s1 = obs.eigvals
+        p = dev.probability(wires=obs.wires)
+
+        # s1 should only contain 1 and -1
+        assert np.allclose(s1 ** 2, 1, atol=tol, rtol=0)
+
+        mean = s1 @ p
+        expected = np.sin(theta) * np.sin(phi) * np.sin(varphi)
+        assert np.allclose(mean, expected, atol=tol, rtol=0)
+
+        var = (s1 ** 2) @ p - (s1 @ p).real ** 2
+        expected = (
+            8 * np.sin(theta) ** 2 * np.cos(2 * varphi) * np.sin(phi) ** 2
+            - np.cos(2 * (theta - phi))
+            - np.cos(2 * (theta + phi))
+            + 2 * np.cos(2 * theta)
+            + 2 * np.cos(2 * phi)
+            + 14
+        ) / 16
+        assert np.allclose(var, expected, atol=tol, rtol=0)
+
+    def test_pauliz_hadamard(self, theta, phi, varphi, monkeypatch, tol):
+        """Test that a tensor product involving PauliZ and PauliY and hadamard works correctly"""
+        dev = qml.device("lightning.qubit", wires=3)
+        obs = qml.PauliZ(0) @ qml.Hadamard(1) @ qml.PauliY(2)
+        dev.apply(
+            [
+                qml.RX(theta, wires=[0]),
+                qml.RX(phi, wires=[1]),
+                qml.RX(varphi, wires=[2]),
+                qml.CNOT(wires=[0, 1]),
+                qml.CNOT(wires=[1, 2])
+            ],
+            obs.diagonalizing_gates()
+        )
+
+        dev._wires_measured = {0, 1, 2}
+        dev._samples = dev.generate_samples()
+        dev.sample(obs)
+
+        s1 = obs.eigvals
+        p = dev.marginal_prob(dev.probability(), wires=obs.wires)
+
+        # s1 should only contain 1 and -1
+        assert np.allclose(s1 ** 2, 1, atol=tol, rtol=0)
+
+        mean = s1 @ p
+        expected = -(np.cos(varphi) * np.sin(phi) + np.sin(varphi) * np.cos(theta)) / np.sqrt(2)
+        assert np.allclose(mean, expected, atol=tol, rtol=0)
+
+        var = (s1 ** 2) @ p - (s1 @ p).real ** 2
+        expected = (
+            3
+            + np.cos(2 * phi) * np.cos(varphi) ** 2
+            - np.cos(2 * theta) * np.sin(varphi) ** 2
+            - 2 * np.cos(theta) * np.sin(phi) * np.sin(2 * varphi)
+        ) / 4
+        assert np.allclose(var, expected, atol=tol, rtol=0)
+
+    def test_hermitian(self, theta, phi, varphi, monkeypatch, tol):
+        """Test that a tensor product involving qml.Hermitian works correctly"""
+        dev = qml.device("lightning.qubit", wires=3)
+
+        A = np.array(
+            [
+                [-6, 2 + 1j, -3, -5 + 2j],
+                [2 - 1j, 0, 2 - 1j, -5 + 4j],
+                [-3, 2 + 1j, 0, -4 + 3j],
+                [-5 - 2j, -5 - 4j, -4 - 3j, -6],
+            ]
+        )
+
+        obs = qml.PauliZ(0) @ qml.Hermitian(A, wires=[1, 2])
+        dev.apply(
+            [
+                qml.RX(theta, wires=[0]),
+                qml.RX(phi, wires=[1]),
+                qml.RX(varphi, wires=[2]),
+                qml.CNOT(wires=[0, 1]),
+                qml.CNOT(wires=[1, 2])
+            ],
+            obs.diagonalizing_gates()
+        )
+
+        dev._wires_measured = {0, 1, 2}
+        dev._samples = dev.generate_samples()
+        dev.sample(obs)
+
+        s1 = obs.eigvals
+        p = dev.marginal_prob(dev.probability(), wires=obs.wires)
+
+        # s1 should only contain the eigenvalues of
+        # the hermitian matrix tensor product Z
+        Z = np.diag([1, -1])
+        eigvals = np.linalg.eigvalsh(np.kron(Z, A))
+        assert set(np.round(s1, 8)).issubset(set(np.round(eigvals, 8)))
+
+        mean = s1 @ p
+        expected = 0.5 * (
+            -6 * np.cos(theta) * (np.cos(varphi) + 1)
+            - 2 * np.sin(varphi) * (np.cos(theta) + np.sin(phi) - 2 * np.cos(phi))
+            + 3 * np.cos(varphi) * np.sin(phi)
+            + np.sin(phi)
+        )
+        assert np.allclose(mean, expected, atol=tol, rtol=0)
+
+        var = (s1 ** 2) @ p - (s1 @ p).real ** 2
+        expected = (
+            1057
+            - np.cos(2 * phi)
+            + 12 * (27 + np.cos(2 * phi)) * np.cos(varphi)
+            - 2 * np.cos(2 * varphi) * np.sin(phi) * (16 * np.cos(phi) + 21 * np.sin(phi))
+            + 16 * np.sin(2 * phi)
+            - 8 * (-17 + np.cos(2 * phi) + 2 * np.sin(2 * phi)) * np.sin(varphi)
+            - 8 * np.cos(2 * theta) * (3 + 3 * np.cos(varphi) + np.sin(varphi)) ** 2
+            - 24 * np.cos(phi) * (np.cos(phi) + 2 * np.sin(phi)) * np.sin(2 * varphi)
+            - 8
+            * np.cos(theta)
+            * (
+                4
+                * np.cos(phi)
+                * (
+                    4
+                    + 8 * np.cos(varphi)
+                    + np.cos(2 * varphi)
+                    - (1 + 6 * np.cos(varphi)) * np.sin(varphi)
+                )
+                + np.sin(phi)
+                * (
+                    15
+                    + 8 * np.cos(varphi)
+                    - 11 * np.cos(2 * varphi)
+                    + 42 * np.sin(varphi)
+                    + 3 * np.sin(2 * varphi)
+                )
+            )
+        ) / 16
+        assert np.allclose(var, expected, atol=tol, rtol=0)

--- a/pennylane_lightning/tests/test_qiskit_device.py
+++ b/pennylane_lightning/tests/test_qiskit_device.py
@@ -1,0 +1,43 @@
+import numpy as np
+import pytest
+
+import pennylane as qml
+from pennylane_qiskit import AerDevice
+
+
+class TestProbabilities:
+    """Tests for the probability function"""
+
+    def test_probability_no_results(self):
+        """Test that the probabilities function returns
+        None if no job has yet been run."""
+        dev = AerDevice(backend="statevector_simulator", wires=1, analytic=True)
+        assert dev.probability() is None
+
+
+class TestAnalyticWarningHWSimulator:
+    """Tests the warnings for when the analytic attribute of a device is set to true"""
+
+    def test_warning_raised_for_hardware_backend_analytic_expval(self, hardware_backend, recorder):
+        """Tests that a warning is raised if the analytic attribute is true on
+            hardware simulators when calculating the expectation"""
+
+        with pytest.warns(UserWarning) as record:
+            dev = qml.device("qiskit.basicaer", backend=hardware_backend, wires=2, analytic=True)
+
+        # check that only one warning was raised
+        assert len(record) == 1
+        # check that the message matches
+        assert record[0].message.args[0] == "The analytic calculation of "\
+                "expectations, variances and probabilities is only supported on "\
+                "statevector backends, not on the {}. Such statistics obtained from this "\
+                "device are estimates based on samples.".format(dev.backend)
+
+    def test_no_warning_raised_for_software_backend_analytic_expval(self, statevector_backend, recorder, recwarn):
+        """Tests that no warning is raised if the analytic attribute is true on
+            statevector simulators when calculating the expectation"""
+
+        dev = qml.device("qiskit.basicaer", backend=statevector_backend, wires=2, analytic=True)
+
+        # check that no warnings were raised
+        assert len(recwarn) == 0

--- a/pennylane_lightning/tests/test_sample.py
+++ b/pennylane_lightning/tests/test_sample.py
@@ -1,0 +1,285 @@
+import pytest
+
+import numpy as np
+import pennylane as qml
+
+from pennylane_qiskit import AerDevice, BasicAerDevice
+
+from conftest import U, U2, A
+
+
+np.random.seed(42)
+
+THETA = np.linspace(0.11, 1, 3)
+PHI = np.linspace(0.32, 1, 3)
+VARPHI = np.linspace(0.02, 1, 3)
+
+
+@pytest.mark.parametrize("analytic", [False])
+@pytest.mark.parametrize("shots", [8192])
+class TestSample:
+    """Tests for the sample return type"""
+
+    def test_sample_values(self, device, shots, tol):
+        """Tests if the samples returned by sample have
+        the correct values
+        """
+        dev = device(1)
+        par = 1.5708
+
+        observable = qml.PauliZ(wires=[0])
+
+        dev.apply(
+            [
+                qml.RX(par, wires=[0]),
+            ],
+            rotations=[*observable.diagonalizing_gates()]
+        )
+
+        dev._samples = dev.generate_samples()
+
+        s1 = dev.sample(observable)
+
+        # s1 should only contain 1 and -1
+        assert np.allclose(s1 ** 2, 1, **tol)
+
+    @pytest.mark.parametrize("theta", THETA)
+    def test_sample_values_hermitian(self, theta, device, shots, tol):
+        """Tests if the samples of a Hermitian observable returned by sample have
+        the correct values
+        """
+        dev = device(1)
+
+        A = np.array([[1, 2j], [-2j, 0]])
+
+        observable = qml.Hermitian(A, wires=[0])
+
+        dev.apply(
+            [
+                qml.RX(theta, wires=[0]),
+            ],
+            rotations=[*observable.diagonalizing_gates()]
+        )
+
+        dev._samples = dev.generate_samples()
+
+        s1 = dev.sample(observable)
+
+        # s1 should only contain the eigenvalues of
+        # the hermitian matrix
+        eigvals = np.linalg.eigvalsh(A)
+        assert set(np.round(s1, 8)).issubset(set(np.round(eigvals, 8)))
+
+        # the analytic mean is 2*sin(theta)+0.5*cos(theta)+0.5
+        assert np.allclose(np.mean(s1), 2 * np.sin(theta) + 0.5 * np.cos(theta) + 0.5, **tol)
+
+        # the analytic variance is 0.25*(sin(theta)-4*cos(theta))^2
+        assert np.allclose(np.var(s1), 0.25 * (np.sin(theta) - 4 * np.cos(theta)) ** 2, **tol)
+
+    @pytest.mark.parametrize("theta", THETA)
+    def test_sample_values_hermitian_multi_qubit(self, theta, device, shots, tol):
+        """Tests if the samples of a multi-qubit Hermitian observable returned by sample have
+        the correct values
+        """
+        dev = device(2)
+
+        A = np.array(
+            [
+                [1, 2j, 1 - 2j, 0.5j],
+                [-2j, 0, 3 + 4j, 1],
+                [1 + 2j, 3 - 4j, 0.75, 1.5 - 2j],
+                [-0.5j, 1, 1.5 + 2j, -1],
+            ]
+        )
+
+        observable = qml.Hermitian(A, wires=[0, 1])
+
+        dev.apply(
+            [
+                qml.RX(theta, wires=[0]),
+                qml.RY(2 * theta, wires=[1]),
+                qml.CNOT(wires=[0, 1])
+            ],
+            rotations=[*observable.diagonalizing_gates()]
+        )
+
+        dev._samples = dev.generate_samples()
+
+        s1 = dev.sample(observable)
+
+        # s1 should only contain the eigenvalues of
+        # the hermitian matrix
+        eigvals = np.linalg.eigvalsh(A)
+        assert set(np.round(s1, 8)).issubset(set(np.round(eigvals, 8)))
+
+        # make sure the mean matches the analytic mean
+        expected = (
+            88 * np.sin(theta)
+            + 24 * np.sin(2 * theta)
+            - 40 * np.sin(3 * theta)
+            + 5 * np.cos(theta)
+            - 6 * np.cos(2 * theta)
+            + 27 * np.cos(3 * theta)
+            + 6
+        ) / 32
+        assert np.allclose(np.mean(s1), expected, **tol)
+
+
+@pytest.mark.parametrize("theta, phi, varphi", list(zip(THETA, PHI, VARPHI)))
+@pytest.mark.parametrize("analytic", [False])
+@pytest.mark.parametrize("shots", [8192])
+class TestTensorSample:
+    """Test tensor expectation values"""
+
+    def test_paulix_pauliy(self, theta, phi, varphi, device, shots, tol):
+        """Test that a tensor product involving PauliX and PauliY works correctly"""
+        dev = device(3)
+
+        observable = qml.PauliX(wires=[0]) @ qml.PauliY(wires=[2])
+
+        dev.apply(
+            [
+                qml.RX(theta, wires=[0]),
+                qml.RX(phi, wires=[1]),
+                qml.RX(varphi, wires=[2]),
+                qml.CNOT(wires=[0, 1]),
+                qml.CNOT(wires=[1, 2])
+            ],
+            rotations=[*observable.diagonalizing_gates()]
+        )
+
+        dev._samples = dev.generate_samples()
+
+        s1 = dev.sample(observable)
+
+        # s1 should only contain 1 and -1
+        assert np.allclose(s1 ** 2, 1, **tol)
+
+        mean = np.mean(s1)
+        expected = np.sin(theta) * np.sin(phi) * np.sin(varphi)
+        assert np.allclose(mean, expected, **tol)
+
+        var = np.var(s1)
+        expected = (
+            8 * np.sin(theta) ** 2 * np.cos(2 * varphi) * np.sin(phi) ** 2
+            - np.cos(2 * (theta - phi))
+            - np.cos(2 * (theta + phi))
+            + 2 * np.cos(2 * theta)
+            + 2 * np.cos(2 * phi)
+            + 14
+        ) / 16
+        assert np.allclose(var, expected, **tol)
+
+    def test_pauliz_hadamard_pauliy(self, theta, phi, varphi, device, shots, tol):
+        """Test that a tensor product involving PauliZ and PauliY and hadamard works correctly"""
+        dev = device(3)
+
+        observable = qml.PauliZ(wires=[0]) @ qml.Hadamard(wires=[1]) @ qml.PauliY(wires=[2])
+
+        dev.apply(
+            [
+                qml.RX(theta, wires=[0]),
+                qml.RX(phi, wires=[1]),
+                qml.RX(varphi, wires=[2]),
+                qml.CNOT(wires=[0, 1]),
+                qml.CNOT(wires=[1, 2])
+            ],
+            rotations=[*observable.diagonalizing_gates()]
+        )
+
+        dev._samples = dev.generate_samples()
+
+        s1 = dev.sample(observable)
+
+        # s1 should only contain 1 and -1
+        assert np.allclose(s1 ** 2, 1, **tol)
+
+        mean = np.mean(s1)
+        expected = -(np.cos(varphi) * np.sin(phi) + np.sin(varphi) * np.cos(theta)) / np.sqrt(2)
+        assert np.allclose(mean, expected, **tol)
+
+        var = np.var(s1)
+        expected = (
+            3
+            + np.cos(2 * phi) * np.cos(varphi) ** 2
+            - np.cos(2 * theta) * np.sin(varphi) ** 2
+            - 2 * np.cos(theta) * np.sin(phi) * np.sin(2 * varphi)
+        ) / 4
+        assert np.allclose(var, expected, **tol)
+
+    def test_hermitian(self, theta, phi, varphi, device, shots, tol):
+        """Test that a tensor product involving qml.Hermitian works correctly"""
+        dev = device(3)
+
+        A = np.array(
+            [
+                [-6, 2 + 1j, -3, -5 + 2j],
+                [2 - 1j, 0, 2 - 1j, -5 + 4j],
+                [-3, 2 + 1j, 0, -4 + 3j],
+                [-5 - 2j, -5 - 4j, -4 - 3j, -6],
+            ]
+        )
+        observable = qml.PauliZ(wires=[0]) @ qml.Hermitian(A, wires=[1, 2])
+
+        dev.apply(
+            [
+                qml.RX(theta, wires=[0]),
+                qml.RX(phi, wires=[1]),
+                qml.RX(varphi, wires=[2]),
+                qml.CNOT(wires=[0, 1]),
+                qml.CNOT(wires=[1, 2])
+            ],
+            rotations=[*observable.diagonalizing_gates()]
+        )
+
+        dev._samples = dev.generate_samples()
+
+        s1 = dev.sample(observable)
+
+        # s1 should only contain the eigenvalues of
+        # the hermitian matrix tensor product Z
+        Z = np.diag([1, -1])
+        eigvals = np.linalg.eigvalsh(np.kron(Z, A))
+        assert set(np.round(s1, 8)).issubset(set(np.round(eigvals, 8)))
+
+        mean = np.mean(s1)
+        expected = 0.5 * (
+            -6 * np.cos(theta) * (np.cos(varphi) + 1)
+            - 2 * np.sin(varphi) * (np.cos(theta) + np.sin(phi) - 2 * np.cos(phi))
+            + 3 * np.cos(varphi) * np.sin(phi)
+            + np.sin(phi)
+        )
+        assert np.allclose(mean, expected, **tol)
+
+        var = np.var(s1)
+        expected = (
+            1057
+            - np.cos(2 * phi)
+            + 12 * (27 + np.cos(2 * phi)) * np.cos(varphi)
+            - 2 * np.cos(2 * varphi) * np.sin(phi) * (16 * np.cos(phi) + 21 * np.sin(phi))
+            + 16 * np.sin(2 * phi)
+            - 8 * (-17 + np.cos(2 * phi) + 2 * np.sin(2 * phi)) * np.sin(varphi)
+            - 8 * np.cos(2 * theta) * (3 + 3 * np.cos(varphi) + np.sin(varphi)) ** 2
+            - 24 * np.cos(phi) * (np.cos(phi) + 2 * np.sin(phi)) * np.sin(2 * varphi)
+            - 8
+            * np.cos(theta)
+            * (
+                4
+                * np.cos(phi)
+                * (
+                    4
+                    + 8 * np.cos(varphi)
+                    + np.cos(2 * varphi)
+                    - (1 + 6 * np.cos(varphi)) * np.sin(varphi)
+                )
+                + np.sin(phi)
+                * (
+                    15
+                    + 8 * np.cos(varphi)
+                    - 11 * np.cos(2 * varphi)
+                    + 42 * np.sin(varphi)
+                    + 3 * np.sin(2 * varphi)
+                )
+            )
+        ) / 16
+        assert np.allclose(var, expected, **tol)

--- a/pennylane_lightning/tests/test_var.py
+++ b/pennylane_lightning/tests/test_var.py
@@ -1,0 +1,199 @@
+import pytest
+
+import numpy as np
+import pennylane as qml
+
+from pennylane_qiskit import AerDevice, BasicAerDevice
+
+from conftest import U, U2, A
+
+
+np.random.seed(42)
+
+THETA = np.linspace(0.11, 1, 3)
+PHI = np.linspace(0.32, 1, 3)
+VARPHI = np.linspace(0.02, 1, 3)
+
+
+@pytest.mark.parametrize("theta, phi", list(zip(THETA, PHI)))
+@pytest.mark.parametrize("analytic", [True, False])
+@pytest.mark.parametrize("shots", [8192])
+class TestVar:
+    """Tests for the variance"""
+
+    def test_var(self, theta, phi, device, shots, tol):
+        """Tests for variance calculation"""
+        dev = device(2)
+
+        # test correct variance for <Z> of a rotated state
+        observable = qml.PauliZ(wires=[0])
+
+        dev.apply(
+            [
+                qml.RX(phi, wires=[0]),
+                qml.RY(theta, wires=[0]),
+            ],
+            rotations=[*observable.diagonalizing_gates()]
+        )
+
+        dev._samples = dev.generate_samples()
+
+        var = dev.var(observable)
+        expected = 0.25 * (3 - np.cos(2 * theta) - 2 * np.cos(theta) ** 2 * np.cos(2 * phi))
+
+        assert np.allclose(var, expected, **tol)
+
+    def test_var_hermitian(self, theta, phi, device, shots, tol):
+        """Tests for variance calculation using an arbitrary Hermitian observable"""
+        dev = device(2)
+
+        # test correct variance for <H> of a rotated state
+        H = np.array([[4, -1 + 6j], [-1 - 6j, 2]])
+
+        observable = qml.Hermitian(H, wires=[0])
+
+        dev.apply(
+            [
+                qml.RX(phi, wires=[0]),
+                qml.RY(theta, wires=[0]),
+            ],
+            rotations=[*observable.diagonalizing_gates()]
+        )
+
+        dev._samples = dev.generate_samples()
+
+        var = dev.var(observable)
+        expected = 0.5 * (
+            2 * np.sin(2 * theta) * np.cos(phi) ** 2
+            + 24 * np.sin(phi) * np.cos(phi) * (np.sin(theta) - np.cos(theta))
+            + 35 * np.cos(2 * phi)
+            + 39
+        )
+
+        assert np.allclose(var, expected, **tol)
+
+
+@pytest.mark.parametrize("theta, phi, varphi", list(zip(THETA, PHI, VARPHI)))
+@pytest.mark.parametrize("analytic", [True, False])
+@pytest.mark.parametrize("shots", [8192])
+class TestTensorVar:
+    """Tests for variance of tensor observables"""
+
+    def test_paulix_pauliy(self, theta, phi, varphi, device, shots, tol):
+        """Test that a tensor product involving PauliX and PauliY works correctly"""
+        dev = device(3)
+        obs = qml.PauliX(0) @ qml.PauliY(2)
+
+        dev.apply(
+            [
+                qml.RX(theta, wires=[0]),
+                qml.RX(phi, wires=[1]),
+                qml.RX(varphi, wires=[2]),
+                qml.CNOT(wires=[0, 1]),
+                qml.CNOT(wires=[1, 2])
+            ],
+            rotations=obs.diagonalizing_gates()
+        )
+
+        dev._samples = dev.generate_samples()
+        res = dev.var(obs)
+
+        expected = (
+            8 * np.sin(theta) ** 2 * np.cos(2 * varphi) * np.sin(phi) ** 2
+            - np.cos(2 * (theta - phi))
+            - np.cos(2 * (theta + phi))
+            + 2 * np.cos(2 * theta)
+            + 2 * np.cos(2 * phi)
+            + 14
+        ) / 16
+
+        assert np.allclose(res, expected, **tol)
+
+    def test_pauliz_hadamard_pauliy(self, theta, phi, varphi, device, shots, tol):
+        """Test that a tensor product involving PauliZ and PauliY and hadamard works correctly"""
+        dev = device(3)
+        obs = qml.PauliZ(0) @ qml.Hadamard(1) @ qml.PauliY(2)
+
+        dev.apply(
+            [
+                qml.RX(theta, wires=[0]),
+                qml.RX(phi, wires=[1]),
+                qml.RX(varphi, wires=[2]),
+                qml.CNOT(wires=[0, 1]),
+                qml.CNOT(wires=[1, 2])
+            ],
+            rotations=obs.diagonalizing_gates()
+        )
+
+        dev._samples = dev.generate_samples()
+        res = dev.var(obs)
+
+        expected = (
+            3
+            + np.cos(2 * phi) * np.cos(varphi) ** 2
+            - np.cos(2 * theta) * np.sin(varphi) ** 2
+            - 2 * np.cos(theta) * np.sin(phi) * np.sin(2 * varphi)
+        ) / 4
+
+        assert np.allclose(res, expected, **tol)
+
+    def test_hermitian(self, theta, phi, varphi, device, shots, tol):
+        """Test that a tensor product involving qml.Hermitian works correctly"""
+        dev = device(3)
+
+        A = np.array(
+            [
+                [-6, 2 + 1j, -3, -5 + 2j],
+                [2 - 1j, 0, 2 - 1j, -5 + 4j],
+                [-3, 2 + 1j, 0, -4 + 3j],
+                [-5 - 2j, -5 - 4j, -4 - 3j, -6],
+            ]
+        )
+        obs = qml.PauliZ(0) @ qml.Hermitian(A, wires=[1, 2])
+
+        dev.apply(
+            [
+                qml.RX(theta, wires=[0]),
+                qml.RX(phi, wires=[1]),
+                qml.RX(varphi, wires=[2]),
+                qml.CNOT(wires=[0, 1]),
+                qml.CNOT(wires=[1, 2])
+            ],
+            rotations=obs.diagonalizing_gates()
+        )
+
+        dev._samples = dev.generate_samples()
+        res = dev.var(obs)
+
+        expected = (
+            1057
+            - np.cos(2 * phi)
+            + 12 * (27 + np.cos(2 * phi)) * np.cos(varphi)
+            - 2 * np.cos(2 * varphi) * np.sin(phi) * (16 * np.cos(phi) + 21 * np.sin(phi))
+            + 16 * np.sin(2 * phi)
+            - 8 * (-17 + np.cos(2 * phi) + 2 * np.sin(2 * phi)) * np.sin(varphi)
+            - 8 * np.cos(2 * theta) * (3 + 3 * np.cos(varphi) + np.sin(varphi)) ** 2
+            - 24 * np.cos(phi) * (np.cos(phi) + 2 * np.sin(phi)) * np.sin(2 * varphi)
+            - 8
+            * np.cos(theta)
+            * (
+                4
+                * np.cos(phi)
+                * (
+                    4
+                    + 8 * np.cos(varphi)
+                    + np.cos(2 * varphi)
+                    - (1 + 6 * np.cos(varphi)) * np.sin(varphi)
+                )
+                + np.sin(phi)
+                * (
+                    15
+                    + 8 * np.cos(varphi)
+                    - 11 * np.cos(2 * varphi)
+                    + 42 * np.sin(varphi)
+                    + 3 * np.sin(2 * varphi)
+                )
+            )
+        ) / 16
+
+        assert np.allclose(res, expected, **tol)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,0 +1,38 @@
+# Copyright 2020 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+EIGEN_INCLUDE_DIR ?= /usr/include/eigen3
+CC = g++
+CFLAGS = -std=c++11 -O3 -g -Wall -fopenmp -fPIC -I/usr/include \
+	-I../include -I$(EIGEN_INCLUDE_DIR) -I$(GOOGLETEST_DIR)/include \
+	-march=native
+
+LFLAGS = -fopenmp -L$(GOOGLETEST_DIR)/lib -lgtest
+
+all: test
+
+lightning_unittest.o: lightning_unittest.cpp
+	$(CC) $^ $(CFLAGS) -c
+
+gtest_main.o: gtest_main.cpp
+	$(CC) $^ $(CFLAGS) -c
+
+cpptests: gtest_main.o lightning_unittest.o
+	$(CC) $^ -o $@ $(LFLAGS)
+
+test: cpptests
+	./cpptests
+
+clean:
+	rm -rf *~ cpptests *.out *.o *.so *.pyc *.mod
+

--- a/tests/gtest_main.cpp
+++ b/tests/gtest_main.cpp
@@ -1,0 +1,49 @@
+// Copyright 2006, Google Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include <cstdio>
+#include "gtest/gtest.h"
+
+#ifdef ARDUINO
+void setup() {
+    testing::InitGoogleTest();
+}
+
+void loop() {
+    RUN_ALL_TESTS();
+}
+
+#else
+
+GTEST_API_ int main(int argc, char **argv) {
+    printf("Running main() from %s\n", __FILE__);
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}
+#endif

--- a/tests/lightning_unittest.cpp
+++ b/tests/lightning_unittest.cpp
@@ -1,0 +1,31 @@
+// Copyright 2020 Xanadu Quantum Technologies Inc.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "gtest/gtest.h"
+
+const double tol = 1.0e-10f;
+
+namespace some_collection_of_tests {
+
+TEST(SomeTestName, TestCase) {
+// "SomeTestName" and "TestCase" are hierarchical names given by the person who makes the test
+  int initial_val = 141;
+  int expected = 142;
+  
+  int val = initial_val + 1; // test some function
+
+  EXPECT_NEAR(expected, val, tol);
+}
+
+}  // namespace some_collection_of_tests
+


### PR DESCRIPTION
Moves the existing (copied and not applicable anyway) python tests to subdirectory, and puts boilerplate for C tests in top-level `tests` folder