### PR TITLE
Add tests that compare to default.qubit

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,5 +76,5 @@ jobs:
       - name: Run PennyLane shared test suite
         run: |
           cd pl
-          pytest pennylane/devices/tests --device lightning.qubit --analytic False --skip-ops
+          pytest pennylane/devices/tests --device lightning.qubit --analytic False --skip-ops --shots=20000
           pytest pennylane/devices/tests --device lightning.qubit --analytic True --skip-ops

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,5 +76,5 @@ jobs:
       - name: Run PennyLane shared test suite
         run: |
           cd pl
-          pytest pennylane/plugins/tests --device lightning.qubit --analytic False --skip-ops
-          pytest pennylane/plugins/tests --device lightning.qubit --analytic True --skip-ops
+          pytest pennylane/devices/tests --device lightning.qubit --analytic False --skip-ops
+          pytest pennylane/devices/tests --device lightning.qubit --analytic True --skip-ops

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -35,7 +35,7 @@ env:
   CIBW_ENVIRONMENT_WINDOWS: EIGEN_INCLUDE_DIR="C:\\eigen-eigen-323c052e1731\\"
 
   CIBW_TEST_COMMAND_WINDOWS: |
-    pytest "C:\\pennylane\\pennylane\\plugins\\tests" --device=lightning.qubit --skip-ops -x --tb=short --no-flaky-report
+    pytest "C:\\pennylane\\pennylane\\devices\\tests" --device=lightning.qubit --skip-ops -x --tb=short --no-flaky-report
 
   # Python build settings
 
@@ -49,7 +49,7 @@ env:
   CIBW_TEST_COMMAND: |
     git clone https://github.com/PennyLaneAI/pennylane.git
     cd pennylane && pip install -e .
-    pytest pennylane/plugins/tests --device=lightning.qubit --skip-ops -x --tb=short --no-flaky-report
+    pytest pennylane/devices/tests --device=lightning.qubit --skip-ops -x --tb=short --no-flaky-report
 
 
 jobs:

--- a/pennylane_lightning/lightning_qubit.py
+++ b/pennylane_lightning/lightning_qubit.py
@@ -130,7 +130,7 @@ class LightningQubit(DefaultQubit):
             array[complex]: the output state tensor
         """
         op_names = [o.name for o in operations]
-        op_wires = [o.wires for o in operations]
+        op_wires = [self.wires.indices(o.wires) for o in operations]
         op_param = [o.parameters for o in operations]
 
         state_vector = np.ravel(state, order="F")

--- a/pennylane_lightning/lightning_qubit.py
+++ b/pennylane_lightning/lightning_qubit.py
@@ -17,7 +17,7 @@ interfaces with C++ for fast linear algebra calculations.
 """
 import warnings
 
-from pennylane.plugins import DefaultQubit
+from pennylane.devices import DefaultQubit
 from .lightning_qubit_ops import apply
 import numpy as np
 from pennylane import QubitStateVector, BasisState, DeviceError

--- a/pennylane_lightning/tests/test_comparison.py
+++ b/pennylane_lightning/tests/test_comparison.py
@@ -108,3 +108,90 @@ class TestComparison:
         default()
         default_state = default_qubit_dev.state
         assert np.allclose(lightning_state, default_state)
