### PR TITLE
Use templates to simplify applying operations to tensors

### DIFF
--- a/pennylane_lightning/lightning_qubit.py
+++ b/pennylane_lightning/lightning_qubit.py
@@ -93,7 +93,9 @@ class LightningQubit(DefaultQubit):
 
         if self.num_wires > self._MAX_WIRES:
             warnings.warn(
-                "The number of wires exceeds {}, reverting to NumPy-based evaluation.".format(self._MAX_WIRES),
+                "The number of wires exceeds {}, reverting to NumPy-based evaluation.".format(
+                    self._MAX_WIRES
+                ),
                 UserWarning,
             )
 

--- a/pennylane_lightning/lightning_qubit.py
+++ b/pennylane_lightning/lightning_qubit.py
@@ -37,8 +37,8 @@ class LightningQubit(DefaultQubit):
 
     .. warning::
 
-        The C++ interface currently supports up to 16 wires. If Lightning Qubit is loaded with
-        more than 16 wires, it will revert to a NumPy-based simulation.
+        The C++ interface currently supports up to 50 wires. If Lightning Qubit is loaded with
+        more than 50 wires, it will revert to a NumPy-based simulation.
 
     Args:
         wires (int): the number of wires to initialize the device with
@@ -84,7 +84,7 @@ class LightningQubit(DefaultQubit):
 
     observables = {"PauliX", "PauliY", "PauliZ", "Hadamard", "Identity"}
 
-    _MAX_WIRES = 16
+    _MAX_WIRES = 50
     """Maximum number of supported wires. Beyond this number, lightning.qubit behaves like 
     default.qubit."""
 
@@ -93,7 +93,7 @@ class LightningQubit(DefaultQubit):
 
         if self.num_wires > self._MAX_WIRES:
             warnings.warn(
-                "The number of wires exceeds 16, reverting to NumPy-based evaluation.",
+                "The number of wires exceeds {}, reverting to NumPy-based evaluation.".format(self._MAX_WIRES),
                 UserWarning,
             )
 

--- a/pennylane_lightning/lightning_qubit.py
+++ b/pennylane_lightning/lightning_qubit.py
@@ -93,9 +93,7 @@ class LightningQubit(DefaultQubit):
 
         if self.num_wires > self._MAX_WIRES:
             warnings.warn(
-                "The number of wires exceeds {}, reverting to NumPy-based evaluation.".format(
-                    self._MAX_WIRES
-                ),
+                f"The number of wires exceeds {self._MAX_WIRES}, reverting to NumPy-based evaluation.",
                 UserWarning,
             )
 

--- a/pennylane_lightning/src/lightning_qubit.cpp
+++ b/pennylane_lightning/src/lightning_qubit.cpp
@@ -25,6 +25,9 @@
 /**
 * Applies specified operations onto an input state of an arbitrary number of qubits.
 *
+* Note that only up to 50 qubits are currently supported. This limitation is due to the Eigen
+* Tensor library not supporting dynamically ranked tensors.
+*
 * @param state the multiqubit statevector
 * @param ops a vector of operation names in the order they should be applied
 * @param wires a vector of wires corresponding to the operations specified in ops

--- a/pennylane_lightning/src/lightning_qubit.cpp
+++ b/pennylane_lightning/src/lightning_qubit.cpp
@@ -58,7 +58,41 @@ VectorXcd apply (
     case 14: return QubitOperations<14>::apply(state, ops, wires, params);
     case 15: return QubitOperations<15>::apply(state, ops, wires, params);
     case 16: return QubitOperations<16>::apply(state, ops, wires, params);
-    default: throw std::invalid_argument("No support for > 16 qubits");
+    case 17: return QubitOperations<17>::apply(state, ops, wires, params);
+    case 18: return QubitOperations<18>::apply(state, ops, wires, params);
+    case 19: return QubitOperations<19>::apply(state, ops, wires, params);
+    case 20: return QubitOperations<20>::apply(state, ops, wires, params);
+    case 21: return QubitOperations<21>::apply(state, ops, wires, params);
+    case 22: return QubitOperations<22>::apply(state, ops, wires, params);
+    case 23: return QubitOperations<23>::apply(state, ops, wires, params);
+    case 24: return QubitOperations<24>::apply(state, ops, wires, params);
+    case 25: return QubitOperations<25>::apply(state, ops, wires, params);
+    case 26: return QubitOperations<26>::apply(state, ops, wires, params);
+    case 27: return QubitOperations<27>::apply(state, ops, wires, params);
+    case 28: return QubitOperations<28>::apply(state, ops, wires, params);
+    case 29: return QubitOperations<29>::apply(state, ops, wires, params);
+    case 30: return QubitOperations<30>::apply(state, ops, wires, params);
+    case 31: return QubitOperations<31>::apply(state, ops, wires, params);
+    case 32: return QubitOperations<32>::apply(state, ops, wires, params);
+    case 33: return QubitOperations<33>::apply(state, ops, wires, params);
+    case 34: return QubitOperations<34>::apply(state, ops, wires, params);
+    case 35: return QubitOperations<35>::apply(state, ops, wires, params);
+    case 36: return QubitOperations<36>::apply(state, ops, wires, params);
+    case 37: return QubitOperations<37>::apply(state, ops, wires, params);
+    case 38: return QubitOperations<38>::apply(state, ops, wires, params);
+    case 39: return QubitOperations<39>::apply(state, ops, wires, params);
+    case 40: return QubitOperations<40>::apply(state, ops, wires, params);
+    case 41: return QubitOperations<41>::apply(state, ops, wires, params);
+    case 42: return QubitOperations<42>::apply(state, ops, wires, params);
+    case 43: return QubitOperations<43>::apply(state, ops, wires, params);
+    case 44: return QubitOperations<44>::apply(state, ops, wires, params);
+    case 45: return QubitOperations<45>::apply(state, ops, wires, params);
+    case 46: return QubitOperations<46>::apply(state, ops, wires, params);
+    case 47: return QubitOperations<47>::apply(state, ops, wires, params);
+    case 48: return QubitOperations<48>::apply(state, ops, wires, params);
+    case 49: return QubitOperations<49>::apply(state, ops, wires, params);
+    case 50: return QubitOperations<50>::apply(state, ops, wires, params);
+    default: throw std::invalid_argument("No support for > 50 qubits");
     }
 }
 

--- a/pennylane_lightning/src/lightning_qubit.cpp
+++ b/pennylane_lightning/src/lightning_qubit.cpp
@@ -22,30 +22,8 @@
 #include "pybind11/eigen.h"
 #include "lightning_qubit.hpp"
 
-// Declare tensor shape for state
-using State_1q = Tensor<complex<double>, 1>;
-using State_2q = Tensor<complex<double>, 2>;
-using State_3q = Tensor<complex<double>, 3>;
-using State_4q = Tensor<complex<double>, 4>;
-using State_5q = Tensor<complex<double>, 5>;
-using State_6q = Tensor<complex<double>, 6>;
-using State_7q = Tensor<complex<double>, 7>;
-using State_8q = Tensor<complex<double>, 8>;
-using State_9q = Tensor<complex<double>, 9>;
-using State_10q = Tensor<complex<double>, 10>;
-using State_11q = Tensor<complex<double>, 11>;
-using State_12q = Tensor<complex<double>, 12>;
-using State_13q = Tensor<complex<double>, 13>;
-using State_14q = Tensor<complex<double>, 14>;
-using State_15q = Tensor<complex<double>, 15>;
-using State_16q = Tensor<complex<double>, 16>;
-
-
 /**
 * Applies specified operations onto an input state of an arbitrary number of qubits.
-*
-* Note that only up to 16 qubits are currently supported. This limitation is due to the Eigen
-* Tensor library not supporting dynamically ranked tensors.
 *
 * @param state the multiqubit statevector
 * @param ops a vector of operation names in the order they should be applied
@@ -60,67 +38,28 @@ VectorXcd apply (
     vector<vector<float>> params,
     const int qubits
 ) {
-    VectorXcd evolved_state;
+    if (qubits <= 0)
+        throw std::invalid_argument("Must specify one or more qubits");
+
     switch (qubits) {
-    case 1:
-        evolved_state = apply_ops_1q (state, ops, params);
-        break;
-    case 2:
-        evolved_state = apply_ops_2q (state, ops, wires, params);
-        break;
-    case 3:
-        evolved_state = apply_ops <State_3q> (state, ops, wires, params, 2, 2, 2);
-        break;
-    case 4:
-        evolved_state = apply_ops <State_4q> (state, ops, wires, params, 2, 2, 2, 2);
-        break;
-    case 5:
-        evolved_state = apply_ops <State_5q> (state, ops, wires, params, 2, 2, 2, 2, 2);
-        break;
-    case 6:
-        evolved_state = apply_ops <State_6q> (state, ops, wires, params, 2, 2, 2, 2, 2, 2);
-        break;
-    case 7:
-        evolved_state = apply_ops <State_7q> (state, ops, wires, params, 2, 2, 2, 2, 2, 2, 2);
-        break;
-    case 8:
-        evolved_state = apply_ops <State_8q> (state, ops, wires, params, 2, 2, 2, 2, 2, 2, 2,
-                                              2);
-        break;
-    case 9:
-        evolved_state = apply_ops <State_9q> (state, ops, wires, params,
-                                              2, 2, 2, 2, 2, 2, 2, 2, 2);
-        break;
-    case 10:
-        evolved_state = apply_ops <State_10q> (state, ops, wires, params,
-                                               2, 2, 2, 2, 2, 2, 2, 2, 2, 2);
-        break;
-    case 11:
-        evolved_state = apply_ops <State_11q> (state, ops, wires, params,
-                                               2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2);
-        break;
-    case 12:
-        evolved_state = apply_ops <State_12q> (state, ops, wires, params,
-                                               2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2);
-        break;
-    case 13:
-        evolved_state = apply_ops <State_13q> (state, ops, wires, params,
-                                               2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2);
-        break;
-    case 14:
-        evolved_state = apply_ops <State_14q> (state, ops, wires, params,
-                                               2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2);
-        break;
-    case 15:
-        evolved_state = apply_ops <State_15q> (state, ops, wires, params,
-                                               2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2);
-        break;
-    case 16:
-        evolved_state = apply_ops <State_16q> (state, ops, wires, params,
-                                               2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2);
-        break;
+    case 1: return QubitOperations<1>::apply(state, ops, wires, params);
+    case 2: return QubitOperations<2>::apply(state, ops, wires, params);
+    case 3: return QubitOperations<3>::apply(state, ops, wires, params);
+    case 4: return QubitOperations<4>::apply(state, ops, wires, params);
+    case 5: return QubitOperations<5>::apply(state, ops, wires, params);
+    case 6: return QubitOperations<6>::apply(state, ops, wires, params);
+    case 7: return QubitOperations<7>::apply(state, ops, wires, params);
+    case 8: return QubitOperations<8>::apply(state, ops, wires, params);
+    case 9: return QubitOperations<9>::apply(state, ops, wires, params);
+    case 10: return QubitOperations<10>::apply(state, ops, wires, params);
+    case 11: return QubitOperations<11>::apply(state, ops, wires, params);
+    case 12: return QubitOperations<12>::apply(state, ops, wires, params);
+    case 13: return QubitOperations<13>::apply(state, ops, wires, params);
+    case 14: return QubitOperations<14>::apply(state, ops, wires, params);
+    case 15: return QubitOperations<15>::apply(state, ops, wires, params);
+    case 16: return QubitOperations<16>::apply(state, ops, wires, params);
+    default: throw std::invalid_argument("No support for > 16 qubits");
     }
-    return evolved_state;
 }
 
 

--- a/pennylane_lightning/src/lightning_qubit.hpp
+++ b/pennylane_lightning/src/lightning_qubit.hpp
@@ -349,8 +349,9 @@ VectorXcd apply_ops_2q(
 
 /**
 * Main recursive template to generate multi-qubit operations
-* @tparam Dim The number of qubits (i.e. tensor rank)
-* @tparam ValueIdx Index to be decremented recursively until 0 to generate the dimensions of the tensor
+* 
+* @tparam Dim the number of qubits (i.e. tensor rank)
+* @tparam ValueIdx index to be decremented recursively until 0 to generate the dimensions of the tensor
 */
 template<int Dim, int ValueIdx>
 class QubitOperationsGenerator
