### PR TITLE
Adds continuous deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -89,7 +89,7 @@ jobs:
           name: ${{ runner.os }}-wheels
           path: ./wheelhouse/*.whl
 
-  upload-source:
+  upload-wheels:
     runs-on: ubuntu-latest
     needs: [build-wheels]
     steps:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,7 +1,7 @@
 name: Deploy
 on:
   release:
-    types: [created]
+    types: [published]
 
 env:
   CIBW_SKIP: "cp27-* cp34-* cp35-* *i686 pp* *win32"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,9 +9,9 @@ env:
   # Linux specific build settings
 
   CIBW_BEFORE_ALL_LINUX: |
-    curl -OsL https://bitbucket.org/eigen/eigen/get/3.3.7.tar.gz
-    tar xzf 3.3.7.tar.gz eigen-eigen-323c052e1731/Eigen --strip-components 1
-    tar xzf 3.3.7.tar.gz eigen-eigen-323c052e1731/unsupported --strip-components 1
+    curl -OsL https://gitlab.com/libeigen/eigen/-/archive/3.3.7/eigen-3.3.7.tar.gz
+    tar xzf eigen-3.3.7.tar.gz eigen-3.3.7/Eigen --strip-components 1
+    tar xzf eigen-3.3.7.tar.gz eigen-3.3.7/unsupported --strip-components 1
     mkdir -p {project}/include
     cp -rf Eigen {project}/include
     cp -rf unsupported {project}/include
@@ -26,7 +26,7 @@ env:
 
   # Windows specific build settings
 
-  CIBW_ENVIRONMENT_WINDOWS: EIGEN_INCLUDE_DIR="C:\\eigen-eigen-323c052e1731\\"
+  CIBW_ENVIRONMENT_WINDOWS: EIGEN_INCLUDE_DIR="C:\\eigen-3.3.7\\"
 
   # Python build settings
 
@@ -63,6 +63,7 @@ jobs:
 
       - name: Install cibuildwheel
         run: |
+          python -m pip install --upgrade pip
           python -m pip install cibuildwheel==1.5.5
 
       - name: Install Eigen on Windows
@@ -72,7 +73,7 @@ jobs:
           GIT_REDIRECT_STDERR: "2>&1"
         run: |
           choco install vcpython27 -f -y
-          Invoke-WebRequest -Uri "http://bitbucket.org/eigen/eigen/get/3.3.7.zip" -UseBasicParsing -OutFile C:\eigen3.zip
+          Invoke-WebRequest -Uri "https://gitlab.com/libeigen/eigen/-/archive/3.3.7/eigen-3.3.7.zip" -UseBasicParsing -OutFile C:\eigen3.zip
           & "C:\\Program Files\\7-Zip\\7z.exe" x C:\eigen3.zip -o"C:\" -y
 
       - name: Build wheels

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,126 @@
+name: Deploy
+on:
+  release:
+    types: [created]
+
+env:
+  CIBW_SKIP: "cp27-* cp34-* cp35-* *i686 pp* *win32"
+
+  # Linux specific build settings
+
+  CIBW_BEFORE_ALL_LINUX: |
+    curl -OsL https://bitbucket.org/eigen/eigen/get/3.3.7.tar.gz
+    tar xzf 3.3.7.tar.gz eigen-eigen-323c052e1731/Eigen --strip-components 1
+    tar xzf 3.3.7.tar.gz eigen-eigen-323c052e1731/unsupported --strip-components 1
+    mkdir -p {project}/include
+    cp -rf Eigen {project}/include
+    cp -rf unsupported {project}/include
+
+  # MacOS specific build settings
+
+  CIBW_BEFORE_ALL_MACOS: |
+    brew cask uninstall --force oclint
+    brew install gcc eigen libomp
+
+  CIBW_ENVIRONMENT_MACOS: EIGEN_INCLUDE_DIR=/usr/local/Cellar/eigen/3.3.7/include/eigen3
+
+  # Windows specific build settings
+
+  CIBW_ENVIRONMENT_WINDOWS: EIGEN_INCLUDE_DIR="C:\\eigen-eigen-323c052e1731\\"
+
+  # Python build settings
+
+  CIBW_BEFORE_BUILD: |
+    pip install numpy scipy pybind11
+
+  # Testing of built wheels
+
+  CIBW_TEST_REQUIRES: numpy scipy pytest pytest-cov pytest-mock flaky
+
+  CIBW_TEST_COMMAND: |
+    pl-device-test --device=lightning.qubit --skip-ops -x --tb=short --no-flaky-report
+
+
+jobs:
+
+  build-wheels:
+    name: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.4.1
+        with:
+          access_token: ${{ github.token }}
+
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.7'
+
+      - name: Install cibuildwheel
+        run: |
+          python -m pip install cibuildwheel==1.5.5
+
+      - name: Install Eigen on Windows
+        if: runner.os == 'Windows'
+        shell: powershell
+        env:
+          GIT_REDIRECT_STDERR: "2>&1"
+        run: |
+          choco install vcpython27 -f -y
+          Invoke-WebRequest -Uri "http://bitbucket.org/eigen/eigen/get/3.3.7.zip" -UseBasicParsing -OutFile C:\eigen3.zip
+          & "C:\\Program Files\\7-Zip\\7z.exe" x C:\eigen3.zip -o"C:\" -y
+
+      - name: Build wheels
+        run: |
+          python -m cibuildwheel --output-dir wheelhouse
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: ${{ runner.os }}-wheels.zip
+          path: ./wheelhouse/*.whl
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: ${{ runner.os }}-wheels
+          path: ./wheelhouse/*.whl
+
+  upload-source:
+    runs-on: ubuntu-latest
+    needs: [build-wheels]
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          path: dist/
+
+      - name: Publish
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI }}
+
+  upload-source:
+    runs-on: ubuntu-latest
+    needs: [build-wheels]
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+
+      - name: Build and install Plugin
+        run: |
+          python -m pip install --upgrade pip wheel
+          python setup.py sdist
+
+      - name: Publish
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI }}


### PR DESCRIPTION
Adds a github actions that, on the creation of a new GitHub release:

* Builds the wheels for all operating systems
* Tests the wheels
* If the wheels pass the tests, uploads the wheel (and source code) to PyPI.

Note:

* GitHub actions hasn't yet released support for composite actions, so for now we need to copy our wheel building steps to this new workflow.
* We can't test this until we make the next release, unless we want to temporarily modify the workflow to upload to test-pypi :)