### PR TITLE
Further separate function definitions

### DIFF
--- a/pennylane_lightning/src/binding.cpp
+++ b/pennylane_lightning/src/binding.cpp
@@ -13,10 +13,7 @@
 // limitations under the License.
 /**
  * @file
- * Contains the main `apply()` function for applying a set of operations to a multiqubit
- * statevector.
- *
- * Also includes PyBind boilerplate for interfacing with Python.
+ * Includes PyBind boilerplate for interfacing with Python.
  */
 #include "pybind11/stl.h"
 #include "pybind11/eigen.h"

--- a/pennylane_lightning/src/binding.cpp
+++ b/pennylane_lightning/src/binding.cpp
@@ -1,0 +1,29 @@
+// Copyright 2020 Xanadu Quantum Technologies Inc.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+/**
+ * @file
+ * Contains the main `apply()` function for applying a set of operations to a multiqubit
+ * statevector.
+ *
+ * Also includes PyBind boilerplate for interfacing with Python.
+ */
+#include "pybind11/stl.h"
+#include "pybind11/eigen.h"
+#include "lightning_qubit.hpp"
+
+PYBIND11_MODULE(lightning_qubit_ops, m)
+{
+    m.doc() = "lightning.qubit apply() method using Eigen";
+    m.def("apply", apply, "lightning.qubit apply() method");
+}

--- a/pennylane_lightning/src/binding.cpp
+++ b/pennylane_lightning/src/binding.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020 Xanadu Quantum Technologies Inc.
+// Copyright 2021 Xanadu Quantum Technologies Inc.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pennylane_lightning/src/lightning_qubit.cpp
+++ b/pennylane_lightning/src/lightning_qubit.cpp
@@ -13,10 +13,8 @@
 // limitations under the License.
 /**
  * @file
- * Contains the main `apply()` function for applying a set of operations to a multiqubit
- * statevector.
- *
- * Also includes PyBind boilerplate for interfacing with Python.
+ * Contains the main `apply()` and auxiliary functions for applying a set of
+ * operations to a multiqubit statevector.
  */
 #include "lightning_qubit.hpp"
 

--- a/pennylane_lightning/src/lightning_qubit.cpp
+++ b/pennylane_lightning/src/lightning_qubit.cpp
@@ -18,22 +18,8 @@
  *
  * Also includes PyBind boilerplate for interfacing with Python.
  */
-#include "pybind11/stl.h"
-#include "pybind11/eigen.h"
 #include "lightning_qubit.hpp"
 