@@ -370,7 +371,8 @@ public:
 
 /**
 * Terminal specialised template for general multi-qubit operations
-* @tparam Dim The number of qubits (i.e. tensor rank)
+* 
+* @tparam Dim the number of qubits (i.e. tensor rank)
 */
 template<int Dim>
 class QubitOperationsGenerator<Dim, 0>
@@ -390,7 +392,8 @@ public:
 
 /**
 * Terminal specialised template for single qubit operations
-* @tparam ValueIdx Ignored, but required to specialised the main recursive template
+* 
+* @tparam ValueIdx ignored, but required to specialised the main recursive template
 */
 template<int ValueIdx>
 class QubitOperationsGenerator<1, ValueIdx>
@@ -410,7 +413,8 @@ public:
 
 /**
 * Terminal specialised template for two qubit operations
-* @tparam ValueIdx Ignored, but required to specialised the main recursive template
+* 
+* @tparam ValueIdx ignored, but required to specialised the main recursive template
 */
 template<int ValueIdx>
 class QubitOperationsGenerator<2, ValueIdx>
@@ -430,7 +434,8 @@ public:
 
 /**
 * Generic interface that invokes the generator to generate the desired multi-qubit operation
-* @tparam Dim The number of qubits (i.e. tensor rank)
+* 
+* @tparam Dim the number of qubits (i.e. tensor rank)
 */
 template<int Dim>
 class QubitOperations

--- a/pennylane_lightning/src/lightning_qubit.hpp
+++ b/pennylane_lightning/src/lightning_qubit.hpp
@@ -347,79 +347,96 @@ VectorXcd apply_ops_2q(
 
 // Template classes for a generic interface for qubit operations
 
+/**
+* Main recursive template to generate multi-qubit operations
+* @tparam Dim The number of qubits (i.e. tensor rank)
+* @tparam ValueIdx Index to be decremented recursively until 0 to generate the dimensions of the tensor
+*/
 template<int Dim, int ValueIdx>
 class QubitOperationsGenerator
 {
 public:
-    template<typename... Values>
+    template<typename... Shape>
     static inline VectorXcd apply(
         Ref<VectorXcd> state,
         const vector<string>& ops,
         const vector<vector<int>>& wires,
         const vector<vector<float>>& params,
-        Values... values)
+        Shape... shape)
     {
-        return QubitOperationsGenerator<Dim, ValueIdx - 1>::apply(state, ops, wires, params, 2, values...);
+        return QubitOperationsGenerator<Dim, ValueIdx - 1>::apply(state, ops, wires, params, 2, shape...);
     }
 };
 
-// Generic multi-qubit case
+/**
+* Terminal specialised template for general multi-qubit operations
+* @tparam Dim The number of qubits (i.e. tensor rank)
+*/
 template<int Dim>
 class QubitOperationsGenerator<Dim, 0>
 {
 public:
-    template<typename... Values>
+    template<typename... Shape>
     static inline VectorXcd apply(
         Ref<VectorXcd> state,
         const vector<string>& ops,
         const vector<vector<int>>& wires,
         const vector<vector<float>>& params,
-        Values... values)
+        Shape... shape)
     {
-        return apply_ops<State_Xq<Dim>>(state, ops, wires, params, values...);
+        return apply_ops<State_Xq<Dim>>(state, ops, wires, params, shape...);
     }
 };
 
-// Specialisation for single qubit case
+/**
+* Terminal specialised template for single qubit operations
+* @tparam ValueIdx Ignored, but required to specialised the main recursive template
+*/
 template<int ValueIdx>
 class QubitOperationsGenerator<1, ValueIdx>
 {
 public:
-    template<typename... Values>
+    template<typename... Shape>
     static inline VectorXcd apply(
         Ref<VectorXcd> state,
         const vector<string>& ops,
         const vector<vector<int>>& wires,
         const vector<vector<float>>& params,
-        Values... values)
+        Shape... shape)
     {
         return apply_ops_1q(state, ops, params);
     }
 };
 
-// Specialisation for two qubit case
+/**
+* Terminal specialised template for two qubit operations
+* @tparam ValueIdx Ignored, but required to specialised the main recursive template
+*/
 template<int ValueIdx>
 class QubitOperationsGenerator<2, ValueIdx>
 {
 public:
-    template<typename... Values>
+    template<typename... Shape>
     static inline VectorXcd apply(
         Ref<VectorXcd> state,
         const vector<string>& ops,
         const vector<vector<int>>& wires,
         const vector<vector<float>>& params,
-        Values... values)
+        Shape... shape)
     {
         return apply_ops_2q(state, ops, wires, params);
     }
 };
 
