### PR TITLE
Windows compiler and linker options

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,13 +1,5 @@
 name: Wheels
-on:
-  workflow_dispatch:
-    inputs:
-      logLevel:
-        description: 'Log level'
-        required: true
-        default: 'warning'
-      tags:
-        description: 'Test scenario tags'
+on: [push, pull_request]
 
 env:
   CIBW_SKIP: "cp27-* cp34-* cp35-* *i686 pp* *win32"

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,5 +1,9 @@
 name: Wheels
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 env:
   CIBW_SKIP: "cp27-* cp34-* cp35-* *i686 pp* *win32"

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ class BuildExt(build_ext):
     """A custom build extension for adding compiler-specific options."""
 
     c_opts = {
-        "msvc": ["/EHsc", "/O2", "/Wall","/std:c++14"],
+        "msvc": ["-EHsc", "-O2", "-Wall","-std:c++11"],
         "unix": ["-O3", "-Wall", "-fPIC", "-shared", "-fopenmp"],
     }
 

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ class BuildExt(build_ext):
     """A custom build extension for adding compiler-specific options."""
 
     c_opts = {
-        "msvc": ["/EHsc", "-static", "-O3", "-Wall", "-fPIC"],
+        "msvc": ["/EHsc", "-static", "/O2", "-Wall", "-fPIC"],
         "unix": ["-O3", "-Wall", "-fPIC", "-shared", "-fopenmp"],
     }
 

--- a/setup.py
+++ b/setup.py
@@ -76,12 +76,12 @@ class BuildExt(build_ext):
     """A custom build extension for adding compiler-specific options."""
 
     c_opts = {
-        "msvc": ["/EHsc", "-static", "/O2", "-Wall", "-fPIC"],
+        "msvc": ["/EHsc", "/O2", "/Wall"],
         "unix": ["-O3", "-Wall", "-fPIC", "-shared", "-fopenmp"],
     }
 
     l_opts = {
-        "msvc": ["-std=c++11", "-static", "-static-libgfortran", "-static-libgcc"],
+        "msvc": ["/std:c++11"],
         "unix": ["-O3", "-Wall", "-fPIC", "-shared", "-fopenmp"],
     }
 

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ class BuildExt(build_ext):
     }
 
     l_opts = {
-        "msvc": ["/std:c++11"],
+        "msvc": ["/std:c++14"],
         "unix": ["-O3", "-Wall", "-fPIC", "-shared", "-fopenmp"],
     }
 

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ class BuildExt(build_ext):
     """A custom build extension for adding compiler-specific options."""
 
     c_opts = {
-        "msvc": ["/EHsc", "/O2", "/Wall"],
+        "msvc": ["/EHsc", "/O2", "/Wall","/std:c++14"],
         "unix": ["-O3", "-Wall", "-fPIC", "-shared", "-fopenmp"],
     }
 

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ class BuildExt(build_ext):
     }
 
     l_opts = {
-        "msvc": ["/std:c++14"],
+        "msvc": [],
         "unix": ["-O3", "-Wall", "-fPIC", "-shared", "-fopenmp"],
     }
 


### PR DESCRIPTION
Modifies the compiler and linker options for Windows. The motivation is to achieve optimized code by using the `/O2` compiler option to achieve faster performance on Windows too.