-/**
-* Applies specified operations onto an input state of an arbitrary number of qubits.
-*
-* Note that only up to 50 qubits are currently supported. This limitation is due to the Eigen
-* Tensor library not supporting dynamically ranked tensors.
-*
-* @param state the multiqubit statevector
-* @param ops a vector of operation names in the order they should be applied
-* @param wires a vector of wires corresponding to the operations specified in ops
-* @param params a vector of parameters corresponding to the operations specified in ops
-* @return the transformed statevector
-*/
 VectorXcd apply (
     Ref<VectorXcd> state,
     vector<string> ops,
@@ -162,80 +148,6 @@ vector<int> calculate_qubit_positions(const vector<int> &tensor_indices) {
     return idx;
 }
 
-template <class State>
-State contract_1q_op(
-    const State &state, const string &op_string, const vector<int> &indices, const vector<float> &p)
-{
-    Gate_Xq<1> op_1q = get_gate_1q(op_string, p);
-    Pairs_Xq<1> pairs_1q = {Pairs(1, indices[0])};
-    return op_1q.contract(state, pairs_1q);
-}
-
-template <class State>
-State contract_2q_op(
-    const State &state, const string &op_string, const vector<int> &indices, const vector<float> &p)
-{
-    Gate_Xq<2> op_2q = get_gate_2q(op_string, p);
-    Pairs_Xq<2> pairs_2q = {Pairs(2, indices[0]), Pairs(3, indices[1])};
-    return op_2q.contract(state, pairs_2q);
-}
-
-template <class State>
-State contract_3q_op(const State &state, const string &op_string, const vector<int> &indices) {
-    Gate_Xq<3> op_3q = get_gate_3q(op_string);
-    Pairs_Xq<3> pairs_3q = {Pairs(3, indices[0]), Pairs(4, indices[1]), Pairs(5, indices[2])};
-    return op_3q.contract(state, pairs_3q);
-}
-
-template <class State, typename... Shape>
-VectorXcd apply_ops(
-    Ref<VectorXcd> state,
-    const vector<string> & ops,
-    const vector<vector<int>> & wires,
-    const vector<vector<float>> &params,
-    Shape... shape
-) {
-    State evolved_tensor = TensorMap<State>(state.data(), shape...);
-    const int qubits = log2(evolved_tensor.size());
-
-    vector<int> tensor_indices(qubits);
-    std::iota(std::begin(tensor_indices), std::end(tensor_indices), 0);
-    vector<int> qubit_positions(qubits);
-    std::iota(std::begin(qubit_positions), std::end(qubit_positions), 0);
-
-    int num_ops = ops.size();
-
-    for (int i = 0; i < num_ops; i++) {
-        // Load operation string and corresponding wires and parameters
-        string op_string = ops[i];
-        vector<int> w = wires[i];
-        int num_wires = w.size();
-        vector<float> p = params[i];
-        State tensor_contracted;
-
-        vector<int> wires_to_contract(w.size());
-        for (int j = 0; j < num_wires; j++) {
-            wires_to_contract[j] = qubit_positions[w[j]];
-        }
-        tensor_indices = calculate_tensor_indices(w, tensor_indices);
-        qubit_positions = calculate_qubit_positions(tensor_indices);
-
-        if (w.size() == 1) {
-            tensor_contracted = contract_1q_op<State> (evolved_tensor, op_string, wires_to_contract, p);
-        }
-        else if (w.size() == 2) {
-            tensor_contracted = contract_2q_op<State> (evolved_tensor, op_string, wires_to_contract, p);
-        }
-        else if (w.size() == 3) {
-            tensor_contracted = contract_3q_op<State> (evolved_tensor, op_string, wires_to_contract);
-        }
-        evolved_tensor = tensor_contracted;
-    }
-    State shuffled_evolved_tensor = evolved_tensor.shuffle(qubit_positions);
-
-    return Map<VectorXcd> (shuffled_evolved_tensor.data(), shuffled_evolved_tensor.size(), 1);
-}
-
 VectorXcd apply_ops_1q(
     Ref<VectorXcd> state,
     vector<string> ops,
@@ -301,11 +213,4 @@ VectorXcd apply_ops_2q(
     State_Xq<2> shuffled_evolved_tensor = evolved_tensor.shuffle(qubit_positions);
 
     return Map<VectorXcd> (shuffled_evolved_tensor.data(), shuffled_evolved_tensor.size(), 1);
-}
-
-
-PYBIND11_MODULE(lightning_qubit_ops, m)
-{
-    m.doc() = "lightning.qubit apply() method using Eigen";
-    m.def("apply", apply, "lightning.qubit apply() method");
 }

--- a/pennylane_lightning/src/lightning_qubit.hpp
+++ b/pennylane_lightning/src/lightning_qubit.hpp
@@ -45,16 +45,7 @@ const double SQRT2INV = 0.7071067811865475;
 * @param tensor_indices the qubit-labelled indices of the state tensor before contraction
 * @return the resultant indices
 */
-vector<int> calculate_tensor_indices(const vector<int> &wires, const vector<int> &tensor_indices) {
-    vector<int> new_tensor_indices = wires;
-    int n_indices = tensor_indices.size();
-    for (int j = 0; j < n_indices; j++) {
-        if (count(wires.begin(), wires.end(), tensor_indices[j]) == 0) {
-            new_tensor_indices.push_back(tensor_indices[j]);
-        }
-    }
-    return new_tensor_indices;
-}
+vector<int> calculate_tensor_indices(const vector<int> &wires, const vector<int> &tensor_indices);
 
 /**
 * Returns the tensor representation of a one-qubit gate given its name and parameters.
@@ -63,23 +54,7 @@ vector<int> calculate_tensor_indices(const vector<int> &wires, const vector<int>
 * @param params the parameters of the gate
 * @return the gate as a tensor
 */
-Gate_Xq<1> get_gate_1q(const string &gate_name, const vector<float> &params) {
-    Gate_Xq<1> op;
-
-    if (params.empty()) {
-        pfunc_Xq<1> f = OneQubitOps.at(gate_name);
-        op = (*f)();
-    }
-    else if (params.size() == 1) {
-        pfunc_Xq_one_param<1> f = OneQubitOpsOneParam.at(gate_name);
-        op = (*f)(params[0]);
-    }
-    else if (params.size() == 3) {
-        pfunc_Xq_three_params<1> f = OneQubitOpsThreeParams.at(gate_name);
-        op = (*f)(params[0], params[1], params[2]);
-    }
-    return op;
-}
+Gate_Xq<1> get_gate_1q(const string &gate_name, const vector<float> &params);
 
 /**
 * Returns the tensor representation of a two-qubit gate given its name and parameters.
@@ -88,23 +63,7 @@ Gate_Xq<1> get_gate_1q(const string &gate_name, const vector<float> &params) {
 * @param params the parameters of the gate
 * @return the gate as a tensor
 */
-Gate_Xq<2> get_gate_2q(const string &gate_name, const vector<float> &params) {
-    Gate_Xq<2> op;
-
-    if (params.empty()) {
-        pfunc_Xq<2> f = TwoQubitOps.at(gate_name);
-        op = (*f)();
-    }
-    else if (params.size() == 1) {
-        pfunc_Xq_one_param<2> f = TwoQubitOpsOneParam.at(gate_name);
-        op = (*f)(params[0]);
-    }
-    else if (params.size() == 3) {
-        pfunc_Xq_three_params<2> f = TwoQubitOpsThreeParams.at(gate_name);
-        op = (*f)(params[0], params[1], params[2]);
-    }
-    return op;
-}
+Gate_Xq<2> get_gate_2q(const string &gate_name, const vector<float> &params);
 
 /**
 * Returns the tensor representation of a three-qubit gate given its name and parameters.
@@ -112,12 +71,7 @@ Gate_Xq<2> get_gate_2q(const string &gate_name, const vector<float> &params) {
 * @param gate_name the name of the gate
 * @return the gate as a tensor
 */
-Gate_Xq<3> get_gate_3q(const string &gate_name) {
-    Gate_Xq<3> op;
-    pfunc_Xq<3> f = ThreeQubitOps.at(gate_name);
-    op = (*f)();
-    return op;
-}
+Gate_Xq<3> get_gate_3q(const string &gate_name);
 
 /**
 * Calculate the positions of qubits in the state tensor.
@@ -131,14 +85,7 @@ Gate_Xq<3> get_gate_3q(const string &gate_name) {
 * @param tensor_indices the wire indices of a contracted tensor, calculated using calculate_tensor_indices()
 * @return the resultant indices
 */
-vector<int> calculate_qubit_positions(const vector<int> &tensor_indices) {
-    vector<int> idx(tensor_indices.size());
-    std::iota(idx.begin(), idx.end(), 0);
-    stable_sort(idx.begin(), idx.end(), [&tensor_indices](size_t i1, size_t i2) {
-        return tensor_indices[i1] < tensor_indices[i2];
-    });
-    return idx;
-}
+vector<int> calculate_qubit_positions(const vector<int> &tensor_indices);
 
 /**
 * Contract a one-qubit gate onto a state tensor.
@@ -151,12 +98,7 @@ vector<int> calculate_qubit_positions(const vector<int> &tensor_indices) {
 */
 template <class State>
 State contract_1q_op(
-    const State &state, const string &op_string, const vector<int> &indices, const vector<float> &p)
-{
-    Gate_Xq<1> op_1q = get_gate_1q(op_string, p);
-    Pairs_Xq<1> pairs_1q = {Pairs(1, indices[0])};
-    return op_1q.contract(state, pairs_1q);
-}
+    const State &state, const string &op_string, const vector<int> &indices, const vector<float> &p);
 
 /**
 * Contract a two-qubit gate onto a state tensor.
@@ -169,12 +111,7 @@ State contract_1q_op(
 */
 template <class State>
 State contract_2q_op(
-    const State &state, const string &op_string, const vector<int> &indices, const vector<float> &p)
-{
-    Gate_Xq<2> op_2q = get_gate_2q(op_string, p);
-    Pairs_Xq<2> pairs_2q = {Pairs(2, indices[0]), Pairs(3, indices[1])};
-    return op_2q.contract(state, pairs_2q);
-}
+    const State &state, const string &op_string, const vector<int> &indices, const vector<float> &p);
 
 /**
 * Contract a three-qubit gate onto a state tensor.
@@ -186,11 +123,7 @@ State contract_2q_op(
 * @return the resultant state tensor
 */
 template <class State>
