### PR TITLE
macOS wheel perf check

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -53,16 +53,6 @@ jobs:
         with:
           python-version: '3.7'
 
-
-      - name: Benchmark performance
-        run: |
-
-          git clone https://github.com/PennyLaneAI/pennylane.git
-          cd pennylane && pip install -e .
-          python3 benchmark/benchmark.py -d default.qubit,lightning.qubit time bm_entangling_layers -w 2
-          python3 benchmark/benchmark.py -d default.qubit,lightning.qubit time bm_entangling_layers -w 6
-          python3 benchmark/benchmark.py -d default.qubit,lightning.qubit time bm_entangling_layers -w 10
-
       - name: Install cibuildwheel
         run: |
           python -m pip install cibuildwheel==1.5.5
@@ -75,3 +65,12 @@ jobs:
         with:
           name: ${{ runner.os }}-wheels.zip
           path: ./wheelhouse/*.whl
+
+      - name: Benchmark performance
+        run: |
+
+          git clone https://github.com/PennyLaneAI/pennylane.git
+          cd pennylane && pip install -e .
+          python3 benchmark/benchmark.py -d default.qubit,lightning.qubit time bm_entangling_layers -w 2
+          python3 benchmark/benchmark.py -d default.qubit,lightning.qubit time bm_entangling_layers -w 6
+          python3 benchmark/benchmark.py -d default.qubit,lightning.qubit time bm_entangling_layers -w 10

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,74 @@
+name: Wheels
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+env:
+  CIBW_SKIP: "cp27-* cp34-* cp35-* *i686 pp* *win32"
+
+  # MacOS specific build settings
+
+  CIBW_BEFORE_ALL_MACOS: |
+    brew cask uninstall --force oclint
+    brew install gcc eigen libomp
+
+  CIBW_ENVIRONMENT_MACOS: EIGEN_INCLUDE_DIR=/usr/local/Cellar/eigen/3.3.7/include/eigen3
+
+  # Python build settings
+
+  CIBW_BEFORE_BUILD: |
+    pip install numpy scipy pybind11
+
+  # Testing of built wheels
+
+  CIBW_TEST_REQUIRES: numpy scipy pytest pytest-cov pytest-mock flaky
+
+  CIBW_TEST_COMMAND: |
+    git clone https://github.com/PennyLaneAI/pennylane.git
+    cd pennylane && pip install -e .
+    pytest pennylane/devices/tests --device=lightning.qubit --skip-ops -x --tb=short --no-flaky-report
+
+
+jobs:
+
+  pythontests:
+    name: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest]
+
+    steps:
+
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.4.1
+        with:
+          access_token: ${{ github.token }}
+
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.7'
+
+      - name: Install cibuildwheel
+        run: |
+          python -m pip install cibuildwheel==1.5.5
+
+      - name: Build wheels
+        run: |
+          python -m cibuildwheel --output-dir wheelhouse
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: ${{ runner.os }}-wheels.zip
+          path: ./wheelhouse/*.whl
+
+      - name: Benchmark performance
+        run: |
+          cd pennylane
+          python3 benchmark/benchmark.py -d default.qubit,lightning.qubit time bm_entangling_layers -w 2
+          python3 benchmark/benchmark.py -d default.qubit,lightning.qubit time bm_entangling_layers -w 6
+          python3 benchmark/benchmark.py -d default.qubit,lightning.qubit time bm_entangling_layers -w 10

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -53,6 +53,16 @@ jobs:
         with:
           python-version: '3.7'
 
+
+      - name: Benchmark performance
+        run: |
+
+          git clone https://github.com/PennyLaneAI/pennylane.git
+          cd pennylane && pip install -e .
+          python3 benchmark/benchmark.py -d default.qubit,lightning.qubit time bm_entangling_layers -w 2
+          python3 benchmark/benchmark.py -d default.qubit,lightning.qubit time bm_entangling_layers -w 6
+          python3 benchmark/benchmark.py -d default.qubit,lightning.qubit time bm_entangling_layers -w 10
+
       - name: Install cibuildwheel
         run: |
           python -m pip install cibuildwheel==1.5.5
@@ -65,10 +75,3 @@ jobs:
         with:
           name: ${{ runner.os }}-wheels.zip
           path: ./wheelhouse/*.whl
-
-      - name: Benchmark performance
-        run: |
-          cd pennylane
-          python3 benchmark/benchmark.py -d default.qubit,lightning.qubit time bm_entangling_layers -w 2
-          python3 benchmark/benchmark.py -d default.qubit,lightning.qubit time bm_entangling_layers -w 6
-          python3 benchmark/benchmark.py -d default.qubit,lightning.qubit time bm_entangling_layers -w 10

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -30,6 +30,11 @@ env:
     cd pennylane && pip install -e .
     pytest pennylane/devices/tests --device=lightning.qubit --skip-ops -x --tb=short --no-flaky-report
 
+    # Benchmark performance
+    python3 benchmark/benchmark.py -d default.qubit,lightning.qubit time bm_entangling_layers -w 2
+    python3 benchmark/benchmark.py -d default.qubit,lightning.qubit time bm_entangling_layers -w 6
+    python3 benchmark/benchmark.py -d default.qubit,lightning.qubit time bm_entangling_layers -w 10
+
 
 jobs:
 
@@ -65,12 +70,3 @@ jobs:
         with:
           name: ${{ runner.os }}-wheels.zip
           path: ./wheelhouse/*.whl
-
-      - name: Benchmark performance
-        run: |
-
-          git clone https://github.com/PennyLaneAI/pennylane.git
-          cd pennylane && pip install -e .
-          python3 benchmark/benchmark.py -d default.qubit,lightning.qubit time bm_entangling_layers -w 2
-          python3 benchmark/benchmark.py -d default.qubit,lightning.qubit time bm_entangling_layers -w 6
-          python3 benchmark/benchmark.py -d default.qubit,lightning.qubit time bm_entangling_layers -w 10

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,4 +1,4 @@
-name: Wheels
+name: macOS wheel check & perf
 on:
   push:
     branches:

--- a/.github/workflows/performance_checks.yml
+++ b/.github/workflows/performance_checks.yml
@@ -8,6 +8,16 @@ on:
 env:
   CIBW_SKIP: "cp27-* cp34-* cp35-* *i686 pp* *win32"
 
+  # Linux specific build settings
+
+  CIBW_BEFORE_ALL_LINUX: |
+    curl -OsL https://bitbucket.org/eigen/eigen/get/3.3.7.tar.gz
+    tar xzf 3.3.7.tar.gz eigen-eigen-323c052e1731/Eigen --strip-components 1
+    tar xzf 3.3.7.tar.gz eigen-eigen-323c052e1731/unsupported --strip-components 1
+    mkdir -p {project}/include
+    cp -rf Eigen {project}/include
+    cp -rf unsupported {project}/include
+
   # MacOS specific build settings
 
   CIBW_BEFORE_ALL_MACOS: |
@@ -15,6 +25,13 @@ env:
     brew install gcc eigen libomp
 
   CIBW_ENVIRONMENT_MACOS: EIGEN_INCLUDE_DIR=/usr/local/Cellar/eigen/3.3.7/include/eigen3
+
+  # Windows specific build settings
+
+  CIBW_ENVIRONMENT_WINDOWS: EIGEN_INCLUDE_DIR="C:\\eigen-eigen-323c052e1731\\"
+
+  CIBW_TEST_COMMAND_WINDOWS: |
+    pytest "C:\\pennylane\\pennylane\\devices\\tests" --device=lightning.qubit --skip-ops -x --tb=short --no-flaky-report
 
   # Python build settings
 
@@ -43,7 +60,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
 
@@ -61,6 +78,18 @@ jobs:
       - name: Install cibuildwheel
         run: |
           python -m pip install cibuildwheel==1.5.5
+
+      - name: Install Eigen on Windows
+        if: runner.os == 'Windows'
+        shell: powershell
+        env:
+          GIT_REDIRECT_STDERR: "2>&1"
+        run: |
+          choco install vcpython27 -f -y
+          Invoke-WebRequest -Uri "http://bitbucket.org/eigen/eigen/get/3.3.7.zip" -UseBasicParsing -OutFile C:\eigen3.zip
+          & "C:\\Program Files\\7-Zip\\7z.exe" x C:\eigen3.zip -o"C:\" -y
+          New-Item -ItemType directory -Path "C:\\pennylane"
+          & git clone https://github.com/PennyLaneAI/pennylane.git "C:\\pennylane"
 
       - name: Build wheels
         run: |

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,9 +1,6 @@
 name: Wheels
 on:
-  push:
-    branches:
-      - master
-  pull_request:
+  workflow_dispatch:
 
 env:
   CIBW_SKIP: "cp27-* cp34-* cp35-* *i686 pp* *win32"


### PR DESCRIPTION
**Context**
We'd like to check the performance of PennyLane-Lightning on macOS. For this we use the wheel built on macOS and the PennyLane benchmarking tool (found in the `benchmark` folder of PennyLane).

**Results**
Performance comparison of `default.qubit` and `lightning.qubit` for the 'Entangling layers' benchmark run on macOS:

[With 2 wires](https://github.com/PennyLaneAI/pennylane-lightning/pull/38/checks?check_run_id=981841206#step:6:953):
```
Timing: 'Entangling layers' benchmark on default.qubit, QNode
10 loops, 5 runs
Timing per loop: [0.07821284 0.07821478 0.07785126 0.07677576 0.07520293]
Timing: 'Entangling layers' benchmark on lightning.qubit, QNode
10 loops, 5 runs
Timing per loop: [0.04033666 0.039648   0.04055351 0.03933717 0.03958955]
```
[With 6 wires](https://github.com/PennyLaneAI/pennylane-lightning/pull/38/checks?check_run_id=981841206#step:6:988):
```
Timing: 'Entangling layers' benchmark on default.qubit, QNode
10 loops, 5 runs
Timing per loop: [0.4530408  0.45083251 0.45257708 0.45071833 0.45597058]
Timing: 'Entangling layers' benchmark on lightning.qubit, QNode
10 loops, 5 runs
Timing per loop: [0.18767837 0.18495741 0.18629023 0.18913664 0.18902163]
```
[With 10 wires](https://github.com/PennyLaneAI/pennylane-lightning/pull/38/checks?check_run_id=981841206#step:6:1023):
```
Timing: 'Entangling layers' benchmark on default.qubit, QNode
10 loops, 5 runs
Timing per loop: [1.81512918 1.81848905 1.79244642 1.79102871 1.82041465]
Timing: 'Entangling layers' benchmark on lightning.qubit, QNode
10 loops, 5 runs
Timing per loop: [1.02808973 1.02623959 1.04195447 1.03139232 1.03201263]
```