### PR TITLE
Add command to makefile to clean binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,9 @@ clean:
 	rm -rf tmp
 	rm -rf *.dat
 
+clean-binaries:
+	rm -f pennylane_lightning/lightning_qubit_ops*
+
 docs:
 	make -C doc html
 

--- a/README.rst
+++ b/README.rst
@@ -60,7 +60,7 @@ Alternatively, to build PennyLane-Lightning from source you can run
     $ pip install -e .
 
 Note that subsequent calls to ``pip install -e .`` will use cached binaries stored in the
-``build`` folder. Run ``make clean`` if you would like to recompile.
+``build`` folder. Run ``make clean`` and ``make clean-binaries`` if you would like to recompile.
 
 The following dependencies are required to install PennyLane-Lightning:
 


### PR DESCRIPTION
Add an extra makefile command `make clean-binaries` to remove the c++ compiled code. This allows one to do
```bash
make clean-binaries
pip install -e .
```
such that recompilation will occur. Otherwise a cached version will be used each time.

`make clean-binaries` is kept separate from `make clean`.