### PR TITLE
Incrementing the version number to 0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,21 @@
 # Release 0.13.0-dev
 
-### New features since last release
-
-### Breaking changes
-
 ### Improvements
 
-### Documentation
+* Extends support from 16 qubits to 50 qubits.
+  [(#52)](https://github.com/PennyLaneAI/pennylane-lightning/pull/52)
 
 ### Bug fixes
+
+* Updates applying basis state preparations to correspond to the
+  changes in `DefaultQubit`.
+  [(#55)](https://github.com/PennyLaneAI/pennylane-lightning/pull/55)
 
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
+
+Thomas Loke, Antal Száva
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Release 0.13.0-dev
+# Release 0.14.0
 
 ### Improvements
 
@@ -15,7 +15,7 @@
 
 This release contains contributions from (in alphabetical order):
 
-Thomas Loke, Antal Száva
+Thomas Loke, Tom Bromley, Josh Izaac, Antal Száva
 
 ---
 

--- a/pennylane_lightning/_version.py
+++ b/pennylane_lightning/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.13.0-dev"
+__version__ = "0.14.0"


### PR DESCRIPTION
* Updates the changelog
* Updates the version number

*Note:* the PennyLane version required needs no update.