### PR TITLE
Eigen from GitLab

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -12,8 +12,8 @@ env:
 
   CIBW_BEFORE_ALL_LINUX: |
     curl -OsL https://gitlab.com/libeigen/eigen/-/archive/3.3.7/eigen-3.3.7.tar.gz
-    tar xzf 3.3.7.tar.gz eigen-eigen-323c052e1731/Eigen --strip-components 1
-    tar xzf 3.3.7.tar.gz eigen-eigen-323c052e1731/unsupported --strip-components 1
+    tar xzf eigen-3.3.7.tar.gz eigen-3.3.7/Eigen --strip-components 1
+    tar xzf eigen-3.3.7.tar.gz eigen-3.3.7/unsupported --strip-components 1
     mkdir -p {project}/include
     cp -rf Eigen {project}/include
     cp -rf unsupported {project}/include
@@ -28,7 +28,7 @@ env:
 
   # Windows specific build settings
 
-  CIBW_ENVIRONMENT_WINDOWS: EIGEN_INCLUDE_DIR="C:\\eigen-eigen-323c052e1731\\"
+  CIBW_ENVIRONMENT_WINDOWS: EIGEN_INCLUDE_DIR="C:\\eigen-3.3.7\\"
 
 #  CIBW_TEST_COMMAND_WINDOWS: |
 #    pytest "C:\\pennylane\\pennylane\\devices\\tests" --device=lightning.qubit --skip-ops -x --tb=short --no-flaky-report

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -11,7 +11,7 @@ env:
   # Linux specific build settings
 
   CIBW_BEFORE_ALL_LINUX: |
-    curl -OsL https://bitbucket.org/eigen/eigen/get/3.3.7.tar.gz
+    curl -OsL https://gitlab.com/libeigen/eigen/-/archive/3.3.7/eigen-3.3.7.tar.gz
     tar xzf 3.3.7.tar.gz eigen-eigen-323c052e1731/Eigen --strip-components 1
     tar xzf 3.3.7.tar.gz eigen-eigen-323c052e1731/unsupported --strip-components 1
     mkdir -p {project}/include
@@ -79,7 +79,7 @@ jobs:
           GIT_REDIRECT_STDERR: "2>&1"
         run: |
           choco install vcpython27 -f -y
-          Invoke-WebRequest -Uri "http://bitbucket.org/eigen/eigen/get/3.3.7.zip" -UseBasicParsing -OutFile C:\eigen3.zip
+          Invoke-WebRequest -Uri "https://gitlab.com/libeigen/eigen/-/archive/3.3.7/eigen-3.3.7.zip" -UseBasicParsing -OutFile C:\eigen3.zip
           & "C:\\Program Files\\7-Zip\\7z.exe" x C:\eigen3.zip -o"C:\" -y
 
 #          New-Item -ItemType directory -Path "C:\\pennylane"


### PR DESCRIPTION
The compressed versions of Eigen became [outdated on `bitbucket`](https://bitbucket.org/eigen/eigen/get/3.3.7.zip).

> Since the end of 2019, Eigen's repository and bugtracker are now both hosted on GitLab.com, meaning that Eigen is now using git for source code management. The old mercurial repository is still readable on bitbucket.org, but it is not synchronized with the git repository, meaning that it should be used for archive purposes only. The same remark applies for the old bugzilla instance.

from the [main page](http://eigen.tuxfamily.org/index.php?title=Main_Page).