### PR TITLE
Benchmarking and polishing README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,22 +21,25 @@ Features
 Installation
 ============
 
-TODO
-
-This plugin requires Python version 3.5 and above.  Installation of this
-plugin, as well as all dependencies, can be done using ``pip``:
+PennyLane-Lightning requires Python version 3.6 and above. It can be installed using ``pip``:
 
 .. code-block:: bash
 
     pip install pennylane-lightning
 
-To test that the PennyLane-Lightning plugin is working correctly you can run
+Alternatively, to build PennyLane-Lightning from source you can run
+
+.. code-block:: bash
+
+    git clone https://github.com/XanaduAI/pennylane-lightning.git
+    cd pennylane-lightning
+    pip install -e .
+
+To test that the plugin is working correctly you can then run
 
 .. code-block:: bash
 
     $ make test
-
-in the source folder.
 
 .. installation-end-inclusion-marker-do-not-remove
 
@@ -70,10 +73,8 @@ If you are doing research using PennyLane and PennyLane-Lightning, please cite `
 Support
 =======
 
-TODO - update
-
-- **Source Code:** https://github.com/XanaduAI/pennylane-lightning
-- **Issue Tracker:** https://github.com/XanaduAI/pennylane-lightning/issues
+- **Source Code:** https://github.com/PennyLaneAI/pennylane-lightning
+- **Issue Tracker:** https://github.com/PennyLaneAI/pennylane-lightning/issues
 - **PennyLane Forum:** https://discuss.pennylane.ai
 
 If you are having issues, please let us know by posting the issue on our Github issue tracker, or

--- a/README.rst
+++ b/README.rst
@@ -35,11 +35,19 @@ Alternatively, to build PennyLane-Lightning from source you can run
     cd pennylane-lightning
     pip install -e .
 
-To test that the plugin is working correctly you can then run
+To test that the plugin is working correctly you can test the Python code with
 
 .. code-block:: bash
 
     $ make test
+
+while the C++ code can be tested with
+
+.. code-block:: bash
+
+    $ make test-cpp
+
+Testing the C++ code requires the `GoogleTest <https://github.com/google/googletest>`__ framework.
 
 .. installation-end-inclusion-marker-do-not-remove
 


### PR DESCRIPTION
This PR tidies up the README file but also takes the opportunity to report some benchmark results comparing `lighting.qubit` with `default.qubit`.

Benchmark details
==============

We benchmark using `default.qubit` from PennyLane with commit hash: 485677c5aa9186ddd8b5fca96c952b6c9ba7f4b1.
This is compared to `lightning.qubit` with commit hash: 6177a879a9d11cc4b7c8ab9dc394914539a99d25.

The `bm_entangling_layers` benchmark is used. Benchmarking was performed on a laptop.

Performance plots
==============

The below plot shows the speedup of `lightning.qubit` relative to `default.qubit` as a function of qubit numbers from 2-10 qubits with two choices of template depth.
![qubit_plots](https://user-images.githubusercontent.com/49409390/89067968-51add000-d33e-11ea-9c6b-1f4df2cab349.png)

We see a "sweet spot" at around 6 qubits where the speedup is most notable.

Profiling
======

We use the profiling tool of PennyLane's benchmarking suite to investigate the 2, 6, and 9 qubit cases.

The profile repeatedly applies the benchmark over a period of ~30 seconds and keeps track of the time spent on individual calls. Since `lightning.qubit` inherits from `default.qubit` and alters the `apply()` method, we focus on these elements of the timing profile.

2 qubits
----------

`default.qubit`: 46.75% time on `apply()`
![image](https://user-images.githubusercontent.com/49409390/89067526-748bb480-d33d-11ea-8680-82b54205f6f4.png)

------------
`lightning.qubit`: 17.91 % time on `apply()`
![image](https://user-images.githubusercontent.com/49409390/89067603-9e44db80-d33d-11ea-97f8-b699b675a4f2.png)

------------

6 qubits
----------

`default.qubit`: 62.24% time on `apply()`
![image](https://user-images.githubusercontent.com/49409390/89067739-e06e1d00-d33d-11ea-8441-3c716e5150db.png)


------------
`lightning.qubit`: 26.13 % time on `apply()`
![image](https://user-images.githubusercontent.com/49409390/89067711-d2200100-d33d-11ea-96ce-d6da149b8533.png)


------------

9 qubits
----------

`default.qubit`: 71.64% time on `apply()`
![image](https://user-images.githubusercontent.com/49409390/89067882-21fec800-d33e-11ea-9a78-b8e566c8d77e.png)

------------
`lightning.qubit`: 50.48 % time on `apply()`
![image](https://user-images.githubusercontent.com/49409390/89067913-3347d480-d33e-11ea-9b2c-1ee1cb2546a2.png)

------------

Analysis
-----------

We saw in the original performance plot that the speedup for 2-3 qubits wasn't quite as high as for 6 qubits. I believe that this is due to non-C++ based overheads outside of the `apply()` method that we have not sped up with `lightning.qubit`.

We also see a drop-off in the speedup beyond 6 qubits. In the 9 qubit case, we can see that the `apply()` method is taking a much larger proportion of total computation time. This seems to suggest a bottleneck on the C++ side for greater qubit numbers, which I speculate to be some unnecessary tensor copying that we could look to prevent in future.