-State contract_3q_op(const State &state, const string &op_string, const vector<int> &indices) {
-    Gate_Xq<3> op_3q = get_gate_3q(op_string);
-    Pairs_Xq<3> pairs_3q = {Pairs(3, indices[0]), Pairs(4, indices[1]), Pairs(5, indices[2])};
-    return op_3q.contract(state, pairs_3q);
-}
+State contract_3q_op(const State &state, const string &op_string, const vector<int> &indices);
 
 /**
 * Applies specified operations onto an input state of three or more qubits.

--- a/pennylane_lightning/src/lightning_qubit.hpp
+++ b/pennylane_lightning/src/lightning_qubit.hpp
@@ -262,7 +262,7 @@ VectorXcd apply_ops_2q(
 
 /**
 * Main recursive template to generate multi-qubit operations
-* 
+*
 * @tparam Dim the number of qubits (i.e. tensor rank)
 * @tparam ValueIdx index to be decremented recursively until 0 to generate the dimensions of the tensor
 */
@@ -284,7 +284,7 @@ public:
 
 /**
 * Terminal specialised template for general multi-qubit operations
-* 
+*
 * @tparam Dim the number of qubits (i.e. tensor rank)
 */
 template<int Dim>
@@ -305,7 +305,7 @@ public:
 
 /**
 * Terminal specialised template for single qubit operations
-* 
+*
 * @tparam ValueIdx ignored, but required to specialised the main recursive template
 */
 template<int ValueIdx>