+
+    @pytest.mark.parametrize("basis_state", itertools.product(*[(0, 1)] * 3))
+    @pytest.mark.parametrize("wires", [3])
+    def test_three_qubit_circuit(self, wires, lightning_qubit_dev, default_qubit_dev, basis_state):
+        """Test a three-qubit circuit"""
+
+        def circuit():
+            """A combination of two and three qubit gates with the one_qubit_block and a simple
+            PauliZ measurement"""
+            qml.BasisState(np.array(basis_state), wires=[0, 1, 2])
+            qml.RX(0.5, wires=0)
+            qml.Hadamard(wires=1)
+            qml.RY(0.9, wires=2)
+            qml.CNOT(wires=[0, 1])
+            qml.CNOT(wires=[2, 0])
+            qml.CZ(wires=[1, 0])
+            one_qubit_block(wires=0)
+            qml.Toffoli(wires=[1, 0, 2])
+            one_qubit_block(wires=2)
+            qml.SWAP(wires=[0, 1])
+            qml.SWAP(wires=[0, 2])
+            qml.CRX(0.5, wires=[1, 0])
+            qml.CSWAP(wires=[2, 1, 0])
+            qml.CRY(0.9, wires=[2, 1])
+            one_qubit_block(wires=1)
+            qml.CRZ(0.02, wires=[0, 1])
+            qml.CRot(0.2, 0.3, 0.7, wires=[2, 1])
+            qml.RZ(0.4, wires=0)
+            qml.Toffoli(wires=[2, 1, 0])
+            return qml.expval(qml.PauliZ(0))
+
+        lightning = qml.QNode(circuit, lightning_qubit_dev)
+        default = qml.QNode(circuit, default_qubit_dev)
+
+        lightning()
+        lightning_state = lightning_qubit_dev.state
+
+        default()
+        default_state = default_qubit_dev.state
+        assert np.allclose(lightning_state, default_state)
+
+    @pytest.mark.parametrize("basis_state", itertools.product(*[(0, 1)] * 4))
+    @pytest.mark.parametrize("wires", [4])
+    def test_four_qubit_circuit(self, wires, lightning_qubit_dev, default_qubit_dev, basis_state):
+        """Test a four-qubit circuit"""
+
+        def circuit():
+            """A combination of two and three qubit gates with the one_qubit_block and a simple
+            PauliZ measurement, all acting on four qubits"""
+            qml.BasisState(np.array(basis_state), wires=[0, 1, 2, 3])
+            qml.RX(0.5, wires=0)
+            qml.Hadamard(wires=1)
+            qml.RY(0.9, wires=2)
+            qml.Rot(0.1, -0.2, -0.3, wires=3)
+            qml.CNOT(wires=[0, 1])
+            qml.CNOT(wires=[3, 1])
+            one_qubit_block(wires=3)
+            qml.CNOT(wires=[2, 0])
+            qml.CZ(wires=[1, 0])
+            one_qubit_block(wires=0)
+            qml.Toffoli(wires=[1, 0, 2])
+            one_qubit_block(wires=2)
+            qml.SWAP(wires=[0, 1])
+            qml.SWAP(wires=[0, 2])
+            qml.Toffoli(wires=[1, 3, 2])
+            qml.CRX(0.5, wires=[1, 0])
+            qml.CSWAP(wires=[2, 1, 0])
+            qml.CRY(0.9, wires=[2, 1])
+            one_qubit_block(wires=1)
+            qml.CRZ(0.02, wires=[0, 1])
+            qml.CRY(0.9, wires=[2, 3])
+            qml.CRot(0.2, 0.3, 0.7, wires=[2, 1])
+            qml.RZ(0.4, wires=0)
+            qml.Toffoli(wires=[2, 1, 0])
+            return qml.expval(qml.PauliZ(0))
+
+        lightning = qml.QNode(circuit, lightning_qubit_dev)
+        default = qml.QNode(circuit, default_qubit_dev)
+
+        lightning()
+        lightning_state = lightning_qubit_dev.state
+
+        default()
+        default_state = default_qubit_dev.state
+        assert np.allclose(lightning_state, default_state)
+
+

--- a/pennylane_lightning/tests/test_comparison.py
+++ b/pennylane_lightning/tests/test_comparison.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Integration tests that
+Integration tests that compare the output states of ``lightning.qubit`` with ``default.qubit``.
 """
 import itertools
 
@@ -61,7 +61,8 @@ class TestComparison:
         """Test a single-qubit circuit"""
 
         def circuit():
-            """A combination of the one_qubit_block and a simple PauliZ measurement"""
+            """A combination of the one_qubit_block and a simple PauliZ measurement applied to a
+            basis state"""
             qml.BasisState(np.array(basis_state), wires=0)
             one_qubit_block(wires=0)
             return qml.expval(qml.PauliZ(0))
@@ -84,7 +85,7 @@ class TestComparison:
 
         def circuit():
             """A combination of two qubit gates with the one_qubit_block and a simple PauliZ
-            measurement"""
+            measurement applied to an input basis state"""
             qml.BasisState(np.array(basis_state), wires=[0, 1])
             qml.RX(0.5, wires=0)
             qml.Hadamard(wires=1)
@@ -116,7 +117,7 @@ class TestComparison:
 
         def circuit():
             """A combination of two and three qubit gates with the one_qubit_block and a simple
-            PauliZ measurement"""
+            PauliZ measurement applied to an input basis state"""
             qml.BasisState(np.array(basis_state), wires=[0, 1, 2])
             qml.RX(0.5, wires=0)
             qml.Hadamard(wires=1)
@@ -156,7 +157,7 @@ class TestComparison:
 
         def circuit():
             """A combination of two and three qubit gates with the one_qubit_block and a simple
-            PauliZ measurement, all acting on four qubits"""
+            PauliZ measurement, all acting on a four qubit input basis state"""
             qml.BasisState(np.array(basis_state), wires=[0, 1, 2, 3])
             qml.RX(0.5, wires=0)
             qml.Hadamard(wires=1)