-// Generic interface
+/**
+* Generic interface that invokes the generator to generate the desired multi-qubit operation
+* @tparam Dim The number of qubits (i.e. tensor rank)
+*/
 template<int Dim>
 class QubitOperations
 {
 public:
-    template<typename... Values>
+    template<typename... Shape>
     static inline VectorXcd apply(
         Ref<VectorXcd> state,
         const vector<string>& ops,

--- a/pennylane_lightning/src/operations.hpp
+++ b/pennylane_lightning/src/operations.hpp
@@ -23,26 +23,7 @@
 
 #include <iostream>
 #include <cmath>
-#include <Eigen/Dense>
-#include <unsupported/Eigen/CXX11/Tensor>
-
-using Eigen::MatrixXd;
-using Eigen::MatrixXcd;
-using Eigen::VectorXcd;
-using Eigen::Tensor;
-
-using State_1q = Eigen::Tensor<std::complex<double>, 1>;
-using State_2q = Eigen::Tensor<std::complex<double>, 2>;
-using State_3q = Eigen::Tensor<std::complex<double>, 3>;
-
-using Gate_1q = Eigen::Tensor<std::complex<double>, 2>;
-using Gate_2q = Eigen::Tensor<std::complex<double>, 4>;
-using Gate_3q = Eigen::Tensor<std::complex<double>, 6>;
-
-using Pairs = Eigen::IndexPair<int>;
-using Pairs_1q = Eigen::array<Pairs, 1>;
-using Pairs_2q = Eigen::array<Pairs, 2>;
-
+#include "typedefs.hpp"
 
 const double SQRT_2 = sqrt(2);
 const std::complex<double> IMAG(0, 1);
@@ -53,8 +34,8 @@ const std::complex<double> NEGATIVE_IMAG(0, -1);
 *
 * @return the identity tensor
 */
-Gate_1q Identity() {
-    Gate_1q X(2, 2);
+Gate_Xq<1> Identity() {
+    Gate_Xq<1> X(2, 2);
     X.setValues({{1, 0}, {0, 1}});
     return X;
 }
@@ -64,8 +45,8 @@ Gate_1q Identity() {
 *
 * @return the X tensor
 */
-Gate_1q X() {
-    Gate_1q X(2, 2);
+Gate_Xq<1> X() {
+    Gate_Xq<1> X(2, 2);
     X.setValues({{0, 1}, {1, 0}});
     return X;
 }
@@ -75,8 +56,8 @@ Gate_1q X() {
 *
 * @return the Y tensor
 */
-Gate_1q Y() {
-    Gate_1q Y(2, 2);
+Gate_Xq<1> Y() {
+    Gate_Xq<1> Y(2, 2);
     Y.setValues({{0, NEGATIVE_IMAG}, {IMAG, 0}});
     return Y;
 }
@@ -86,8 +67,8 @@ Gate_1q Y() {
 *
 * @return the Z tensor
 */
-Gate_1q Z() {
-    Gate_1q Z(2, 2);
+Gate_Xq<1> Z() {
+    Gate_Xq<1> Z(2, 2);
     Z.setValues({{1, 0}, {0, -1}});
     return Z;
 }
@@ -97,8 +78,8 @@ Gate_1q Z() {
 *
 * @return the H tensor
 */
-Gate_1q H() {
-    Gate_1q H(2, 2);
+Gate_Xq<1> H() {
+    Gate_Xq<1> H(2, 2);
     H.setValues({{1/SQRT_2, 1/SQRT_2}, {1/SQRT_2, -1/SQRT_2}});
     return H;
 }
@@ -108,8 +89,8 @@ Gate_1q H() {
 *
 * @return the S tensor
 */
-Gate_1q S() {
-    Gate_1q S(2, 2);
+Gate_Xq<1> S() {
+    Gate_Xq<1> S(2, 2);
     S.setValues({{1, 0}, {0, IMAG}});
     return S;
 }
@@ -119,8 +100,8 @@ Gate_1q S() {
 *
 * @return the T tensor
 */
-Gate_1q T() {
-    Gate_1q T(2, 2);
+Gate_Xq<1> T() {
+    Gate_Xq<1> T(2, 2);
 
     const std::complex<double> exponent(0, M_PI/4);
     T.setValues({{1, 0}, {0, std::pow(M_E, exponent)}});
@@ -133,8 +114,8 @@ Gate_1q T() {
 * @param parameter the rotation angle
 * @return the RX tensor
 */
-Gate_1q RX(const double& parameter) {
-    Gate_1q RX(2, 2);
+Gate_Xq<1> RX(const double& parameter) {
+    Gate_Xq<1> RX(2, 2);
 
     const std::complex<double> c (std::cos(parameter / 2), 0);
     const std::complex<double> js (0, std::sin(-parameter / 2));
@@ -149,8 +130,8 @@ Gate_1q RX(const double& parameter) {
 * @param parameter the rotation angle
 * @return the RY tensor
 */
-Gate_1q RY(const double& parameter) {
-    Gate_1q RY(2, 2);
+Gate_Xq<1> RY(const double& parameter) {
+    Gate_Xq<1> RY(2, 2);
 
     const double c = std::cos(parameter / 2);
     const double s = std::sin(parameter / 2);
@@ -165,8 +146,8 @@ Gate_1q RY(const double& parameter) {
 * @param parameter the rotation angle
 * @return the RZ tensor
 */
-Gate_1q RZ(const double& parameter) {
-    Gate_1q RZ(2, 2);
+Gate_Xq<1> RZ(const double& parameter) {
+    Gate_Xq<1> RZ(2, 2);
 
     const std::complex<double> exponent(0, -parameter/2);
     const std::complex<double> exponent_second(0, parameter/2);
@@ -183,8 +164,8 @@ Gate_1q RZ(const double& parameter) {
 * @param parameter the phase shift
 * @return the phase-shift tensor
 */
-Gate_1q PhaseShift(const double& parameter) {
-    Gate_1q PhaseShift(2, 2);
+Gate_Xq<1> PhaseShift(const double& parameter) {
+    Gate_Xq<1> PhaseShift(2, 2);
 
     const std::complex<double> exponent(0, parameter);
     const std::complex<double> shift = std::pow(M_E, exponent);
@@ -204,8 +185,8 @@ Gate_1q PhaseShift(const double& parameter) {
 * @param omega the third rotation angle
 * @return the rotation tensor
 */
-Gate_1q Rot(const double& phi, const double& theta, const double& omega) {
-    Gate_1q Rot(2, 2);
+Gate_Xq<1> Rot(const double& phi, const double& theta, const double& omega) {
+    Gate_Xq<1> Rot(2, 2);
 
     const std::complex<double> e00(0, (-phi - omega)/2);
     const std::complex<double> e10(0, (-phi + omega)/2);
@@ -230,8 +211,8 @@ Gate_1q Rot(const double& phi, const double& theta, const double& omega) {
 *
 * @return the CNOT tensor
 */
-Gate_2q CNOT() {
-    Gate_2q CNOT(2,2,2,2);
+Gate_Xq<2> CNOT() {
+    Gate_Xq<2> CNOT(2,2,2,2);
     CNOT.setValues({{{{1, 0},{0, 0}},{{0, 1},{0, 0}}},{{{0, 0},{0, 1}},{{0, 0},{1, 0}}}});
     return CNOT;
 }
@@ -241,8 +222,8 @@ Gate_2q CNOT() {
 *
 * @return the SWAP tensor
 */
-Gate_2q SWAP() {
-    Gate_2q SWAP(2,2,2,2);
+Gate_Xq<2> SWAP() {
+    Gate_Xq<2> SWAP(2,2,2,2);
     SWAP.setValues({{{{1, 0},{0, 0}},{{0, 0},{1, 0}}},{{{0, 1},{0, 0}},{{0, 0},{0, 1}}}});
     return SWAP;
 }
@@ -252,8 +233,8 @@ Gate_2q SWAP() {
 *
 * @return the CZ tensor
 */
-Gate_2q CZ() {
-    Gate_2q CZ(2,2,2,2);
+Gate_Xq<2> CZ() {
+    Gate_Xq<2> CZ(2,2,2,2);
     CZ.setValues({{{{1, 0},{0, 0}},{{0, 1},{0, 0}}},{{{0, 0},{1, 0}},{{0, 0},{0, -1}}}});
     return CZ;
 }
@@ -263,8 +244,8 @@ Gate_2q CZ() {
 *
 * @return the Toffoli tensor
 */
-Gate_3q Toffoli() {
-    Gate_3q Toffoli(2,2,2,2,2,2);
+Gate_Xq<3> Toffoli() {
+    Gate_Xq<3> Toffoli(2,2,2,2,2,2);
     Toffoli.setValues({{{{{{1, 0},{0, 0}},{{0, 0},{0, 0}}},{{{0, 1},{0, 0}},{{0, 0},{0, 0}}}},
             {{{{0, 0},{1, 0}},{{0, 0},{0, 0}}},{{{0, 0},{0, 1}},{{0, 0},{0, 0}}}}
         },
@@ -279,8 +260,8 @@ Gate_3q Toffoli() {
 *
 * @return the CSWAP tensor
 */
-Gate_3q CSWAP() {
-    Gate_3q CSWAP(2,2,2,2,2,2);
+Gate_Xq<3> CSWAP() {
+    Gate_Xq<3> CSWAP(2,2,2,2,2,2);
     CSWAP.setValues({{{{{{1, 0},{0, 0}},{{0, 0},{0, 0}}},{{{0, 1},{0, 0}},{{0, 0},{0, 0}}}},
             {{{{0, 0},{1, 0}},{{0, 0},{0, 0}}},{{{0, 0},{0, 1}},{{0, 0},{0, 0}}}}
         },
@@ -296,8 +277,8 @@ Gate_3q CSWAP() {
 * @param parameter the rotation angle
 * @return the CRX tensor
 */
-Gate_2q CRX(const double& parameter) {
-    Gate_2q CRX(2, 2, 2, 2);
+Gate_Xq<2> CRX(const double& parameter) {
+    Gate_Xq<2> CRX(2, 2, 2, 2);
 
     const std::complex<double> c (std::cos(parameter / 2), 0);
     const std::complex<double> js (0, std::sin(-parameter / 2));
@@ -312,8 +293,8 @@ Gate_2q CRX(const double& parameter) {
 * @param parameter the rotation angle
 * @return the CRY tensor
 */
-Gate_2q CRY(const double& parameter) {
-    Gate_2q CRY(2, 2, 2, 2);
+Gate_Xq<2> CRY(const double& parameter) {
+    Gate_Xq<2> CRY(2, 2, 2, 2);
 
     const double c = std::cos(parameter / 2);
     const double s = std::sin(parameter / 2);
@@ -328,8 +309,8 @@ Gate_2q CRY(const double& parameter) {
 * @param parameter the rotation angle
 * @return the CRZ tensor
 */
-Gate_2q CRZ(const double& parameter) {
-    Gate_2q CRZ(2, 2, 2, 2);
+Gate_Xq<2> CRZ(const double& parameter) {
+    Gate_Xq<2> CRZ(2, 2, 2, 2);
 
     const std::complex<double> exponent(0, -parameter/2);
     const std::complex<double> exponent_second(0, parameter/2);
@@ -352,8 +333,8 @@ Gate_2q CRZ(const double& parameter) {
 * @param omega the third rotation angle
 * @return the controlled rotation tensor
 */
-Gate_2q CRot(const double& phi, const double& theta, const double& omega) {
-    Gate_2q CRot(2,2,2,2);
+Gate_Xq<2> CRot(const double& phi, const double& theta, const double& omega) {
+    Gate_Xq<2> CRot(2,2,2,2);
 
     const std::complex<double> e00(0, (-phi - omega)/2);
     const std::complex<double> e10(0, (-phi + omega)/2);
@@ -374,20 +355,8 @@ Gate_2q CRot(const double& phi, const double& theta, const double& omega) {
     return CRot;
 }
 
-
-// Creating aliases based on the function signatures of each operation
-typedef Gate_1q (*pfunc_1q)();
-typedef Gate_1q (*pfunc_1q_one_param)(const double&);
-typedef Gate_1q (*pfunc_1q_three_params)(const double&, const double&, const double&);
-
-typedef Gate_2q (*pfunc_2q)();
-typedef Gate_2q (*pfunc_2q_one_param)(const double&);
-typedef Gate_2q (*pfunc_2q_three_params)(const double&, const double&, const double&);
-
-typedef Gate_3q (*pfunc_3q)();
-
 // Defining the operation maps
-const std::map<std::string, pfunc_1q> OneQubitOps = {
+const std::map<std::string, pfunc_Xq<1>> OneQubitOps = {
     {"Identity", Identity},
     {"PauliX", X},
     {"PauliY", Y},
@@ -397,35 +366,35 @@ const std::map<std::string, pfunc_1q> OneQubitOps = {
     {"T", T}
 };
 
-const std::map<std::string, pfunc_1q_one_param> OneQubitOpsOneParam = {
+const std::map<std::string, pfunc_Xq_one_param<1>> OneQubitOpsOneParam = {
     {"RX", RX},
     {"RY", RY},
     {"RZ", RZ},
     {"PhaseShift", PhaseShift}
 };
 
-const std::map<std::string, pfunc_1q_three_params> OneQubitOpsThreeParams = {
+const std::map<std::string, pfunc_Xq_three_params<1>> OneQubitOpsThreeParams = {
     {"Rot", Rot}
 };
 
 
-const std::map<std::string, pfunc_2q> TwoQubitOps = {
+const std::map<std::string, pfunc_Xq<2>> TwoQubitOps = {
     {"CNOT", CNOT},
     {"SWAP", SWAP},
     {"CZ", CZ}
 };
 
-const std::map<std::string, pfunc_2q_one_param> TwoQubitOpsOneParam = {
+const std::map<std::string, pfunc_Xq_one_param<2>> TwoQubitOpsOneParam = {
     {"CRX", CRX},
     {"CRY", CRY},
     {"CRZ", CRZ}
 };
 
-const std::map<std::string, pfunc_2q_three_params> TwoQubitOpsThreeParams = {
+const std::map<std::string, pfunc_Xq_three_params<2>> TwoQubitOpsThreeParams = {
     {"CRot", CRot}
 };
 
-const std::map<std::string, pfunc_3q> ThreeQubitOps = {
+const std::map<std::string, pfunc_Xq<3>> ThreeQubitOps = {
     {"Toffoli", Toffoli},
     {"CSWAP", CSWAP}
 };

--- a/pennylane_lightning/src/tests/lightning_unittest.cpp
+++ b/pennylane_lightning/src/tests/lightning_unittest.cpp
@@ -29,14 +29,14 @@ namespace one_qubit_ops {
 
 
 TEST(PauliX, ApplyToZero) {
-    State_1q input_state(2);
+    State_Xq<1> input_state(2);
     input_state.setValues({1, 0});
 
     auto operation = X();
-    Pairs_1q product_dims = { Pairs(1, 0) };
-    State_1q output_state = operation.contract(input_state, product_dims);
+    Pairs_Xq<1> product_dims = { Pairs(1, 0) };
+    State_Xq<1> output_state = operation.contract(input_state, product_dims);
 
-    State_1q expected_output_state(2);
+    State_Xq<1> expected_output_state(2);
     expected_output_state.setValues({0, 1});
 
     // Casting to a vector for comparison
@@ -47,14 +47,14 @@ TEST(PauliX, ApplyToZero) {
 }
 
 TEST(PauliX, ApplyToPlus) {
-    State_1q input_state(2);
+    State_Xq<1> input_state(2);
     input_state.setValues({1/SQRT_2, 1/SQRT_2});
 
     auto operation = X();
-    Pairs_1q product_dims = { Pairs(1, 0) };
-    State_1q output_state = operation.contract(input_state, product_dims);
+    Pairs_Xq<1> product_dims = { Pairs(1, 0) };
+    State_Xq<1> output_state = operation.contract(input_state, product_dims);
 
-    State_1q expected_output_state(2);
+    State_Xq<1> expected_output_state(2);
     expected_output_state.setValues({1/SQRT_2, 1/SQRT_2});
 
     // Casting to a vector for comparison
@@ -65,14 +65,14 @@ TEST(PauliX, ApplyToPlus) {
 }
 
 TEST(PauliY, ApplyToZero) {
-    State_1q input_state(2);
+    State_Xq<1> input_state(2);
     input_state.setValues({1, 0});
 
     auto operation = Y();
-    Pairs_1q product_dims = { Pairs(1, 0) };
-    State_1q output_state = operation.contract(input_state, product_dims);
+    Pairs_Xq<1> product_dims = { Pairs(1, 0) };
+    State_Xq<1> output_state = operation.contract(input_state, product_dims);
 
-    State_1q expected_output_state(2);
+    State_Xq<1> expected_output_state(2);
     std::complex<double> Val(0, 1);
     expected_output_state.setValues({0, Val});
 
@@ -84,14 +84,14 @@ TEST(PauliY, ApplyToZero) {
 }
 
 TEST(PauliY, ApplyToPlus) {
-    State_1q input_state(2);
+    State_Xq<1> input_state(2);
     input_state.setValues({1/SQRT_2, 1/SQRT_2});
 
     auto operation = Y();
-    Pairs_1q product_dims = { Pairs(1, 0) };
-    State_1q output_state = operation.contract(input_state, product_dims);
+    Pairs_Xq<1> product_dims = { Pairs(1, 0) };
+    State_Xq<1> output_state = operation.contract(input_state, product_dims);
 
-    State_1q expected_output_state(2);
+    State_Xq<1> expected_output_state(2);
 
     std::complex<double> first(0, -1/SQRT_2);
     std::complex<double> second(0, 1/SQRT_2);
@@ -105,14 +105,14 @@ TEST(PauliY, ApplyToPlus) {
 }
 
 TEST(PauliZ, ApplyToZero) {
-    State_1q input_state(2);
+    State_Xq<1> input_state(2);
     input_state.setValues({1, 0});
 
     auto operation = Z();
-    Pairs_1q product_dims = { Pairs(1, 0) };
-    State_1q output_state = operation.contract(input_state, product_dims);
+    Pairs_Xq<1> product_dims = { Pairs(1, 0) };
+    State_Xq<1> output_state = operation.contract(input_state, product_dims);
 
-    State_1q expected_output_state(2);
+    State_Xq<1> expected_output_state(2);
     expected_output_state.setValues({1, 0});
 
     // Casting to a vector for comparison
@@ -123,14 +123,14 @@ TEST(PauliZ, ApplyToZero) {
 }
 
 TEST(PauliZ, ApplyToPlus) {
-    State_1q input_state(2);
+    State_Xq<1> input_state(2);
     input_state.setValues({1/SQRT_2, 1/SQRT_2});
 
     auto operation = Z();
-    Pairs_1q product_dims = { Pairs(1, 0) };
-    State_1q output_state = operation.contract(input_state, product_dims);
+    Pairs_Xq<1> product_dims = { Pairs(1, 0) };
+    State_Xq<1> output_state = operation.contract(input_state, product_dims);
 
-    State_1q expected_output_state(2);
+    State_Xq<1> expected_output_state(2);
     expected_output_state.setValues({1/SQRT_2, -1/SQRT_2});
 
     // Casting to a vector for comparison
@@ -141,14 +141,14 @@ TEST(PauliZ, ApplyToPlus) {
 }
 
 TEST(Hadamard, ApplyToZero) {
-    State_1q input_state(2);
+    State_Xq<1> input_state(2);
     input_state.setValues({1, 0});
 
     auto operation = H();
-    Pairs_1q product_dims = { Pairs(1, 0) };
-    State_1q output_state = operation.contract(input_state, product_dims);
+    Pairs_Xq<1> product_dims = { Pairs(1, 0) };
+    State_Xq<1> output_state = operation.contract(input_state, product_dims);
 
-    State_1q expected_output_state(2);
+    State_Xq<1> expected_output_state(2);
     expected_output_state.setValues({1/SQRT_2, 1/SQRT_2});
 
     // Casting to a vector for comparison
@@ -159,14 +159,14 @@ TEST(Hadamard, ApplyToZero) {
 }
 
 TEST(Hadamard, ApplyToMinus) {
-    State_1q input_state(2);
+    State_Xq<1> input_state(2);
     input_state.setValues({1/SQRT_2, -1/SQRT_2});
 
     auto operation = H();
-    Pairs_1q product_dims = { Pairs(1, 0) };
-    State_1q output_state = operation.contract(input_state, product_dims);
+    Pairs_Xq<1> product_dims = { Pairs(1, 0) };
+    State_Xq<1> output_state = operation.contract(input_state, product_dims);
 
-    State_1q expected_output_state(2);
+    State_Xq<1> expected_output_state(2);
     expected_output_state.setValues({0, 1});
 
     // Casting to a vector for comparison
@@ -177,14 +177,14 @@ TEST(Hadamard, ApplyToMinus) {
 }
 
 TEST(SGate, ApplyToZero) {
-    State_1q input_state(2);
+    State_Xq<1> input_state(2);
     input_state.setValues({1, 0});
 
     auto operation = S();
-    Pairs_1q product_dims = { Pairs(1, 0) };
-    State_1q output_state = operation.contract(input_state, product_dims);
+    Pairs_Xq<1> product_dims = { Pairs(1, 0) };
+    State_Xq<1> output_state = operation.contract(input_state, product_dims);
 
-    State_1q expected_output_state(2);
+    State_Xq<1> expected_output_state(2);
     expected_output_state.setValues({1, 0});
 
     // Casting to a vector for comparison
@@ -195,14 +195,14 @@ TEST(SGate, ApplyToZero) {
 }
 
 TEST(SGate, ApplyToPlus) {
-    State_1q input_state(2);
+    State_Xq<1> input_state(2);
     input_state.setValues({1/SQRT_2, 1/SQRT_2});
 
     auto operation = S();
-    Pairs_1q product_dims = { Pairs(1, 0) };
-    State_1q output_state = operation.contract(input_state, product_dims);
+    Pairs_Xq<1> product_dims = { Pairs(1, 0) };
+    State_Xq<1> output_state = operation.contract(input_state, product_dims);
 
-    State_1q expected_output_state(2);
+    State_Xq<1> expected_output_state(2);
     std::complex<double> imag_val(0, 1/SQRT_2);
     expected_output_state.setValues({1/SQRT_2, imag_val});
 
@@ -214,14 +214,14 @@ TEST(SGate, ApplyToPlus) {
 }
 
 TEST(TGate, ApplyToZero) {
-    State_1q input_state(2);
+    State_Xq<1> input_state(2);
     input_state.setValues({1, 0});
 
     auto operation = T();
-    Pairs_1q product_dims = { Pairs(1, 0) };
-    State_1q output_state = operation.contract(input_state, product_dims);
+    Pairs_Xq<1> product_dims = { Pairs(1, 0) };
+    State_Xq<1> output_state = operation.contract(input_state, product_dims);
 
-    State_1q expected_output_state(2);
+    State_Xq<1> expected_output_state(2);
     expected_output_state.setValues({1, 0});
 
     // Casting to a vector for comparison
@@ -232,14 +232,14 @@ TEST(TGate, ApplyToZero) {
 }
 
 TEST(TGate, ApplyToPlus) {
-    State_1q input_state(2);
+    State_Xq<1> input_state(2);
     input_state.setValues({1/SQRT_2, 1/SQRT_2});
 
     auto operation = T();
-    Pairs_1q product_dims = { Pairs(1, 0) };
-    State_1q output_state = operation.contract(input_state, product_dims);
+    Pairs_Xq<1> product_dims = { Pairs(1, 0) };
+    State_Xq<1> output_state = operation.contract(input_state, product_dims);
 
-    State_1q expected_output_state(2);
+    State_Xq<1> expected_output_state(2);
 
     const std::complex<double> exponent(0, M_PI/4);
     std::complex<double> val = std::pow(M_E, exponent)/SQRT_2;
@@ -253,16 +253,16 @@ TEST(TGate, ApplyToPlus) {
 }
 
 TEST(RXGate, ApplyToZeroPiHalf) {
-    State_1q input_state(2);
+    State_Xq<1> input_state(2);
     input_state.setValues({1, 0});
 
     double par = M_PI/2;
 
     auto operation = RX(par);
-    Pairs_1q product_dims = { Pairs(1, 0) };
-    State_1q output_state = operation.contract(input_state, product_dims);
+    Pairs_Xq<1> product_dims = { Pairs(1, 0) };
+    State_Xq<1> output_state = operation.contract(input_state, product_dims);
 
-    State_1q expected_output_state(2);
+    State_Xq<1> expected_output_state(2);
 
     const std::complex<double> first(1/SQRT_2, 0);
     const std::complex<double> second(0, -1/SQRT_2);
@@ -276,16 +276,16 @@ TEST(RXGate, ApplyToZeroPiHalf) {
 }
 
 TEST(RXGate, ApplyToZeroPi) {
-    State_1q input_state(2);
+    State_Xq<1> input_state(2);
     input_state.setValues({1, 0});
 
     double par = M_PI;
 
     auto operation = RX(par);
-    Pairs_1q product_dims = { Pairs(1, 0) };
-    State_1q output_state = operation.contract(input_state, product_dims);
+    Pairs_Xq<1> product_dims = { Pairs(1, 0) };
+    State_Xq<1> output_state = operation.contract(input_state, product_dims);
 
-    State_1q expected_output_state(2);
+    State_Xq<1> expected_output_state(2);
 
     const std::complex<double> second(0, -1);
     expected_output_state.setValues({0, second});
@@ -299,16 +299,16 @@ TEST(RXGate, ApplyToZeroPi) {
 
 
 TEST(RXGate, ApplyToPlusPiHalf) {
-    State_1q input_state(2);
+    State_Xq<1> input_state(2);
     input_state.setValues({1/SQRT_2, 1/SQRT_2});
 
     double par = M_PI/2;
 
     auto operation = RX(par);
-    Pairs_1q product_dims = { Pairs(1, 0) };
-    State_1q output_state = operation.contract(input_state, product_dims);
+    Pairs_Xq<1> product_dims = { Pairs(1, 0) };
+    State_Xq<1> output_state = operation.contract(input_state, product_dims);
 
-    State_1q expected_output_state(2);
+    State_Xq<1> expected_output_state(2);
 
     const std::complex<double> val(0.5, -0.5);
     expected_output_state.setValues({val, val});
@@ -322,16 +322,16 @@ TEST(RXGate, ApplyToPlusPiHalf) {
 
 
 TEST(RYGate, ApplyToZeroPiHalf) {
-    State_1q input_state(2);
+    State_Xq<1> input_state(2);
     input_state.setValues({1, 0});
 
     double par = M_PI/2;
 
     auto operation = RY(par);
-    Pairs_1q product_dims = { Pairs(1, 0) };
-    State_1q output_state = operation.contract(input_state, product_dims);
+    Pairs_Xq<1> product_dims = { Pairs(1, 0) };
+    State_Xq<1> output_state = operation.contract(input_state, product_dims);
 
-    State_1q expected_output_state(2);
+    State_Xq<1> expected_output_state(2);
 
     expected_output_state.setValues({1/SQRT_2, 1/SQRT_2});
 
@@ -343,16 +343,16 @@ TEST(RYGate, ApplyToZeroPiHalf) {
 }
 
 TEST(RYGate, ApplyToZeroPi) {
-    State_1q input_state(2);
+    State_Xq<1> input_state(2);
     input_state.setValues({1, 0});
 
     double par = M_PI;
 
     auto operation = RY(par);
-    Pairs_1q product_dims = { Pairs(1, 0) };
-    State_1q output_state = operation.contract(input_state, product_dims);
+    Pairs_Xq<1> product_dims = { Pairs(1, 0) };
+    State_Xq<1> output_state = operation.contract(input_state, product_dims);
 
-    State_1q expected_output_state(2);
+    State_Xq<1> expected_output_state(2);
     expected_output_state.setValues({0, 1});
 
     // Casting to a vector for comparison
@@ -364,16 +364,16 @@ TEST(RYGate, ApplyToZeroPi) {
 
 
 TEST(RYGate, ApplyToPlusPiHalf) {
-    State_1q input_state(2);
+    State_Xq<1> input_state(2);
     input_state.setValues({1/SQRT_2, 1/SQRT_2});
 
     double par = M_PI/2;
 
     auto operation = RY(par);
-    Pairs_1q product_dims = { Pairs(1, 0) };
-    State_1q output_state = operation.contract(input_state, product_dims);
+    Pairs_Xq<1> product_dims = { Pairs(1, 0) };
+    State_Xq<1> output_state = operation.contract(input_state, product_dims);
 
-    State_1q expected_output_state(2);
+    State_Xq<1> expected_output_state(2);
     expected_output_state.setValues({0, 1});
 
     // Casting to a vector for comparison
@@ -385,16 +385,16 @@ TEST(RYGate, ApplyToPlusPiHalf) {
 
 
 TEST(RZGate, ApplyToZeroPiHalf) {
-    State_1q input_state(2);
+    State_Xq<1> input_state(2);
     input_state.setValues({1, 0});
 
     double par = M_PI/2;
 
     auto operation = RZ(par);
-    Pairs_1q product_dims = { Pairs(1, 0) };
-    State_1q output_state = operation.contract(input_state, product_dims);
+    Pairs_Xq<1> product_dims = { Pairs(1, 0) };
+    State_Xq<1> output_state = operation.contract(input_state, product_dims);
 
-    State_1q expected_output_state(2);
+    State_Xq<1> expected_output_state(2);
 
     std::complex<double> val(1/SQRT_2, -1/SQRT_2);
     expected_output_state.setValues({val, 0});
@@ -407,16 +407,16 @@ TEST(RZGate, ApplyToZeroPiHalf) {
 }
 
 TEST(RZGate, ApplyToOnePi) {
-    State_1q input_state(2);
+    State_Xq<1> input_state(2);
     input_state.setValues({0, 1});
 
     double par = M_PI;
 
     auto operation = RZ(par);
-    Pairs_1q product_dims = { Pairs(1, 0) };
-    State_1q output_state = operation.contract(input_state, product_dims);
+    Pairs_Xq<1> product_dims = { Pairs(1, 0) };
+    State_Xq<1> output_state = operation.contract(input_state, product_dims);
 
-    State_1q expected_output_state(2);
+    State_Xq<1> expected_output_state(2);
 
     const std::complex<double> val(0, 1);
     expected_output_state.setValues({0, val});
@@ -430,16 +430,16 @@ TEST(RZGate, ApplyToOnePi) {
 
 
 TEST(RZGate, ApplyToPlusHalfPi) {
-    State_1q input_state(2);
+    State_Xq<1> input_state(2);
     input_state.setValues({1/SQRT_2, 1/SQRT_2});
 
     double par = M_PI/2;
 
     auto operation = RZ(par);
-    Pairs_1q product_dims = { Pairs(1, 0) };
-    State_1q output_state = operation.contract(input_state, product_dims);
+    Pairs_Xq<1> product_dims = { Pairs(1, 0) };
+    State_Xq<1> output_state = operation.contract(input_state, product_dims);
 
-    State_1q expected_output_state(2);
+    State_Xq<1> expected_output_state(2);
     const std::complex<double> first(0.5, -0.5);
     const std::complex<double> second(0.5, 0.5);
     expected_output_state.setValues({first, second});
@@ -453,16 +453,16 @@ TEST(RZGate, ApplyToPlusHalfPi) {
 
 
 TEST(RotGate, ApplyToZeroPiHalfZeroZero) {
-    State_1q input_state(2);
+    State_Xq<1> input_state(2);
     input_state.setValues({1, 0});
 
     const double par = M_PI/2;
 
     auto operation = Rot(par, 0, 0);
-    Pairs_1q product_dims = { Pairs(1, 0) };
-    State_1q output_state = operation.contract(input_state, product_dims);
+    Pairs_Xq<1> product_dims = { Pairs(1, 0) };
+    State_Xq<1> output_state = operation.contract(input_state, product_dims);
 
-    State_1q expected_output_state(2);
+    State_Xq<1> expected_output_state(2);
 
     std::complex<double> val(1/SQRT_2, -1/SQRT_2);
     expected_output_state.setValues({val, 0});
@@ -476,16 +476,16 @@ TEST(RotGate, ApplyToZeroPiHalfZeroZero) {
 
 
 TEST(RotGate, ApplyToZeroZeroPiHalfZero) {
-    State_1q input_state(2);
+    State_Xq<1> input_state(2);
     input_state.setValues({1, 0});
 
     const double par = M_PI/2;
 
     auto operation = Rot(0, par, 0);
-    Pairs_1q product_dims = { Pairs(1, 0) };
-    State_1q output_state = operation.contract(input_state, product_dims);
+    Pairs_Xq<1> product_dims = { Pairs(1, 0) };
+    State_Xq<1> output_state = operation.contract(input_state, product_dims);
 
-    State_1q expected_output_state(2);
+    State_Xq<1> expected_output_state(2);
 
     expected_output_state.setValues({1/SQRT_2, 1/SQRT_2});
 
@@ -498,16 +498,16 @@ TEST(RotGate, ApplyToZeroZeroPiHalfZero) {
 
 
 TEST(RotGate, ApplyToPlusZeroZeroPiHalf) {
-    State_1q input_state(2);
+    State_Xq<1> input_state(2);
     input_state.setValues({1/SQRT_2, 1/SQRT_2});
 
     const double par = M_PI/2;
 
     auto operation = Rot(0, 0, par);
-    Pairs_1q product_dims = { Pairs(1, 0) };
-    State_1q output_state = operation.contract(input_state, product_dims);
+    Pairs_Xq<1> product_dims = { Pairs(1, 0) };
+    State_Xq<1> output_state = operation.contract(input_state, product_dims);
 
-    State_1q expected_output_state(2);
+    State_Xq<1> expected_output_state(2);
 
     std::complex<double> val1(0.5, -0.5);
     std::complex<double> val2(0.5, 0.5);
@@ -521,7 +521,7 @@ TEST(RotGate, ApplyToPlusZeroZeroPiHalf) {
 }
 
 TEST(RotGate, ApplyToZeroPiHalfNegPiHalfPiHalf) {
-    State_1q input_state(2);
+    State_Xq<1> input_state(2);
     input_state.setValues({1, 0});
 
     const double par1 = M_PI/2;
@@ -529,10 +529,10 @@ TEST(RotGate, ApplyToZeroPiHalfNegPiHalfPiHalf) {
     const double par3 = M_PI/2;
 
     auto operation = Rot(par1, par2, par3);
-    Pairs_1q product_dims = { Pairs(1, 0) };
-    State_1q output_state = operation.contract(input_state, product_dims);
+    Pairs_Xq<1> product_dims = { Pairs(1, 0) };
+    State_Xq<1> output_state = operation.contract(input_state, product_dims);
 
-    State_1q expected_output_state(2);
+    State_Xq<1> expected_output_state(2);
 
     std::complex<double> val(0, -1/SQRT_2);
     expected_output_state.setValues({val, -1/SQRT_2});
@@ -546,7 +546,7 @@ TEST(RotGate, ApplyToZeroPiHalfNegPiHalfPiHalf) {
 
 
 TEST(RotGate, ApplyToPlusNegPiHalfPiPi) {
-    State_1q input_state(2);
+    State_Xq<1> input_state(2);
     input_state.setValues({1/SQRT_2, 1/SQRT_2});
 
     const double par1 = -M_PI/2;
@@ -554,10 +554,10 @@ TEST(RotGate, ApplyToPlusNegPiHalfPiPi) {
     const double par3 = M_PI;
 
     auto operation = Rot(par1, par2, par3);
-    Pairs_1q product_dims = { Pairs(1, 0) };
-    State_1q output_state = operation.contract(input_state, product_dims);
+    Pairs_Xq<1> product_dims = { Pairs(1, 0) };
+    State_Xq<1> output_state = operation.contract(input_state, product_dims);
 
-    State_1q expected_output_state(2);
+    State_Xq<1> expected_output_state(2);
 
     std::complex<double> val1(0.5, 0.5);
     std::complex<double> val2(-0.5, 0.5);
@@ -571,15 +571,15 @@ TEST(RotGate, ApplyToPlusNegPiHalfPiPi) {
 }
 
 TEST(PhaseShift, ApplyToZeroAndOne) {
-    State_1q input_state_0(2);
-    State_1q input_state_1(2);
+    State_Xq<1> input_state_0(2);
+    State_Xq<1> input_state_1(2);
     input_state_0.setValues({1, 0});
     input_state_1.setValues({0, 1});
 
 
     std::complex<double> const1(0.99500417, 0.09983342);
-    State_1q expected_state_0(2);
-    State_1q expected_state_1(2);
+    State_Xq<1> expected_state_0(2);
+    State_Xq<1> expected_state_1(2);
     expected_state_0.setValues({1, 0});
     expected_state_1.setValues({0, const1});
 
@@ -604,14 +604,14 @@ namespace two_qubit_ops {
 
 
 TEST(CNOT, ApplyToZero) {
-    State_2q input_state(2, 2);
+    State_Xq<2> input_state(2, 2);
     input_state.setValues({{1, 0}, {0, 0}});
 
     auto operation = CNOT();
-    Pairs_2q product_dims = { Pairs(2, 0), Pairs(3, 1) };
-    State_2q output_state = operation.contract(input_state, product_dims);
+    Pairs_Xq<2> product_dims = { Pairs(2, 0), Pairs(3, 1) };
+    State_Xq<2> output_state = operation.contract(input_state, product_dims);
 
-    State_2q expected_output_state(2, 2);
+    State_Xq<2> expected_output_state(2, 2);
     expected_output_state.setValues({{1, 0}, {0, 0}});
 
     // Casting to a vector for comparison
@@ -622,14 +622,14 @@ TEST(CNOT, ApplyToZero) {
 }
 
 TEST(CNOT, ApplyToOneZero) {
-    State_2q input_state(2, 2);
+    State_Xq<2> input_state(2, 2);
     input_state.setValues({{0, 0}, {1, 0}});
 
     auto operation = CNOT();
-    Pairs_2q product_dims = { Pairs(2, 0), Pairs(3, 1) };
-    State_2q output_state = operation.contract(input_state, product_dims);
+    Pairs_Xq<2> product_dims = { Pairs(2, 0), Pairs(3, 1) };
+    State_Xq<2> output_state = operation.contract(input_state, product_dims);
 
-    State_2q expected_output_state(2, 2);
+    State_Xq<2> expected_output_state(2, 2);
     expected_output_state.setValues({{0, 0}, {0, 1}});
 
     // Casting to a vector for comparison
@@ -640,14 +640,14 @@ TEST(CNOT, ApplyToOneZero) {
 }
 
 TEST(CNOT, ApplyToBellState) {
-    State_2q input_state(2, 2);
+    State_Xq<2> input_state(2, 2);
     input_state.setValues({{1/SQRT_2, 0}, {0, 1/SQRT_2}});
 
     auto operation = CNOT();
-    Pairs_2q product_dims = { Pairs(2, 0), Pairs(3, 1) };
-    State_2q output_state = operation.contract(input_state, product_dims);
+    Pairs_Xq<2> product_dims = { Pairs(2, 0), Pairs(3, 1) };
+    State_Xq<2> output_state = operation.contract(input_state, product_dims);
 
-    State_2q expected_output_state(2, 2);
+    State_Xq<2> expected_output_state(2, 2);
     expected_output_state.setValues({{1/SQRT_2, 0}, {1/SQRT_2, 0}});
 
     // Casting to a vector for comparison
@@ -658,14 +658,14 @@ TEST(CNOT, ApplyToBellState) {
 }
 
 TEST(CNOT, ApplyToThreeQubitControlThird) {
-    State_3q input_state(2, 2, 2);
+    State_Xq<3> input_state(2, 2, 2);
     input_state.setValues({{{0, 0}, {0, 0}}, {{0, 0}, {0, 1}}});
 
     auto operation = CNOT();
-    Pairs_2q product_dims = { Pairs(3, 2), Pairs(2, 1) };
-    State_3q output_state = operation.contract(input_state, product_dims);
+    Pairs_Xq<2> product_dims = { Pairs(3, 2), Pairs(2, 1) };
+    State_Xq<3> output_state = operation.contract(input_state, product_dims);
 
-    State_3q expected_output_state(2, 2, 2);
+    State_Xq<3> expected_output_state(2, 2, 2);
 
     // The output dimensions are ordered according to the output of the tensor
     // contraction (no shuffling takes place)
@@ -705,10 +705,10 @@ TEST(CZ, ToMatrix) {
 }
 
 TEST(CRots, ApplyTo00) {
-    State_2q input_state(2, 2);
+    State_Xq<2> input_state(2, 2);
     input_state.setValues({{1, 0}, {0, 0}});
 
-    State_2q expected_output_state(2, 2);
+    State_Xq<2> expected_output_state(2, 2);
     expected_output_state.setValues({{1, 0}, {0, 0}});
 
     vector<int> w{0, 1};
@@ -735,10 +735,10 @@ TEST(CRots, ApplyTo00) {
 }
 
 TEST(CRots, ApplyTo01) {
-    State_2q input_state(2, 2);
+    State_Xq<2> input_state(2, 2);
     input_state.setValues({{0, 1}, {0, 0}});
 
-    State_2q expected_output_state(2, 2);
+    State_Xq<2> expected_output_state(2, 2);
     expected_output_state.setValues({{0, 1}, {0, 0}});
 
     vector<int> w{0, 1};
@@ -765,7 +765,7 @@ TEST(CRots, ApplyTo01) {
 }
 
 TEST(CRots, ApplyTo10) {
-    State_2q input_state(2, 2);
+    State_Xq<2> input_state(2, 2);
     input_state.setValues({{0, 0}, {1, 0}});
 
     float phi(0.1);
@@ -776,13 +776,13 @@ TEST(CRots, ApplyTo10) {
     complex<double> sin_imag(0, sin);
     complex<double> sin_real(sin, 0);
 
-    State_2q expected_output_state_X(2, 2);
+    State_Xq<2> expected_output_state_X(2, 2);
     expected_output_state_X.setValues({{0, 0}, {cos_real, -sin_imag}});
 
-    State_2q expected_output_state_Y(2, 2);
+    State_Xq<2> expected_output_state_Y(2, 2);
     expected_output_state_Y.setValues({{0, 0}, {cos_real, sin_real}});
 
-    State_2q expected_output_state_Z(2, 2);
+    State_Xq<2> expected_output_state_Z(2, 2);
     expected_output_state_Z.setValues({{0, 0}, {cos_real-sin_imag, 0}});
 
     vector<float> p2{0.4, 0.1, 0.3};
@@ -791,7 +791,7 @@ TEST(CRots, ApplyTo10) {
     auto exp_plus = std::pow(M_E, imag_phi_plus_omega);
     auto exp_minus = std::pow(M_E, imag_phi_minus_omega);
 
-    State_2q expected_output_state_Rot(2, 2);
+    State_Xq<2> expected_output_state_Rot(2, 2);
     expected_output_state_Rot.setValues({{0, 0}, {cos_real * exp_plus, sin_real * exp_minus}});
 
     vector<int> w{0, 1};
@@ -821,7 +821,7 @@ TEST(CRots, ApplyTo10) {
 }
 
 TEST(CRots, ApplyTo11) {
-    State_2q input_state(2, 2);
+    State_Xq<2> input_state(2, 2);
     input_state.setValues({{0, 0}, {0, 1}});
 
     float phi(0.1);
@@ -832,13 +832,13 @@ TEST(CRots, ApplyTo11) {
     complex<double> sin_imag(0, sin);
     complex<double> sin_real(sin, 0);
 
-    State_2q expected_output_state_X(2, 2);
+    State_Xq<2> expected_output_state_X(2, 2);
     expected_output_state_X.setValues({{0, 0}, {-sin_imag, cos_real}});
 
-    State_2q expected_output_state_Y(2, 2);
+    State_Xq<2> expected_output_state_Y(2, 2);
     expected_output_state_Y.setValues({{0, 0}, {-sin_real, cos_real}});
 
-    State_2q expected_output_state_Z(2, 2);
+    State_Xq<2> expected_output_state_Z(2, 2);
     expected_output_state_Z.setValues({{0, 0}, {0, cos_real+sin_imag}});
 
     vector<float> p2{0.4, 0.1, 0.3};
@@ -847,7 +847,7 @@ TEST(CRots, ApplyTo11) {
     auto exp_plus = std::pow(M_E, imag_phi_plus_omega);
     auto exp_minus = std::pow(M_E, imag_phi_minus_omega);
 
-    State_2q expected_output_state_Rot(2, 2);
+    State_Xq<2> expected_output_state_Rot(2, 2);
     expected_output_state_Rot.setValues({{0, 0}, {-sin_real * exp_minus, cos_real * exp_plus}});
 
     vector<int> w{0, 1};
@@ -880,24 +880,24 @@ TEST(CRots, ApplyTo11) {
 namespace three_qubit_ops {
 
 TEST(Toffoli, ApplyToAll) {
-    State_3q input_state_000(2, 2, 2);
+    State_Xq<3> input_state_000(2, 2, 2);
     input_state_000.setValues({{{1, 0}, {0, 0}}, {{0, 0}, {0, 0}}});
-    State_3q input_state_001(2, 2, 2);
+    State_Xq<3> input_state_001(2, 2, 2);
     input_state_001.setValues({{{0, 1}, {0, 0}}, {{0, 0}, {0, 0}}});
-    State_3q input_state_010(2, 2, 2);
+    State_Xq<3> input_state_010(2, 2, 2);
     input_state_010.setValues({{{0, 0}, {1, 0}}, {{0, 0}, {0, 0}}});
-    State_3q input_state_011(2, 2, 2);
+    State_Xq<3> input_state_011(2, 2, 2);
     input_state_011.setValues({{{0, 0}, {0, 1}}, {{0, 0}, {0, 0}}});
-    State_3q input_state_100(2, 2, 2);
+    State_Xq<3> input_state_100(2, 2, 2);
     input_state_100.setValues({{{0, 0}, {0, 0}}, {{1, 0}, {0, 0}}});
-    State_3q input_state_101(2, 2, 2);
+    State_Xq<3> input_state_101(2, 2, 2);
     input_state_101.setValues({{{0, 0}, {0, 0}}, {{0, 1}, {0, 0}}});
-    State_3q input_state_110(2, 2, 2);
+    State_Xq<3> input_state_110(2, 2, 2);
     input_state_110.setValues({{{0, 0}, {0, 0}}, {{0, 0}, {1, 0}}});
-    State_3q input_state_111(2, 2, 2);
+    State_Xq<3> input_state_111(2, 2, 2);
     input_state_111.setValues({{{0, 0}, {0, 0}}, {{0, 0}, {0, 1}}});
 
-    std::vector<State_3q> input_states{
+    std::vector<State_Xq<3>> input_states{
         input_state_000,
         input_state_001,
         input_state_010,
@@ -907,7 +907,7 @@ TEST(Toffoli, ApplyToAll) {
         input_state_110,
         input_state_111,
     };
-    std::vector<State_3q> output_states;
+    std::vector<State_Xq<3>> output_states;
 
     vector<int> w{0, 1, 2};
 
@@ -915,9 +915,9 @@ TEST(Toffoli, ApplyToAll) {
         output_states.push_back(contract_3q_op(input_states[i], "Toffoli", w));
     }
 
-    State_3q target_state_110(2, 2, 2);
+    State_Xq<3> target_state_110(2, 2, 2);
     target_state_110.setValues({{{0, 0}, {0, 0}}, {{0, 0}, {0, 1}}});
-    State_3q target_state_111(2, 2, 2);
+    State_Xq<3> target_state_111(2, 2, 2);
     target_state_111.setValues({{{0, 0}, {0, 0}}, {{0, 0}, {1, 0}}});
 
     auto expected_states = input_states;
@@ -932,24 +932,24 @@ TEST(Toffoli, ApplyToAll) {
 }
 
 TEST(CSWAP, ApplyToAll) {
-    State_3q input_state_000(2, 2, 2);
+    State_Xq<3> input_state_000(2, 2, 2);
     input_state_000.setValues({{{1, 0}, {0, 0}}, {{0, 0}, {0, 0}}});
-    State_3q input_state_001(2, 2, 2);
+    State_Xq<3> input_state_001(2, 2, 2);
     input_state_001.setValues({{{0, 1}, {0, 0}}, {{0, 0}, {0, 0}}});
-    State_3q input_state_010(2, 2, 2);
+    State_Xq<3> input_state_010(2, 2, 2);
     input_state_010.setValues({{{0, 0}, {1, 0}}, {{0, 0}, {0, 0}}});
-    State_3q input_state_011(2, 2, 2);
+    State_Xq<3> input_state_011(2, 2, 2);
     input_state_011.setValues({{{0, 0}, {0, 1}}, {{0, 0}, {0, 0}}});
-    State_3q input_state_100(2, 2, 2);
+    State_Xq<3> input_state_100(2, 2, 2);
     input_state_100.setValues({{{0, 0}, {0, 0}}, {{1, 0}, {0, 0}}});
-    State_3q input_state_101(2, 2, 2);
+    State_Xq<3> input_state_101(2, 2, 2);
     input_state_101.setValues({{{0, 0}, {0, 0}}, {{0, 1}, {0, 0}}});
-    State_3q input_state_110(2, 2, 2);
+    State_Xq<3> input_state_110(2, 2, 2);
     input_state_110.setValues({{{0, 0}, {0, 0}}, {{0, 0}, {1, 0}}});
-    State_3q input_state_111(2, 2, 2);
+    State_Xq<3> input_state_111(2, 2, 2);
     input_state_111.setValues({{{0, 0}, {0, 0}}, {{0, 0}, {0, 1}}});
 
-    std::vector<State_3q> input_states{
+    std::vector<State_Xq<3>> input_states{
         input_state_000,
         input_state_001,
         input_state_010,
@@ -959,7 +959,7 @@ TEST(CSWAP, ApplyToAll) {
         input_state_110,
         input_state_111,
     };
-    std::vector<State_3q> output_states;
+    std::vector<State_Xq<3>> output_states;
 
     vector<int> w{0, 1, 2};
 
@@ -967,9 +967,9 @@ TEST(CSWAP, ApplyToAll) {
         output_states.push_back(contract_3q_op(input_states[i], "CSWAP", w));
     }
 
-    State_3q target_state_101(2, 2, 2);
+    State_Xq<3> target_state_101(2, 2, 2);
     target_state_101.setValues({{{0, 0}, {0, 0}}, {{0, 0}, {1, 0}}});
-    State_3q target_state_110(2, 2, 2);
+    State_Xq<3> target_state_110(2, 2, 2);
     target_state_110.setValues({{{0, 0}, {0, 0}}, {{0, 1}, {0, 0}}});
 
     auto expected_states = input_states;

--- a/pennylane_lightning/src/tests/lightning_unittest.cpp
+++ b/pennylane_lightning/src/tests/lightning_unittest.cpp
@@ -1,8 +1,11 @@
 // Copyright 2020 Xanadu Quantum Technologies Inc.
+
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
+
 //     http://www.apache.org/licenses/LICENSE-2.0
+
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/pennylane_lightning/src/typedefs.hpp
+++ b/pennylane_lightning/src/typedefs.hpp
@@ -1,8 +1,11 @@
 // Copyright 2020 Xanadu Quantum Technologies Inc.
+
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
+
 //     http://www.apache.org/licenses/LICENSE-2.0
+
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/pennylane_lightning/src/typedefs.hpp
+++ b/pennylane_lightning/src/typedefs.hpp
@@ -1,3 +1,13 @@
+// Copyright 2020 Xanadu Quantum Technologies Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #pragma once
 
 #include <array>

--- a/pennylane_lightning/src/typedefs.hpp
+++ b/pennylane_lightning/src/typedefs.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <array>
+#include <complex>
+#include "unsupported/Eigen/CXX11/Tensor"
+
+template<int X>
+using State_Xq = Eigen::Tensor<std::complex<double>, X>;
+
+template<int X>
+using Gate_Xq = Eigen::Tensor<std::complex<double>, 2 * X>;
+
+using Pairs = Eigen::IndexPair<int>;
+template<int X>
+using Pairs_Xq = std::array<Eigen::IndexPair<int>, X>;
+
+// Creating aliases based on the function signatures of each operation
+
+template<int X>
+using pfunc_Xq = Gate_Xq<X>(*)();
+
+template<int X>
+using pfunc_Xq_one_param = Gate_Xq<X>(*)(const double&);
+
+template<int X>
+using pfunc_Xq_three_params = Gate_Xq<X>(*)(const double&, const double&, const double&);

--- a/setup.py
+++ b/setup.py
@@ -154,6 +154,7 @@ if not os.environ.get("MOCK_DOCS", False):
             depends=[
                 "pennylane_lightning/src/lightning_qubit.hpp",
                 "pennylane_lightning/src/operations.hpp",
+                "pennylane_lightning/src/typedefs.hpp",
             ],
             include_dirs=include_dirs,
             language="c++",

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -1028,11 +1028,22 @@ class TestTooManyQubits:
     """Test for when too many wires are requested, where lightning.qubit should behave like
     default.qubit."""
 
-    def test_warning(self):
+    def test_warning(self, monkeypatch):
         """Test that a warning is produced when lightning.qubit is instantiated with more than
         the supported number of qubits"""
-        with pytest.warns(UserWarning, match="The number of wires exceeds"):
-            qml.device("lightning.qubit", wires=LightningQubit._MAX_WIRES + 1)
+
+        class MockDefaultQubit:
+            """Mock DefaultQubit class."""
+
+            def __init__(self, wires, *args, **kwargs):
+                """Mock __init__ method."""
+                self.num_wires = wires
+
+        with monkeypatch.context() as m:
+            # Mock the DefaultQubit class to avoid an extensive memory allocation
+            m.setattr(pennylane_lightning.lightning_qubit.DefaultQubit, "__init__", MockDefaultQubit.__init__)
+            with pytest.warns(UserWarning, match="The number of wires exceeds"):
+                pennylane_lightning.lightning_qubit.LightningQubit(wires=LightningQubit._MAX_WIRES + 1)
 
     def test_apply(self, mocker):
         """Test that the apply method uses the one in default.qubit when the number of wires

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -21,6 +21,7 @@ from unittest import mock
 
 import numpy as np
 import pennylane as qml
+import pennylane_lightning
 import pytest
 from pennylane import DeviceError
 from pennylane.devices.default_qubit import DefaultQubit


### PR DESCRIPTION
Also extends support from 16 qubits to 50 qubits (its unlikely anyone would have memory on the order of petabytes).