@@ -326,7 +326,7 @@ public:
 
 /**
 * Terminal specialised template for two qubit operations
-* 
+*
 * @tparam ValueIdx ignored, but required to specialised the main recursive template
 */
 template<int ValueIdx>
@@ -347,7 +347,7 @@ public:
 
 /**
 * Generic interface that invokes the generator to generate the desired multi-qubit operation
-* 
+*
 * @tparam Dim the number of qubits (i.e. tensor rank)
 */
 template<int Dim>

--- a/pennylane_lightning/src/operations.hpp
+++ b/pennylane_lightning/src/operations.hpp
@@ -34,7 +34,7 @@ const std::complex<double> NEGATIVE_IMAG(0, -1);
 *
 * @return the identity tensor
 */
-Gate_Xq<1> Identity() {
+inline Gate_Xq<1> Identity() {
     Gate_Xq<1> X(2, 2);
     X.setValues({{1, 0}, {0, 1}});
     return X;
@@ -45,7 +45,7 @@ Gate_Xq<1> Identity() {
 *
 * @return the X tensor
 */
-Gate_Xq<1> X() {
+inline Gate_Xq<1> X() {
     Gate_Xq<1> X(2, 2);
     X.setValues({{0, 1}, {1, 0}});
     return X;
@@ -56,7 +56,7 @@ Gate_Xq<1> X() {
 *
 * @return the Y tensor
 */
-Gate_Xq<1> Y() {
+inline Gate_Xq<1> Y() {
     Gate_Xq<1> Y(2, 2);
     Y.setValues({{0, NEGATIVE_IMAG}, {IMAG, 0}});
     return Y;
@@ -67,7 +67,7 @@ Gate_Xq<1> Y() {
 *
 * @return the Z tensor
 */
-Gate_Xq<1> Z() {
+inline Gate_Xq<1> Z() {
     Gate_Xq<1> Z(2, 2);
     Z.setValues({{1, 0}, {0, -1}});
     return Z;
@@ -78,7 +78,7 @@ Gate_Xq<1> Z() {
 *
 * @return the H tensor
 */
-Gate_Xq<1> H() {
+inline Gate_Xq<1> H() {
     Gate_Xq<1> H(2, 2);
     H.setValues({{1/SQRT_2, 1/SQRT_2}, {1/SQRT_2, -1/SQRT_2}});
     return H;
@@ -89,7 +89,7 @@ Gate_Xq<1> H() {
 *
 * @return the S tensor
 */
-Gate_Xq<1> S() {
+inline Gate_Xq<1> S() {
     Gate_Xq<1> S(2, 2);
     S.setValues({{1, 0}, {0, IMAG}});
     return S;
@@ -100,7 +100,7 @@ Gate_Xq<1> S() {
 *
 * @return the T tensor
 */
-Gate_Xq<1> T() {
+inline Gate_Xq<1> T() {
     Gate_Xq<1> T(2, 2);
 
     const std::complex<double> exponent(0, M_PI/4);
@@ -114,7 +114,7 @@ Gate_Xq<1> T() {
 * @param parameter the rotation angle
 * @return the RX tensor
 */
-Gate_Xq<1> RX(const double& parameter) {
+inline Gate_Xq<1> RX(const double& parameter) {
     Gate_Xq<1> RX(2, 2);
 
     const std::complex<double> c (std::cos(parameter / 2), 0);
@@ -130,7 +130,7 @@ Gate_Xq<1> RX(const double& parameter) {
 * @param parameter the rotation angle
 * @return the RY tensor
 */
-Gate_Xq<1> RY(const double& parameter) {
+inline Gate_Xq<1> RY(const double& parameter) {
     Gate_Xq<1> RY(2, 2);
 
     const double c = std::cos(parameter / 2);
@@ -146,7 +146,7 @@ Gate_Xq<1> RY(const double& parameter) {
 * @param parameter the rotation angle
 * @return the RZ tensor
 */
-Gate_Xq<1> RZ(const double& parameter) {
+inline Gate_Xq<1> RZ(const double& parameter) {
     Gate_Xq<1> RZ(2, 2);
 
     const std::complex<double> exponent(0, -parameter/2);
@@ -164,7 +164,7 @@ Gate_Xq<1> RZ(const double& parameter) {
 * @param parameter the phase shift
 * @return the phase-shift tensor
 */
-Gate_Xq<1> PhaseShift(const double& parameter) {
+inline Gate_Xq<1> PhaseShift(const double& parameter) {
     Gate_Xq<1> PhaseShift(2, 2);
 
     const std::complex<double> exponent(0, parameter);
@@ -185,7 +185,7 @@ Gate_Xq<1> PhaseShift(const double& parameter) {
 * @param omega the third rotation angle
 * @return the rotation tensor
 */
-Gate_Xq<1> Rot(const double& phi, const double& theta, const double& omega) {
+inline Gate_Xq<1> Rot(const double& phi, const double& theta, const double& omega) {
     Gate_Xq<1> Rot(2, 2);
 
     const std::complex<double> e00(0, (-phi - omega)/2);
@@ -211,7 +211,7 @@ Gate_Xq<1> Rot(const double& phi, const double& theta, const double& omega) {
 *
 * @return the CNOT tensor
 */
-Gate_Xq<2> CNOT() {
+inline Gate_Xq<2> CNOT() {
     Gate_Xq<2> CNOT(2,2,2,2);
     CNOT.setValues({{{{1, 0},{0, 0}},{{0, 1},{0, 0}}},{{{0, 0},{0, 1}},{{0, 0},{1, 0}}}});
     return CNOT;
@@ -222,7 +222,7 @@ Gate_Xq<2> CNOT() {
 *
 * @return the SWAP tensor
 */
-Gate_Xq<2> SWAP() {
+inline Gate_Xq<2> SWAP() {
     Gate_Xq<2> SWAP(2,2,2,2);
     SWAP.setValues({{{{1, 0},{0, 0}},{{0, 0},{1, 0}}},{{{0, 1},{0, 0}},{{0, 0},{0, 1}}}});
     return SWAP;
@@ -233,7 +233,7 @@ Gate_Xq<2> SWAP() {
 *
 * @return the CZ tensor
 */
-Gate_Xq<2> CZ() {
+inline Gate_Xq<2> CZ() {
     Gate_Xq<2> CZ(2,2,2,2);
     CZ.setValues({{{{1, 0},{0, 0}},{{0, 1},{0, 0}}},{{{0, 0},{1, 0}},{{0, 0},{0, -1}}}});
     return CZ;
@@ -244,7 +244,7 @@ Gate_Xq<2> CZ() {
 *
 * @return the Toffoli tensor
 */
-Gate_Xq<3> Toffoli() {
+inline Gate_Xq<3> Toffoli() {
     Gate_Xq<3> Toffoli(2,2,2,2,2,2);
     Toffoli.setValues({{{{{{1, 0},{0, 0}},{{0, 0},{0, 0}}},{{{0, 1},{0, 0}},{{0, 0},{0, 0}}}},
             {{{{0, 0},{1, 0}},{{0, 0},{0, 0}}},{{{0, 0},{0, 1}},{{0, 0},{0, 0}}}}
@@ -260,7 +260,7 @@ Gate_Xq<3> Toffoli() {
 *
 * @return the CSWAP tensor
 */
-Gate_Xq<3> CSWAP() {
+inline Gate_Xq<3> CSWAP() {
     Gate_Xq<3> CSWAP(2,2,2,2,2,2);
     CSWAP.setValues({{{{{{1, 0},{0, 0}},{{0, 0},{0, 0}}},{{{0, 1},{0, 0}},{{0, 0},{0, 0}}}},
             {{{{0, 0},{1, 0}},{{0, 0},{0, 0}}},{{{0, 0},{0, 1}},{{0, 0},{0, 0}}}}
@@ -277,7 +277,7 @@ Gate_Xq<3> CSWAP() {
 * @param parameter the rotation angle
 * @return the CRX tensor
 */
-Gate_Xq<2> CRX(const double& parameter) {
+inline Gate_Xq<2> CRX(const double& parameter) {
     Gate_Xq<2> CRX(2, 2, 2, 2);
 
     const std::complex<double> c (std::cos(parameter / 2), 0);
@@ -293,7 +293,7 @@ Gate_Xq<2> CRX(const double& parameter) {
 * @param parameter the rotation angle
 * @return the CRY tensor
 */
-Gate_Xq<2> CRY(const double& parameter) {
+inline Gate_Xq<2> CRY(const double& parameter) {
     Gate_Xq<2> CRY(2, 2, 2, 2);
 
     const double c = std::cos(parameter / 2);
@@ -309,7 +309,7 @@ Gate_Xq<2> CRY(const double& parameter) {
 * @param parameter the rotation angle
 * @return the CRZ tensor
 */
-Gate_Xq<2> CRZ(const double& parameter) {
+inline Gate_Xq<2> CRZ(const double& parameter) {
     Gate_Xq<2> CRZ(2, 2, 2, 2);
 
     const std::complex<double> exponent(0, -parameter/2);
@@ -333,7 +333,7 @@ Gate_Xq<2> CRZ(const double& parameter) {
 * @param omega the third rotation angle
 * @return the controlled rotation tensor
 */
-Gate_Xq<2> CRot(const double& phi, const double& theta, const double& omega) {
+inline Gate_Xq<2> CRot(const double& phi, const double& theta, const double& omega) {
     Gate_Xq<2> CRot(2,2,2,2);
 
     const std::complex<double> e00(0, (-phi - omega)/2);

--- a/pennylane_lightning/src/operations.hpp
+++ b/pennylane_lightning/src/operations.hpp
@@ -23,6 +23,8 @@
 
 #include <iostream>
 #include <cmath>
+#include <map>
+
 #include "typedefs.hpp"
 
 const double SQRT_2 = sqrt(2);

--- a/pennylane_lightning/src/tests/Makefile
+++ b/pennylane_lightning/src/tests/Makefile
@@ -21,13 +21,13 @@ LFLAGS = -fopenmp -L$(GOOGLETEST_DIR)/lib -lgtest
 
 all: test
 
-lightning_unittest.o: lightning_unittest.cpp
+lightning_unittest.o: lightning_unittest.cpp probs_unittest.cpp
 	$(CC) $^ $(CFLAGS) -c
 
 gtest_main.o: gtest_main.cpp
 	$(CC) $^ $(CFLAGS) -c
 
-cpptests: gtest_main.o lightning_unittest.o
+cpptests: gtest_main.o lightning_unittest.o probs_unittest.o
 	$(CC) $^ -o $@ $(LFLAGS)
 
 test: cpptests

--- a/pennylane_lightning/src/tests/Makefile
+++ b/pennylane_lightning/src/tests/Makefile
@@ -21,13 +21,13 @@ LFLAGS = -fopenmp -L$(GOOGLETEST_DIR)/lib -lgtest
 
 all: test
 
-lightning_unittest.o: lightning_unittest.cpp probs_unittest.cpp
+lightning_unittest.o: lightning_unittest.cpp
 	$(CC) $^ $(CFLAGS) -c
 
 gtest_main.o: gtest_main.cpp
 	$(CC) $^ $(CFLAGS) -c
 
-cpptests: gtest_main.o lightning_unittest.o probs_unittest.o
+cpptests: gtest_main.o lightning_unittest.o
 	$(CC) $^ -o $@ $(LFLAGS)
 
 test: cpptests

--- a/pennylane_lightning/src/tests/Makefile
+++ b/pennylane_lightning/src/tests/Makefile
@@ -21,13 +21,16 @@ LFLAGS = -fopenmp -L$(GOOGLETEST_DIR)/lib -lgtest
 
 all: test
 
+lightning_qubit.o: ../lightning_qubit.cpp
+	$(CC) $^ $(CFLAGS) -c
+
 lightning_unittest.o: lightning_unittest.cpp
 	$(CC) $^ $(CFLAGS) -c
 
 gtest_main.o: gtest_main.cpp
 	$(CC) $^ $(CFLAGS) -c
 
-cpptests: gtest_main.o lightning_unittest.o
+cpptests: gtest_main.o lightning_qubit.o lightning_unittest.o
 	$(CC) $^ -o $@ $(LFLAGS)
 
 test: cpptests

--- a/setup.py
+++ b/setup.py
@@ -150,7 +150,10 @@ if not os.environ.get("MOCK_DOCS", False):
     ext_modules = [
         Extension(
             "lightning_qubit_ops",
-            sources=["pennylane_lightning/src/lightning_qubit.cpp"],
+            sources=[
+                "pennylane_lightning/src/binding.cpp",
+                "pennylane_lightning/src/lightning_qubit.cpp"
+                ],
             depends=[
                 "pennylane_lightning/src/lightning_qubit.hpp",
                 "pennylane_lightning/src/operations.hpp",


### PR DESCRIPTION
**Context**

As a preliminary step before adding more test cases and reorganizing the test suite, some function definitions need rearranging.

**Changes**
* To ensure that no compiler errors are raised for multiple function definitions (happens when including the same header in several translation units e.g., separate test files):
    * Function definitions are moved to `lightning_qubit.cpp` from `lightning_qubit.hpp`: the `lightning_qubit.hpp`
    * Smaller functions got `inline`
* The PyBind definitions are separated into a new file (thus PyBind is not a dependency while unit testing with C++)