--- a/pennylane_lightning/tests/test_comparison.py
+++ b/pennylane_lightning/tests/test_comparison.py
@@ -194,4 +194,26 @@ class TestComparison:
         default_state = default_qubit_dev.state
         assert np.allclose(lightning_state, default_state)
 
+    @pytest.mark.parametrize("wires", range(1, 17))
+    def test_n_qubit_circuit(self, wires, lightning_qubit_dev, default_qubit_dev):
+        """Test an n-qubit circuit"""
 
+        vec = np.array([1] * (2 ** wires)) / np.sqrt(2 ** wires)
+        w = qml.init.strong_ent_layers_uniform(2, wires)
+
+        def circuit():
+            """Prepares the equal superposition state and then applies StronglyEntanglingLayers
+            and concludes with a simple PauliZ measurement"""
+            qml.QubitStateVector(vec, wires=range(wires))
+            qml.templates.StronglyEntanglingLayers(w, wires=range(wires))
+            return qml.expval(qml.PauliZ(0))
+
+        lightning = qml.QNode(circuit, lightning_qubit_dev)
+        default = qml.QNode(circuit, default_qubit_dev)
+
+        lightning()
+        lightning_state = lightning_qubit_dev.state
+
+        default()
+        default_state = default_qubit_dev.state
+        assert np.allclose(lightning_state, default_state)

--- a/pennylane_lightning/tests/test_comparison.py
+++ b/pennylane_lightning/tests/test_comparison.py
@@ -14,3 +14,61 @@
 """
 Integration tests that
 """
+import numpy as np
+import pennylane as qml
+import pytest
+
+
+@pytest.fixture
+def lightning_qubit_dev(wires):
+    """Loads ``lightning.qubit``"""
+    return qml.device("lightning.qubit", wires=wires)
+
+
+@pytest.fixture
+def default_qubit_dev(wires):
+    """Loads ``default.qubit``"""
+    return qml.device("default.qubit", wires=wires)
+
+
+def one_qubit_block(wires=None):
+    """A block containing all of the supported gates in ``lightning.qubit``"""
+    qml.PauliX(wires=wires)
+    qml.PauliY(wires=wires)
+    qml.S(wires=wires)
+    qml.Hadamard(wires=wires)
+    qml.PauliX(wires=wires)
+    qml.T(wires=wires)
+    qml.PhaseShift(-1, wires=wires)
+    qml.Rot(0.1, 0.2, 0.3, wires=wires)
+    qml.RZ(0.11, wires=wires)
+    qml.RY(0.22, wires=wires)
+    qml.RX(0.33, wires=wires)
+    qml.PauliX(wires=wires)
+
+
+@pytest.mark.usefixtures("lightning_qubit_dev", "default_qubit_dev")
+class TestComparison:
+    """A test that compares the output states of ``lightning.qubit`` and ``default.qubit`` for a
+    variety of different circuits. This uses ``default.qubit`` as a gold standard to compare
+    against."""
+
+    @pytest.mark.parametrize("wires", [1])
+    def test_one_qubit_circuit(self, wires, lightning_qubit_dev, default_qubit_dev):
+        """Test a single qubit circuit"""
+
+        def circuit():
+            """A combination of the one_qubit_block and a simple PauliZ measurement"""
+            one_qubit_block(wires=0)
+            return qml.expval(qml.PauliZ(0))
+
+        lightning = qml.QNode(circuit, lightning_qubit_dev)
+        default = qml.QNode(circuit, default_qubit_dev)
+
+        lightning()
+        lightning_state = lightning_qubit_dev.state
+
+        default()
+        default_state = default_qubit_dev.state
+
+        assert np.allclose(lightning_state, default_state)

--- a/pennylane_lightning/tests/test_comparison.py
+++ b/pennylane_lightning/tests/test_comparison.py
@@ -17,8 +17,9 @@ Integration tests that compare the output states of ``lightning.qubit`` with ``d
 import itertools
 
 import numpy as np
-import pennylane as qml
 import pytest
+
+import pennylane as qml
 
 
 @pytest.fixture

--- a/pennylane_lightning/tests/test_comparison.py
+++ b/pennylane_lightning/tests/test_comparison.py
@@ -1,0 +1,16 @@
+# Copyright 2018-2020 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Integration tests that
+"""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 numpy
 git+https://github.com/XanaduAI/pennylane.git#egg=pennylane
+pytest
+pytest-cov


### PR DESCRIPTION
This PR adds a series of tests that compare the output state of `lightning.qubit` with the output state of `default.qubit` for a variety of different circuits that use all of the supported gates in `lightning.qubit`.

These tests allow us to be confident that `lightning.qubit` is processing states correctly.