### PR TITLE
Add new lightweight backend with performance comparisons

### DIFF
--- a/lightning_benchmark.ipynb
+++ b/lightning_benchmark.ipynb
@@ -7,6 +7,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Requires pip install py-cpuinfo\n",
+    "\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
     "\n",

--- a/lightning_benchmark.ipynb
+++ b/lightning_benchmark.ipynb
@@ -1,0 +1,360 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "thrown-argentina",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "\n",
+    "import pennylane as qml\n",
+    "import pennylane_lightning\n",
+    "import pennylane_lightning.lightning_benchmark as bench"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "technological-drink",
+   "metadata": {},
+   "source": [
+    "## Processor info"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "micro-lyric",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "python_version: 3.9.0.final.0 (64 bit)\n",
+      "cpuinfo_version: [7, 0, 0]\n",
+      "cpuinfo_version_string: 7.0.0\n",
+      "arch: X86_64\n",
+      "bits: 64\n",
+      "count: 8\n",
+      "arch_string_raw: AMD64\n",
+      "vendor_id_raw: GenuineIntel\n",
+      "brand_raw: Intel(R) Core(TM) i7-4770K CPU @ 3.50GHz\n",
+      "hz_advertised_friendly: 3.5000 GHz\n",
+      "hz_actual_friendly: 3.5010 GHz\n",
+      "hz_advertised: [3500000000, 0]\n",
+      "hz_actual: [3501000000, 0]\n",
+      "l2_cache_size: 1048576\n",
+      "stepping: 3\n",
+      "model: 60\n",
+      "family: 6\n",
+      "l3_cache_size: 8388608\n",
+      "flags: ['3dnow', 'abm', 'acpi', 'aes', 'apic', 'avx', 'avx2', 'bmi1', 'bmi2', 'clflush', 'cmov', 'cx16', 'cx8', 'de', 'ds_cpl', 'dtes64', 'dts', 'erms', 'est', 'f16c', 'fma', 'fpu', 'fxsr', 'ht', 'ia64', 'invpcid', 'lahf_lm', 'mca', 'mce', 'mmx', 'monitor', 'movbe', 'msr', 'mtrr', 'osxsave', 'pae', 'pat', 'pbe', 'pcid', 'pclmulqdq', 'pdcm', 'pge', 'pni', 'popcnt', 'pse', 'pse36', 'rdrnd', 'sep', 'serial', 'smep', 'ss', 'sse', 'sse2', 'sse4_1', 'sse4_2', 'ssse3', 'tm', 'tm2', 'tsc', 'tscdeadline', 'vme', 'vmx', 'xsave', 'xtpr']\n",
+      "l2_cache_line_size: 256\n",
+      "l2_cache_associativity: 6\n"
+     ]
+    }
+   ],
+   "source": [
+    "from cpuinfo import get_cpu_info\n",
+    "for key, value in get_cpu_info().items():\n",
+    "    print(\"{0}: {1}\".format(key, value))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "coated-luxury",
+   "metadata": {},
+   "source": [
+    "## Initialisation code"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "favorite-method",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def benchmarkAndPlot(numRepetitions, nValues, colour, plotLabel, methodForN):\n",
+    "    timingResults = np.empty([len(nValues), 3])\n",
+    "    idx = 0\n",
+    "    for n in nValues:\n",
+    "        timingResult = [n, *bench.benchmarkMethod(numRepetitions, lambda: methodForN(n))]\n",
+    "        print(f\"n={n:2} took an average of {timingResult[1]} sec (std dev: {timingResult[2]} sec)\")\n",
+    "        timingResults[idx] = timingResult\n",
+    "        idx += 1\n",
+    "    plt.errorbar(timingResults[:,0], timingResults[:,1], yerr=timingResults[:,2], ls = \"None\", color=colour)\n",
+    "    plt.scatter(timingResults[:,0], timingResults[:,1], s = 20, color=colour, label=plotLabel)\n",
+    "    \n",
+    "def benchmarkCompare(title, numRepetitions, nValues, operationsForN):\n",
+    "    plt.subplot()\n",
+    "    plt.title(title)\n",
+    "    plt.yscale('log')\n",
+    "    plt.xlabel('Number of qubits')\n",
+    "    plt.ylabel('Runtime (seconds)')\n",
+    "    plt.grid(True)\n",
+    "    \n",
+    "    print(\"Running with old backend:\")\n",
+    "    benchmarkAndPlot(numRepetitions, nValues, 'b', 'Old', lambda n: bench.benchmarkApply(n, operationsForN(n)))\n",
+    "    print(\"Running with new backend:\")\n",
+    "    benchmarkAndPlot(numRepetitions, nValues, 'r', 'New', lambda n: bench.benchmarkApplyNew(n, operationsForN(n)))\n",
+    "    plt.legend(loc=\"upper left\")\n",
+    "    plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ahead-significance",
+   "metadata": {},
+   "source": [
+    "## Comparisons"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "resident-repair",
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Running with old backend:\n",
+      "n=10 took an average of 0.00039985179901123045 sec (std dev: 0.0005162064818993355 sec)\n",
+      "n=11 took an average of 0.0008969783782958984 sec (std dev: 0.0003152393297288236 sec)\n",
+      "n=12 took an average of 0.0016013622283935548 sec (std dev: 0.0005148734849031851 sec)\n",
+      "n=13 took an average of 0.002799367904663086 sec (std dev: 0.00042399330308265923 sec)\n",
+      "n=14 took an average of 0.005999183654785157 sec (std dev: 0.0006623620396257136 sec)\n",
+      "n=15 took an average of 0.013145518302917481 sec (std dev: 0.0007432160861058601 sec)\n",
+      "n=16 took an average of 0.02920055389404297 sec (std dev: 0.005265665567232792 sec)\n",
+      "n=17 took an average of 0.06129906177520752 sec (std dev: 0.0034996106870989613 sec)\n",
+      "n=18 took an average of 0.12829575538635254 sec (std dev: 0.006236971477736959 sec)\n",
+      "n=19 took an average of 0.27519228458404543 sec (std dev: 0.007114234561363958 sec)\n",
+      "n=20 took an average of 0.5821371078491211 sec (std dev: 0.01510324806134441 sec)\n",
+      "Running with new backend:\n",
+      "n=10 took an average of 0.0002985954284667969 sec (std dev: 0.0004808015034304681 sec)\n",
+      "n=11 took an average of 0.00029888153076171873 sec (std dev: 0.000481251984472027 sec)\n",
+      "n=12 took an average of 0.0005002498626708984 sec (std dev: 0.0005273330541116729 sec)\n",
+      "n=13 took an average of 0.0004995107650756836 sec (std dev: 0.0005265630291106574 sec)\n",
+      "n=14 took an average of 0.0007980823516845703 sec (std dev: 0.00042066134300115164 sec)\n",
+      "n=15 took an average of 0.0009000778198242187 sec (std dev: 0.0007379047003149202 sec)\n",
+      "n=16 took an average of 0.001798701286315918 sec (std dev: 0.000632594129371727 sec)\n",
+      "n=17 took an average of 0.003098583221435547 sec (std dev: 0.0008778994632552386 sec)\n",
+      "n=18 took an average of 0.006200933456420898 sec (std dev: 0.0012288476543834408 sec)\n",
+      "n=19 took an average of 0.012999701499938964 sec (std dev: 0.0029429468087787724 sec)\n",
+      "n=20 took an average of 0.024596762657165528 sec (std dev: 0.003240389650410357 sec)\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYoAAAEWCAYAAAB42tAoAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/Il7ecAAAACXBIWXMAAAsTAAALEwEAmpwYAAAjlklEQVR4nO3de5gcdZ3v8fcnYSAEEi4hm10MMIEk7IYFggR0IcCggYNCuKnoHFmOyGVBkMuD7gE9R3TPo3jBheVyFtGwiItRQFCigIAwhs2BNcAOLgG5yCaQgBIiuZEEcvmeP6o6NMNMT89MV1d39ef1PP1MV3VdvkWH+nb9flW/ryICMzOzvgzLOwAzM2tsThRmZlaRE4WZmVXkRGFmZhU5UZiZWUVOFGZmVpEThbUkSe2SQtIWecfSmzS2iXnHYQZOFNYkJC2UNKPHvE9J+re8YmpEkjokLa7xNg+X9KCkFZIW1nLb1hycKMxy1KhXND28AdwAfD7vQCwfThRWGJIulvR7SaskPSXphLLPhku6XNJrkl4Aju6x7qmSnk7XfUHS35V91iFpsaS/l/SqpFckHS/pw5KelfQnSV8oW/5ASQ9LWp4ue42kLcs+D0nnSHoOeC6d9/l02Zclfbqf4+w1VknbAHcDO0tanb527mX9GyVdK+kX6Tb+XdIefe0vIn4TET8AXqgUlxWXE4UVye+BQ4DtgK8A/yrpL9LPzgCOAfYDpgEf7bHuq+nno4FTgSskvbfs8z8HRgDvAb4EfBc4Gdg/3ef/ljQhXXYjcCGwE/A3wAeBz/TY3/HA+4Apko4CPgccAUwCZlBZr7FGxBvAh4CXI2Lb9PVyH9v4BMl/ox2A54Gv9rNPa2FOFNZMfpr+Sl8uaTnwf8s/jIhbI+LliNgUET8m+bV+YPrxScCVEfFSRPwJuKzHur+IiN9H4tfAvSQJoGQ98NWIWA/8iCQJ/FNErIqIBcBTwL7pth6LiEciYkNELAS+AxzW41gui4g/RcTaNLZ/iYgn05P9lyv9R6gi1mrckV4pbABuBqYOcH1rIU4U1kyOj4jtSy96/EqXdIqk7rJE8tckJ3SAnYGXyhZf1GPdD0l6JG1GWg58uGxdgGURsTF9vzb9+8eyz9cC26bbmizp55L+IGkl8LUe26JHLBVj66mKWKvxh7L3a8pi/0JZs9V1A9ymFZQThRWCpN1ImoPOBcakieRJQOkirwC7lK2ya9m6WwE/AS4HxqXr3lW27kD9M/A7YFJEjAa+0Mu2yodt7jO2nqqIdUjDQUfE18qarc4ayrasOJworCi2ITlJLoWkw5fkiqLkFuA8SeMl7QBcXPbZlsBW6bobJH0IOHIIsYwCVgKrJf0lcHY/y98CfErSFEkjgUsrLNtfrH8ExkjabtDR9yBpmKQRQFsyqRHlnfNWfE4UVggR8RTwbeBhkpPl3sC8skW+C/wSeAJ4HLi9bN1VwHkkJ+zXgf8O3DmEcD6XbmNVut8f9xP73cCVwAMkHcsPVFi2YqwR8TtgNvBC2gT3rrueBuFQkqa1u0iudtaS9ItYi5ALF5mZWSW+ojAzs4qcKMzMrCInCjMzq8iJwszMKmqGAckGbKeddor29vZBrfvGG2+wzTbb1DagBudjbg0+5uIb6vE+9thjr0XE2J7zC5ko2tvbefTRRwe1bldXFx0dHbUNqMH5mFuDj7n4hnq8knodFcBNT2ZmVlGhEoWkmZKuX7FiRd6hmJkVRqESRUTMiYgzt9uuZqMXmJm1vEL2UfRm/fr1LF68mHXr1lVcbrvttuPpp5+uU1S1NWLECMaPH09bW1veoZhZgRQqUUiaCcycOPHdNekXL17MqFGjaG9vR+p7UNBVq1YxatSoDKPMRkSwbNkyFi9ezIQJE/pfwcysSi3T9LRu3TrGjBlTMUk0M0mMGTOm3ysmM7OBKlSi6E9Rk0RJ0Y/PzPq2dCmsWZP8rbWWShRmZkU0ezbsths8+2zyd/bs2m6/UImi0W+PXbx4MccddxyTJk1ijz324Pzzz+ett96iq6uLY445ptd12tvbee211+ocqZk1i6VL4bTTYO1auPrqqaxdm0zX8sqiUImikW+PjQhOPPFEjj/+eJ577jmeffZZVq9ezRe/+MW8QzOzJrZwIWzZo95gW1syv1YKlShqbelSmD+/Npn5gQceYMSIEZx66qkADB8+nCuuuIIbbriBNWvWbF5u2bJlHHnkkey1116cfvrpuLCUmVXS3g5vvZW8/8xnugFYvz6ZXytOFH0otfkdcURt2vwWLFjA/vvv/455o0ePZtddd+X555/fPO8rX/kK06dPZ8GCBZxwwgm8+OKLQ9uxmRXa2LEwaxZsvTUMH578nTUrmV8rThS9KG/zW7GCTNr8+jJ37lxOPvlkAI4++mh22GGH7HdqZk2tsxMWLYLJk5O/nZ213X6hEkWtOrOzaPObMmUKjz322DvmrVy5khdffJHeHhA0MxuIsWNh5MjaXkmUFCpR1Kozu7zNr2SobX4f/OAHWbNmDTfddBMAGzdu5KKLLuJTn/oUI0eO3LzcoYceyg9/+EMA7r77bl5//fXB79TMrAYKlShqpbzNb/To2rT5SeKOO+7g1ltvZdKkSUyePJkRI0bwta997R3LXXrppcydO5e99tqL22+/nV133XWIR2NmNjSFGuupljo7YcaMpLmpvb02l3O77LILc+bMedf8jo6OzcVGxowZw7333jv0nZmZ1YgTRQVjx2bT3mdm1kzc9GRmZhUVKlE0+hAeZmbNqFCJopGH8DAza1aFShRmZlZ7ThRmZlaRE0UdSeKiiy7aPH355Zfz5S9/Ob+AzMyq4ERRR1tttRW3336760uYWVNxoqikluOMA1tssQVnnnkmV1xxRS+7WspHPvIRDjjgAA444ADmzZsHwN57783y5cuJCMaMGbN5CJBTTjmF++67ryZxmVnt1Pi00RAKlShqentsrccZT51zzjncfPPN9Izx/PPP58ILL2T+/Pn85Cc/4fTTTwfg4IMPZt68eSxYsIDdd9+dhx56CICHH36Ygw46qCYxmVltZHTayF2hnsyOiDnAnGnTpp0xpA2VjzO+dm0y77TTkjE9hvio9ujRoznllFO46qqr2HrrrTfPv//++3nqqac2T69cuZLVq1dzyCGHMHfuXHbbbTfOPvtsrr/+epYsWcIOO+zANttsM6RYzKx2Mjxt5K5QVxQ1k3FtwQsuuIBZs2bxxhtvbJ63adMmHnnkEbq7u+nu7mbJkiVsu+22HHrooTz00EM89NBDdHR0MHbsWG677TYOOeSQmsRiZrVRj5KkeXGi6E0W44yX2XHHHTnppJOYNWvW5nlHHnkkV1999ebp7u5uIBlI8LXXXuO5555j9913Z/r06Vx++eUceuihNYnFzGoj49NGrpwoepPFOOM9XHTRRe+4++mqq67i0UcfZZ999mHKlClcd911mz973/vex+TJkwE45JBDWLJkCdOnT69ZLGY2dHU4beSmUH0UNZXBOOOrV6/e/H7cuHGsWbNm8/ROO+3Ej3/8417X+8EPfrD5/UEHHcSmTZuGHIuZ1V4W5QkagRNFJR5n3MwGqIinDTc9mZlZRS2VKCIi7xAyVfTjM7N8tEyiGDFiBMuWLSvsyTQiWLZsGSNGjMg7FDMrmJbpoxg/fjyLFy9maT/P1a9bt65pT7YjRoxg/PjxeYdhZgVTqEQhaSYwc+LEie/6rK2tjQkTJvS7ja6uLvbbb78MojMza06FanpyhTszs9orVKIwM7Pac6IwM7OKnCjMzKwiJwozM6vIicLMzCpyojAzs4qcKMyskJYuhTVrilW7Oi9OFGZWOKXa1c8+W6za1XlxojCzQimvXX311VNZuzaZ9pXF4DlRmFmhFLl2dV6cKMysUIpcuzovThRmVijltas/+9nuQtWuzkvDJwpJu0uaJem2vGMxs+bQ2QmLFsHkycnfzs68I2pumSYKSTdIelXSkz3mHyXpGUnPS7q40jYi4oWIOC3LOM2seMaOhZEjfSVRC1nXo7gRuAa4qTRD0nDgWuAIYDEwX9KdwHDgsh7rfzoiXs04RjMzqyDTRBERcyW195h9IPB8RLwAIOlHwHERcRlwTJbxmJnZwOVR4e49wEtl04uB9/W1sKQxwFeB/SRdkiaU3pY7EzgTYNy4cXR1dQ0quNWrVw963WblY24NPubiy+p4G74UakQsA86qYrnrgesBpk2bFh0dHYPaX1dXF4Ndt1n5mFuDj7n4sjrePO56WgLsUjY9Pp03ZJJmSrp+xYoVtdicmZmRT6KYD0ySNEHSlsAngDtrsWHXzDYzq72sb4+dDTwM7ClpsaTTImIDcC7wS+Bp4JaIWJBlHGZmNnhZ3/XU62MuEXEXcFeW+zYzs9po+CezB8J9FGZmtVeoROE+CjOz2quq6UnSNOAQYGdgLfAkcF9EvJ5hbGZm1gAqXlFIOlXS48AlwNbAM8CrwHTgfknfl7Rr9mFWx01PZo1l6VKYP99Fg5pdf1cUI4GDI2Jtbx9KmgpMAl6scVyDEhFzgDnTpk07I+9YzFrd7NlJZbktt0zqQ8ya5VFcm1XFK4qIuLavJJF+3h0Rv6p9WGbWzMrLka5YgcuRNrmqOrMlfVPSaEltkn4laamkk7MOzsyak8uRFku1dz0dGRErSUZ3XQhMBD6fVVCD5T4Ks8bgcqTFUm2iKPVlHA3cGhENeSb27bFmjaG8HOno0bgcaZOr9snsn0v6HcmtsWdLGgusyy4sM2t2nZ0wY0bS3NTe7iTRzKpKFBFxsaRvAisiYqOkNcBx2YZmZs1u7FgniCKomCgkndjLvPLJ22sdkJmZNZb+rihmpn//DDgIeCCdPhz4fzRYopA0E5g5ceLEvEMxMyuM/p6jODUiTgXagCkR8ZGI+AiwVzqvobgz28ys9qq962mXiHilbPqPQMMM3WFmZtmp9q6nX0n6JTA7nf44cH82IZmZWSOp9q6nc9OO7UPSWddHxB3ZhWVmZo2i6gp3EXE7DdZ5bWZm2at2rKcTJT0naYWklZJWSVqZdXAD5SE8zMxqr9rO7G8Cx0bEdhExOiJGRcToLAMbDN/1ZGZWe9Umij9GxNOZRmJmZg2p2j6KRyX9GPgp8GZpZtpvYWYNrqMDli+fSnd33pFYM6o2UYwG1gBHls0L3LltZlZ41d4ee2rWgZhZdtavh02bkgpzHqTPBqrau57GS7pD0qvp6yeSxmcdnJkN3ezZ8MgjsGYN7LZbMm02ENV2Zv8LcCewc/qak85rKL491uydSrWrN22CCNeutsGpNlGMjYh/iYgN6etGoOEuYH17rNk7uXa11UK1iWKZpJMlDU9fJwPLsgzMzIbOtatbyMEHM/W88zK5XKw2UXwaOAn4A/AK8FHAHdxmDa5Uu3rYMJBcu7qwMu6Iqvaup0XAsTXds5nVRWcnXHMNrFoFixY5SRROXx1RM2bU7Muu9q6n70vavmx6B0k31CQCM8tcW1tyVeEkUUB16Iiq9oG7fSJieWkiIl6XtF/NojCzTHV1QVdXN9CRbyBWe3XoiKq2j2KYpB1KE5J2ZABDlJuZWUbq0BFV7cn+28DDkm5Npz8GfLVmUZiZ2eBl3BFVbWf2TZIeBT6QzjoxIp6qaSRmZjZ48+bR3dVFRwYdUdU2PQHsCLwREdcASyVNqHk0ZmbWcKq96+lS4H8Cl6Sz2oB/zSqowfIQHmZmtVftFcUJJM9RvAEQES8Do7IKarA8hIeZWe1VmyjeioggqUGBpG2yC8nMzBpJtYniFknfAbaXdAZwP/Dd7MIyM7NGUe1dT5dLOgJYCewJfCki7ss0MjMzawhVJYq0qemBiLhP0p7AnpLaImJ9tuGZmTWZjo7kb1dXnlHUVLVNT3OBrSS9B7gH+FvgxqyCMjOzxlFtolBErAFOBP45Ij4G7JVdWGbFs3QpzJ/v6nLWfKpOFJL+Bvgk8It03vBsQjIrntmzkzIBRxzhutWFt359MpRGgX4RVJsozid52O6OiFggaXfgwezCMiuOUrmAtWthxQrXrS60UgGhJ54o1C+CqhJFRMyNiGMj4hvp9AsRcV62oZkVg+tWt4jyAkIbNxbqF0HFRCHpu5L27uOzbSR9WtInswnNrBhct7pFFPgXQX+3x14L/O80WTwJLAVGAJOA0cANwM2ZRmjW5ErlAk47LTlvrF/vutWFVOBfBBUTRUR0AydJ2haYBvwFsBZ4OiKeyT48s2Lo7ExKGC9cmJw3nCQKqPSL4OSTkwJCW25ZmF8E1T6ZvRroyjaU3kk6Hjia5ApmVkTcm0ccZkM1dmwhzhlWSamA0Lp1cM89hfnCB1KPYsAk3SDpVUlP9ph/lKRnJD0v6eJK24iIn0bEGcBZwMezjNfMbMja2mDUqMIkCci+7vWNwDXATaUZkoaT9H0cASwG5ku6k+S5jMt6rP/piHg1ff+/0vXMzKyOBpQoJI1Mn9CuSkTMldTeY/aBwPMR8UK6zR8Bx0XEZcAxvexTwNeBuyPi8YHEa2ZWdwUa46mk2kEBDwK+B2wL7CppX+DvIuIzg9jne4CXyqYXA++rsPxngRnAdpImRsR1fcR4JnAmwLhx4+ga5Je1evXqQa/brHzMrcHHXHxZHW+1VxRXAP8NuBMgIp6QdGjNo+lFRFwFXFXFctcD1wNMmzYtOkojOA5QV1cXg123WfmYW4OPufiyOt6qO7Mj4qUeszYOcp9LgF3Kpsen84bMNbPNzGqv2kTxUtr8FJLaJH0OeHqQ+5wPTJI0QdKWwCdIr1SGyjWzzcxqr9pEcRZwDkn/whJgajpdkaTZwMMkhY4WSzotIjYA5wK/JEk2t0TEgkHEbmZmdVDtA3evkQwxPiAR0dnH/LuAuwa6vf5ImgnMnDhxYq03bWbWsqq962kCyd1H7eXrRMSx2YQ1OBExB5gzbdq0M/KOxcysKKq96+mnwCxgDrAps2jMzGqlo4Opy5dDd3fekTS9ahPFuvQ2VTMzazHVJop/knQpcC/wZmlmoz0p7T4KM9ts/fqkiNDSpYUadykP1d71tDdwBslQGt9OX5dnFdRg+fZYq8bBB8N5500tQuEx60upJOmaNYUqSZqXahPFx4DdI+KwiDg8fX0gy8DMsuDzRwsoL0kaUaiSpHmpNlE8CWyfYRxmmfP5o0UUuCRpXqrto9ge+J2k+byzj6Khbo91H4VVUjp/rF379rzS+cNN2AVS4JKkeak2UVyaaRQ14ucorBKfP1pEz5KkW29dmJKkean2yexfZx2IWdZ8/mghpZKkq1bBokX+koeoYqKQ9G8RMV3SKiDKPwIiIkZnGp1ZjXV2wowZMH9+Nwcc0OHzR5G1tcGwYU4SNVAxUUTE9PTvqPqEY5a9sWNh5EifP8yqVdVdT5J+UM28vLkehZlt1tVF95VX5h1FIVR7e+xe5ROStgD2r304Q+MH7szMaq9iopB0Sdo/sY+klelrFfBH4Gd1idDMzHJVMVFExGVp/8S3ImJ0+hoVEWMi4pI6xWhmZjmq9vbYSyS9B9iNd9ajmJtVYGZm1hiqLVz0dZLa1k8BG9PZATRUovCT2WZmtVftk9knAHtGxJv9LpkjP5lt1mA6OpK/XV15RmFDVO1dTy8AbVkGYmZmjanaK4o1QLekX/HOQQHPyyQqMzNrGNUmijvTl5lZ9davh3XrXGWuyVV719P3sw7EzAqmVCVKSqpEzZqVDLZlTafau57+i3cOCghAROxe84isJbiPs+DKq0TB21WiZszwlUUTqrbpaVrZ+xEkpVF3rH041ircIlFwrhJVKFXd9RQRy8peSyLiSuDobEMbOA8K2BxKLRJPPOG61YXlKlGFUu3ose8te02TdBbVX43UjQcFbHzlLRIbN7pudWGVqkQNGwbDh7tKVJOr9mT/7bL3G4CFJM1PZgPiFokWUqoyt24d3HOPv+AmVu1dT4eXT0saTjKkx7NZBGXF5RaJFtPWlrycJJpaf8OMj06HGr9G0hFKnAs8D5xUnxCtSNwiYdZ8+rui+AHwOvAwcAbwRZJ62SdERHe2oVlRuUUiBx0dTF2+HLq7847EmlB/iWL3iNgbQNL3gFeAXSNiXeaRWaHNm5d3BGZWrf7uelpfehMRG4HFThJmZq2lvyuKfSWtTN8L2DqdFhARMTrT6MysufnR+0KomCgiYni9ArF8dHTA8uVT3XRtZn2qth5FU/CT2WZ9WL8+ecrRTzbaIBQqUfjJbLNelMZMWbPGY6bYoBQqUZhZD+VjpkR4zBQbFCeKFucWiYIrjZlSrjRmilmVnChamFskWoDHTLEacKJoUW6RaBHlY6ZIHjPFBsWJokW5RSIHHR1vl/arp85OeP/7YeRIWLTI5UhtwJwoWpRbJFpMW1tyVeErCRsEJ4oW5RYJM6tWw1Wps/opjeK6alXSIuEkYWa98RVFi3OLhJn1x4nCzMwqcqIwM7OK3EfRAEp3THpE5jpxtTezAXGiMGsFXV10d3XRkXcc1pQavulJ0l9Juk7SbZLOzjseM7NWk2mikHSDpFclPdlj/lGSnpH0vKSLK20jIp6OiLOAk4CDs4y3FXV1wZVXducdhpk1sKyvKG4EjiqfIWk4cC3wIWAK0ClpiqS9Jf28x+vP0nWOBX4B3JVxvGZm1kOmfRQRMVdSe4/ZBwLPR8QLAJJ+BBwXEZcBx/SxnTuBOyX9Avhhb8tIOhM4E2DcuHF0DbJnePXq1YNed7Bef30qEXD//d1sUedeo6kXXMDeGzfSdfXVdd8vQPeVV9Z1vwBTly9n48aNdf+ep77+OkTQff/91P2LJp9/23lrtWPO7HgjItMX0A48WTb9UeB7ZdN/C1xTYf0O4CrgO8A51exz//33j8F68MEHB73uYPzwhxHDhkUMHx6x9dbJdF0ddli8vu++dd5pst847LD67zfdd92POfcvuv7/thtBqx3zUI8XeDR6Oac2/F1PEdEFdOUcRibKh/qGt4f6njHDT0oXir9oa3J53PW0BNilbHp8Om/IJM2UdP2KFSsGtX5HB1xwwdRahFIVD/Wdk3qX9fMXbU0uj0QxH5gkaYKkLYFPAHfWYsMRMSciztxuu+1qsbnMeajvHORR1s9ftDW5rG+PnQ08DOwpabGk0yJiA3Au8EvgaeCWiFiQZRyNqnyo7+HDPdR35vIq6+cv2ppc1nc99VpKKyLuIoNbXSXNBGZOnDix1pvOTGmo73Xr4J57fO7IVKkJaO3at+eVmoCy/g/vL9qaWMN3Zg9ERMwB5kybNu2Mwax/ZXcHGzZsAP6ttoH149oFHQCMHdtV1/22nLybgNrakpeThDWZhh/Cw6xmXNbPbFAKdUVh1i+X9TMbsEJdUQz19lhrES7rZzYghUoUzXZ7rJlZMyhUojAzs9pzojAzs4oKlSjcR2FmVnuFShTN2kcxdWryykW9xz0ys6ZTqERhA5THuEcl69cnt6g6QZk1PCeKVpXXuEfwdoJ64on6JygzGzAnilaV19DX5Qlq48b6JigzG5RCJQp3Zg9AXuMeuTaDWdMpVKJo1s7sXOQ17lHeA/OZ2YAVKlEM1aaAoIVaQTo74f3vh5Ejk3GPOnsdFb62XJvBrOk4UaRmz4aVK2HTxhbrX81j3KNSgtp33/olKDMbNCcK3u5fheSKwv2rddDWBqNG+UrCrAkUKlEMtjPb/atmZn0rVKIYbGe2+1fNzPpWqEQxWKX+VQDh/tXC6+qi+8or847CrGm4wl2qsxMePyt5BmzRfzlJmJmV+IqizDAlVxROEmZmb3OiKBcBRP1vd/IAeWbWwJwoSkoPUmzcVN8HKTxAnpk1OCcKKHuQIpLpej1I4QHyzKwJFCpRDHpQwLwepPADHGbWBAqVKAY9KGBeD1L4AQ4zawKFShSDtvlBCiXT9XqQwgPkmVkTcKIo6eyE0aNh+LD6DlTnAfLMrMH5gbtyEqD6/6Jva0tevpIwswbkKwozM6vIicLMzCpyojAzs4qcKMzMrCInCjMzq0gRkXcMNSdpKbBokKvvBLxWw3CagY+5NfiYi2+ox7tbRLzr9stCJoqhkPRoREzLO4568jG3Bh9z8WV1vG56MjOzipwozMysIieKd7s+7wBy4GNuDT7m4svkeN1HYWZmFfmKwszMKnKiMDOzilo6UUi6QdKrkp4sm7ejpPskPZf+3SHPGGutj2P+lqTfSfqtpDskbZ9jiDXX2zGXfXaRpJC0Ux6xZaGv45X02fR7XiDpm3nFl4U+/l1PlfSIpG5Jj0o6MM8Ya03SLpIelPRU+p2en86v+TmspRMFcCNwVI95FwO/iohJwK/S6SK5kXcf833AX0fEPsCzwCX1DipjN/LuY0bSLsCRwIv1DihjN9LjeCUdDhwH7BsRewGX5xBXlm7k3d/xN4GvRMRU4EvpdJFsAC6KiCnA+4FzJE0hg3NYSyeKiJgL/KnH7OOA76fvvw8cX8+YstbbMUfEvRGxIZ18BBhf98Ay1Mf3DHAF8PdAoe7o6ON4zwa+HhFvpsu8WvfAMtTHMQcwOn2/HfByXYPKWES8EhGPp+9XAU8D7yGDc1hLJ4o+jIuIV9L3fwDG5RlMDj4N3J13EFmTdBywJCKeyDuWOpkMHCLp3yX9WtIBeQdUBxcA35L0EskVVNGulDeT1A7sB/w7GZzDnCgqiOTe4UL92qxE0hdJLmdvzjuWLEkaCXyBpDmiVWwB7EjSRPF54BZJyjekzJ0NXBgRuwAXArNyjicTkrYFfgJcEBEryz+r1TnMieLd/ijpLwDSv4W6RO+LpE8BxwCfjOI/XLMHMAF4QtJCkqa2xyX9ea5RZWsxcHskfgNsIhlArsj+B3B7+v5WoFCd2QCS2kiSxM0RUTrWmp/DnCje7U6Sf2Ckf3+WYyx1Iekokrb6YyNiTd7xZC0i/jMi/iwi2iOineQk+t6I+EPOoWXpp8DhAJImA1tS/FFVXwYOS99/AHgux1hqLr0inAU8HRH/WPZR7c9hEdGyL2A28AqwnuRkcRowhuROgeeA+4Ed846zDsf8PPAS0J2+rss7zqyPucfnC4Gd8o4z4+94S+BfgSeBx4EP5B1nHY55OvAY8ARJ2/3+ecdZ42OeTtKs9Nuy/3c/nMU5zEN4mJlZRW56MjOzipwozMysIicKMzOryInCzMwqcqIwM7OKnCisENIRYL9dNv05SV+u0bZvlPTRWmyrn/18TNLTkh6swba+LOlzvczfWdJt6fupkj481H1Z8TlRWFG8CZzYaMOFS9piAIufBpwREYdnFU9EvBwRpaQ3leS+e7OKnCisKDaQ1Au+sOcHPa8IJK1O/3akA+T9TNILkr4u6ZOSfiPpPyXtUbaZGWlNg2clHZOuPzyt5TE/reXxd2XbfUjSncBTvcTTmW7/SUnfSOd9ieQBqlmSvtVjeUm6RtIzku6XdFfpeCQtLCVHSdMkdZWtuq+kh9O6BGeky7Sn+90S+Afg42m9ho9LOix93y3pPySNGthXYEU1kF87Zo3uWuC3AyzKsy/wVyRDVL8AfC8iDkyLwHyWZARSgHaSsYL2AB6UNBE4BVgREQdI2gqYJ+nedPn3ktT4+K/ynUnaGfgGsD/wOnCvpOMj4h8kfQD4XEQ82iPGE4A9gSkkI4E+BdxQxbHtQzII4DbAf0j6RemDiHgrTU7TIuLcNLY5wDkRMS8daG5dFfuwFuArCiuMSEbOvAk4bwCrzY9kXP83gd8DpRP9f5Ikh5JbImJTRDxHklD+kqTo0SmSukmGiBgDTEqX/03PJJE6AOiKiKWR1AC5GTi0nxgPBWZHxMaIeBl4oMpj+1lErI2I14AH6X9QvHnAP0o6D9g+3q5RYi3OicKK5kqStv5tyuZtIP23LmkYybhHJW+Wvd9UNr2Jd15x9xzrJgABn42IqelrQkSUEs0bQzmIAdh8bMCIXmKsNP3ODyO+DpwObE1ydfSXNYnQmp4ThRVKRPwJuIUkWZQsJGnqATgWaBvEpj8maVjab7E78AzwS+DsdKhnJE2WtE2ljQC/AQ6TtJOk4UAn8Ot+1plL0pcwPB02uryzeyFvH9tHeqx3nKQRksYAHcD8Hp+vAjb3Q0jaI5KRdb+RLutEYYAThRXTt3lnrYXvkpycnwD+hsH92n+R5CR/N3BWRKwDvkfSX/C4pCeB79BPv18klccuJmkKegJ4LCL6Gwb6DpKRQJ8iaVp7uOyzrwD/JOlRYGOP9X6b7ucR4P+kzVblHgSmlDqzgQvSju7fkozCWvhKh1Ydjx5r1mQk3Qj8PCJuyzsWaw2+ojAzs4p8RWFmZhX5isLMzCpyojAzs4qcKMzMrCInCjMzq8iJwszMKvr/89REacZu9jUAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "benchmarkCompare(\"Hadamard at n-1\", 10, list(range(10,21)), lambda n: [qml.Hadamard(wires=(n-1))])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "specific-switch",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Running with old backend:\n",
+      "n=10 took an average of 0.00040056705474853513 sec (std dev: 0.0005171318760342542 sec)\n",
+      "n=11 took an average of 0.0007977008819580079 sec (std dev: 0.000420456927697162 sec)\n",
+      "n=12 took an average of 0.0014971256256103515 sec (std dev: 0.0005255731493787098 sec)\n",
+      "n=13 took an average of 0.003098464012145996 sec (std dev: 0.00031761877863812005 sec)\n",
+      "n=14 took an average of 0.006099152565002442 sec (std dev: 0.0005668104646766745 sec)\n",
+      "n=15 took an average of 0.012996149063110352 sec (std dev: 0.0006676415547231663 sec)\n",
+      "n=16 took an average of 0.029199504852294923 sec (std dev: 0.0017529596323175285 sec)\n",
+      "n=17 took an average of 0.05899534225463867 sec (std dev: 0.0026679203822505856 sec)\n",
+      "n=18 took an average of 0.13122453689575195 sec (std dev: 0.008542911924467529 sec)\n",
+      "n=19 took an average of 0.2784926176071167 sec (std dev: 0.005485490092164815 sec)\n",
+      "n=20 took an average of 0.6029375314712524 sec (std dev: 0.024008973364595003 sec)\n",
+      "Running with new backend:\n",
+      "n=10 took an average of 0.00040075778961181643 sec (std dev: 0.0005173789550392614 sec)\n",
+      "n=11 took an average of 0.0002990245819091797 sec (std dev: 0.00048148341723841255 sec)\n",
+      "n=12 took an average of 0.00040030479431152344 sec (std dev: 0.0005168097518616734 sec)\n",
+      "n=13 took an average of 0.0006988525390625 sec (std dev: 0.0004823040800878117 sec)\n",
+      "n=14 took an average of 0.00040004253387451174 sec (std dev: 0.0005164527439940671 sec)\n",
+      "n=15 took an average of 0.0009965896606445312 sec (std dev: 5.168791625184727e-06 sec)\n",
+      "n=16 took an average of 0.0017998933792114258 sec (std dev: 0.00042174489353259367 sec)\n",
+      "n=17 took an average of 0.0033983945846557616 sec (std dev: 0.0006979360514536127 sec)\n",
+      "n=18 took an average of 0.006597089767456055 sec (std dev: 0.001775840210528492 sec)\n",
+      "n=19 took an average of 0.011401009559631348 sec (std dev: 0.0006982952094258571 sec)\n",
+      "n=20 took an average of 0.022799468040466307 sec (std dev: 0.0014769762426474502 sec)\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYoAAAEWCAYAAAB42tAoAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/Il7ecAAAACXBIWXMAAAsTAAALEwEAmpwYAAAkDElEQVR4nO3de5hcVZnv8e+PpiGEJFxCiEKADiRhDAMECaDcbBQYlDsqTh85DBhg5C4HZw6MZwTnPOMVBgbwDKJhEIeJAoKCgtzbMBwYA9ooIXKR4ZKA0kRyoxPpJO/8sXeFStOpru7eu6tq1+/zPPVU7V21q95Fh3prrb32uxQRmJmZbchGtQ7AzMzqmxOFmZlV5ERhZmYVOVGYmVlFThRmZlaRE4WZmVXkRGFWRlKbpJC0ca1j6U8a25Rax2HNxYnCGpqkFyUd2mffKZL+o1Yx1SNJ7ZIWDvAaSfqapMXp7WuSNFIxWv2qy19NZs1O0sYRsXqEP/YM4DhgTyCA+4D/Aq4d4TiszrhHYYUn6SJJv5O0XNLTko4ve65F0mWS3pD0AnBkn2NPlbQgPfYFSX9d9ly7pIWS/lbS65Jek3ScpI9JelbSHyX9Xdnr95X0qKQl6WuvkbRJ2fMh6WxJzwHPpfv+Jn3tq5I+M0A7+41V0ubA3cB2klakt+36eYu/Ai6PiIURsQi4HDil6v/QVlhOFNYMfgccBGwBfAn4N0nvTZ87HTgK2AuYCXyiz7Gvp8+PA04FrpD0/rLn3wOMArYHvgh8GzgJ2Dv9zL+XNDl97RrgAmAb4IPAR4Cz+nzeccB+wHRJRwCfBw4DpgKHUlm/sUbEW8BHgVcjYkx6e7Wf43cDnizbfjLdZ03OicKK4Efpr/QlkpYA/6/8yYi4JSJejYi1EfEDkl/r+6ZPnwhcGRGvRMQfga/0OfanEfG7SPwcuJckAZT0Av8YEb3A90mSwD9HxPKImA88TTKUQ0Q8ERGPRcTqiHgR+BbwoT5t+UpE/DEiVqax/WtEPJV+2V9a6T9CFbEOZAywtGx7KTDG5ynMicKK4LiI2LJ0o8+vdEknS+oqSyR/TvKFDrAd8ErZy1/qc+xHJT2WDiMtAT5WdizA4ohYkz5emd7/oez5lSRfwEiaJuknkn4vaRnw5T7vRZ9YKsbWVxWxDmQFSW+kZBywIlw5tOk5UVihSdqJZDjoHGB8mkieAkq/kl8Ddig7ZMeyYzcFfghcBkxMj72r7NjB+hfgt8DUiBgH/F0/71X+pbzB2PqqItZqvuznk/Z+Unum+6zJOVFY0W1O8iXZDckJX5IeRcnNwHmSJknaCrio7LlNgE3TY1dL+ihw+DBiGQssA1ZI+jPgzAFefzNwiqTpkkYDl1R47UCx/gEYL2mLCu9xI/C/JG2fnuy+ELhhgBitCThRWKFFxNMks3ceJfmy3B14pOwl3wbuITlx+0vgtrJjlwPnkXxhvwn8D+COYYTz+fQ9lqef+4MBYr8buBJ4EHg+vd/QayvGGhG/BeYAL6RDcP3NevoWcCfwG5Je10/Tfdbk5OFHMzOrxD0KMzOryInCzMwqcqIwM7OKnCjMzKyiQhYF3GabbaKtrW1Ix7711ltsvvnm2QZU59zm5uA2F99w2/vEE0+8ERET+u4vVKKQdDRw9JQpU3j88ceH9B6dnZ20t7dnGle9c5ubg9tcfMNtr6R+r/4v1NBTRNwZEWdssUWla4rMzGwwCpUozMwse4VKFJKOlnTd0qVLB36xmZlVpVDnKCLiTuDOmTNnnt73ud7eXhYuXMiqVasqvscWW2zBggUL8goxV6NGjWLSpEm0trbWOhQzK5BCJYpKFi5cyNixY2lra6NSef3ly5czduzYEYwsGxHB4sWLWbhwIZMnTx74ADOzKjXN0NOqVasYP358xSTRyCQxfvz4AXtMZmaDVahEMdCsp6ImiZKit8/MNqy7G3p6kvusFSpRmJk1ozlzYKed4Nlnk/s5c7J9fyeKEbRw4UKOPfZYpk6dyi677ML555/P22+/TWdnJ0cddVS/x7S1tfHGG2+McKRm1ii6u2HWLFi5Eq6+egYrVybbWfYsCpUo6nl6bERwwgkncNxxx/Hcc8/x7LPPsmLFCr7whS/UOjQza2AvvgibbLL+vtbWZH9WCpUosr4yu7sb5s3LJjM/+OCDjBo1ilNPPRWAlpYWrrjiCq6//np6enrWvW7x4sUcfvjh7Lbbbpx22ml4YSkzq6StDd5+O3l81lldAPT2JvuzUqhEkaXSmN9hh2Uz5jd//nz23nvv9faNGzeOHXfckeeff37dvi996UsceOCBzJ8/n+OPP56XX355eB9sZoU2YQLMng2bbQYtLcn97NnJ/qw4UfSjfMxv6VJyGfPbkLlz53LSSScBcOSRR7LVVlvl/6Fm1tA6OuCll2DatOS+oyPb93ei6EceY37Tp0/niSeeWG/fsmXLePnll5kyZcrQ39jMjKQHMXp0tj2JkkIliqxOZpeP+ZUMd8zvIx/5CD09Pdx4440ArFmzhgsvvJBTTjmF0aNHr3vdwQcfzL//+78DcPfdd/Pmm28O/UPNzDJQqESR1cns8jG/ceOyGfOTxO23384tt9zC1KlTmTZtGqNGjeLLX/7yeq+75JJLmDt3Lrvtthu33XYbO+6447DaYmY2XE1T62mwOjrg0EOT4aa2tmy6czvssAN33nnnu/a3t7evW2xk/Pjx3HvvvcP/MDOzjDhRVDBhQj7jfWZmjaRQQ09mZpY9JwozM6uoUIminkt4mJk1qkIliqxLeJiZWcEShZmZZc+JYgRJ4sILL1y3fdlll3HppZfWLiAzsyo4UYygTTfdlNtuu83rS5hZQ3GiqCTLOuPAxhtvzBlnnMEVV1zRz0d18/GPf5x99tmHffbZh0ceeQSA3XffnSVLlhARjB8/fl0JkJNPPpn77rsvk7jMzCpxotiQrOuMp84++2xuuukm+s7MOv/887nggguYN28eP/zhDznttNMAOOCAA3jkkUeYP38+O++8Mw8//DAAjz76KPvvv38mMZlZdjL+fVkXCnVltqSjgaOHXY21vM74ypXJvlmzkpoew7xUe9y4cZx88slcddVVbLbZZuv233///Tz99NPrtpctW8aKFSs46KCDmDt3LjvttBNnnnkm1113HYsWLWKrrbZi8803H1YsZpatOXOSr4pNNkkKi86enX3J71ooVI8is+mxOa8t+LnPfY7Zs2fz1ltvrdu3du1aHnvsMbq6uujq6mLRokWMGTOGgw8+mIcffpiHH36Y9vZ2JkyYwK233spBBx2USSxmlo1armOTt0IliszkUWe8zNZbb82JJ57I7Nmz1+07/PDDufrqq9dtd3V1AUkhwTfeeIPnnnuOnXfemQMPPJDLLruMgw8+OJNYzCwbI7F2da04UfQnjzrjfVx44YXrzX666qqrePzxx9ljjz2YPn0611577brn9ttvP6ZNmwbAQQcdxKJFizjwwAMzi8XMhi/n35c1VahzFJnKoc74ihUr1j2eOHEiPT0967a32WYbfvCDH/R73Pe+9711j/fff3/Wrl077FjMLFul35ezZiU9id7e7NeurhUnikpcZ9zMBiGPdWzqgROFmVmGivj7sqnOUURErUPIVdHbZ2a10TSJYtSoUSxevLiwX6YRweLFixk1alStQzGzgmmaoadJkyaxcOFCugeY1Lxq1aqG/bIdNWoUkyZNqnUYZlYwTZMoWltbmTx58oCv6+zsZK+99hqBiMzMGkOhhp68wp2ZWfYKlSi8wp2ZWfYKlSjMzCx7ThRmZlaRE4WZmVXkRGFmZhU5UZiZWUVOFGZmVpEThZkVUnc39PQUY4W5WnOiMLPCmTMH3vMeOO+8Gey0U7JtQ+dEYWaFUlq7eu1aiCjW2tW14kRhZoVS5LWra8WJwswKpXzt6rPO6gKKs3Z1rThRmFmhlNau3mwzaGlJ7ouydnWt1H2ikLSzpNmSbq11LGbWGDo64KWXYNq05L6jo9YRNbZcE4Wk6yW9LumpPvuPkPSMpOclXVTpPSLihYiYlWecZlY8EybA6NHuSWQh74WLbgCuAW4s7ZDUAnwTOAxYCMyTdAfQAnylz/GfiYjXc47RzMwqyDVRRMRcSW19du8LPB8RLwBI+j5wbER8BTgqz3jMzGzwarEU6vbAK2XbC4H9NvRiSeOBfwT2knRxmlD6e90ZwBkAEydOpLOzc0jBrVixYsjHNiq3uTm4zcWXV3vrfs3siFgMfLaK110HXAcwc+bMaG9vH9LndXZ2MtRjG5Xb3Bzc5uLLq721mPW0CNihbHtSum/YvGa2mVn2apEo5gFTJU2WtAnwl8AdWbyx18w2M8te3tNj5wCPArtKWihpVkSsBs4B7gEWADdHxPw84zAzs6HLe9ZTv5e5RMRdwF1Zf56ko4Gjp0yZkvVbm5k1rbq/MnswPPRkZpa9qnoUkmYCBwHbASuBp4D7IuLNHGMzM7M6ULFHIelUSb8ELgY2A54BXgcOBO6X9F1JO+YfppmZ1cpAPYrRwAERsbK/JyXNAKYCL2cc15D4HIWZWfYq9igi4psbShLp810R8UD2YQ2Nz1GY1Zfubpg3z6vLNbqqTmZL+rqkcZJaJT0gqVvSSXkHZ2aNa84c2GknOOwwvG51g6t21tPhEbGMpGjfi8AU4G/yCsrMGltp3eqVK2HpUq9b3eiqTRSlcxlHArdERF3WyHAJD7P64HWri6XaRPETSb8F9gYekDQBWJVfWEPjcxRm9aF83eoSr1vduKpKFBFxEbA/MDMieoEe4Ng8AzOzxlW+bvW4cV63utFVnB4r6YR+9pVv3pZ1QGZWDB0dcOihyXBTW5uTRCMb6DqKo9P7bUl6FA+m24cA/x8nCjOrYMIEJ4giqJgoIuJUAEn3AtMj4rV0+70k62HXFV9wZ2aWvWpPZu9QShKpPwB1V7rDJ7PNzLJXbZnxByTdA5QumfkUcH8+IZmZWT2pKlFExDnpie2D0l3XRcTt+YVlZmb1ouqFiyLiNnzy2sys6VRb6+kESc9JWippmaTlkpblHdxg+cpsM7PsVXsy++vAMRGxRUSMi4ixETEuz8CGwiezzcyyV22i+ENELMg1EjMzq0vVnqN4XNIPgB8BfyrtTM9bmJlZgVWbKMaR1Hc6vGxf4JPbZmaFV+302FPzDsTMzOpTtbOeJkm6XdLr6e2HkiblHZyZZaO7G3p6vHCQDU21J7P/FbgD2C693ZnuM7M6N2cOvOc9cN55M7wkqQ1JtYliQkT8a0SsTm83AHVXE9LXUZitr7Qk6dq1EOElSW1oqk0UiyWdJKklvZ0ELM4zsKHwdRRm6/OSpJaFahPFZ4ATgd8DrwGfAHyC26zOlS9JetZZXYCXJLXBq3Yp1Jci4piImBAR20bEcRHxct7BmdnwlC9J2tLiJUltaKqd9fRdSVuWbW8l6frcojKzzHR0wEsvwbRpyX1HR60jslzkOLWt2qGnPSJiSWkjIt4E9so8GjPLxYQJMHq0exKFlU5tm3HeeeQxta3aRLGRpK1KG5K2ZhAlys3MLCcjMLWt2i/7y4FHJd2Sbn8S+MfMojAzs6EpTW1bufKdfaWpbRl1Iast4XGjpMeBD6e7ToiIpzOJwMzMhq58altJxlPbqh16AtgaeCsirgG6JU3OLAozMxuasqltXeeem8vUtmpnPV0C/G/g4nRXK/BvmUWREV+ZbWZNKeepbdX2KI4HjgHeAoiIV4GxmUaSAV+ZbWZNK8epbdUmircjIkjWoEDS5plHYmZmdanaRHGzpG8BW0o6Hbgf+HZ+YZmZWb2odtbTZZIOA5YBuwJfjIj7co3MzMzqQlWJIh1qejAi7pO0K7CrpNaI6M03PDMzq7Vqh57mAptK2h74GfA/gRvyCsrMzOpHtYlCEdEDnAD8S0R8Etgtv7DMzKxeVJ0oJH0Q+DTw03RfSz4hmRVTdzfMm+fV5azxVJsozie52O72iJgvaWfgofzCMiuWOXOSop6HHZZLcU+zXFU762kuyXmK0vYLwHl5BWVWJKXinitXvlO3bdYsOPRQl/22xlCxRyHp25J238Bzm0v6jKRP5xOaWTF43WprdAP1KL4J/H2aLJ4CuoFRwFRgHHA9cFOuEZo1uBEo7mn1pLs7+RXQ1laYLmPFRBERXcCJksYAM4H3AiuBBRHxTP7hmTW+UnHPWbOSnkRvr9etLqw5c+Ckk0BKupGzZxdi7dlqz1GsADrzDcWsuDo6knMSBfuhaeXKV5qDd1aaK8DJqLpfzlTSccCRJENdsyPi3tpGZDY0EyY0/PeFVTICK83VymAWLho0SddLel3SU332HyHpGUnPS7qo0ntExI8i4nTgs8Cn8ozXzGzICnwyalCJQtLoQb7/DcARfd6jheQk+UeB6UCHpOmSdpf0kz63bcsO/T/pcWZm9adspTnGjctlpblaUbLMxAAvkvYHvgOMiYgdJe0J/HVEnFXFsW3ATyLiz9PtDwKXRsRfpNsXA0TEVzZwvICvAvdFxP0VPucM4AyAiRMn7v39739/wHb1Z8WKFYwZM2ZIxzYqt7k5uM0jZPXqpGexySaw8ciO7g+3vYcccsgTETGz7/5qW3EF8BfAHQAR8aSkg4cYy/bAK2XbC4H9Krz+XOBQYAtJUyLi2v5eFBHXAdcBzJw5M9rb24cUXGdnJ0M9tlG5zc3BbS6+vNpbdbqLiFeSH/frrMk8mv4/9yrgqpH4LDMze7dqz1G8kg4/haRWSZ8HFgzxMxcBO5RtT0r3DZukoyVdt3Tp0izezszMqD5RfBY4m2TYaBEwI90einnAVEmTJW0C/CXpkNZwRcSdEXHGFltskcXbmZkZ1V9w9wZJifFBkTQHaAe2kbQQuCQiZks6B7iHpFT59RExf7DvbWZWUXs7M5Ysga6uWkfS8KpdCnUyyUnltvJjIuKYSsdFRL/XrkfEXcBdVUdZJUlHA0dPmTIl67c2M2ta1Z7M/hEwG7gTWJtbNMMUEXcCd86cOfP0WsdiZlYU1SaKVensIzOzxtDbm9Rd6u4uxEVvtVTtyex/lnSJpA9Ken/plmtkQ+BZT2YGJFVcH3sMenq8pGAGqk0UuwOnk1whfXl6uyyvoIbKs56sGt3dyfeH164uqPIqrhHvVHH1H3zIqh16+iSwc0S8PeArzepYabmAyZNn8OqrhVkuwMoVuIprrVTbo3gK2DLHOMxy5x+aTaLAVVxrpdpEsSXwW0n3SLqjdMsxriHxOQqrxGtXN4lSFdeNNkpWmitQFddaqXbo6ZJco8iIp8daJf6h2UQ6OuCaa2D5cnjpJSeJYar2yuyf5x2IWd5KPzRLSxr7h2bBtbYmvQr/gYetYqKQ9B8RcaCk5UD5whUCIiLG5RqdWcZKa1fPm9fFPvu0+zvErAoVE0VEHJjejx2ZcMzyN2ECjB7tH5pm1arqZLak71Wzr9Z8MtvMLHvVznrarXxD0sbA3tmHMzy+4M7M1unspOvKK2sdRSFUTBSSLk7PT+whaVl6Ww78AfjxiERoZmY1VTFRRMRX0vMT34iIceltbESMj4iLRyhGMzOroWqnx14saXtgJ9Zfj2JuXoGZmVl9qHbhoq+SLFn6NLAm3R2AE4WZbVh7e3Lf2VnLKGyYqr0y+3hg14j4U57BDJdXuDMzy161s55eAFrzDCQLnvVkVmd6e5MyGq682NCq7VH0AF2SHgDW9Soi4rxcojKzxldaPEhKFg9yTfeGVW2iuCO9mWWiuzup2trW5iukC6m8pju8U9P90EP9B29A1c56+m7egVjzKC0eJCVlv/1Ds4C8eFChVDvr6b9YvyggABGxc+YRWaH5h2aTcE33Qql26Glm2eNRJEujbp19OFZ0/qHZJPrWdC91Hf1HbkhVzXqKiMVlt0URcSVwZL6hDZ6LAtY//9BsIh0d8IEPwJ57JosHeXyxYVVbPfb9ZbeZkj5L9b2REePpsfWvfJXKlhYvHlR4ra0wdqz/wA2u2i/7y8serwZeJBl+Mhu00uJBnvVk1hiqnfV0SPm2pBaSkh7P5hGUFd+ECU4QTcGlOwphoDLj49JS49dIOkyJc4DngRNHJkQzM6ulgXoU3wPeBB4FTge+QLJe9vER0ZVvaGZmVg8GShQ7R8TuAJK+A7wG7BgRq3KPzMzM6sJAs556Sw8iYg2w0EnCzKy5DNSj2FPSsvSxgM3SbQEREeNyjc7MstHezowlS6Crq9aRWAOqmCgiomWkAjEzs/pU7XoUZmbWpOru6urh8Ap3g9feDkuWzPCIRNH19iaVGLu7fQGLDVqhehQu4WHWj9ICQj09yQJCc+bUOiJrMIVKFGbWR3ld94h36rp7aVIbBCcKsyIr1XUvV6rrblYlJ4omVz50bQXkuu6WASeKJuah6yZQXtddcl13GxIniibloesmUlpAaPRoLyBkQ+JE0aQ8dN1kWluTXoV7EjYEThRNykPXZlYtJ4om5aHrJtPZSdeVV9Y6CmtQhboy2wanowOuuQaWL0+Grp0kzKw/7lE0OQ9dm9lAnCjMzKwiJ4o60N6e3JpKUzbarDHVfaKQ9D5J10q6VdKZtY7HzKzZ5JooJF0v6XVJT/XZf4SkZyQ9L+miSu8REQsi4rPAicABecZrlqvubpg3z1c1WsPJu0dxA3BE+Q5JLcA3gY8C04EOSdMl7S7pJ31u26bHHAP8FLgr53jN8jFnTlIn5bDDXC/FGk6uiSIi5gJ/7LN7X+D5iHghIt4Gvg8cGxG/iYij+txeT9/njoj4KPDpPOM1y0WpXsrKlbB0qeulWMOpxXUU2wOvlG0vBPbb0IsltQMnAJtSoUch6QzgDICJEyfS2dk5pOBWrFgx5GOHasmSGQB0dnaN6OcCXHppqc1jRvRzZyxZAkDXCP+3LhnRv3NPD3z5y7BmzTv7WlqSYajRo0cmBmrzb7vWmq3NebW37i+4i4hOoLOK110HXAcwc+bMaB/ijJrOzk6GeuxQbbllcj/Sn1tSizaXGt0Ube7uhk98IulJlGy22Yhf5ViTv3ONNVub82pvLRLFImCHsu1J6b5hG+6a2V1btjNm9WpY8R9ZhNMY2tuTX/fNtGj2SLe5VC9l1qzkCsfeXtdLsYZSi+mx84CpkiZL2gT4S+COLN64UdfM7u1Nymh4yLrAOjqSHsT997vUtzWcvKfHzgEeBXaVtFDSrIhYDZwD3AMsAG6OiPl5xlHPSosHPfmkJ8MU3oQJsM8+7klYw8l16Cki+v3ZFBF3kcNU1+EOPY208sWD4J3JMIce6u8SM6sfdX9l9mA02tBTafGgh2jnIdqBJlo8yONtZg2jUImi0TTt4kEebzNrKE4UNVSaDAMgmmTxoPLxtjVrfPGZWQMoVKKQdLSk65YuXVrrUKrW0QHjxsHmY5pkMowX6zZrOIVKFI12jqJkI8HGLQXvSZQ07XibWeMqVKKwBlC+WHdLS5OMt5k1trov4WEFVFqse9Uq+NnPnCTM6lyhehSNeI6iabW2wtixThJmDaBQiaJRz1GYmdWzQiUKMzPLnhOFmZlV5ERhZmYVFSpR+GS2mVn2CpUofDLbzCx7hUoUw7V2bRARvLGgieoO9fYmdZeaqdZSM7bZbBicKFKPnDsHLV8Ga9cyevpOPHJuE1Q0LVVx7elpniquzdhms2FyogDeWNDNXtfMQgQCRrOSva6ZVeyeRXkV14jmqOLajG02y0ChEsVQT2a//osX6WX9iqa9tPL6L17MMLo604xVXJuxzWYZKFSiGOrJ7G33baOV9SuattLLtvu2ZRhdnWnGKq7N2GazDBQqUQzVNu+bwK/OmU0gAuhhM351zmy2ed/I1CGaMSO5jajyKq5Sc1RxbcY2m2XAiSJ1wNUdxNhxsNFG9Dz9EgdcXfQVhEiquH7gAzB6dJOsmkRzttlsmJwoymy0kZA0Yj2JutDamvzCbqZf1c3YZrNhcKKoB729sHy5Z9+YWV1yoqi10rz+J5/0vH4zq0tOFLVUPq9/zRrP6zezulSoRNFwRQE9r9/MGkChEkXDFQX0vH4zawCFShQNp3xef0uL5/WbWV3auNYBNL2ODrjmGli1Cn72MycJM6s7ThT1oLU1uTlJmFkd8tCTmZlV5ERhZmYVOVGYmVlFPkdhtdHZWesIzKxK7lGYmVlFiohax5A5Sd3AS0M8fBvgjQzDaQRuc3Nwm4tvuO3dKSLeNf2ykIliOCQ9HhEzax3HSHKbm4PbXHx5tddDT2ZmVpEThZmZVeRE8W7X1TqAGnCbm4PbXHy5tNfnKMzMrCL3KMzMrCInCjMzq6ipE4Wk6yW9Lumpsn1bS7pP0nPp/Va1jDFrG2jzNyT9VtKvJd0uacsahpi5/tpc9tyFkkLSNrWILQ8baq+kc9O/83xJX69VfHnYwL/rGZIek9Ql6XFJ+9YyxqxJ2kHSQ5KeTv+m56f7M/8Oa+pEAdwAHNFn30XAAxExFXgg3S6SG3h3m+8D/jwi9gCeBS4e6aBydgPvbjOSdgAOB14e6YBydgN92ivpEOBYYM+I2A24rAZx5ekG3v03/jrwpYiYAXwx3S6S1cCFETEd+ABwtqTp5PAd1tSJIiLmAn/ss/tY4Lvp4+8Cx41kTHnrr80RcW9ErE43HwMmjXhgOdrA3xngCuBvgULN6NhAe88EvhoRf0pf8/qIB5ajDbQ5gHHp4y2AV0c0qJxFxGsR8cv08XJgAbA9OXyHNXWi2ICJEfFa+vj3wMRaBlMDnwHurnUQeZN0LLAoIp6sdSwjZBpwkKT/lPRzSfvUOqAR8DngG5JeIelBFa2nvI6kNmAv4D/J4TvMiaKCSOYOF+rXZiWSvkDSnb2p1rHkSdJo4O9IhiOaxcbA1iRDFH8D3CxJtQ0pd2cCF0TEDsAFwOwax5MLSWOAHwKfi4hl5c9l9R3mRPFuf5D0XoD0vlBd9A2RdApwFPDpKP7FNbsAk4EnJb1IMtT2S0nvqWlU+VoI3BaJXwBrSQrIFdlfAbelj28BCnUyG0BSK0mSuCkiSm3N/DvMieLd7iD5B0Z6/+MaxjIiJB1BMlZ/TET01DqevEXEbyJi24hoi4g2ki/R90fE72scWp5+BBwCIGkasAnFr6r6KvCh9PGHgedqGEvm0h7hbGBBRPxT2VPZf4dFRNPegDnAa0AvyZfFLGA8yUyB54D7ga1rHecItPl54BWgK71dW+s4825zn+dfBLapdZw5/403Af4NeAr4JfDhWsc5Am0+EHgCeJJk7H7vWseZcZsPJBlW+nXZ/7sfy+M7zCU8zMysIg89mZlZRU4UZmZWkROFmZlV5ERhZmYVOVGYmVlFThRWCGkF2MvLtj8v6dKM3vsGSZ/I4r0G+JxPSlog6aEM3utSSZ/vZ/92km5NH8+Q9LHhfpYVnxOFFcWfgBPqrVy4pI0H8fJZwOkRcUhe8UTEqxFRSnozSObdm1XkRGFFsZpkveAL+j7Rt0cgaUV6354WyPuxpBckfVXSpyX9QtJvJO1S9jaHpmsaPCvpqPT4lnQtj3npWh5/Xfa+D0u6A3i6n3g60vd/StLX0n1fJLmAarakb/R5vSRdI+kZSfdLuqvUHkkvlpKjpJmSOssO3VPSo+m6BKenr2lLP3cT4B+AT6XrNXxK0ofSx12SfiVp7OD+BFZUg/m1Y1bvvgn8epCL8uwJvI+kRPULwHciYt90EZhzSSqQArSR1AraBXhI0hTgZGBpROwjaVPgEUn3pq9/P8kaH/9V/mGStgO+BuwNvAncK+m4iPgHSR8GPh8Rj/eJ8XhgV2A6SSXQp4Hrq2jbHiRFADcHfiXpp6UnIuLtNDnNjIhz0tjuBM6OiEfSQnOrqvgMawLuUVhhRFI580bgvEEcNi+Suv5/An4HlL7of0OSHEpujoi1EfEcSUL5M5JFj06W1EVSImI8MDV9/S/6JonUPkBnRHRHsgbITcDBA8R4MDAnItZExKvAg1W27ccRsTIi3gAeYuCieI8A/yTpPGDLeGeNEmtyThRWNFeSjPVvXrZvNem/dUkbkdQ9KvlT2eO1ZdtrWb/H3bfWTQACzo2IGeltckSUEs1bw2nEIKxrGzCqnxgrba//ZMRXgdOAzUh6R3+WSYTW8JworFAi4o/AzSTJouRFkqEegGOA1iG89SclbZSet9gZeAa4BzgzLfWMpGmSNq/0JsAvgA9J2kZSC9AB/HyAY+aSnEtoSctGl5/sfpF32vbxPscdK2mUpPFAOzCvz/PLgXXnISTtEkll3a+lr3WiMMCJworpctZfa+HbJF/OTwIfZGi/9l8m+ZK/G/hsRKwCvkNyvuCXkp4CvsUA5/0iWXnsIpKhoCeBJyJioDLQt5NUAn2aZGjt0bLnvgT8s6THgTV9jvt1+jmPAf83HbYq9xAwvXQyG/hceqL71yRVWAu/0qFVx9VjzRqMpBuAn0TErbWOxZqDexRmZlaRexRmZlaRexRmZlaRE4WZmVXkRGFmZhU5UZiZWUVOFGZmVtF/A8PrjFK9tTpuAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "benchmarkCompare(\"Hadamard at 0\", 10, list(range(10,21)), lambda n: [qml.Hadamard(wires=(0))])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "patent-convert",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Running with old backend:\n",
+      "n=10 took an average of 0.0003976106643676758 sec (std dev: 0.000513330845979032 sec)\n",
+      "n=11 took an average of 0.0007998466491699219 sec (std dev: 0.0004216017574737235 sec)\n",
+      "n=12 took an average of 0.0016967296600341798 sec (std dev: 0.00048460339724868827 sec)\n",
+      "n=13 took an average of 0.0033998966217041017 sec (std dev: 0.0005193051815450249 sec)\n",
+      "n=14 took an average of 0.005602359771728516 sec (std dev: 0.0007033538276988751 sec)\n",
+      "n=15 took an average of 0.013700532913208007 sec (std dev: 0.0010583363803630015 sec)\n",
+      "n=16 took an average of 0.030200266838073732 sec (std dev: 0.001316543831523577 sec)\n",
+      "n=17 took an average of 0.06789846420288086 sec (std dev: 0.003381681096401736 sec)\n",
+      "n=18 took an average of 0.14289479255676268 sec (std dev: 0.006905108453799577 sec)\n",
+      "n=19 took an average of 0.2936877250671387 sec (std dev: 0.006455953442562644 sec)\n",
+      "n=20 took an average of 0.6086820602416992 sec (std dev: 0.01271580197888051 sec)\n",
+      "Running with new backend:\n",
+      "n=10 took an average of 0.00020041465759277344 sec (std dev: 0.0004225124071491866 sec)\n",
+      "n=11 took an average of 0.0003983259201049805 sec (std dev: 0.000514283336866798 sec)\n",
+      "n=12 took an average of 0.0005992412567138672 sec (std dev: 0.0005157571992798073 sec)\n",
+      "n=13 took an average of 0.0005977392196655273 sec (std dev: 0.0005144676840276629 sec)\n",
+      "n=14 took an average of 0.0006971359252929688 sec (std dev: 0.0004811570599522002 sec)\n",
+      "n=15 took an average of 0.0009994745254516602 sec (std dev: 0.00047218798688191765 sec)\n",
+      "n=16 took an average of 0.0018994808197021484 sec (std dev: 0.0005659814917078239 sec)\n",
+      "n=17 took an average of 0.0034969568252563475 sec (std dev: 0.0007012151402308746 sec)\n",
+      "n=18 took an average of 0.006701421737670898 sec (std dev: 0.0013383385630171187 sec)\n",
+      "n=19 took an average of 0.01409909725189209 sec (std dev: 0.0028831788493639504 sec)\n",
+      "n=20 took an average of 0.028097009658813475 sec (std dev: 0.004067521774778753 sec)\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYoAAAEWCAYAAAB42tAoAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/Il7ecAAAACXBIWXMAAAsTAAALEwEAmpwYAAAkhklEQVR4nO3deZgc5XXv8e8PMSCEJBYhy4sAAZJIRAARhtiAIIMNmMTILLZx5kKIMctlNTjgXLg4BpIb27FxsAXkOopFZGwsDBhsyWFfJiIKxAIyshGY5TosEmCEjDYkgZZz/6hq0Ro0PT09VdPd1b/P8/QzXdW1nJcWdbreqnqPIgIzM7PebFXvAMzMrLE5UZiZWUVOFGZmVpEThZmZVeREYWZmFTlRmJlZRU4UZoNIUkh6S9Lf1TuWgZI0UdIqSRsknVHveCw/ThTWsCT9D0mPpQejVyXdJWlK+tmV6UH3pLLlt07njSubd4ikByWtlLRc0hxJk9LPTk63vUrSGkkby6ZX1RDvlZJ+WMWi+0fE5f3dfrqPiZJ+JmmJpN9JukfS3rVsq8r9nZ9+B29Lmln+WUQ8GxHDgYfz2r81BicKa0iS/hL4NvBVYAywG/CPwHFli/0OuErSkF62cTBwL/Az4IPAHsACYJ6kPSPipogYnh7s/gR4pTSdzmtEOwKzgb1J/rv8gqR9eXkF+D/ADTnuwxqcE4U1HEk7AH8DnBcRt0fEWxGxLiLmRMSXyha9G3gHOKWXTX0DuDEivhMRKyPidxHxZeBR4MoaY/uOpJclrZD0uKTD0vnHAP8b+Gx6RrKgyu2NS8+C/kLSS5LekNTr2UZE/CIiZqRtWQdcA+wtaVSV+3tB0iWSfpmeYf1Y0tAK+7s9In4KLK1m+1ZMThTWiA4GhgJ39LFcAH8NXCGprfwDScOAQ4Bbt7DeLcBRNcY2H5gM7Az8CLhV0tCIuJvk7OfH6RnJ/v3c7hSSs4SPAV+R9PtVrnc48FpE9OdAfhJwDMkZ1n7A5/qxrrUgJwprRKOANyJifV8LRsRsYAnQ82LqziT/vl/dwmqvArvUElhE/DAilkbE+oj4FrAtyQF+oK6KiDURsYCke6zPRCNpLHA98Jf93Ne0iHglIn4HzCFJfGa9cqKwRrQU2EXS1lUu/2XgcpKzkJI3gY3AB7aw/AeAN2oJLO22eTrttlkG7ECNSaeH18rerwaGp/tbVfbarSyO0STXX/4xImZltK+7yvZ1ck2tsEKq9n9Es8H0CPA2cDxwW18LR8R9kp4Hzi2b95akR4DPAA/1WOUk4IH+BpVej/grku6hhRGxUdKbgEq77e82+7Kli+qSdiJJErMjIrPbbCPiT7LalhWLE4U1nIhYLukrwPWS1pMcFNcBRwJHRMRfbWG1y3nv3T+XAvdI+jXwLyT/3i8muQZyUA2hjQDWk3R1bS3pUmBk2ee/BY6StFVEbKxh+32SNBK4B5gXEZdu4fMO4KGIUM/Patzf1iT/3YYAQ9IL3+ur6Ra04nDXkzWktP//L0m6lZYALwPnAz/tZfl5JLeKls/7d+DjwIkk1yVeBA4ApkTEczWEdQ/JnVbPpttam8ZVUrpwvlTSEzVsvxonkCS503rpltoV+I8M9/dlYA1J0j0lff/lDLdvTUAuXGQ2eCStJelWmxYRf53D9r8H3BoR92S97S3sawLJXWDbAOdGxMy892n14URhZmYVuevJzMwqcqIwM7OKnCjMzKyiQt4eu8suu8S4ceNqWvett95i++23zzagBuc2twa3ufgG2t7HH3/8jYgY3XN+oRKFpKnA1PHjx/PYY4/VtI2uri46OjoyjavRuc2twW0uvoG2V9KLW5pfqK6ndHTRs3bYYYd6h2JmVhiFShRmZpa9QiUKSVMlTV++fHm9QzEzK4xCXaOIiDnAnPb29jN7frZu3ToWLVrE2rVrK25jhx124Omnn84rxFwNHTqUsWPH0tbW1vfCZmZVKlSiqGTRokWMGDGCcePGIfU+XtrKlSsZMWLEIEaWjYhg6dKlLFq0iD322KPe4ZhZgbRM19PatWsZNWpUxSTRzCQxatSoPs+YzMz6q1CJoq+7noqaJEqK3j4z692SJbB6dfI3a4VKFGZmrWjWLNh9d3j22eTvrP7WPOyDE8UgWrRoEccddxwTJkxgr7324sILL+Sdd96hq6uLY489dovrjBs3jjfeqKlqp5m1gCVL4PTTYc0auPbayaxZk0xneWZRqETRyLfHRgQnnngixx9/PM899xzPPvssq1at4vLLL693aGbWxF54AbbZJnl/7rndALS1JfOzUqhEkfWT2UuWwPz52WTmBx98kKFDh3LaaacBMGTIEK655hpuuOEGVq9evWm5pUuXcvTRR7PPPvtwxhln4HohZlbJuHHwzjubz1u3LpmflUIliiyV+vyOOiqbPr+FCxdy4IEHbjZv5MiR7Lbbbjz//POb5l111VVMmTKFhQsXcsIJJ/DSSy8NbMdmVmijR8OMGbDddjBkSPJ3xoxkflacKLagvM9v+XJy6fPrzdy5cznllFMA+MQnPsFOO+2U/07NrKl1dsKLL8LEicnfzs5st+9EsQXlfX4lA+3zmzRpEo8//vhm81asWMFLL73E+PHja9+wmRnJGcSwYdmeSZQUKlFkdTE7jz6/j33sY6xevZobb7wRgA0bNnDxxRfzuc99jmHDhm1a7vDDD+dHP/oRAHfddRdvvvlm7Ts1M8tAoRJFVhezy/v8Ro7Mps9PEnfccQe33norEyZMYOLEiQwdOpSvfvWrmy13xRVXMHfuXPbZZx9uv/12dttttwG1xcxsoFpmrKf+6uyEI49MupvGjcvmdG7XXXdlzpw575nf0dGxqdjIqFGjuPfeewe+MzOzjDhRVDB6dD79fWZmzaRQXU9mZpa9QiWKRn4y28ysWRUqUbhmtplZ9gqVKMzMLHtOFGZmVpETxSCSxMUXX7xp+uqrr+bKK6+sX0BmZlVwohhE2267LbfffrvrS5gVWJajTjcKJ4pKMv7Gt956a8466yyuueaaLexqCZ/61Kc46KCDOOigg5g3bx4A++67L8uWLSMiGDVq1KYhQE499VTuu+++TOIys2xkPep0oyhUosj09ticvvHzzjuPm266iZ4xXnjhhXzxi19k/vz5/OQnP+GMM84A4NBDD2XevHksXLiQPffck4cffhiARx55hEMOOSSTmMxs4Oo56nTeCvVkdkTMAea0t7efOaANlX/ja9Yk804/PRnTY4CPao8cOZJTTz2VadOmsd12222af//99/PUU09tml6xYgWrVq3isMMOY+7cuey+++6cc845TJ8+ncWLF7PTTjux/fbbDygWM8tOadTp0iED3h11utlHeCjUGUVm8hhnvMxFF13EjBkzeOuttzbN27hxI48++ijd3d10d3ezePFihg8fzuGHH87DDz/Mww8/TEdHB6NHj+a2227jsMMOyyQWM8vGYFSaqxcnii3J+RvfeeedOemkk5gxY8ameUcffTTXXnvtpunu7m4gGUjwjTfe4LnnnmPPPfdkypQpXH311Rx++OGZxGJm2chj1OlG4USxJYPwjV988cWb3f00bdo0HnvsMfbbbz8mTZrEd7/73U2fffjDH2bixIkAHHbYYSxevJgpU6ZkFouZZaNUae7++/OpNFcvhbpGkakcxhlftWrVpvdjxoxh9erVm6Z32WUXfvzjH29xvR/84Aeb3h9yyCFs3LhxwLGYWT6KOOq0E0UlRfzGzcz6yV1PZmZWUUslioiodwi5Knr7zKw+WiZRDB06lKVLlxb2YBoRLF26lKFDh9Y7FDMrmEJdo5A0FZg6fvz493w2duxYFi1axJI+HpNcu3Zt0x5shw4dytixY+sdhpkVTKESRaUns9va2thjjz363EZXVxcHHHBAHuGZmTWllul6MjOz2jhRmJlZRU4UZmZWkROFmRXSkiWwenUxhvmuNycKMyucUjmZZ58tVgGhenGiMLNCKS8nc+21kwtVQKhenCjMrFByLifTkpwozKxQilxAqF6cKMysUMrLyVxwQXehCgjVS6GezDYzg3fLycyfnxQQcpIYGJ9RmFkhjR4Nw4Y5SWTBicLMzCpq+EQhaU9JMyTdVu9YzMxaUa6JQtINkl6X9GSP+cdIekbS85IurbSNiPhNRJyeZ5xmZta7vC9mzwSuA24szZA0BLgeOApYBMyXNBsYAnytx/qfj4jXc47RzMwqUN4V3ySNA34eEX+QTh8MXBkRH0+nLwOIiJ5Joud2bouIT1f4/CzgLIAxY8YcePPNN9cU76pVqxg+fHhN6zYrt7k1uM3FN9D2HnHEEY9HRHvP+fW4PfZDwMtl04uAD/e2sKRRwN8BB0i6rLeEEhHTgekA7e3t0dHRUVNwXV1d1Lpus3KbW4PbXHx5tbfhn6OIiKXA2fWOw8ysVdXjrqfFwK5l02PTeQMmaaqk6cuXL89ic2ZmRn0SxXxggqQ9JG0D/BkwO4sNR8SciDhrhx12yGJzZmZG/rfHzgIeAfaWtEjS6RGxHjgfuAd4GrglIhbmGYeZmdUu12sUEdHZy/w7gTuz3p+kqcDU8ePHZ71pM7OW1fBPZveHu57MGsuSJcnAfC4a1NwKlSjMrHHMmgXvfz8cfLDLkTa7QiUK3/Vk1hhK5Ug3boQNG3A50iZX1TUKSe3AYcAHgTXAk8B9EfFmjrH1W0TMAea0t7efWe9YzFpZqRzpmjXvziuVI/Ww382n4hmFpNMkPQFcBmwHPAO8DkwB7pf0fUm75R+mmTUTlyMtlr7OKIYBh0bEmi19KGkyMAF4KeO4zKyJlcqRnn56ciaxbp3LkTaziokiIq7v4/PuTKMZIN8ea9Y4SuVIX3ghOZNwkmheVV3MlvQNSSMltUl6QNISSafkHVx/+fZYs8YyejQcdJCTRLOr9q6noyNiBXAs8AIwHvhSXkGZmVnjqDZRlLqoPgHcGhG+/9TMrEVUmyh+LunXwIHAA5JGA2vzC6s2fo7CzCx7VSWKiLgUOARoj4h1wGrguDwDq4WvUZiZZa/iXU+STtzCvPLJ27MOyMzMGktfz1FMTf++j+SM4sF0+gjgP3CiMDMrvL6eozgNQNK9wKSIeDWd/gAwM/fozMys7qq9mL1rKUmkfgt46A4zsxZQbeGiByTdA5QGCv4scH8+IdXOT2abmWWv2ruezgf+Cdg/fU2PiAvyDKwWvuvJzCx7VZdCjYjb8cVrM7OWU+1YTydKek7SckkrJK2UtCLv4MzMrP6qvZj9DeCTEbFDRIyMiBERMTLPwMwsO0uWwOrVrjBntak2Ufw2Ip7ONRIzy8WsWUnN6mefde3qQjv0UCZ/4Qu5/BqoNlE8JunHkjrTbqgTt/TUtpk1llLt6jVr4NprJ7t2dVHNmgWPPpqcNubwa6DaRDGSZHyno0me1p5KMuR4Q/GggGabK9WuLleqXW0FUfo1sHEjRJDHr4Fqb489bQuvz2cWRUZ8e6zZ5sprV597bjfg2tWFMwi/Bqq962mspDskvZ6+fiJpbGZRmFkuSrWrt9sOhgxJ/rp2dcGU/xooyfjXQLVdT/8CzAY+mL7mpPPMrMF1dsKLL8LEicnfzs56R2SZKv0a2GorkHL5NVBtohgdEf8SEevT10zAv0nMmsTo0TBsmM8kCquzEz7ykeRLzuHXQLWJYqmkUyQNSV+nAEszjcTMzGo3bx7d06bl8mug2kTxeeAk4DXgVeDTwGmZR2NmZg2nqrGeIuJF4JM5x2JmZg2o2ruevi9px7LpnSTdkFtUZmbWMKrtetovIpaVJiLiTeCAXCIyM7OGUm2i2ErSTqUJSTvTjyHKB4ufzDYzy161ieJbwCOS/lbS3wL/QTKibEPxk9lmZtmr9mL2jZIeAz6azjoxIp7KLywzM2sU1Z5RAOwMvBUR1wFLJO2RU0xmZtZAqr3r6QrgfwGXpbPagB/mFZSZWdPq6EheBVLtGcUJJM9RvAUQEa8AI/IKysysaa1bBytXFqroR7WJ4p2ICCAAJG2fX0hmxbRkCcyfX6jjh/VUKiC0YEGhyglWmyhukfRPwI6SzgTuB/45v7DMimXWLHj/++Hggwt1/LBy5QWENmzIpYBQvVRbuOhq4DbgJ8DewFci4to8AzMrigIfP6xcgcsJVnV7bNrV9GBE3Cdpb2BvSW0RsS7f8MyaX+n4sWbNu/NKxw8P+10gg1BAqF6q7XqaC2wr6UPA3cCfAzPzCsqsSAp8/LBy5QWEClZOsNpEoYhYDZwI/N+I+AywT35hmRVHeTnSkSMLdfywnkoFhPbfv1DlBKsdr0mSDgZOBk5P5w3JJySz4unshCOPTLqbxo1zkii0trbkVaAvudpEcSHJw3Z3RMRCSXsCD+UXllnxjB5dqGOHtZBqx3qaS3KdojT9G+ALeQVVTtLxwCeAkcCMiLh3MPZrZlaTrq56R5C5itcoJP2zpH17+Wx7SZ+XdHKF9W+Q9LqkJ3vMP0bSM5Kel3RppRgi4qcRcSZwNvDZSsuamVn2+jqjuB746zRZPAksAYYCE0h+4d8A3FRh/ZnAdcCNpRmShqTbPQpYBMyXNJvkmsfXeqz/+Yh4PX3/5XQ9MzMbREpG5uhjIWk40A58AFgDPB0Rz1S1A2kc8POI+IN0+mDgyoj4eDp9GUBE9EwSpfUFfB24LyLur7Cfs4CzAMaMGXPgzTffXE1477Fq1SqGDx9e07rNym1uDW5z8Q20vUccccTjEdHec3611yhWAV01731zHwJeLpteBHy4wvIXAEcCO0gaHxHf7SXG6cB0gPb29uiocfTGrq4ual23WbnNrcFtLr682ttw5Ux7iohpwLRqlpU0FZg6fvz4fIMyM2sh/SlclJXFwK5l02PTeQPmUqhmZtnrV6KQNCyDfc4HJkjaQ9I2wJ8BszPYrpmZ5aDaCneHSHoK+HU6vb+kf6xivVnAIySDCC6SdHpErAfOB+4BngZuiYiFNbdg8/1NlTR9+fLlWWzOzJpZRweTL7qo3lEUQrXXKK4BPk76yz8iFkg6vK+VImKLA51ExJ3AndUGWa2ImAPMaW9vPzPrbZuZtaqqu54i4uUeszZkHIuZWXbWrUuKgLjwx4BVmyhelnQIEJLaJF1C0m1kZtZ4SiVJV692ScEMVJsozgbOI3kGYjEwOZ1uKL5GYWablRSMcEnBDFRbCvWNiDg5IsZExPsi4pSIWJp3cP3l22PNrMglSeul2lKoe5A8IT2ufJ2I+GQ+YZnl59BDYeXKyTzwgIf9LiSXFMxctV1PPwVeAK4FvlX2aijuerK+uOu6BZSXJJVcUjAD1SaKtRExLSIeioh/K71yjawG7nqyStx13UJKJUmHDStUSdJ6qfY5iu9IugK4F3i7NDMinsglKrMclLqu16x5d16p69o/NguorS05q/CXO2DVJop9gT8HPgpsTOdFOm3WFNx13WK6uuju6qKj3nEUQLWJ4jPAnhHxTp9LmjWoUtf1Kae469qsP6q9RvEksGOOcWTCF7OtL52d8NprMG1at7uuzapUbaLYEfi1pHskzS69coyrJr6YbdUYPTq5xukzCbPqVNv1dEWuUZiZWcOqthRqw90Ka2Zmg6NiopD07xExRdJKkrucNn0ERESMzDU6M2tupfrNXV31jMIGqGKiiIgp6d8RgxPOwLhmtplZ9qqtcPeDaubVmy9mN49DD4UDD/RT0YW3bh2sXOkvuslVe9fTPuUTkrYGDsw+HGsFpfGWFizweEuF5i+6MComCkmXpdcn9pO0In2tBH4L/GxQIrRCKR9vacMGj7dUWP6iC6ViooiIr6XXJ74ZESPT14iIGBURlw1SjFYgLhXQIvxFF0q1t8deJulDwO5sXo9ibl6BWTF5vKUW4S+6UKq9mP11YB7wZeBL6euSHOOygiovFTBkiMdbKix/0YVS7ZPZJwB7R8TbfS5ZR749tjl0dsJ118HatXD33T52FJa/6MKo9q6n3wBteQaSBd8e2zzmzYPHH/exo/Da2mDECH/RTa7aM4rVQLekB9i8cNEXconKzIrBT2QXQrWJYnb6MjOzFlPtXU/fzzsQMzNrTFUlCkn/zeaDAgIQEXtmHpGZZa+jg8nLlkF3d70jsSZUbddTe9n7oSSlUXfOPhwzM2s0Vd31FBFLy16LI+LbwCfyDc3MzBpBtV1Pf1g2uRXJGUa1ZyPWwDo6YNmyye6RMLNeVXuw/1bZ+/XACyTdT2bWDNatSwboW7LEzzRYv1Xb9XRE2eso4GzgoHxD6z9JUyVNX758eb1DMWscpeG+V6/2cN9Wk76GGR+ZDjV+naSjlDgfeB44aXBCrJ6fzO6/8h+aVkDlw31HeLhvq0lfZxQ/APYGfgWcCTxE0uV0QkQcl3NsljP/0GwBHu7bMtDXNYo9I2JfAEnfA14FdouItblHZrnq7YfmkUe6C7tQPNy3ZaCvM4p1pTcRsQFY5CRRDP6h2SLKh/uWPNy31aSvM4r9Ja1I3wvYLp0WEBExMtfoLDf+odlCSsN9r1wJL77oJGH91lcp1CE9SqBuXfbeSaKJ+Ydmi2lrS75sf8FWAz8018L8Q9PMqlFt4SIrKP/QHEQdHcnLrMk4UZiZWUXuejJrBV1ddHd10VHvOKwp+YzCzMwqcqJoAO66NrNG5q6nFtfVBV1d3dBKnRKu9mbWLw1/RiHp9yV9V9Jtks6pdzxmNVu3LrkX2QPyWZPJNVFIukHS65Ke7DH/GEnPSHpe0qWVthERT0fE2SSj1R6aZ7wtqaODyRddVJf9tlR/W2kExgULPAKjNZ28zyhmAseUz5A0BLge+BNgEtApaZKkfSX9vMfrfek6nwT+Fbgz53jNslc+AuOGDR7q25pOrtcoImKupHE9Zv8R8HxE/AZA0s3AcRHxNeDYXrYzG5gt6V+BH21pGUlnAWcBjBkzhq6urppiXrVqVc3r1mrZsslA6VrB4Jq8bBkbNmwY9DZPXrYMgO5B3m9p34Pa5tWr4atfZfK11wLQfe65MGQIzJ8Pw4YNTgzU5992vbVam/Nqbz0uZn8IeLlsehHw4d4WltQBnAhsS4UzioiYDkwHaG9vj44auzW6urqodd1a7bhj8new91va+bJlywZ/32mjW6LNS5bApz+dnEkAHZdckgyuNcjjptTj33a9tVqb82pvw9/1FBFdQFedwzCrXWkExlNOSUZg3GYbj8BoTaUeiWIxsGvZ9Nh03oBJmgpMHT9+fE3rd3Qk3UCDfdfkP/xXR1qOtMvHjqIqjcC4di3cfbeThDWVetweOx+YIGkPSdsAfwbMzmLDzVgze9YsWLEC3lrlm2EKr60NRoxwkrCmk/ftsbOAR4C9JS2SdHpErAfOB+4BngZuiYiFecbRqEo3wwAEvhnGzBpT3nc9dfYy/05yuNV1oF1Pg21TOdI1784rlSP1j84crVtH2tfn/9BmVWj4J7P7o9m6nlyOtA5KD76tXu2+PrMqFSpRNJvSzTCQFiR3OdJ8lT/4FuG+PrMqFSpRSJoqafry5cvrHUrVOjth5EjYfnhyW33nFjvrLBOb+vrKlPr6zKxXhUoUzdb1VLKVYOshdTqTKO+vH+z9DvYAee7rM6tJoRKF9VO9+uvrNUBeqa9vq62SB9/c12dWFSeKMt/u7uB7z29xuKniqVd/fb0HyOvshI98JBljyX19ZlUpVKJoxmsUdVOv/vpGuE7Q1pacVfhMwqwqhUoUzXqNoi7q1V/v6wRmTadQicL6oV799eX7HTLE1wnMmkDDjx5rOSoNVLdy5eAOed2qA+S1UF0EK5ZCnVH4GkUN6tVf7wHyzJpGoRKFr1GYmWWvUInCzMyy50RRZmMkw30P+tA/EckzBR5zyMwakBNFqlRAaOOGQR5UtLTjVa5cZGaNyYmCOhYQ2rTjSF4ezdTMGlChEkWtdz3V7WHhRnhK2cysD4VKFLXe9VS3h4XTHU9mAZNZMIg7NjOrXqESRa3qVkDITymbWRPwk9mpzk544uzk5qMX/3sQj9Wt+pSymTUNJ4oyWwk2UodjdVtb8nKSMLMG5K4nMzOryInCzMwqKlSi8KCAZmbZK1Si8KCAZmbZK1SiMDOz7DlRmJlZRU4UZmZWkROFmZlV5ERhZmYVOVGUi3S4bw/zbWa2iRNFSamA0IaNLiBUdF1ddH/72/WOwqxpOFFAjwJCuICQmVmZQiWKmp/MdgEhM7NeFSpR1Pxkdt0qF5mZNb5CJYqabapcpGTaBYTMzDZxoijp7ISRI2HIVvDii8m0mZk5UWxGAuQzCTOzMk4UZmZWkROFmZlV5ERhZmYVOVGYmVlFThRmZlaRIqLeMWRO0hLgxRpX3wV4I8NwmoHb3Brc5uIbaHt3j4j33PZZyEQxEJIei4j2escxmNzm1uA2F19e7XXXk5mZVeREYWZmFTlRvNf0egdQB25za3Cbiy+X9voahZmZVeQzCjMzq8iJwszMKmrpRCHpBkmvS3qybN7Oku6T9Fz6d6d6xpi1Xtr8TUm/lvRLSXdI2rGOIWZuS20u++xiSSFpl3rElofe2ivpgvR7XijpG/WKLw+9/LueLOlRSd2SHpP0R/WMMWuSdpX0kKSn0u/0wnR+5sewlk4UwEzgmB7zLgUeiIgJwAPpdJHM5L1tvg/4g4jYD3gWuGywg8rZTN7bZiTtChwNvDTYAeVsJj3aK+kI4Dhg/4jYB7i6DnHlaSbv/Y6/AVwVEZOBr6TTRbIeuDgiJgEfAc6TNIkcjmEtnSgiYi7wux6zjwO+n77/PnD8YMaUty21OSLujYj16eSjwNhBDyxHvXzPANcAfwUU6o6OXtp7DvD1iHg7Xeb1QQ8sR720OYCR6fsdgFcGNaicRcSrEfFE+n4l8DTwIXI4hrV0oujFmIh4NX3/GjCmnsHUweeBu+odRN4kHQcsjogF9Y5lkEwEDpP0n5L+TdJB9Q5oEFwEfFPSyyRnUEU7U95E0jjgAOA/yeEY5kRRQST3Dhfq12Ylki4nOZ29qd6x5EnSMOB/k3RHtIqtgZ1Juii+BNwiSfUNKXfnAF+MiF2BLwIz6hxPLiQNB34CXBQRK8o/y+oY5kTxXr+V9AGA9G+hTtF7I+lzwLHAyVH8h2v2AvYAFkh6gaSr7QlJ769rVPlaBNweiV8AG0kGkCuyvwBuT9/fChTqYjaApDaSJHFTRJTamvkxzInivWaT/AMj/fuzOsYyKCQdQ9JX/8mIWF3vePIWEb+KiPdFxLiIGEdyEP3DiHitzqHl6afAEQCSJgLbUPxRVV8B/jh9/1HguTrGkrn0jHAG8HRE/EPZR9kfwyKiZV/ALOBVYB3JweJ0YBTJnQLPAfcDO9c7zkFo8/PAy0B3+vpuvePMu809Pn8B2KXeceb8HW8D/BB4EngC+Gi94xyENk8BHgcWkPTdH1jvODNu8xSSbqVflv2/+6d5HMM8hIeZmVXkriczM6vIicLMzCpyojAzs4qcKMzMrCInCjMzq8iJwgohHQH2W2XTl0i6MqNtz5T06Sy21cd+PiPpaUkPZbCtKyVdsoX5H5R0W/p+sqQ/Hei+rPicKKwo3gZObLThwiVt3Y/FTwfOjIgj8oonIl6JiFLSm0xy371ZRU4UVhTrSeoFf7HnBz3PCCStSv92pAPk/UzSbyR9XdLJkn4h6VeS9irbzJFpTYNnJR2brj8kreUxP63l8T/LtvuwpNnAU1uIpzPd/pOS/j6d9xWSB6hmSPpmj+Ul6TpJz0i6X9KdpfZIeqGUHCW1S+oqW3V/SY+kdQnOTJcZl+53G+BvgM+m9Ro+K+mP0/fdkv5L0oj+fQVWVP35tWPW6K4HftnPojz7A79PMkT1b4DvRcQfpUVgLiAZgRRgHMlYQXsBD0kaD5wKLI+IgyRtC8yTdG+6/B+S1Pj47/KdSfog8PfAgcCbwL2Sjo+Iv5H0UeCSiHisR4wnAHsDk0hGAn0KuKGKtu1HMgjg9sB/SfrX0gcR8U6anNoj4vw0tjnAeRExLx1obm0V+7AW4DMKK4xIRs68EfhCP1abH8m4/m8D/w8oHeh/RZIcSm6JiI0R8RxJQvk9kqJHp0rqJhkiYhQwIV3+Fz2TROogoCsilkRSA+Qm4PA+YjwcmBURGyLiFeDBKtv2s4hYExFvAA/R96B484B/kPQFYMd4t0aJtTgnCiuab5P09W9fNm896b91SVuRjHtU8nbZ+41l0xvZ/Iy751g3AQi4ICImp689IqKUaN4aSCP6YVPbgKFbiLHS9OYfRnwdOAPYjuTs6PcyidCanhOFFUpE/A64hSRZlLxA0tUD8EmgrYZNf0bSVul1iz2BZ4B7gHPSoZ6RNFHS9pU2AvwC+GNJu0gaAnQC/9bHOnNJriUMSYeNLr/Y/QLvtu1TPdY7TtJQSaOADmB+j89XApuuQ0jaK5KRdf8+XdaJwgAnCiumb7F5rYV/Jjk4LwAOprZf+y+RHOTvAs6OiLXA90iuFzwh6Ungn+jjul8klccuJekKWgA8HhF9DQN9B8lIoE+RdK09UvbZVcB3JD0GbOix3i/T/TwK/G3abVXuIWBS6WI2cFF6ofuXJKOwFr7SoVXHo8eaNRlJM4GfR8Rt9Y7FWoPPKMzMrCKfUZiZWUU+ozAzs4qcKMzMrCInCjMzq8iJwszMKnKiMDOziv4/5jMSK6Tln84AAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "benchmarkCompare(\"CNOT at [n-2, n-1]\", 10, list(range(10,21)), lambda n: [qml.CNOT(wires=(n-2, n-1))])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "attractive-collaboration",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Running with old backend:\n",
+      "n=10 took an average of 0.0004998207092285156 sec (std dev: 0.000526857352362508 sec)\n",
+      "n=11 took an average of 0.0008984804153442383 sec (std dev: 0.0003158036106504085 sec)\n",
+      "n=12 took an average of 0.0014996528625488281 sec (std dev: 0.0005221197893919869 sec)\n",
+      "n=13 took an average of 0.0026993751525878906 sec (std dev: 0.00048011086487951903 sec)\n",
+      "n=14 took an average of 0.005796909332275391 sec (std dev: 0.00041948785212514276 sec)\n",
+      "n=15 took an average of 0.013196253776550293 sec (std dev: 0.0006270396588559307 sec)\n",
+      "n=16 took an average of 0.029094791412353514 sec (std dev: 0.0019719941258335115 sec)\n",
+      "n=17 took an average of 0.062000393867492676 sec (std dev: 0.0027083582669710344 sec)\n",
+      "n=18 took an average of 0.13059635162353517 sec (std dev: 0.004137456765160311 sec)\n",
+      "n=19 took an average of 0.2751962184906006 sec (std dev: 0.009358921601928059 sec)\n",
+      "n=20 took an average of 0.5742841720581054 sec (std dev: 0.010937156521778714 sec)\n",
+      "Running with new backend:\n",
+      "n=10 took an average of 0.00019891262054443358 sec (std dev: 0.00041935035125698316 sec)\n",
+      "n=11 took an average of 0.00020003318786621094 sec (std dev: 0.0004217069875210556 sec)\n",
+      "n=12 took an average of 0.0 sec (std dev: 0.0 sec)\n",
+      "n=13 took an average of 9.968280792236329e-05 sec (std dev: 0.00031522471659574494 sec)\n",
+      "n=14 took an average of 0.0002998828887939453 sec (std dev: 0.00048285738126463515 sec)\n",
+      "n=15 took an average of 0.0010056495666503906 sec (std dev: 1.5613535015739347e-05 sec)\n",
+      "n=16 took an average of 0.0024011611938476564 sec (std dev: 0.000844023080749532 sec)\n",
+      "n=17 took an average of 0.003400850296020508 sec (std dev: 0.0005164441019776096 sec)\n",
+      "n=18 took an average of 0.006601190567016602 sec (std dev: 0.0009659203569419522 sec)\n",
+      "n=19 took an average of 0.012701654434204101 sec (std dev: 0.0009481639892672348 sec)\n",
+      "n=20 took an average of 0.027499794960021973 sec (std dev: 0.005213825005146015 sec)\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYoAAAEWCAYAAAB42tAoAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/Il7ecAAAACXBIWXMAAAsTAAALEwEAmpwYAAAlL0lEQVR4nO3de5xddXnv8c83w2AISbiEMVUDJFxCGwpEGZRLwEFBsYJcVHSOlqIRjtyh0BZKK6CnaBWLcvEoGgsoBhEBiaLcp6Ep1AQ6KAG5HMolkcoQyY0kkMtz/lhrh53JzJ41M3vty5rv+/Xar5m19ro8i032M7/fb63np4jAzMysP6PqHYCZmTU2JwozM6vIicLMzCpyojAzs4qcKMzMrCInCjMzq8iJwqyBSQpJr0n6pxqc6zBJKyVtkHRY3uez5uFEYYUh6X9JWpB+2b0k6ZeSZqTvXZx+6R5ftv0W6brJZesOlHSfpBWSlkmaI2la+t6n0mOvlLQ6/UItLa8cQrwXS/phhk33iYgLy/abLulhSavSn9MHcc4vSfqtpHWSLi5/LyLuiYixwAtZj2cjgxOFFYKkvwa+AVwKTAR2Ar4FHF222R+BSyS19HOMA4C7gJ8BbwemAI8C8yTtEhE3RMTY9Mv0Q8DvS8vputxJ2jKN74fAdsB1wM/S9Vk8A/wt8It8IrQicqKwpidpG+CLwGkRcUtEvBYRayNiTkT8TdmmvwLeAD7dz6G+ClwfEd+MiBUR8ceI+AfgIeDiIcb2TUkvSlqe/vV/cLr+CODvgU+kLZJHMx6yA9gC+EZEvB4RVwAC3pdl54i4LiJ+CawY9MXYiOVEYUVwADAauHWA7QL4R+AiSa3lb0gaAxwI/KSP/W4CDh9ibPOB6cD2wI+An0gaHRG/Imn9/DhtkeyT8Xh7Ar+JTWvv/CZdb5YLJworggnAKxGxbqANI+J2oAf4XK+3tif59/BSH7u9BOwwlMAi4ocRsSQi1kXE14G3AHsM5VipscCyXuuWAeOGcUyzipworAiWADtI2iLj9v8AXEjSCil5FdgAvK2P7d8GvDKUwCSdJ+mJdGB8KbANQ0w6qZXA+F7rxuOuJMuRE4UVwYPA68AxWTaOiLtJBnVPLVv3Wnqcj/exy/HAvYMNKh2P+Nt0/+0iYluSv/5VOu1gjwksBPaWpLJ1e6frzXLhRGFNLyKWAV8ArpZ0jKQxklolfUjSV/vZ7UKSL/Fy5wN/JelMSeMkbSfp/5CMgVwyhNDGAetIurq2kPQFNm0N/AGYLGkw/w67gPXAmZLeIun0dP19AJJOlPRcfzun/11Gk/zb30LS6P7uAjMrcaKwQkj7//+apFupB3gROB24rZ/t5wG/7rXu34EPAseRjEs8D7wTmBERTw8hrDtJ7rR6Kj3WmjSuktLA+RJJj2Q5YES8QdJyOgFYCnwWOCZdD7AjMK/CIb4LrAY6SZLlauAvs5zbRi554iKzxiVpDUm32hUR8Y8Ztr8LOCsinhjCud4P/JRkwP0vIuL+wR7DismJwszMKnLXk5mZVeREYWZmFTlRmJlZRVkfUGoKko4Cjho3btxJU6dOHdIxXnvtNbbeeuvqBtbgfM0jg6+5+IZ7vQ8//PArEdHWe30hB7Pb29tjwYIFQ9q3q6uLjo6O6gbU4HzNI4OvufiGe72SHo6I9t7r3fVkZmYVFSpRSDpK0jXLlvWumWZmZkNVqESRzj9w8jbbbFPvUMzMCqNQg9mVrF27lkWLFrFmzZqK222zzTY88cSgH2ptCKNHj2bSpEm0trYOvLGZWUaFShSlu5522223zd5btGgR48aNY/LkyWxaeHNTK1asYNy45ivtHxEsWbKERYsWMWXKlHqHY2YFMmK6ntasWcOECRMqJolmJokJEyYM2GIyMxusQiWKgRQ1SZQU/frMrH89PbBqVfKz2kZUojAzK6LZs2HnneGpp5Kfs2dX9/iFShSNfnvsokWLOProo9l9993ZddddOeuss3jjjTfo6uriyCOP7HOfyZMn88orQ5qF08xGgJ4emDkTVq+GK6+czurVyXI1WxaFShSNfHtsRHDcccdxzDHH8PTTT/PUU0+xcuVKLrzwwnqHZmZN7LnnYMstk99PPbUbgNbWZH21FOqup2rr6Un+Y0+eDG2bVT8ZnPvuu4/Ro0fzmc98BoCWlhYuv/xypkyZwqGHHrpxuyVLltDZ2cnixYs54IADKGKJFTOrnsmT4Y03Nl23dm2yvloK1aKoplKf3+GHV6fPb+HChey7776brBs/fjw77bQTzzzzzMZ1l1xyCTNmzGDhwoUce+yxvPDCC8M7sZkVWlsbzJoFW20FLS3Jz1mzhv/HbblCJYpqjVGU9/ktW0YufX79mTt3Lp/+9KcB+PCHP8x2222X/0nNrKl1dsLzz8PUqcnPzs7qHr9QiaJaYxTlfX4lw+3zmzZtGg8//PAm65YvX84LL7xAXw8ImpkNRlsbjBlT3ZZESaESRbXk0ef3/ve/n1WrVnH99dcDsH79es4991xOPPFExowZs3G7Qw45hB/96EcA/PKXv+TVV18d+knNzKrAiaIP5X1+48dXp89PErfeeis/+clP2H333Zk6dSqjR4/m0ksv3WS7iy66iLlz57Lnnntyyy23sNNOOw3zaszMhsd3PfWjsxMOO6x6dz0B7LjjjsyZM2ez9R0dHRsnG5kwYQJ33XXX8E9mZlYlhUoUlYoCDkVbWz79fWZmzaRQXU+N/MCdmVmzKlSiMDOz6nOiMDOzipwozMysIicKM7Mq6umB+fNrU8mhVgqVKBq9zLgkzj333I3Ll112GRdffHH9AjKzqqp2jbhGUahE0eh3Pb3lLW/hlltu8fwSZgVUzxpxeStUoqi6Krcht9hiC04++WQuv/zyPk7Vw0c/+lH2228/9ttvP+bNmwfAXnvtxdKlS4kIJkyYsLEEyAknnMDdd99dlbjMbPjyqBHXKJwo+pNTG/K0007jhhtuoHf32FlnncU555zD/Pnz+elPf8rnPvc5AA466CDmzZvHwoUL2WWXXXjggQcAePDBBznwwAOrEpOZDV8t5oWol0I9mV015W3I1auTdTNnJjU9hvmo9vjx4znhhBO44oor2GqrrTauv+eee3j88cc3Li9fvpyVK1dy8MEHM3fuXHbeeWdOOeUUrrnmGhYvXsx2223H1ltvPaxYzKx6SjXiZs5MWhJr11Z/Xoh6cYuiLzm3Ic8++2xmzZrFa6+9tnHdhg0beOihh+ju7qa7u5vFixczduxYDjnkEB544AEeeOABOjo6aGtr4+abb+bggw+uSixmVj2leSHuuSefeSHqxYmiLzm3IbfffnuOP/54Zs2atXHdBz7wAa688sqNy93d3UBSSPCVV17h6aefZpdddmHGjBlcdtllHHLIIVWJxcyqq60N9tuvGC2JEieKvuRRZ7yXc889d5O7n6644goWLFjA3nvvzbRp0/j2t7+98b33vOc9TJ06FYCDDz6YxYsXM2PGjKrFYmZWicco+pNDnfGVK1du/H3ixImsWrVq4/IOO+zAj3/84z73+8EPfrDx9wMPPJANGzYMOxYzs6ycKCpxnXEzs2J1PTX6k9lmZs2oUIlioCezI6LGEdVW0a/PzOqjUImiktGjR7NkyZLCfplGBEuWLGH06NH1DsXMCmbEjFFMmjSJRYsW0TNAOY41a9Y07Zft6NGjmTRpUr3DMLOCGTGJorW1lSlTpgy4XVdXF+985ztrEJGZWXMYMV1PZmY2NE4UZlZIPT2walUxynzXmxOFmRVOqfjzU08VawKhenGiMLNCKS/+vH59sSYQqhcnCjMrlPLiz9/61nSgOBMI1YsThZkVSnnx51NP7QaKM4FQvThRmFmhlBd/bmnJpfjziNPwiULSLpJmSbq53rGYWXMoTSA0dWqxJhCql1wThaTvS3pZ0mO91h8h6UlJz0g6v9IxIuLZiJiZZ5xmVjxtbTBmjFsS1ZD3k9nXAlcB15dWSGoBrgYOBxYB8yXdDrQAX+61/2cj4uWcYzQzswqUd5E8SZOBn0fEn6fLBwAXR8QH0+ULACKid5LofZybI+JjFd4/GTgZYOLEifveeOONQ4p35cqVjB07dkj7Nitf88jgay6+4V7voYce+nBEtPdeX49aT+8AXixbXgS8p7+NJU0A/gl4p6QL+ksoEXENcA1Ae3t7dHR0DCm4rq4uhrpvs/I1jwy+5uLL63obvihgRCwBPl/vOMzMRqp63PW0GNixbHlSum7YPMOdmVn11SNRzAd2lzRF0pbAJ4Hbq3HggWa4MzOzwcv79tjZwIPAHpIWSZoZEeuA04E7gSeAmyJiYZ5xmJnZ0OU6RhERfT7mEhF3AHdU+3ySjgKO2m233ap9aDOzEavhn8weDHc9mZlVX6EShZk1lp4emD/fJb6bXaEShe96MmscpcmDDj/ckwc1u0IlCnc9mTWG8smDli3z5EHNrlCJwswaQ/nkQSWePKh5FSpRuOvJrDGUTx5U4smDmlehEoW7nswaQ/nkQePHe/KgZtfwtZ7MrDl1dsJhhyXdTZMnO0k0s0yJQlI7cDDwdmA18Bhwd0S8mmNsZtbk2tqcIIqgYteTpM9IegS4ANgKeBJ4GZgB3CPpOkk75R9mNh6jMDOrvoFaFGOAgyJidV9vSpoO7A68UOW4hiQi5gBz2tvbT6p3LGZmRVExUUTE1QO8313VaMzMrOFkuutJ0lcljZfUKuleST2SPp13cGZmVn9Zb4/9QEQsB44EngN2A/4mr6DMzKxxZE0UpS6qDwM/iYiGHC32YLaZWfVlTRQ/l/Q7YF/gXkltwJr8whoaP3BnZlZ9mRJFRJwPHAi0R8RaYBVwdJ6BmZlZY6h415Ok4/pYV754S7UDMjOzxjLQcxRHpT/fStKiuC9dPhT4D5wozMwKb6DnKD4DIOkuYFpEvJQuvw24NvfozKwqenpg1arkp0tqFFRHB9OXLoXu7qofOutg9o6lJJH6A9AwpTvMrH+zZ8Of/AmceeZ0zzRXZGvXwoYNucwOlTVR3CvpTkknSjoR+AVwT9WjGSbfHmu2qdJMcxs2QIRnmius2bPhoYeSZmMOfw1kvevpdOA7wD7p65qIOKOqkVSBb48125RnmhsBavDXQOaJiyLilog4J33dWrUIzCw35TPNnXpqN+CZ5gqnBn8NZK31dJykpyUtk7Rc0gpJy6sWhZnlonymuZYWzzRXSDWYdzZri+KrwEciYpuIGB8R4yJifNWiMLPcdHbC88/D1KnJz87OekdkVVX6a2DUKJBy+Wsg61Sof4iIJ6p2VjOrqbY2GDPGLYnC6uyEq66CFSuSvwaq/EFnTRQLJP0YuA14vbQyIvzAnZlZI2htTVoVOfw1kDVRjCep7/SBsnWBn8w2M2sMXV10d3XRkcOhMyWK0hPaZmY28mS962mSpFslvZy+fippUt7BDZYfuDMzq76sdz39K3A78Pb0NSdd11D8wJ2ZWfVlTRRtEfGvEbEufV0L+P4JM7MRIGuiWCLp05Ja0tengSV5BmZmZo0ha6L4LHA88D/AS8DHAA9wm5mNAFnvenoe+EjOsZiZWQPKetfTdZK2LVveTtL3c4vKzMwaRtaup70jYmlpISJeBd6ZS0RmBdXTA/Pney6IwivgB501UYyStF1pQdL2ZH+q22zEmz07mU/m8MNzmVfGGkVBP+isieLrwIOSviTpS8B/kFSUNbMBlOaVWb0ali3zLHOFVeAPOusMd9cDx5HMlf0H4LiI+EGegZkVhWeZGyEK/EFnnuEO2B54LSKuAnokTckpJrNCqcG8MtYICvxBZ73r6SLg74AL0lWtwA/zCsqsSMpnmRs/3rPMFVaBP+isA9LHktzl9AhARPxe0rjcoupF0jHAh0nKnc+KiLtqdW6zaujshMMOS3ohJk8uxHeH9aWgH3TWRPFGRISkAJC0ddYTpM9bHAm8HBF/Xrb+COCbQAvwvYj4Sn/HiIjbgNvSO68uA5worOm0tRXme8MqKeAHnXWM4iZJ3wG2lXQScA/w3Yz7XgscUb5CUgtwNfAhYBrQKWmapL0k/bzX661lu/5Dup+ZmdWIIiLbhtLhJDPcCbgzIu7OfBJpMvDzUotC0gHAxRHxwXT5AoCI+HI/+wv4CnB3RNzTzzYnAycDTJw4cd8bb7wxa3ibWLlyJWPHjh3Svs3K1zwy+JqLb7jXe+ihhz4cEe2912fqekq7mu6LiLsl7QHsIak1ItYOMZ53AC+WLS8C3lNh+zOAw4BtJO0WEd/uvUFEXANcA9De3h4dHR1DCqyrq4uh7tusfM0jg6+5+PK63qxjFHOBg9Mxgl8BC4BPAJ+qekR9iIgrgCsG2k7SUcBRu+22W/5BmZmNEFnHKBQRq0geuvu/EfFxYM9hnHcxsGPZ8qR03bB4hjszs+rLnCjScYVPAb9I17UM47zzgd0lTZG0JfBJkqlWzcyswWRNFGeRPGx3a0QslLQLcH+WHSXNBh4kGddYJGlmRKwDTgfuBJ4AboqIhYMPf7NzHSXpmmXLlg33UGZmlso6cdFcknGK0vKzwJkZ9+3sZ/0dwB1ZjpFVRMwB5rS3t59UzeOaWRM66CCmr1gB995buOcaaq1ii0LSdyXt1c97W0v6rKSaDGibmWU2ezY89BCsWlWoct/1MlCL4mrgH9Nk8RjQA4wGdicpp/F94IZcIxwE3/VkZhvLfW/YABFvlvs+7DC3LIaoYqKIiG7geEljgXbgbcBq4ImIeDL/8AbHXU+WRU9P8odmT4+/NwqpVO579eo315XKffsDH5Ks81GsjIiuiJgdEbc1YpIwy6I0AdlTT7lHorAKXO67XgYzH4VZUyufgOzKK6cXaQIyK1cq9z1qFEiFKvddL4VKFL491iop8ARk1ltnJ+y/P4wZA88/nyzbkA0qUUgak1cg1eAns60S90iMMPPm0X3FFW5JVEHWGe4OlPQ48Lt0eR9J38o1MrMqK5+A7Iwzut0jYZZR1hbF5cAHgSUAEfEocEheQZnlpbMz6YmYOtU9EmZZZe56iogXe61aX+VYhs1jFJZFW1vSde2WhFk2WRPFi5IOBEJSq6TzSGo0NRSPUZiZVV/WRPF54DSSCYcWA9PTZTMzK7isRQFfoUaTFJmZWWPJOhXqFJLpSCeX7xMRH8knLDMzaxRZp0K9DZgFzAE25BbNMLkooFmDKc3f3NVVzyhsmLImijXpvNUNzUUBzRrM2rWwZo0rMDa5rIPZ35R0kaQDJL2r9Mo1MjNrbqU5IR591BUYm1zWFsVewF8C7+PNrqdIl83MNlU+JwR4TogmlzVRfBzYJSLeGHBLMzPPCVEoWRPFY8C2wMv5hWIjicc4a6yjg+lLl0J3d23O5wqMhZJ1jGJb4HeS7pR0e+mVY1xD4hIezWPtWlixwnNBFFb5nBAtLZ4TosllbVFclGsUVeK7nppDaYxTSsY4Z81ycb5C6uxMxiSeey5pSThJNK2sT2b/W96B2MjgMc46Wbs2+Y9e69tU29r8wRZAxa4nSf+e/lwhaXnZa4Wk5bUJ0YrEs8zVQakJt2qVb1O1IamYKCJiRvpzXESML3uNi4jxtQnRisRjnDVW3oSLwBOF21BkneHuB1nWmQ3EY5w15iacVUHWwew9yxckbQHsW/1wbCTo7ISrrkoqO/zqV04SuXITzqpgoDGKCyStAPYuH58A/gD8rCYRWiHNmwcPP+wkkbvyJpzkJpwNyUBjFF+OiHHA13qNT0yIiAtqFKOZDUdnJ+y/fzL/qycKtyHIenvsBZLeAezMpvNRzM0rMKuNjg5YunR6zR7YtTppbU1aFW5J2BBknbjoK8AngceB9enqABoqUXg+CjOz6ss6mH0ssEdEvJ5nMMPlJ7PNzKova62nZ4HWPAMxM7PGlLVFsQrolnQvsLFVERFn5hKV1Uy9KjuYWfPImihuT19WIKXKDlOmuDifmfUv611P1+UdiNVWf5UdXJyvoLq66O7qoqPecVhTynrX03+T3OW0iYjYpeoRWU14AjIzyypr11N72e+jSaZG3b764VituLKDmWWV6a6niFhS9locEd8APpxvaJYnV3Yws6yydj29q2xxFEkLI2trxBpUqTjfihVJZQcnCTPrS9Yv+6+X/b4OeI6k+8manCs7mNlAst71dGj5sqQWkpIeT+UR1EjU0ZH87OqqZxRmZpsbqMz4+LTU+FWSDlfidOAZ4PhaBCjpzyR9W9LNkk6pxTnNctHTA/Pne3Y5azoDDWb/ANgD+C1wEnA/SZfTsRFx9EAHl/R9SS9LeqzX+iMkPSnpGUnnVzpGRDwREZ8nSUwHDXROs4Y0e3byVOPhh3veams6A3U97RIRewFI+h7wErBTRKzJePxrgauA60sr0m6rq4HDgUXAfEm3Ay3Al3vt/9mIeFnSR4BTSBKXWXMpPd24evWbD6746UZrIgMlirWlXyJivaRFg0gSRMRcSZN7rX438ExEPAsg6Ubg6Ij4MnBkP8e5Hbhd0i+AH/W1jaSTgZMBJk6cSNcQOvvPPns669fvxZVXDn7f4Xr11elEwD33dLNFDe8nW7p0OuvXrx/Sf69mtnLlytpd86pVcOmlTL/ySgC6Tz01mTB8/vxkMqEaqek1N4iRds25XW9E9PsimXtiefpaQXLHU+n35ZX2LTvGZOCxsuWPAd8rW/5L4KoK+3cAVwDfAU7Lcs599903huK9743YZ59Xh7TvcPzoRxGjRkW0tERstVWyXEv3339/bU/YAGp6zS+/nHywSbWU5LXVVsn6GvLnXHzDvV5gQfTxnVrxb9eIaKluWhq8iOgCuuocRm7Kay6Bay4VUunpxpkzk/uR1671043WVOrx0NxiYMey5UnpumFrxhnuXHNphOjsTLL/c88ldVL84VoTyTpxUTXNB3aXNEXSliTPY1SlhHlEzImIk7fZZptqHK4mXHNpBGlrg/32c5KwppNropA0G3gQ2EPSIkkzI2IdcDpwJ/AEcFNELKzS+Y6SdM2yZcuqcbiaKK+51NLimktm1nhy7XqKiD6nwYmIO4A7cjhfU86ZXaq5tGYN/OpXThK56+hg+tKl0N1d70jMmoIL+zWI1tbk5SRhZo2mHmMUZmbWRAqVKJpxjMLMrNEVKlE0411PZmaNzmMUZb7R3cG6deuAf6/LuRNdNT+3mVklhWpRuOvJzKz6CpUohtv1tCEgqM90AdOnJy8zs0ZTqEQxHLNnw/LlsGG9pwswMyvnRMGbhfkgaVGUCvN5IjIzs4IliqGOUZQK85UrFeYzMxvpCpUohjpG4cJ8Zmb9K1SiGKpSYT4A4cJ8Zmbl/BxFqrMTHvk8rF8Pz/+3k4SZWYlbFGVGKWlROEnUQEdH8jKzhleoROEH7szMqq9QicK1nszMqq9QicLMzKrPicLMzCpyorCRZ+1a2LDBj96bZeREYSPL7Nnw0EOwapWLepll5ERhI0epqNeGDRDhol5mGRUqUfj2WKvIRb3MhqRQicK3x1pFLuplNiSFShRmFZWKeo0aBZKLepll5FpPNrJ0dsJVV8GKFfD8804SZhm4RWEjT2tr0qpwkjDLxInCzMwqcqIoFwFEfW6XXLs26Q7xrZpm1mCcKEpmz4bly2H9hto/iFV6COzRR/0QmJk1HCcKePNBLCJZruWDWOUPga1f74fAzKzhFCpRDPmBu3o+iOWHwMyswRUqUQz5gbt6Pojlh8DMrMEVKlEMWelBLJQs1/JBrPKHwFpa/BCYmTUcJ4qSzk4YPx5aRiUPYnV21vbc++8P++xT+3ObmQ3AT2aXkwDV56/51tbk5ZaEmTUYtyjMzKwiJwozM6vIicLMzCpyojAzs4qcKMzMrCInCjMzq8iJwszMKnKiMDOzipoiUUjaWtICSUfWOxarEs+/YdY0ck0Ukr4v6WVJj/Vaf4SkJyU9I+n8DIf6O+CmfKK0mvP8G2ZNJe8WxbXAEeUrJLUAVwMfAqYBnZKmSdpL0s97vd4q6XDgceDlnGO1WvD8G2ZNJ9daTxExV9LkXqvfDTwTEc8CSLoRODoivgxs1rUkqQPYmiSprJZ0R0Rs6GO7k4GTASZOnEhXV9eg4x27bh0RMaR9h2v60qUAdNfh3CtXrqzdNa9aBZdeyvQrrwSg+9RTk6q58+fDmDE1CWH60qWsX7++Lp9zPdX0c24QI+2a87reehQFfAfwYtnyIuA9/W0cERcCSDoReKWvJJFudw1wDUB7e3t0dHQMOrDuLbZg3bp1DGXfYdt2W4C6nLurq6t25+3pgY99LGlJAB3nnZeUVn/++doVRNx2W5YuXVqfz7mOavo5N4iRds15XW9TDGYDRMS1EfHzStsMeYY7qx3Pv2HWdOqRKBYDO5YtT0rXDduQZ7iz2vL8G2ZNpR6JYj6wu6QpkrYEPgncXoc4rJ5aW2HcOLckzJpA3rfHzgYeBPaQtEjSzIhYB5wO3Ak8AdwUEQurdD53PZmZVVnedz312acQEXcAd+RwvjnAnPb29pOqfWwzs5GqaQazzcysPgqVKNz1ZGZWfYVKFL7rycys+hQR9Y6h6iT1AM8PcfcdgFeqGE4z8DWPDL7m4hvu9e4cEZvdiljIRDEckhZERHu946glX/PI4Gsuvryut1BdT2ZmVn1OFGZmVpETxeauqXcAdeBrHhl8zcWXy/V6jMLMzCpyi8LMzCpyojAzs4pGdKLoa05vSdtLulvS0+nP7eoZY7X1c81fk/Q7Sb+RdKukbesYYtX1N3d7+t65kkLSDvWILQ8V5qo/I/2cF0r6ar3iy0M//19Pl/SQpG5JCyS9u54xVpukHSXdL+nx9DM9K11f9e+wEZ0o6GNOb+B84N6I2B24N10ukmvZ/JrvBv48IvYGngIuqHVQObuWza8ZSTsCHwBeqHVAObuWzeeqPxQ4GtgnIvYELqtDXHm6ls0/468Cl0TEdOAL6XKRrAPOjYhpwP7AaZKmkcN32IhOFBExF/hjr9VHA9elv18HHFPLmPLW1zVHxF1p+XeAh0gmkyqMfj5ngMuBvwUKdUdHP9d7CvCViHg93eblmgeWo36uOYDx6e/bAL+vaVA5i4iXIuKR9PcVJNM2vIMcvsNGdKLox8SIeCn9/X+AifUMpg4+C/yy3kHkTdLRwOKIeLTesdTIVOBgSf8p6d8k7VfvgGrgbOBrkl4kaUEVraW8kaTJwDuB/ySH7zAnigoiuXe4UH9tViLpQpLm7A31jiVPksYAf0/SHTFSbAFsT9JF8TfATZJU35BydwpwTkTsCJwDzKpzPLmQNBb4KXB2RCwvf69a32FOFJv7g6S3AaQ/C9VE74+kE4EjgU9F8R+u2RWYAjwq6TmSrrZHJP1JXaPK1yLglkj8GthAUkCuyP4KuCX9/SdAoQazASS1kiSJGyKidK1V/w5zotjc7ST/g5H+/FkdY6kJSUeQ9NV/JCJW1TuevEXEbyPirRExOSImk3yJvisi/qfOoeXpNuBQAElTgS0pflXV3wPvTX9/H/B0HWOpurRFOAt4IiL+peyt6n+HRcSIfQGzgZeAtSRfFjOBCSR3CjwN3ANsX+84a3DNzwAvAt3p69v1jjPva+71/nPADvWOM+fPeEvgh8BjwCPA++odZw2ueQbwMPAoSd/9vvWOs8rXPIOkW+k3Zf92/yKP7zCX8DAzs4rc9WRmZhU5UZiZWUVOFGZmVpEThZmZVeREYWZmFTlRWCGkFWC/XrZ8nqSLq3TsayV9rBrHGuA8H5f0hKT7q3CsiyWd18f6t0u6Of19uqS/GO65rPicKKwoXgeOa7Ry4ZK2GMTmM4GTIuLQvOKJiN9HRCnpTSe5796sIicKK4p1JPMFn9P7jd4tAkkr058daYG8n0l6VtJXJH1K0q8l/VbSrmWHOSyd0+ApSUem+7ekc3nMT+fy+N9lx31A0u3A433E05ke/zFJ/5yu+wLJA1SzJH2t1/aSdJWkJyXdI+mO0vVIeq6UHCW1S+oq23UfSQ+m8xKclG4zOT3vlsAXgU+k8zV8QtJ709+7Jf2XpHGD+wisqAbz145Zo7sa+M0gJ+XZB/gzkhLVzwLfi4h3p5PAnEFSgRRgMkmtoF2B+yXtBpwALIuI/SS9BZgn6a50+3eRzPHx3+Unk/R24J+BfYFXgbskHRMRX5T0PuC8iFjQK8ZjgT2AaSSVQB8Hvp/h2vYmKQK4NfBfkn5ReiMi3kiTU3tEnJ7GNgc4LSLmpYXm1mQ4h40AblFYYURSOfN64MxB7DY/krr+rwP/Dyh90f+WJDmU3BQRGyLiaZKE8qckkx6dIKmbpETEBGD3dPtf904Sqf2ArojoiWQOkBuAQwaI8RBgdkSsj4jfA/dlvLafRcTqiHgFuJ+Bi+LNA/5F0pnAtvHmHCU2wjlRWNF8g6Svf+uydetI/1+XNIqk7lHJ62W/byhb3sCmLe7etW4CEHBGRExPX1MiopRoXhvORQzCxmsDRvcRY6XlTd+M+ArwOWArktbRn1YlQmt6ThRWKBHxR+AmkmRR8hxJVw/AR4DWIRz645JGpeMWuwBPAncCp6SlnpE0VdLWlQ4C/Bp4r6QdJLUAncC/DbDPXJKxhJa0bHT5YPdzvHltH+2139GSRkuaAHQA83u9vwLYOA4haddIKuv+c7qtE4UBThRWTF9n07kWvkvy5fwocABD+2v/BZIv+V8Cn4+INcD3SMYLHpH0GPAdBhj3i2TmsfNJuoIeBR6OiIHKQN9KUgn0cZKutQfL3rsE+KakBcD6Xvv9Jj3PQ8CX0m6rcvcD00qD2cDZ6UD3b0iqsBZ+pkPLxtVjzZqMpGuBn0fEzfWOxUYGtyjMzKwityjMzKwityjMzKwiJwozM6vIicLMzCpyojAzs4qcKMzMrKL/D3z4ewGVnN4xAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "benchmarkCompare(\"CNOT at [0, 1]\", 10, list(range(10,21)), lambda n: [qml.CNOT(wires=(0, 1))])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "leading-sport",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/pennylane_lightning/__init__.py
+++ b/pennylane_lightning/__init__.py
@@ -15,3 +15,4 @@
 
 from ._version import __version__
 from .lightning_qubit import LightningQubit
+from .lightning_qubit_new import LightningQubitNew

--- a/pennylane_lightning/lightning_benchmark.py
+++ b/pennylane_lightning/lightning_benchmark.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Xanadu Quantum Technologies Inc.
+# Copyright 2021 Xanadu Quantum Technologies Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pennylane_lightning/lightning_benchmark.py
+++ b/pennylane_lightning/lightning_benchmark.py
@@ -1,0 +1,47 @@
+# Copyright 2020 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+r"""
+This module serves to benchmark the legacy (Eigen) backend with the new backend
+"""
+
+import gc
+import time
+import statistics
+
+from pennylane_lightning import LightningQubit, LightningQubitNew
+
+
+def benchmarkApply(numWires, operations):
+    dev = LightningQubit(wires=numWires)
+    dev.apply(operations)
+    return dev.state
+
+
+def benchmarkApplyNew(numWires, operations):
+    dev = LightningQubitNew(wires=numWires)
+    dev.apply(operations)
+    return dev.state
+
+
+def benchmarkMethod(numRepetitions, method):
+    durations = []
+
+    for i in range(numRepetitions):
+        startTime = time.time()
+        result = method()
+        endTime = time.time()
+        durations.append(endTime - startTime)
+        gc.collect()
+
+    return [statistics.mean(durations), statistics.stdev(durations)]

--- a/pennylane_lightning/lightning_benchmark.py
+++ b/pennylane_lightning/lightning_benchmark.py
@@ -42,6 +42,5 @@ def benchmarkMethod(numRepetitions, method):
         result = method()
         endTime = time.time()
         durations.append(endTime - startTime)
-        gc.collect()
 
     return [statistics.mean(durations), statistics.stdev(durations)]

--- a/pennylane_lightning/lightning_qubit_new.py
+++ b/pennylane_lightning/lightning_qubit_new.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Xanadu Quantum Technologies Inc.
+# Copyright 2021 Xanadu Quantum Technologies Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pennylane_lightning/lightning_qubit_new.py
+++ b/pennylane_lightning/lightning_qubit_new.py
@@ -1,0 +1,136 @@
+# Copyright 2020 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+r"""
+This module contains the :class:`~.LightningQubit` class, a PennyLane simulator device that
+interfaces with C++ for fast linear algebra calculations.
+"""
+import warnings
+
+from pennylane.devices import DefaultQubit
+from .lightning_qubit_new_ops import apply
+import numpy as np
+from pennylane import QubitStateVector, BasisState, DeviceError
+
+from ._version import __version__
+
+
+class LightningQubitNew(DefaultQubit):
+    """PennyLane Lightning device.
+
+    An extension of PennyLane's built-in ``default.qubit`` device that interfaces with C++ to
+    perform fast linear algebra calculations
+
+    Use of this device requires pre-built binaries or compilation from source. Check out the
+    :doc:`/installation` guide for more details.
+
+    Args:
+        wires (int): the number of wires to initialize the device with
+        shots (int): How many times the circuit should be evaluated (or sampled) to estimate
+            the expectation values. Defaults to 1000 if not specified.
+            If ``analytic == True``, then the number of shots is ignored
+            in the calculation of expectation values and variances, and only controls the number
+            of samples returned by ``sample``.
+        analytic (bool): indicates if the device should calculate expectations
+            and variances analytically
+    """
+
+    name = "Lightning Qubit PennyLane plugin"
+    short_name = "lightning.qubit"
+    pennylane_requires = ">=0.12"
+    version = __version__
+    author = "Xanadu Inc."
+
+    operations = {
+        "BasisState",
+        "QubitStateVector",
+        "PauliX",
+        "PauliY",
+        "PauliZ",
+        "Hadamard",
+        "S",
+        "T",
+        "CNOT",
+        "SWAP",
+        "CSWAP",
+        "Toffoli",
+        "CZ",
+        "PhaseShift",
+        "RX",
+        "RY",
+        "RZ",
+        "Rot",
+        "CRX",
+        "CRY",
+        "CRZ",
+        "CRot",
+    }
+
+    observables = {"PauliX", "PauliY", "PauliZ", "Hadamard", "Identity"}
+
+    def __init__(self, wires, *, shots=1000, analytic=True):
+        super().__init__(wires, shots=shots, analytic=analytic)
+
+    @classmethod
+    def capabilities(cls):
+        capabilities = super().capabilities().copy()
+        capabilities.update(
+            model="qubit",
+            supports_reversible_diff=False,
+            supports_inverse_operations=False,
+            supports_analytic_computation=True,
+            returns_state=True,
+        )
+        return capabilities
+
+    def apply(self, operations, rotations=None, **kwargs):
+        for i, operation in enumerate(operations):  # State preparation is currently done in Python
+            if isinstance(operation, (QubitStateVector, BasisState)):
+                if i == 0:
+                    self._apply_operation(operation)
+                    del operations[0]
+                else:
+                    raise DeviceError(
+                        "Operation {} cannot be used after other Operations have already been "
+                        "applied on a {} device.".format(operation.name, self.short_name)
+                    )
+
+        if operations:
+            # XXX: Do we need a copy here? Not sure of the required copy semantics
+            self._pre_rotated_state = self.apply_lightning(self._state, operations)
+        else:
+            self._pre_rotated_state = self._state
+
+        if rotations:
+            self._state = self.apply_lightning(np.copy(self._pre_rotated_state), rotations)
+        else:
+            self._state = self._pre_rotated_state
+
+    def apply_lightning(self, state, operations):
+        """Apply a list of operations to the state tensor.
+
+        Args:
+            state (array[complex]): the input state tensor
+            operations (list[~pennylane.operation.Operation]): operations to apply
+
+        Returns:
+            array[complex]: the output state tensor
+        """
+        op_names = [o.name for o in operations]
+        op_wires = [self.wires.indices(o.wires) for o in operations]
+        op_param = [o.parameters for o in operations]
+
+        state_vector = np.ravel(state)
+        assert state_vector.flags["C_CONTIGUOUS"]
+        apply(state_vector, op_names, op_wires, op_param, self.num_wires)
+        return np.reshape(state_vector, state.shape)

--- a/pennylane_lightning/lightning_qubit_new.py
+++ b/pennylane_lightning/lightning_qubit_new.py
@@ -112,7 +112,6 @@ class LightningQubitNew(DefaultQubit):
                     )
 
         if operations:
-            # XXX: Do we need a copy here? Not sure of the required copy semantics
             self._pre_rotated_state = self.apply_lightning(self._state, operations)
         else:
             self._pre_rotated_state = self._state

--- a/pennylane_lightning/src/rework/Apply.cpp
+++ b/pennylane_lightning/src/rework/Apply.cpp
@@ -23,23 +23,23 @@ using std::string;
 using std::unique_ptr;
 using std::vector;
 
-vector<unsigned int> Pennylane::getIndicesExcluding(vector<unsigned int>& excludedIndices, const unsigned int qubits) {
+vector<unsigned int> Pennylane::getIndicesAfterExclusion(const vector<unsigned int>& indicesToExclude, const unsigned int qubits) {
     set<unsigned int> indices;
     for (unsigned int i = 0; i < qubits; i++) {
         indices.insert(indices.end(), i);
     }
-    for (const unsigned int& excludedIndex : excludedIndices) {
+    for (const unsigned int& excludedIndex : indicesToExclude) {
         indices.erase(excludedIndex);
     }
     return vector<unsigned int>(indices.begin(), indices.end());
 }
 
-vector<size_t> Pennylane::generateBitPatterns(vector<unsigned int>& qubitIndices, const unsigned int qubits) {
+vector<size_t> Pennylane::generateBitPatterns(const vector<unsigned int>& qubitIndices, const unsigned int qubits) {
     vector<size_t> indices;
     indices.reserve(exp2(qubitIndices.size()));
     indices.push_back(0);
     for (int i = qubitIndices.size() - 1; i >= 0; i--) {
-        size_t value = decimalValueForQubit(qubitIndices[i], qubits);
+        size_t value = maxDecimalForQubit(qubitIndices[i], qubits);
         size_t currentSize = indices.size();
         for (size_t j = 0; j < currentSize; j++) {
             indices.push_back(indices[j] + value);
@@ -50,18 +50,20 @@ vector<size_t> Pennylane::generateBitPatterns(vector<unsigned int>& qubitIndices
 
 void Pennylane::constructAndApplyOperation(
     StateVector& state,
-    string& opLabel,
-    vector<unsigned int>& opWires,
-    vector<double>& opParams,
+    const string& opLabel,
+    const vector<unsigned int>& opWires,
+    const vector<double>& opParams,
     const unsigned int qubits
 ) {
     unique_ptr<AbstractGate> gate = constructGate(opLabel, opParams);
+    if (gate->numQubits != opWires.size())
+        throw std::invalid_argument(string("The gate of type ") + opLabel + " requires " + std::to_string(gate->numQubits) + " wires, but " + std::to_string(opWires.size()) + " were supplied");
+
     const vector<CplxType>& matrix = gate->asMatrix();
-    assert(matrix.size() == exp2(opWires.size()) * exp2(opWires.size()));
     
     vector<size_t> internalIndices = generateBitPatterns(opWires, qubits);
 
-    vector<unsigned int> externalWires = getIndicesExcluding(opWires, qubits);
+    vector<unsigned int> externalWires = getIndicesAfterExclusion(opWires, qubits);
     vector<size_t> externalIndices = generateBitPatterns(externalWires, qubits);
 
     vector<CplxType> inputVector(internalIndices.size());
@@ -100,7 +102,7 @@ void Pennylane::apply(
     size_t expectedLength = exp2(qubits);
     StateVector state = StateVector::create(&stateNumpyArray);
     if (state.length != expectedLength)
-        throw std::invalid_argument(string("Input state vector length (" + std::to_string(state.length) + ") does not match the given number of qubits ") + std::to_string(qubits));
+        throw std::invalid_argument(string("Input state vector length (") + std::to_string(state.length) + ") does not match the given number of qubits " + std::to_string(qubits));
 
     size_t numOperations = ops.size();
     if (numOperations != wires.size() || numOperations != params.size())

--- a/pennylane_lightning/src/rework/Apply.cpp
+++ b/pennylane_lightning/src/rework/Apply.cpp
@@ -104,7 +104,7 @@ void Pennylane::apply(
         throw std::invalid_argument("Must specify one or more qubits");
 
     size_t expectedLength = exp2(qubits);
-    StateVector state(&stateNumpyArray);
+    StateVector state = StateVector::create(&stateNumpyArray);
     if (state.length != expectedLength)
         throw std::invalid_argument(string("Input state vector length (" + std::to_string(state.length) + ") does not match the given number of qubits ") + std::to_string(qubits));
 

--- a/pennylane_lightning/src/rework/Apply.cpp
+++ b/pennylane_lightning/src/rework/Apply.cpp
@@ -1,0 +1,126 @@
+// Copyright 2020 Xanadu Quantum Technologies Inc.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#define NDEBUG
+#include <set>
+
+#include "Apply.hpp"
+#include "GateFactory.hpp"
+#include "StateVector.hpp"
+#include "Util.hpp"
+
+using std::set;
+using std::string;
+using std::unique_ptr;
+using std::vector;
+
+vector<unsigned int> Pennylane::getIndicesExcluding(vector<unsigned int>& excludedIndices, const unsigned int qubits) {
+    set<unsigned int> indices;
+    for (unsigned int i = 0; i < qubits; i++) {
+        indices.insert(indices.end(), i);
+    }
+    for (const unsigned int& excludedIndex : excludedIndices) {
+        indices.erase(excludedIndex);
+    }
+    return vector<unsigned int>(indices.begin(), indices.end());
+}
+
+static inline size_t decimalValueForQubit(unsigned int qubitIndex, const unsigned int qubits) {
+    assert(qubitIndex < qubits);
+    return exp2(qubits - qubitIndex - 1);
+}
+
+vector<size_t> Pennylane::generateBitPatterns(vector<unsigned int>& qubitIndices, const unsigned int qubits) {
+    vector<size_t> indices;
+    indices.reserve(exp2(qubitIndices.size()));
+    indices.push_back(0);
+    for (int i = qubitIndices.size() - 1; i >= 0; i--) {
+        size_t value = decimalValueForQubit(qubitIndices[i], qubits);
+        size_t currentSize = indices.size();
+        for (size_t j = 0; j < currentSize; j++) {
+            indices.push_back(indices[j] + value);
+        }
+    }
+    return indices;
+}
+
+void Pennylane::constructAndApplyOperation(
+    StateVector& state,
+    string& opLabel,
+    vector<unsigned int>& opWires,
+    vector<double>& opParams,
+    const unsigned int qubits
+) {
+    unique_ptr<AbstractGate> gate = constructGate(opLabel, opParams);
+    const vector<CplxType>& matrix = gate->asMatrix();
+    assert(matrix.size() == exp2(opWires.size()) * exp2(opWires.size()));
+    
+    vector<size_t> internalIndices = generateBitPatterns(opWires, qubits);
+
+    vector<unsigned int> externalWires = getIndicesExcluding(opWires, qubits);
+    vector<size_t> externalIndices = generateBitPatterns(externalWires, qubits);
+
+    vector<CplxType> inputVector(internalIndices.size());
+    for (const size_t& externalIndex : externalIndices) {
+        CplxType* shiftedStatePtr = state.arr + externalIndex;
+
+        // Gather
+        size_t pos = 0;
+        for (const size_t& internalIndex : internalIndices) {
+            inputVector[pos] = shiftedStatePtr[internalIndex];
+            pos++;
+        }
+
+        // Apply + scatter
+        for (size_t i = 0; i < internalIndices.size(); i++) {
+            size_t internalIndex = internalIndices[i];
+            shiftedStatePtr[internalIndex] = 0;
+            size_t baseIndex = i * internalIndices.size();
+            for (size_t j = 0; j < internalIndices.size(); j++) {
+                shiftedStatePtr[internalIndex] += matrix[baseIndex + j] * inputVector[j];
+            }
+        }
+    }
+}
+
+void Pennylane::apply(
+    pybind11::array_t<CplxType>& stateNumpyArray,
+    vector<string> ops,
+    vector<vector<unsigned int>> wires,
+    vector<vector<double>> params,
+    const unsigned int qubits
+) { 
+    if (qubits <= 0)
+        throw std::invalid_argument("Must specify one or more qubits");
+
+    size_t expectedLength = exp2(qubits);
+    StateVector state(&stateNumpyArray);
+    if (state.length != expectedLength)
+        throw std::invalid_argument(string("Input state vector length (" + std::to_string(state.length) + ") does not match the given number of qubits ") + std::to_string(qubits));
+
+    size_t numOperations = ops.size();
+    if (numOperations != wires.size() || numOperations != params.size())
+        throw std::invalid_argument("Invalid arguments: number of operations, wires, and parameters must all be equal");
+
+    for (int i = 0; i < numOperations; i++) {
+        constructAndApplyOperation(state, ops[i], wires[i], params[i], qubits);
+    }
+
+}
+
+
+PYBIND11_MODULE(lightning_qubit_new_ops, m)
+{
+    m.doc() = "lightning.qubit apply() method";
+    m.def("apply", Pennylane::apply, "lightning.qubit apply() method");
+}

--- a/pennylane_lightning/src/rework/Apply.cpp
+++ b/pennylane_lightning/src/rework/Apply.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020 Xanadu Quantum Technologies Inc.
+// Copyright 2021 Xanadu Quantum Technologies Inc.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pennylane_lightning/src/rework/Apply.cpp
+++ b/pennylane_lightning/src/rework/Apply.cpp
@@ -11,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#define NDEBUG
 #include <set>
 
 #include "Apply.hpp"
@@ -33,11 +32,6 @@ vector<unsigned int> Pennylane::getIndicesExcluding(vector<unsigned int>& exclud
         indices.erase(excludedIndex);
     }
     return vector<unsigned int>(indices.begin(), indices.end());
-}
-
-static inline size_t decimalValueForQubit(unsigned int qubitIndex, const unsigned int qubits) {
-    assert(qubitIndex < qubits);
-    return exp2(qubits - qubitIndex - 1);
 }
 
 vector<size_t> Pennylane::generateBitPatterns(vector<unsigned int>& qubitIndices, const unsigned int qubits) {

--- a/pennylane_lightning/src/rework/Apply.hpp
+++ b/pennylane_lightning/src/rework/Apply.hpp
@@ -1,0 +1,96 @@
+// Copyright 2020 Xanadu Quantum Technologies Inc.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+/**
+ * @file
+ * Contains the main `apply()` function for applying a set of operations to a multiqubit
+ * statevector.
+ *
+ * Also includes PyBind boilerplate for interfacing with Python.
+ */
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "pybind11/complex.h"
+#include "pybind11/pybind11.h"
+#include "pybind11/numpy.h"
+#include "pybind11/stl.h"
+
+#include "StateVector.hpp"
+#include "typedefs.hpp"
+
+namespace Pennylane {
+
+    /**
+     * Produces the list of qubit indices that excludes a given set of indices.
+     * 
+     * @param excludedIndices indices to exclude (must be in the range [0, qubits-1])
+     * @param qubits number of qubits
+     * @return Set difference of [0, ..., qubits-1] and excludedIndices, in ascending order
+     */
+    std::vector<unsigned int> getIndicesExcluding(std::vector<unsigned int>& excludedIndices, const unsigned int qubits);
+
+    /**
+     * Produces the decimal values for all possible bit patterns for a given set of indices, taking other indices to be fixed at 0.
+     * The qubit indices are taken to be big-endian, i.e. qubit 0 is the most significant bit.
+     * 
+     * For instance, in a circuit with 5 qubits:
+     * [0, 1] -> 00000, 01000, 10000, 11000 -> 0, 8, 16, 24
+     * 
+     * The order of the indices determines the order in which bit patterns are generated, e.g.
+     * [1, 0] -> 00000, 10000, 01000, 11000 -> 0, 16, 8, 24
+     * 
+     * i.e. the qubit indices are evaluted from last-to-first.
+     *  
+     * @param qubitIndices indices of qubits that comprise the bit pattern
+     * @param qubits number of qubits
+     * @return decimal value corresponding to all possible bit patterns for the given indices
+     */
+    std::vector<size_t> generateBitPatterns(std::vector<unsigned int>& qubitIndices, const unsigned int qubits);
+
+    /*
+     * Constructs the gate defined by the supplied parameters and applies it to the state vector.
+     * 
+     * @param state state vector to which to apply the operation
+     * @param opLabel unique string corresponding to a gate type
+     * @param opWires index of qubits on which the gate acts
+     * @param opParams defines the gate parameterisation (may be zero-length for some gates)
+     * @param qubits number of qubits
+     */
+    void constructAndApplyOperation(
+        StateVector& state,
+        std::string& opLabel,
+        std::vector<unsigned int>& opWires,
+        std::vector<double>& opParams,
+        const unsigned int qubits
+    );
+
+    /**
+     * Applies specified operations onto an input state of an arbitrary number of qubits.
+     *
+     * @param state the multiqubit statevector as a numpy array; modified in place
+     * @param ops list of unique string names corresponding to gate types, in the order they should be applied
+     * @param wires list of wires on which each gate acts
+     * @param params list of parameters that defines the gate parameterisation
+     */
+    void apply(
+        pybind11::array_t<CplxType>& stateNumpyArray,
+        std::vector<std::string> ops,
+        std::vector<std::vector<unsigned int>> wires,
+        std::vector<std::vector<double>> params,
+        const unsigned int qubits
+    );
+
+}

--- a/pennylane_lightning/src/rework/Apply.hpp
+++ b/pennylane_lightning/src/rework/Apply.hpp
@@ -40,10 +40,10 @@ namespace Pennylane {
      * @param qubits number of qubits
      * @return Set difference of [0, ..., qubits-1] and excludedIndices, in ascending order
      */
-    std::vector<unsigned int> getIndicesExcluding(std::vector<unsigned int>& excludedIndices, const unsigned int qubits);
+    std::vector<unsigned int> getIndicesAfterExclusion(const std::vector<unsigned int>& indicesToExclude, const unsigned int qubits);
 
     /**
-     * Produces the decimal values for all possible bit patterns for a given set of indices, taking other indices to be fixed at 0.
+     * Produces the decimal values for all possible bit patterns determined by a set of indices, taking other indices to be fixed at 0.
      * The qubit indices are taken to be big-endian, i.e. qubit 0 is the most significant bit.
      * 
      * For instance, in a circuit with 5 qubits:
@@ -58,7 +58,7 @@ namespace Pennylane {
      * @param qubits number of qubits
      * @return decimal value corresponding to all possible bit patterns for the given indices
      */
-    std::vector<size_t> generateBitPatterns(std::vector<unsigned int>& qubitIndices, const unsigned int qubits);
+    std::vector<size_t> generateBitPatterns(const std::vector<unsigned int>& qubitIndices, const unsigned int qubits);
 
     /*
      * Constructs the gate defined by the supplied parameters and applies it to the state vector.
@@ -71,9 +71,9 @@ namespace Pennylane {
      */
     void constructAndApplyOperation(
         StateVector& state,
-        std::string& opLabel,
-        std::vector<unsigned int>& opWires,
-        std::vector<double>& opParams,
+        const std::string& opLabel,
+        const std::vector<unsigned int>& opWires,
+        const std::vector<double>& opParams,
         const unsigned int qubits
     );
 

--- a/pennylane_lightning/src/rework/Apply.hpp
+++ b/pennylane_lightning/src/rework/Apply.hpp
@@ -1,4 +1,4 @@
-// Copyright 2020 Xanadu Quantum Technologies Inc.
+// Copyright 2021 Xanadu Quantum Technologies Inc.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pennylane_lightning/src/rework/GateFactory.cpp
+++ b/pennylane_lightning/src/rework/GateFactory.cpp
@@ -56,9 +56,9 @@ static map<string, function<unique_ptr<Pennylane::AbstractGate>(const vector<dou
 static const map<string, function<unique_ptr<Pennylane::AbstractGate>(const vector<double>&)>> dispatchTable = createDispatchTable();
 
 unique_ptr<Pennylane::AbstractGate> Pennylane::constructGate(const string& label, const vector<double>& parameters) {
-    auto it = dispatchTable.find(label);
-    if (it == dispatchTable.end())
+    auto dispatchTableIterator = dispatchTable.find(label);
+    if (dispatchTableIterator == dispatchTable.end())
         throw std::invalid_argument(label + " is not a supported gate type");
 
-    return it->second(parameters);
+    return dispatchTableIterator->second(parameters);
 }

--- a/pennylane_lightning/src/rework/GateFactory.cpp
+++ b/pennylane_lightning/src/rework/GateFactory.cpp
@@ -1,0 +1,90 @@
+// Copyright 2020 Xanadu Quantum Technologies Inc.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "GateFactory.hpp"
+
+using std::string;
+using std::unique_ptr;
+using std::vector;
+
+// FIXME: This should be reworked to use a function dispatch table
+unique_ptr<Pennylane::AbstractGate> Pennylane::constructGate(const string& label, const vector<double>& parameters) {
+    std::unique_ptr<Pennylane::AbstractGate> gate;
+
+    if (Pennylane::XGate::label == label) {
+        gate = std::make_unique<Pennylane::XGate>(Pennylane::XGate::create(parameters));
+    }
+    else if (Pennylane::YGate::label == label) {
+        gate = std::make_unique<Pennylane::YGate>(Pennylane::YGate::create(parameters));
+    }
+    else if (Pennylane::ZGate::label == label) {
+        gate = std::make_unique<Pennylane::ZGate>(Pennylane::ZGate::create(parameters));
+    }
+    else if (Pennylane::HadamardGate::label == label) {
+        gate = std::make_unique<Pennylane::HadamardGate>(Pennylane::HadamardGate::create(parameters));
+    }
+    else if (Pennylane::SGate::label == label) {
+        gate = std::make_unique<Pennylane::SGate>(Pennylane::SGate::create(parameters));
+    }
+    else if (Pennylane::TGate::label == label) {
+        gate = std::make_unique<Pennylane::TGate>(Pennylane::TGate::create(parameters));
+    }
+    else if (Pennylane::RotationXGate::label == label) {
+        gate = std::make_unique<Pennylane::RotationXGate>(Pennylane::RotationXGate::create(parameters));
+    }
+    else if (Pennylane::RotationYGate::label == label) {
+        gate = std::make_unique<Pennylane::RotationYGate>(Pennylane::RotationYGate::create(parameters));
+    }
+    else if (Pennylane::RotationZGate::label == label) {
+        gate = std::make_unique<Pennylane::RotationZGate>(Pennylane::RotationZGate::create(parameters));
+    }
+    else if (Pennylane::PhaseShiftGate::label == label) {
+        gate = std::make_unique<Pennylane::PhaseShiftGate>(Pennylane::PhaseShiftGate::create(parameters));
+    }
+    else if (Pennylane::GeneralRotationGate::label == label) {
+        gate = std::make_unique<Pennylane::GeneralRotationGate>(Pennylane::GeneralRotationGate::create(parameters));
+    }
+    else if (Pennylane::CNOTGate::label == label) {
+        gate = std::make_unique<Pennylane::CNOTGate>(Pennylane::CNOTGate::create(parameters));
+    }
+    else if (Pennylane::SWAPGate::label == label) {
+        gate = std::make_unique<Pennylane::SWAPGate>(Pennylane::SWAPGate::create(parameters));
+    }
+    else if (Pennylane::CZGate::label == label) {
+        gate = std::make_unique<Pennylane::CZGate>(Pennylane::CZGate::create(parameters));
+    }
+    else if (Pennylane::CRotationXGate::label == label) {
+        gate = std::make_unique<Pennylane::CRotationXGate>(Pennylane::CRotationXGate::create(parameters));
+    }
+    else if (Pennylane::CRotationYGate::label == label) {
+        gate = std::make_unique<Pennylane::CRotationYGate>(Pennylane::CRotationYGate::create(parameters));
+    }
+    else if (Pennylane::CRotationZGate::label == label) {
+        gate = std::make_unique<Pennylane::CRotationZGate>(Pennylane::CRotationZGate::create(parameters));
+    }
+    else if (Pennylane::CGeneralRotationGate::label == label) {
+        gate = std::make_unique<Pennylane::CGeneralRotationGate>(Pennylane::CGeneralRotationGate::create(parameters));
+    }
+    else if (Pennylane::ToffoliGate::label == label) {
+        gate = std::make_unique<Pennylane::ToffoliGate>(Pennylane::ToffoliGate::create(parameters));
+    }
+    else if (Pennylane::CSWAPGate::label == label) {
+        gate = std::make_unique<Pennylane::CSWAPGate>(Pennylane::CSWAPGate::create(parameters));
+    }
+    else {
+        throw std::invalid_argument(label + " is not a valid gate type");
+    }
+
+    return gate;
+}

--- a/pennylane_lightning/src/rework/GateFactory.cpp
+++ b/pennylane_lightning/src/rework/GateFactory.cpp
@@ -12,79 +12,53 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <functional>
+#include <map>
+
 #include "GateFactory.hpp"
 
+using std::function;
+using std::map;
 using std::string;
 using std::unique_ptr;
 using std::vector;
 
-// FIXME: This should be reworked to use a function dispatch table
+template<class GateType>
+static void addToDispatchTable(map<string, function<unique_ptr<Pennylane::AbstractGate>(const vector<double>&)>>& dispatchTable) {
+    dispatchTable.emplace(GateType::label, [](const vector<double>& parameters) { return std::make_unique<GateType>(GateType::create(parameters)); });
+}
+
+static map<string, function<unique_ptr<Pennylane::AbstractGate>(const vector<double>&)>> createDispatchTable() {
+    map<string, function<unique_ptr<Pennylane::AbstractGate>(const vector<double>&)>> dispatchTable;
+    addToDispatchTable<Pennylane::XGate>(dispatchTable);
+    addToDispatchTable<Pennylane::YGate>(dispatchTable);
+    addToDispatchTable<Pennylane::ZGate>(dispatchTable);
+    addToDispatchTable<Pennylane::HadamardGate>(dispatchTable);
+    addToDispatchTable<Pennylane::SGate>(dispatchTable);
+    addToDispatchTable<Pennylane::TGate>(dispatchTable);
+    addToDispatchTable<Pennylane::RotationXGate>(dispatchTable);
+    addToDispatchTable<Pennylane::RotationYGate>(dispatchTable);
+    addToDispatchTable<Pennylane::RotationZGate>(dispatchTable);
+    addToDispatchTable<Pennylane::PhaseShiftGate>(dispatchTable);
+    addToDispatchTable<Pennylane::GeneralRotationGate>(dispatchTable);
+    addToDispatchTable<Pennylane::CNOTGate>(dispatchTable);
+    addToDispatchTable<Pennylane::SWAPGate>(dispatchTable);
+    addToDispatchTable<Pennylane::CZGate>(dispatchTable);
+    addToDispatchTable<Pennylane::CRotationXGate>(dispatchTable);
+    addToDispatchTable<Pennylane::CRotationYGate>(dispatchTable);
+    addToDispatchTable<Pennylane::CRotationZGate>(dispatchTable);
+    addToDispatchTable<Pennylane::CGeneralRotationGate>(dispatchTable);
+    addToDispatchTable<Pennylane::ToffoliGate>(dispatchTable);
+    addToDispatchTable<Pennylane::CSWAPGate>(dispatchTable);
+    return dispatchTable;
+}
+
+static const map<string, function<unique_ptr<Pennylane::AbstractGate>(const vector<double>&)>> dispatchTable = createDispatchTable();
+
 unique_ptr<Pennylane::AbstractGate> Pennylane::constructGate(const string& label, const vector<double>& parameters) {
-    std::unique_ptr<Pennylane::AbstractGate> gate;
+    auto it = dispatchTable.find(label);
+    if (it == dispatchTable.end())
+        throw std::invalid_argument(label + " is not a supported gate type");
 
-    if (Pennylane::XGate::label == label) {
-        gate = std::make_unique<Pennylane::XGate>(Pennylane::XGate::create(parameters));
-    }
-    else if (Pennylane::YGate::label == label) {
-        gate = std::make_unique<Pennylane::YGate>(Pennylane::YGate::create(parameters));
-    }
-    else if (Pennylane::ZGate::label == label) {
-        gate = std::make_unique<Pennylane::ZGate>(Pennylane::ZGate::create(parameters));
-    }
-    else if (Pennylane::HadamardGate::label == label) {
-        gate = std::make_unique<Pennylane::HadamardGate>(Pennylane::HadamardGate::create(parameters));
-    }
-    else if (Pennylane::SGate::label == label) {
-        gate = std::make_unique<Pennylane::SGate>(Pennylane::SGate::create(parameters));
-    }
-    else if (Pennylane::TGate::label == label) {
-        gate = std::make_unique<Pennylane::TGate>(Pennylane::TGate::create(parameters));
-    }
-    else if (Pennylane::RotationXGate::label == label) {
-        gate = std::make_unique<Pennylane::RotationXGate>(Pennylane::RotationXGate::create(parameters));
-    }
-    else if (Pennylane::RotationYGate::label == label) {
-        gate = std::make_unique<Pennylane::RotationYGate>(Pennylane::RotationYGate::create(parameters));
-    }
-    else if (Pennylane::RotationZGate::label == label) {
-        gate = std::make_unique<Pennylane::RotationZGate>(Pennylane::RotationZGate::create(parameters));
-    }
-    else if (Pennylane::PhaseShiftGate::label == label) {
-        gate = std::make_unique<Pennylane::PhaseShiftGate>(Pennylane::PhaseShiftGate::create(parameters));
-    }
-    else if (Pennylane::GeneralRotationGate::label == label) {
-        gate = std::make_unique<Pennylane::GeneralRotationGate>(Pennylane::GeneralRotationGate::create(parameters));
-    }
-    else if (Pennylane::CNOTGate::label == label) {
-        gate = std::make_unique<Pennylane::CNOTGate>(Pennylane::CNOTGate::create(parameters));
-    }
-    else if (Pennylane::SWAPGate::label == label) {
-        gate = std::make_unique<Pennylane::SWAPGate>(Pennylane::SWAPGate::create(parameters));
-    }
-    else if (Pennylane::CZGate::label == label) {
-        gate = std::make_unique<Pennylane::CZGate>(Pennylane::CZGate::create(parameters));
-    }
-    else if (Pennylane::CRotationXGate::label == label) {
-        gate = std::make_unique<Pennylane::CRotationXGate>(Pennylane::CRotationXGate::create(parameters));
-    }
-    else if (Pennylane::CRotationYGate::label == label) {
-        gate = std::make_unique<Pennylane::CRotationYGate>(Pennylane::CRotationYGate::create(parameters));
-    }
-    else if (Pennylane::CRotationZGate::label == label) {
-        gate = std::make_unique<Pennylane::CRotationZGate>(Pennylane::CRotationZGate::create(parameters));
-    }
-    else if (Pennylane::CGeneralRotationGate::label == label) {
-        gate = std::make_unique<Pennylane::CGeneralRotationGate>(Pennylane::CGeneralRotationGate::create(parameters));
-    }
-    else if (Pennylane::ToffoliGate::label == label) {
-        gate = std::make_unique<Pennylane::ToffoliGate>(Pennylane::ToffoliGate::create(parameters));
-    }
-    else if (Pennylane::CSWAPGate::label == label) {
-        gate = std::make_unique<Pennylane::CSWAPGate>(Pennylane::CSWAPGate::create(parameters));
-    }
-    else {
-        throw std::invalid_argument(label + " is not a valid gate type");
-    }
-
-    return gate;
+    return it->second(parameters);
 }

--- a/pennylane_lightning/src/rework/GateFactory.cpp
+++ b/pennylane_lightning/src/rework/GateFactory.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020 Xanadu Quantum Technologies Inc.
+// Copyright 2021 Xanadu Quantum Technologies Inc.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pennylane_lightning/src/rework/GateFactory.hpp
+++ b/pennylane_lightning/src/rework/GateFactory.hpp
@@ -1,0 +1,37 @@
+// Copyright 2020 Xanadu Quantum Technologies Inc.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+/**
+ * @file
+ * Contains methods that produce gates from the requisite parameters.
+ */
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include "Gates.hpp"
+
+namespace Pennylane {
+
+    /**
+     * Produces the requested gate, defined by a label and the list of parameters
+     *
+     * @param label unique string corresponding to a gate type
+     * @param parameters defines the gate parameterisation (may be zero-length for some gates)
+     * @return the gate wrapped in std::unique_ptr
+     * @throws std::invalid_argument thrown if the gate type is not defined, or if the number of parameters to the gate is incorrect
+     */
+    std::unique_ptr<AbstractGate> constructGate(const std::string& label, const std::vector<double>& parameters);
+
+}

--- a/pennylane_lightning/src/rework/GateFactory.hpp
+++ b/pennylane_lightning/src/rework/GateFactory.hpp
@@ -1,4 +1,4 @@
-// Copyright 2020 Xanadu Quantum Technologies Inc.
+// Copyright 2021 Xanadu Quantum Technologies Inc.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pennylane_lightning/src/rework/Gates.cpp
+++ b/pennylane_lightning/src/rework/Gates.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020 Xanadu Quantum Technologies Inc.
+// Copyright 2021 Xanadu Quantum Technologies Inc.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -331,7 +331,7 @@ Pennylane::CGeneralRotationGate::CGeneralRotationGate(double phi, double theta, 
 // -------------------------------------------------------------------------------------------------------------
 
 Pennylane::ThreeQubitGate::ThreeQubitGate()
-    : AbstractGate(2)
+    : AbstractGate(3)
 {}
 
 // -------------------------------------------------------------------------------------------------------------

--- a/pennylane_lightning/src/rework/Gates.cpp
+++ b/pennylane_lightning/src/rework/Gates.cpp
@@ -198,9 +198,11 @@ Pennylane::GeneralRotationGate Pennylane::GeneralRotationGate::create(const vect
 }
 
 Pennylane::GeneralRotationGate::GeneralRotationGate(double phi, double theta, double omega)
-    : matrix{
-      std::cos(theta / 2) * std::pow(M_E, CplxType(0, (-phi - omega) / 2)), -std::sin(theta / 2) * std::pow(M_E, CplxType(0, (phi - omega) / 2)),
-      std::sin(theta / 2) * std::pow(M_E, CplxType(0, (-phi + omega) / 2)), std::cos(theta / 2) * std::pow(M_E, CplxType(0, (phi + omega) / 2)) }
+    : c(std::cos(theta / 2), 0)
+    , s(std::sin(theta / 2), 0)
+    , matrix{
+      c * std::pow(M_E, CplxType(0, (-phi - omega) / 2)), -s * std::pow(M_E, CplxType(0, (phi - omega) / 2)),
+      s * std::pow(M_E, CplxType(0, (-phi + omega) / 2)), c * std::pow(M_E, CplxType(0, (phi + omega) / 2)) }
 {}
 
 // -------------------------------------------------------------------------------------------------------------
@@ -321,11 +323,13 @@ Pennylane::CGeneralRotationGate Pennylane::CGeneralRotationGate::create(const ve
 }
 
 Pennylane::CGeneralRotationGate::CGeneralRotationGate(double phi, double theta, double omega)
-    : matrix{
+    : c(std::cos(theta / 2), 0)
+    , s(std::sin(theta / 2), 0)
+    , matrix{
       1, 0, 0, 0,
       0, 1, 0, 0,
-      0, 0, std::cos(theta / 2) * std::pow(M_E, CplxType(0, (-phi - omega) / 2)), -std::sin(theta / 2) * std::pow(M_E, CplxType(0, (phi - omega) / 2)),
-      0, 0, std::sin(theta / 2) * std::pow(M_E, CplxType(0, (-phi + omega) / 2)), std::cos(theta / 2) * std::pow(M_E, CplxType(0, (phi + omega) / 2)) }
+      0, 0, c * std::pow(M_E, CplxType(0, (-phi - omega) / 2)), -s * std::pow(M_E, CplxType(0, (phi - omega) / 2)),
+      0, 0, s * std::pow(M_E, CplxType(0, (-phi + omega) / 2)), c * std::pow(M_E, CplxType(0, (phi + omega) / 2)) }
 {}
 
 // -------------------------------------------------------------------------------------------------------------

--- a/pennylane_lightning/src/rework/Gates.cpp
+++ b/pennylane_lightning/src/rework/Gates.cpp
@@ -1,0 +1,373 @@
+// Copyright 2020 Xanadu Quantum Technologies Inc.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#define _USE_MATH_DEFINES
+
+#include <cmath>
+
+#include "Gates.hpp"
+#include "typedefs.hpp"
+#include "Util.hpp"
+
+using Pennylane::CplxType;
+using std::string;
+using std::vector;
+
+template<class T>
+static void validateLength(const string& errorPrefix, const vector<T>& vec, int requiredLength) {
+    if (vec.size() != requiredLength)
+        throw std::invalid_argument(errorPrefix + ": requires " + std::to_string(requiredLength) + " arguments but got " + std::to_string(vec.size()) + " arguments instead");
+}
+
+// -------------------------------------------------------------------------------------------------------------
+
+Pennylane::AbstractGate::AbstractGate(int numQubits)
+    : numQubits(numQubits)
+    , length(exp2(numQubits))
+{}
+
+// -------------------------------------------------------------------------------------------------------------
+
+Pennylane::SingleQubitGate::SingleQubitGate()
+    : AbstractGate(1)
+{}
+
+// -------------------------------------------------------------------------------------------------------------
+
+const string Pennylane::XGate::label = "PauliX";
+
+Pennylane::XGate Pennylane::XGate::create(const vector<double>& parameters) {
+    validateLength(Pennylane::XGate::label, parameters, 0);
+    return Pennylane::XGate();
+}
+
+const vector<CplxType> Pennylane::XGate::matrix{
+    0, 1,
+    1, 0 };
+
+// -------------------------------------------------------------------------------------------------------------
+
+const string Pennylane::YGate::label = "PauliY";
+
+Pennylane::YGate Pennylane::YGate::create(const vector<double>& parameters) {
+    validateLength(Pennylane::YGate::label, parameters, 0);
+    return Pennylane::YGate();
+}
+
+const vector<CplxType> Pennylane::YGate::matrix{
+    0, -IMAG,
+    IMAG, 0 };
+
+// -------------------------------------------------------------------------------------------------------------
+
+const string Pennylane::ZGate::label = "PauliZ";
+
+Pennylane::ZGate Pennylane::ZGate::create(const vector<double>& parameters) {
+    validateLength(Pennylane::ZGate::label, parameters, 0);
+    return Pennylane::ZGate();
+}
+
+const std::vector<CplxType> Pennylane::ZGate::matrix{
+    1, 0,
+    0, -1 };
+
+// -------------------------------------------------------------------------------------------------------------
+
+const string Pennylane::HadamardGate::label = "Hadamard";
+
+Pennylane::HadamardGate Pennylane::HadamardGate::create(const vector<double>& parameters) {
+    validateLength(Pennylane::HadamardGate::label, parameters, 0);
+    return Pennylane::HadamardGate();
+}
+
+const vector<CplxType> Pennylane::HadamardGate::matrix{
+    SQRT2INV, SQRT2INV,
+    SQRT2INV, -SQRT2INV };
+
+// -------------------------------------------------------------------------------------------------------------
+
+const string Pennylane::SGate::label = "S";
+
+Pennylane::SGate Pennylane::SGate::create(const vector<double>& parameters) {
+    validateLength(Pennylane::SGate::label, parameters, 0);
+    return Pennylane::SGate();
+}
+
+const vector<CplxType> Pennylane::SGate::matrix{
+    1, 0,
+    0, IMAG };
+
+// -------------------------------------------------------------------------------------------------------------
+
+const string Pennylane::TGate::label = "T";
+
+Pennylane::TGate Pennylane::TGate::create(const vector<double>& parameters) {
+    validateLength(Pennylane::TGate::label, parameters, 0);
+    return Pennylane::TGate();
+}
+
+const vector<CplxType> Pennylane::TGate::matrix{
+    1, 0,
+    0, std::pow(M_E, M_PI / 4) };
+
+// -------------------------------------------------------------------------------------------------------------
+
+const string Pennylane::RotationXGate::label = "RX";
+
+Pennylane::RotationXGate Pennylane::RotationXGate::create(const vector<double>& parameters) {
+    validateLength(Pennylane::RotationXGate::label, parameters, 1);
+    return Pennylane::RotationXGate(parameters[0]);
+}
+
+Pennylane::RotationXGate::RotationXGate(double rotationAngle)
+    : c(std::cos(rotationAngle / 2), 0)
+    , js(0, std::sin(-rotationAngle / 2))
+    , matrix{
+      c, js,
+      js, c }
+{}
+
+// -------------------------------------------------------------------------------------------------------------
+
+const string Pennylane::RotationYGate::label = "RY";
+
+Pennylane::RotationYGate Pennylane::RotationYGate::create(const vector<double>& parameters) {
+    validateLength(Pennylane::RotationYGate::label, parameters, 1);
+    return Pennylane::RotationYGate(parameters[0]);
+}
+
+Pennylane::RotationYGate::RotationYGate(double rotationAngle)
+    : c(std::cos(rotationAngle / 2), 0)
+    , s(std::sin(-rotationAngle / 2), 0)
+    , matrix{
+      c, -s,
+      s, c }
+{}
+
+// -------------------------------------------------------------------------------------------------------------
+
+const string Pennylane::RotationZGate::label = "RZ";
+
+Pennylane::RotationZGate Pennylane::RotationZGate::create(const vector<double>& parameters) {
+    validateLength(Pennylane::RotationZGate::label, parameters, 1);
+    return Pennylane::RotationZGate(parameters[0]);
+}
+
+Pennylane::RotationZGate::RotationZGate(double rotationAngle)
+    : first(std::pow(M_E, CplxType(0, -rotationAngle / 2)))
+    , second(std::pow(M_E, CplxType(0, rotationAngle / 2)))
+    , matrix{
+      first, 0,
+      0, second }
+{}
+
+// -------------------------------------------------------------------------------------------------------------
+
+const string Pennylane::PhaseShiftGate::label = "PhaseShift";
+
+Pennylane::PhaseShiftGate Pennylane::PhaseShiftGate::create(const vector<double>& parameters) {
+    validateLength(Pennylane::PhaseShiftGate::label, parameters, 1);
+    return Pennylane::PhaseShiftGate(parameters[0]);
+}
+
+Pennylane::PhaseShiftGate::PhaseShiftGate(double rotationAngle)
+    : shift(std::pow(M_E, CplxType(0, rotationAngle / 2)))
+    , matrix{
+      1, 0,
+      0, shift }
+{}
+
+// -------------------------------------------------------------------------------------------------------------
+
+const string Pennylane::GeneralRotationGate::label = "Rot";
+
+Pennylane::GeneralRotationGate Pennylane::GeneralRotationGate::create(const vector<double>& parameters) {
+    validateLength(Pennylane::GeneralRotationGate::label, parameters, 3);
+    return Pennylane::GeneralRotationGate(parameters[0], parameters[1], parameters[2]);
+}
+
+Pennylane::GeneralRotationGate::GeneralRotationGate(double phi, double theta, double omega)
+    : matrix{
+      std::cos(theta / 2) * std::pow(M_E, CplxType(0, (-phi - omega) / 2)), -std::sin(theta / 2) * std::pow(M_E, CplxType(0, (phi - omega) / 2)),
+      std::sin(theta / 2) * std::pow(M_E, CplxType(0, (-phi + omega) / 2)), std::cos(theta / 2) * std::pow(M_E, CplxType(0, (phi + omega) / 2)) }
+{}
+
+// -------------------------------------------------------------------------------------------------------------
+
+Pennylane::TwoQubitGate::TwoQubitGate()
+    : AbstractGate(2)
+{}
+
+// -------------------------------------------------------------------------------------------------------------
+
+const string Pennylane::CNOTGate::label = "CNOT";
+
+Pennylane::CNOTGate Pennylane::CNOTGate::create(const vector<double>& parameters) {
+    validateLength(Pennylane::CNOTGate::label, parameters, 0);
+    return Pennylane::CNOTGate();
+}
+
+const std::vector<CplxType> Pennylane::CNOTGate::matrix{
+    1, 0, 0, 0,
+    0, 1, 0, 0,
+    0, 0, 0, 1,
+    0, 0, 1, 0 };
+
+// -------------------------------------------------------------------------------------------------------------
+
+const string Pennylane::SWAPGate::label = "SWAP";
+
+Pennylane::SWAPGate Pennylane::SWAPGate::create(const vector<double>& parameters) {
+    validateLength(Pennylane::SWAPGate::label, parameters, 0);
+    return Pennylane::SWAPGate();
+}
+
+const std::vector<CplxType> Pennylane::SWAPGate::matrix{
+    1, 0, 0, 0,
+    0, 0, 1, 0,
+    0, 1, 0, 0,
+    0, 0, 0, 1 };
+
+// -------------------------------------------------------------------------------------------------------------
+
+const string Pennylane::CZGate::label = "CZ";
+
+Pennylane::CZGate Pennylane::CZGate::create(const vector<double>& parameters) {
+    validateLength(Pennylane::CZGate::label, parameters, 0);
+    return Pennylane::CZGate();
+}
+
+const std::vector<CplxType> Pennylane::CZGate::matrix{
+    1, 0, 0, 0,
+    0, 1, 0, 0,
+    0, 0, 1, 0,
+    0, 0, 0, -1 };
+
+// -------------------------------------------------------------------------------------------------------------
+
+const string Pennylane::CRotationXGate::label = "CRX";
+
+Pennylane::CRotationXGate Pennylane::CRotationXGate::create(const vector<double>& parameters) {
+    validateLength(Pennylane::CRotationXGate::label, parameters, 1);
+    return Pennylane::CRotationXGate(parameters[0]);
+}
+
+Pennylane::CRotationXGate::CRotationXGate(double rotationAngle)
+    : c(std::cos(rotationAngle / 2), 0)
+    , js(0, std::sin(-rotationAngle / 2))
+    , matrix{
+      1, 0, 0, 0,
+      0, 1, 0, 0,
+      0, 0, c, js,
+      0, 0, js, c }
+{}
+
+// -------------------------------------------------------------------------------------------------------------
+
+const string Pennylane::CRotationYGate::label = "CRY";
+
+Pennylane::CRotationYGate Pennylane::CRotationYGate::create(const vector<double>& parameters) {
+    validateLength(Pennylane::CRotationYGate::label, parameters, 1);
+    return Pennylane::CRotationYGate(parameters[0]);
+}
+
+Pennylane::CRotationYGate::CRotationYGate(double rotationAngle)
+    : c(std::cos(rotationAngle / 2), 0)
+    , s(std::sin(-rotationAngle / 2), 0)
+    , matrix{
+      1, 0, 0, 0,
+      0, 1, 0, 0,
+      0, 0, c, -s,
+      0, 0, s, c }
+{}
+
+// -------------------------------------------------------------------------------------------------------------
+
+const string Pennylane::CRotationZGate::label = "CRZ";
+
+Pennylane::CRotationZGate Pennylane::CRotationZGate::create(const vector<double>& parameters) {
+    validateLength(Pennylane::CRotationZGate::label, parameters, 1);
+    return Pennylane::CRotationZGate(parameters[0]);
+}
+
+Pennylane::CRotationZGate::CRotationZGate(double rotationAngle)
+    : first(std::pow(M_E, CplxType(0, -rotationAngle / 2)))
+    , second(std::pow(M_E, CplxType(0, rotationAngle / 2)))
+    , matrix{
+      1, 0, 0, 0,
+      0, 1, 0, 0,
+      0, 0, first, 0,
+      0, 0, 0, second }
+{}
+
+// -------------------------------------------------------------------------------------------------------------
+
+const string Pennylane::CGeneralRotationGate::label = "CRot";
+
+Pennylane::CGeneralRotationGate Pennylane::CGeneralRotationGate::create(const vector<double>& parameters) {
+    validateLength(Pennylane::CGeneralRotationGate::label, parameters, 3);
+    return Pennylane::CGeneralRotationGate(parameters[0], parameters[1], parameters[2]);
+}
+
+Pennylane::CGeneralRotationGate::CGeneralRotationGate(double phi, double theta, double omega)
+    : matrix{
+      1, 0, 0, 0,
+      0, 1, 0, 0,
+      0, 0, std::cos(theta / 2) * std::pow(M_E, CplxType(0, (-phi - omega) / 2)), -std::sin(theta / 2) * std::pow(M_E, CplxType(0, (phi - omega) / 2)),
+      0, 0, std::sin(theta / 2) * std::pow(M_E, CplxType(0, (-phi + omega) / 2)), std::cos(theta / 2) * std::pow(M_E, CplxType(0, (phi + omega) / 2)) }
+{}
+
+// -------------------------------------------------------------------------------------------------------------
+
+Pennylane::ThreeQubitGate::ThreeQubitGate()
+    : AbstractGate(2)
+{}
+
+// -------------------------------------------------------------------------------------------------------------
+
+const string Pennylane::ToffoliGate::label = "Toffoli";
+
+Pennylane::ToffoliGate Pennylane::ToffoliGate::create(const vector<double>& parameters) {
+    validateLength(Pennylane::ToffoliGate::label, parameters, 0);
+    return Pennylane::ToffoliGate();
+}
+
+const std::vector<CplxType> Pennylane::ToffoliGate::matrix{
+    1, 0, 0, 0, 0, 0, 0, 0,
+    0, 1, 0, 0, 0, 0, 0, 0,
+    0, 0, 1, 0, 0, 0, 0, 0,
+    0, 0, 0, 1, 0, 0, 0, 0,
+    0, 0, 0, 0, 1, 0, 0, 0,
+    0, 0, 0, 0, 0, 1, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 1,
+    0, 0, 0, 0, 0, 0, 1, 0 };
+
+// -------------------------------------------------------------------------------------------------------------
+
+const string Pennylane::CSWAPGate::label = "CSWAP";
+
+Pennylane::CSWAPGate Pennylane::CSWAPGate::create(const vector<double>& parameters) {
+    validateLength(Pennylane::CSWAPGate::label, parameters, 0);
+    return Pennylane::CSWAPGate();
+}
+
+const std::vector<CplxType> Pennylane::CSWAPGate::matrix{
+    1, 0, 0, 0, 0, 0, 0, 0,
+    0, 1, 0, 0, 0, 0, 0, 0,
+    0, 0, 1, 0, 0, 0, 0, 0,
+    0, 0, 0, 1, 0, 0, 0, 0,
+    0, 0, 0, 0, 1, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 1, 0,
+    0, 0, 0, 0, 0, 1, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 1 };

--- a/pennylane_lightning/src/rework/Gates.hpp
+++ b/pennylane_lightning/src/rework/Gates.hpp
@@ -27,9 +27,10 @@ namespace Pennylane {
     const CplxType IMAG = CplxType(0, 1);
 
     class AbstractGate {
-    protected:
+    public:
         const int numQubits;
         const size_t length;
+    protected:
         AbstractGate(int numQubits);
     public:
         /**
@@ -165,6 +166,7 @@ namespace Pennylane {
 
     class GeneralRotationGate : public SingleQubitGate {
     private:
+        const CplxType c, s;
         const std::vector<CplxType> matrix;
     public:
         static const std::string label;
@@ -256,6 +258,7 @@ namespace Pennylane {
 
     class CGeneralRotationGate : public SingleQubitGate {
     private:
+        const CplxType c, s;
         const std::vector<CplxType> matrix;
     public:
         static const std::string label;

--- a/pennylane_lightning/src/rework/Gates.hpp
+++ b/pennylane_lightning/src/rework/Gates.hpp
@@ -1,4 +1,4 @@
-// Copyright 2020 Xanadu Quantum Technologies Inc.
+// Copyright 2021 Xanadu Quantum Technologies Inc.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pennylane_lightning/src/rework/Gates.hpp
+++ b/pennylane_lightning/src/rework/Gates.hpp
@@ -1,0 +1,298 @@
+// Copyright 2020 Xanadu Quantum Technologies Inc.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+/**
+ * @file
+ * Defines quantum gates and their actions.
+ */
+#pragma once
+
+#include <vector>
+
+#include "typedefs.hpp"
+
+namespace Pennylane {
+
+    const double SQRT2INV = 0.7071067811865475;
+    const CplxType IMAG = CplxType(0, 1);
+
+    class AbstractGate {
+    protected:
+        const int numQubits;
+        const size_t length;
+        AbstractGate(int numQubits);
+    public:
+        /**
+         * @return the matrix representation for the gate as a one-dimensional vector.
+         */
+        virtual const std::vector<CplxType>& asMatrix() = 0;
+    };
+
+    // Single-qubit gates:
+
+    class SingleQubitGate : public AbstractGate {
+    protected:
+        SingleQubitGate();
+    };
+
+    class XGate : public SingleQubitGate {
+    private:
+        static const std::vector<CplxType> matrix;
+    public:
+        static const std::string label;
+        static XGate create(const std::vector<double>& parameters);
+        inline const std::vector<CplxType>& asMatrix() {
+            return matrix;
+        }
+    };
+
+    class YGate : public SingleQubitGate {
+    private:
+        static const std::vector<CplxType> matrix;
+    public:
+        static const std::string label;
+        static YGate create(const std::vector<double>& parameters);
+        inline const std::vector<CplxType>& asMatrix() {
+            return matrix;
+        }
+    };
+
+    class ZGate : public SingleQubitGate {
+    private:
+        static const std::vector<CplxType> matrix;
+    public:
+        static const std::string label;
+        static ZGate create(const std::vector<double>& parameters);
+        inline const std::vector<CplxType>& asMatrix() {
+            return matrix;
+        }
+    };
+
+    class HadamardGate : public SingleQubitGate {
+    private:
+        static const std::vector<CplxType> matrix;
+    public:
+        static const std::string label;
+        static HadamardGate create(const std::vector<double>& parameters);
+        inline const std::vector<CplxType>& asMatrix() {
+            return matrix;
+        }
+    };
+
+    class SGate : public SingleQubitGate {
+    private:
+        static const std::vector<CplxType> matrix;
+    public:
+        static const std::string label;
+        static SGate create(const std::vector<double>& parameters);
+        inline const std::vector<CplxType>& asMatrix() {
+            return matrix;
+        }
+    };
+
+    class TGate : public SingleQubitGate {
+    private:
+        static const std::vector<CplxType> matrix;
+    public:
+        static const std::string label;
+        static TGate create(const std::vector<double>& parameters);
+        inline const std::vector<CplxType>& asMatrix() {
+            return matrix;
+        }
+    };
+
+    class RotationXGate : public SingleQubitGate {
+    private:
+        const CplxType c, js;
+        const std::vector<CplxType> matrix;
+    public:
+        static const std::string label;
+        static RotationXGate create(const std::vector<double>& parameters);
+        RotationXGate(double rotationAngle);
+        inline const std::vector<CplxType>& asMatrix() {
+            return matrix;
+        }
+    };
+
+    class RotationYGate : public SingleQubitGate {
+    private:
+        const CplxType c, s;
+        const std::vector<CplxType> matrix;
+    public:
+        static const std::string label;
+        static RotationYGate create(const std::vector<double>& parameters);
+        RotationYGate(double rotationAngle);
+        inline const std::vector<CplxType>& asMatrix() {
+            return matrix;
+        }
+    };
+
+    class RotationZGate : public SingleQubitGate {
+    private:
+        const CplxType first, second;
+        const std::vector<CplxType> matrix;
+    public:
+        static const std::string label;
+        static RotationZGate create(const std::vector<double>& parameters);
+        RotationZGate(double rotationAngle);
+        inline const std::vector<CplxType>& asMatrix() {
+            return matrix;
+        }
+    };
+
+    class PhaseShiftGate : public SingleQubitGate {
+    private:
+        const CplxType shift;
+        const std::vector<CplxType> matrix;
+    public:
+        static const std::string label;
+        static PhaseShiftGate create(const std::vector<double>& parameters);
+        PhaseShiftGate(double rotationAngle);
+        inline const std::vector<CplxType>& asMatrix() {
+            return matrix;
+        }
+    };
+
+    class GeneralRotationGate : public SingleQubitGate {
+    private:
+        const std::vector<CplxType> matrix;
+    public:
+        static const std::string label;
+        static GeneralRotationGate create(const std::vector<double>& parameters);
+        GeneralRotationGate(double phi, double theta, double omega);
+        inline const std::vector<CplxType>& asMatrix() {
+            return matrix;
+        }
+    };
+
+    // Two-qubit gates
+
+    class TwoQubitGate : public AbstractGate {
+    protected:
+        TwoQubitGate();
+    };
+
+    class CNOTGate : public TwoQubitGate {
+    private:
+        static const std::vector<CplxType> matrix;
+    public:
+        static const std::string label;
+        static CNOTGate create(const std::vector<double>& parameters);
+        inline const std::vector<CplxType>& asMatrix() {
+            return matrix;
+        }
+    };
+
+    class SWAPGate : public TwoQubitGate {
+    private:
+        static const std::vector<CplxType> matrix;
+    public:
+        static const std::string label;
+        static SWAPGate create(const std::vector<double>& parameters);
+        inline const std::vector<CplxType>& asMatrix() {
+            return matrix;
+        }
+    };
+
+    class CZGate : public TwoQubitGate {
+    private:
+        static const std::vector<CplxType> matrix;
+    public:
+        static const std::string label;
+        static CZGate create(const std::vector<double>& parameters);
+        inline const std::vector<CplxType>& asMatrix() {
+            return matrix;
+        }
+    };
+
+    class CRotationXGate : public TwoQubitGate {
+    private:
+        const CplxType c, js;
+        const std::vector<CplxType> matrix;
+    public:
+        static const std::string label;
+        static CRotationXGate create(const std::vector<double>& parameters);
+        CRotationXGate(double rotationAngle);
+        inline const std::vector<CplxType>& asMatrix() {
+            return matrix;
+        }
+    };
+
+    class CRotationYGate : public SingleQubitGate {
+    private:
+        const CplxType c, s;
+        const std::vector<CplxType> matrix;
+    public:
+        static const std::string label;
+        static CRotationYGate create(const std::vector<double>& parameters);
+        CRotationYGate(double rotationAngle);
+        inline const std::vector<CplxType>& asMatrix() {
+            return matrix;
+        }
+    };
+
+    class CRotationZGate : public SingleQubitGate {
+    private:
+        const CplxType first, second;
+        const std::vector<CplxType> matrix;
+    public:
+        static const std::string label;
+        static CRotationZGate create(const std::vector<double>& parameters);
+        CRotationZGate(double rotationAngle);
+        inline const std::vector<CplxType>& asMatrix() {
+            return matrix;
+        }
+    };
+
+    class CGeneralRotationGate : public SingleQubitGate {
+    private:
+        const std::vector<CplxType> matrix;
+    public:
+        static const std::string label;
+        static CGeneralRotationGate create(const std::vector<double>& parameters);
+        CGeneralRotationGate(double phi, double theta, double omega);
+        inline const std::vector<CplxType>& asMatrix() {
+            return matrix;
+        }
+    };
+
+    // Three-qubit gates
+
+    class ThreeQubitGate : public AbstractGate {
+    protected:
+        ThreeQubitGate();
+    };
+
+    class ToffoliGate : public ThreeQubitGate {
+    private:
+        static const std::vector<CplxType> matrix;
+    public:
+        static const std::string label;
+        static ToffoliGate create(const std::vector<double>& parameters);
+        inline const std::vector<CplxType>& asMatrix() {
+            return matrix;
+        }
+    };
+
+    class CSWAPGate : public ThreeQubitGate {
+    private:
+        static const std::vector<CplxType> matrix;
+    public:
+        static const std::string label;
+        static CSWAPGate create(const std::vector<double>& parameters);
+        inline const std::vector<CplxType>& asMatrix() {
+            return matrix;
+        }
+    };
+
+}

--- a/pennylane_lightning/src/rework/StateVector.cpp
+++ b/pennylane_lightning/src/rework/StateVector.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020 Xanadu Quantum Technologies Inc.
+// Copyright 2021 Xanadu Quantum Technologies Inc.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ Pennylane::StateVector Pennylane::StateVector::create(const pybind11::array_t<Cp
     if (numpyArrayInfo.ndim != 1)
         throw std::invalid_argument("NumPy array must be a 1-dimensional array");
     if (numpyArrayInfo.itemsize != sizeof(CplxType))
-        throw std::invalid_argument("NumPy array must be a complex double-precision array");
+        throw std::invalid_argument("NumPy array must be a complex128 array");
 
     return StateVector((CplxType*)numpyArrayInfo.ptr, numpyArrayInfo.shape[0]);
 }

--- a/pennylane_lightning/src/rework/StateVector.cpp
+++ b/pennylane_lightning/src/rework/StateVector.cpp
@@ -13,7 +13,7 @@
 // limitations under the License.
 #include "StateVector.hpp"
 
-Pennylane::StateVector::StateVector(pybind11::array_t<CplxType>* numpyArray) {
+Pennylane::StateVector Pennylane::StateVector::create(const pybind11::array_t<CplxType>* numpyArray) {
     pybind11::buffer_info numpyArrayInfo = numpyArray->request();
 
     if (numpyArrayInfo.ndim != 1)
@@ -21,11 +21,10 @@ Pennylane::StateVector::StateVector(pybind11::array_t<CplxType>* numpyArray) {
     if (numpyArrayInfo.itemsize != sizeof(CplxType))
         throw std::invalid_argument("NumPy array must be a complex double-precision array");
 
-    this->arr = (CplxType*)numpyArrayInfo.ptr;
-    this->length = numpyArrayInfo.shape[0];
+    return StateVector((CplxType*)numpyArrayInfo.ptr, numpyArrayInfo.shape[0]);
 }
 
-Pennylane::StateVector::StateVector(CplxType* arr, size_t length) {
-    this->arr = arr;
-    this->length = length;
-}
+Pennylane::StateVector::StateVector(CplxType* const arr, const size_t length)
+    : arr(arr)
+    , length(length)
+{}

--- a/pennylane_lightning/src/rework/StateVector.cpp
+++ b/pennylane_lightning/src/rework/StateVector.cpp
@@ -1,0 +1,31 @@
+// Copyright 2020 Xanadu Quantum Technologies Inc.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "StateVector.hpp"
+
+Pennylane::StateVector::StateVector(pybind11::array_t<CplxType>* numpyArray) {
+    pybind11::buffer_info numpyArrayInfo = numpyArray->request();
+
+    if (numpyArrayInfo.ndim != 1)
+        throw std::invalid_argument("NumPy array must be a 1-dimensional array");
+    if (numpyArrayInfo.itemsize != sizeof(CplxType))
+        throw std::invalid_argument("NumPy array must be a complex double-precision array");
+
+    this->arr = (CplxType*)numpyArrayInfo.ptr;
+    this->length = numpyArrayInfo.shape[0];
+}
+
+Pennylane::StateVector::StateVector(CplxType* arr, size_t length) {
+    this->arr = arr;
+    this->length = length;
+}

--- a/pennylane_lightning/src/rework/StateVector.cpp
+++ b/pennylane_lightning/src/rework/StateVector.cpp
@@ -24,7 +24,7 @@ Pennylane::StateVector Pennylane::StateVector::create(const pybind11::array_t<Cp
     return StateVector((CplxType*)numpyArrayInfo.ptr, numpyArrayInfo.shape[0]);
 }
 
-Pennylane::StateVector::StateVector(CplxType* const arr, const size_t length)
+Pennylane::StateVector::StateVector(CplxType* arr, size_t length)
     : arr(arr)
     , length(length)
 {}

--- a/pennylane_lightning/src/rework/StateVector.hpp
+++ b/pennylane_lightning/src/rework/StateVector.hpp
@@ -1,0 +1,38 @@
+// Copyright 2020 Xanadu Quantum Technologies Inc.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+/**
+ * @file
+ * Defines the class representation for quantum state vectors.
+ */
+#pragma once
+
+#include "pybind11/numpy.h"
+
+#include "typedefs.hpp"
+
+namespace Pennylane {
+
+    class StateVector {
+
+    public:
+        CplxType* arr = NULL;
+        size_t length = 0;
+
+        StateVector(pybind11::array_t<CplxType>* numpyArray);
+
+        StateVector(CplxType* arr, size_t length);
+
+    };
+
+}

--- a/pennylane_lightning/src/rework/StateVector.hpp
+++ b/pennylane_lightning/src/rework/StateVector.hpp
@@ -30,7 +30,7 @@ namespace Pennylane {
         const size_t length;
 
         static StateVector create(const pybind11::array_t<CplxType>* numpyArray);
-        StateVector(CplxType* const arr, const size_t length);
+        StateVector(CplxType* arr, size_t length);
 
     };
 

--- a/pennylane_lightning/src/rework/StateVector.hpp
+++ b/pennylane_lightning/src/rework/StateVector.hpp
@@ -26,12 +26,11 @@ namespace Pennylane {
     class StateVector {
 
     public:
-        CplxType* arr = NULL;
-        size_t length = 0;
+        CplxType* const arr;
+        const size_t length;
 
-        StateVector(pybind11::array_t<CplxType>* numpyArray);
-
-        StateVector(CplxType* arr, size_t length);
+        static StateVector create(const pybind11::array_t<CplxType>* numpyArray);
+        StateVector(CplxType* const arr, const size_t length);
 
     };
 

--- a/pennylane_lightning/src/rework/StateVector.hpp
+++ b/pennylane_lightning/src/rework/StateVector.hpp
@@ -1,4 +1,4 @@
-// Copyright 2020 Xanadu Quantum Technologies Inc.
+// Copyright 2021 Xanadu Quantum Technologies Inc.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pennylane_lightning/src/rework/Util.hpp
+++ b/pennylane_lightning/src/rework/Util.hpp
@@ -1,0 +1,32 @@
+// Copyright 2020 Xanadu Quantum Technologies Inc.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+/**
+ * @file
+ * Contains uncategorised utility functions.
+ */
+#pragma once
+
+namespace Pennylane {
+
+    /**
+     * Calculates 2^n for some integer n > 0 using bitshifts.
+     * 
+     * @param n the exponent
+     * @return value of 2^pow
+     */
+    inline size_t exp2(const unsigned int& n) {
+        return (size_t)1 << n;
+    }
+
+}

--- a/pennylane_lightning/src/rework/Util.hpp
+++ b/pennylane_lightning/src/rework/Util.hpp
@@ -1,4 +1,4 @@
-// Copyright 2020 Xanadu Quantum Technologies Inc.
+// Copyright 2021 Xanadu Quantum Technologies Inc.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -38,7 +38,7 @@ namespace Pennylane {
      * @param qubits the number of qubits in the circuit
      * @return decimal value for the qubit at specified index
      */
-    inline size_t decimalValueForQubit(unsigned int qubitIndex, const unsigned int qubits) {
+    inline size_t decimalValueForQubit(const unsigned int qubitIndex, const unsigned int qubits) {
         assert(qubitIndex < qubits);
         return exp2(qubits - qubitIndex - 1);
     }

--- a/pennylane_lightning/src/rework/Util.hpp
+++ b/pennylane_lightning/src/rework/Util.hpp
@@ -38,7 +38,7 @@ namespace Pennylane {
      * @param qubits the number of qubits in the circuit
      * @return decimal value for the qubit at specified index
      */
-    inline size_t decimalValueForQubit(const unsigned int qubitIndex, const unsigned int qubits) {
+    inline size_t maxDecimalForQubit(const unsigned int qubitIndex, const unsigned int qubits) {
         assert(qubitIndex < qubits);
         return exp2(qubits - qubitIndex - 1);
     }

--- a/pennylane_lightning/src/rework/Util.hpp
+++ b/pennylane_lightning/src/rework/Util.hpp
@@ -17,16 +17,30 @@
  */
 #pragma once
 
+#include <assert.h>
+
 namespace Pennylane {
 
     /**
      * Calculates 2^n for some integer n > 0 using bitshifts.
      * 
      * @param n the exponent
-     * @return value of 2^pow
+     * @return value of 2^n
      */
     inline size_t exp2(const unsigned int& n) {
         return (size_t)1 << n;
+    }
+
+    /**
+     * Calculates the decimal value for a qubit, assuming a big-endian convention.
+     * 
+     * @param qubitIndex the index of the qubit in the range [0, qubits)
+     * @param qubits the number of qubits in the circuit
+     * @return decimal value for the qubit at specified index
+     */
+    inline size_t decimalValueForQubit(unsigned int qubitIndex, const unsigned int qubits) {
+        assert(qubitIndex < qubits);
+        return exp2(qubits - qubitIndex - 1);
     }
 
 }

--- a/pennylane_lightning/src/rework/typedefs.hpp
+++ b/pennylane_lightning/src/rework/typedefs.hpp
@@ -1,0 +1,26 @@
+// Copyright 2020 Xanadu Quantum Technologies Inc.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+/**
+ * @file
+ * Contains any widely-used type aliases.
+ */
+#pragma once
+
+#include <complex>
+
+namespace Pennylane {
+
+    using CplxType = std::complex<double>;
+
+}

--- a/pennylane_lightning/src/rework/typedefs.hpp
+++ b/pennylane_lightning/src/rework/typedefs.hpp
@@ -1,4 +1,4 @@
-// Copyright 2020 Xanadu Quantum Technologies Inc.
+// Copyright 2021 Xanadu Quantum Technologies Inc.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/setup.py
+++ b/setup.py
@@ -148,13 +148,36 @@ if not os.environ.get("MOCK_DOCS", False):
         libraries += ["omp"]
 
     ext_modules = [
+        # Extension(
+        #     "lightning_qubit_ops",
+        #     sources=["pennylane_lightning/src/lightning_qubit.cpp"],
+        #     depends=[
+        #         "pennylane_lightning/src/lightning_qubit.hpp",
+        #         "pennylane_lightning/src/operations.hpp",
+        #         "pennylane_lightning/src/typedefs.hpp",
+        #     ],
+        #     include_dirs=include_dirs,
+        #     language="c++",
+        #     libraries=libraries,
+        #     library_dirs=library_dirs,
+        #     extra_compile_args=extra_compile_args,
+        #     extra_link_args=extra_link_args,
+        # ),
         Extension(
-            "lightning_qubit_ops",
-            sources=["pennylane_lightning/src/lightning_qubit.cpp"],
+            "lightning_qubit_new_ops",
+            sources=[
+                "pennylane_lightning/src/rework/Apply.cpp",
+                "pennylane_lightning/src/rework/GateFactory.cpp",
+                "pennylane_lightning/src/rework/Gates.cpp",
+                "pennylane_lightning/src/rework/StateVector.cpp",
+            ],
             depends=[
-                "pennylane_lightning/src/lightning_qubit.hpp",
-                "pennylane_lightning/src/operations.hpp",
-                "pennylane_lightning/src/typedefs.hpp",
+                "pennylane_lightning/src/rework/Apply.hpp",
+                "pennylane_lightning/src/rework/GateFactory.hpp",
+                "pennylane_lightning/src/rework/Gates.hpp",
+                "pennylane_lightning/src/rework/StateVector.hpp",
+                "pennylane_lightning/src/rework/typedefs.hpp",
+                "pennylane_lightning/src/rework/Util.hpp",
             ],
             include_dirs=include_dirs,
             language="c++",

--- a/setup.py
+++ b/setup.py
@@ -76,12 +76,12 @@ class BuildExt(build_ext):
 
     c_opts = {
         "msvc": ["-EHsc", "-O2", "-W1", "-std:c++11"],
-        "unix": ["-O3", "-W1", "-fPIC", "-shared", "-fopenmp"],
+        "unix": ["-O3", "-W", "-fPIC", "-shared", "-fopenmp"],
     }
 
     l_opts = {
         "msvc": [],
-        "unix": ["-O3", "-W1", "-fPIC", "-shared", "-fopenmp"],
+        "unix": ["-O3", "-W", "-fPIC", "-shared", "-fopenmp"],
     }
 
     if platform.system() == "Darwin":

--- a/setup.py
+++ b/setup.py
@@ -209,6 +209,7 @@ info = {
     "entry_points": {
         "pennylane.plugins": [
             "lightning.qubit = pennylane_lightning:LightningQubit",
+            "lightning.qubit.new = pennylane_lightning:LightningQubitNew",
         ],
     },
     "description": "PennyLane-Lightning plugin",

--- a/setup.py
+++ b/setup.py
@@ -75,13 +75,13 @@ class BuildExt(build_ext):
     """A custom build extension for adding compiler-specific options."""
 
     c_opts = {
-        "msvc": ["-EHsc", "-O2", "-Wall", "-std:c++11"],
-        "unix": ["-O3", "-Wall", "-fPIC", "-shared", "-fopenmp"],
+        "msvc": ["-EHsc", "-O2", "-W1", "-std:c++11"],
+        "unix": ["-O3", "-W1", "-fPIC", "-shared", "-fopenmp"],
     }
 
     l_opts = {
         "msvc": [],
-        "unix": ["-O3", "-Wall", "-fPIC", "-shared", "-fopenmp"],
+        "unix": ["-O3", "-W1", "-fPIC", "-shared", "-fopenmp"],
     }
 
     if platform.system() == "Darwin":

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ class get_pybind_include(object):
     """Helper class to determine the pybind11 include path
     The purpose of this class is to postpone importing pybind11
     until it is actually installed, so that the ``get_include()``
-    method can be invoked. """
+    method can be invoked."""
 
     def __str__(self):
         import pybind11
@@ -184,7 +184,9 @@ info = {
     "packages": find_packages(where="."),
     "package_data": {"pennylane_lightning": ["src/*"]},
     "entry_points": {
-        "pennylane.plugins": ["lightning.qubit = pennylane_lightning:LightningQubit",],
+        "pennylane.plugins": [
+            "lightning.qubit = pennylane_lightning:LightningQubit",
+        ],
     },
     "description": "PennyLane-Lightning plugin",
     "long_description": open("README.rst").read(),

--- a/setup.py
+++ b/setup.py
@@ -148,21 +148,21 @@ if not os.environ.get("MOCK_DOCS", False):
         libraries += ["omp"]
 
     ext_modules = [
-        # Extension(
-        #     "lightning_qubit_ops",
-        #     sources=["pennylane_lightning/src/lightning_qubit.cpp"],
-        #     depends=[
-        #         "pennylane_lightning/src/lightning_qubit.hpp",
-        #         "pennylane_lightning/src/operations.hpp",
-        #         "pennylane_lightning/src/typedefs.hpp",
-        #     ],
-        #     include_dirs=include_dirs,
-        #     language="c++",
-        #     libraries=libraries,
-        #     library_dirs=library_dirs,
-        #     extra_compile_args=extra_compile_args,
-        #     extra_link_args=extra_link_args,
-        # ),
+        Extension(
+            "lightning_qubit_ops",
+            sources=["pennylane_lightning/src/lightning_qubit.cpp"],
+            depends=[
+                "pennylane_lightning/src/lightning_qubit.hpp",
+                "pennylane_lightning/src/operations.hpp",
+                "pennylane_lightning/src/typedefs.hpp",
+            ],
+            include_dirs=include_dirs,
+            language="c++",
+            libraries=libraries,
+            library_dirs=library_dirs,
+            extra_compile_args=extra_compile_args,
+            extra_link_args=extra_link_args,
+        ),
         Extension(
             "lightning_qubit_new_ops",
             sources=[

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,10 +35,12 @@ U = np.array(
 U2 = np.array([[0, 1, 1, 1], [1, 0, 1, -1], [1, -1, 0, 1], [1, 1, -1, 0]]) / np.sqrt(3)
 A = np.array([[1.02789352, 1.61296440 - 0.3498192j], [1.61296440 + 0.3498192j, 1.23920938 + 0j]])
 
+
 @pytest.fixture(scope="session")
 def tol():
     """Numerical tolerance for equality tests."""
     return float(os.environ.get("TOL", TOL))
+
 
 @pytest.fixture(scope="session", params=[2, 3])
 def n_subsystems(request):

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -16,6 +16,7 @@ Unit tests for the :mod:`pennylane_lightning.LightningQubit` device.
 """
 import cmath
 import math
+
 # pylint: disable=protected-access,cell-var-from-loop
 from unittest import mock
 
@@ -63,25 +64,26 @@ U_toffoli[6:8, 6:8] = np.array([[0, 1], [1, 0]])
 
 U_swap = np.array([[1, 0, 0, 0], [0, 0, 1, 0], [0, 1, 0, 0], [0, 0, 0, 1]])
 
-U_cswap = np.array([[1, 0, 0, 0, 0, 0, 0, 0],
-                    [0, 1, 0, 0, 0, 0, 0, 0],
-                    [0, 0, 1, 0, 0, 0, 0, 0],
-                    [0, 0, 0, 1, 0, 0, 0, 0],
-                    [0, 0, 0, 0, 1, 0, 0, 0],
-                    [0, 0, 0, 0, 0, 0, 1, 0],
-                    [0, 0, 0, 0, 0, 1, 0, 0],
-                    [0, 0, 0, 0, 0, 0, 0, 1]])
-
-
-H = np.array(
-    [[1.02789352, 1.61296440 - 0.3498192j], [1.61296440 + 0.3498192j, 1.23920938 + 0j]]
+U_cswap = np.array(
+    [
+        [1, 0, 0, 0, 0, 0, 0, 0],
+        [0, 1, 0, 0, 0, 0, 0, 0],
+        [0, 0, 1, 0, 0, 0, 0, 0],
+        [0, 0, 0, 1, 0, 0, 0, 0],
+        [0, 0, 0, 0, 1, 0, 0, 0],
+        [0, 0, 0, 0, 0, 0, 1, 0],
+        [0, 0, 0, 0, 0, 1, 0, 0],
+        [0, 0, 0, 0, 0, 0, 0, 1],
+    ]
 )
+
+
+H = np.array([[1.02789352, 1.61296440 - 0.3498192j], [1.61296440 + 0.3498192j, 1.23920938 + 0j]])
 
 
 THETA = np.linspace(0.11, 1, 3)
 PHI = np.linspace(0.32, 1, 3)
 VARPHI = np.linspace(0.02, 1, 3)
-
 
 
 class TestApply:
@@ -91,23 +93,29 @@ class TestApply:
 
     test_data_no_parameters = [
         (qml.PauliX, [1, 0], np.array([0, 1])),
-        (qml.PauliX, [1/math.sqrt(2), 1/math.sqrt(2)], [1/math.sqrt(2), 1/math.sqrt(2)]),
+        (qml.PauliX, [1 / math.sqrt(2), 1 / math.sqrt(2)], [1 / math.sqrt(2), 1 / math.sqrt(2)]),
         (qml.PauliY, [1, 0], [0, 1j]),
-        (qml.PauliY, [1/math.sqrt(2), 1/math.sqrt(2)], [-1j/math.sqrt(2), 1j/math.sqrt(2)]),
+        (qml.PauliY, [1 / math.sqrt(2), 1 / math.sqrt(2)], [-1j / math.sqrt(2), 1j / math.sqrt(2)]),
         (qml.PauliZ, [1, 0], [1, 0]),
-        (qml.PauliZ, [1/math.sqrt(2), 1/math.sqrt(2)], [1/math.sqrt(2), -1/math.sqrt(2)]),
+        (qml.PauliZ, [1 / math.sqrt(2), 1 / math.sqrt(2)], [1 / math.sqrt(2), -1 / math.sqrt(2)]),
         (qml.S, [1, 0], [1, 0]),
-        (qml.S, [1/math.sqrt(2), 1/math.sqrt(2)], [1/math.sqrt(2), 1j/math.sqrt(2)]),
+        (qml.S, [1 / math.sqrt(2), 1 / math.sqrt(2)], [1 / math.sqrt(2), 1j / math.sqrt(2)]),
         (qml.T, [1, 0], [1, 0]),
-        (qml.T, [1 / math.sqrt(2), 1 / math.sqrt(2)], [1 / math.sqrt(2), np.exp(1j * np.pi / 4) / math.sqrt(2)]),
-        (qml.Hadamard, [1, 0], [1/math.sqrt(2), 1/math.sqrt(2)]),
-        (qml.Hadamard, [1/math.sqrt(2), -1/math.sqrt(2)], [0, 1]),
+        (
+            qml.T,
+            [1 / math.sqrt(2), 1 / math.sqrt(2)],
+            [1 / math.sqrt(2), np.exp(1j * np.pi / 4) / math.sqrt(2)],
+        ),
+        (qml.Hadamard, [1, 0], [1 / math.sqrt(2), 1 / math.sqrt(2)]),
+        (qml.Hadamard, [1 / math.sqrt(2), -1 / math.sqrt(2)], [0, 1]),
     ]
 
     @pytest.mark.parametrize("operation,input,expected_output", test_data_no_parameters)
-    def test_apply_operation_single_wire_no_parameters(self, qubit_device_1_wire, tol, operation, input, expected_output):
+    def test_apply_operation_single_wire_no_parameters(
+        self, qubit_device_1_wire, tol, operation, input, expected_output
+    ):
         """Tests that applying an operation yields the expected output state for single wire
-           operations that have no parameters."""
+        operations that have no parameters."""
 
         qubit_device_1_wire._state = np.array(input).astype(complex)
         qubit_device_1_wire.apply([operation(wires=[0])])
@@ -117,20 +125,34 @@ class TestApply:
     test_data_two_wires_no_parameters = [
         (qml.CNOT, [1, 0, 0, 0], [1, 0, 0, 0]),
         (qml.CNOT, [0, 0, 1, 0], [0, 0, 0, 1]),
-        (qml.CNOT, [1 / math.sqrt(2), 0, 0, 1 / math.sqrt(2)], [1 / math.sqrt(2), 0, 1 / math.sqrt(2), 0]),
+        (
+            qml.CNOT,
+            [1 / math.sqrt(2), 0, 0, 1 / math.sqrt(2)],
+            [1 / math.sqrt(2), 0, 1 / math.sqrt(2), 0],
+        ),
         (qml.SWAP, [1, 0, 0, 0], [1, 0, 0, 0]),
         (qml.SWAP, [0, 0, 1, 0], [0, 1, 0, 0]),
-        (qml.SWAP, [1 / math.sqrt(2), 0, -1 / math.sqrt(2), 0], [1 / math.sqrt(2), -1 / math.sqrt(2), 0, 0]),
+        (
+            qml.SWAP,
+            [1 / math.sqrt(2), 0, -1 / math.sqrt(2), 0],
+            [1 / math.sqrt(2), -1 / math.sqrt(2), 0, 0],
+        ),
         (qml.CZ, [1, 0, 0, 0], [1, 0, 0, 0]),
         (qml.CZ, [0, 0, 0, 1], [0, 0, 0, -1]),
-        (qml.CZ, [1 / math.sqrt(2), 0, 0, -1 / math.sqrt(2)], [1 / math.sqrt(2), 0, 0, 1 / math.sqrt(2)]),
+        (
+            qml.CZ,
+            [1 / math.sqrt(2), 0, 0, -1 / math.sqrt(2)],
+            [1 / math.sqrt(2), 0, 0, 1 / math.sqrt(2)],
+        ),
     ]
 
     @pytest.mark.parametrize("operation,input,expected_output", test_data_two_wires_no_parameters)
-    def test_apply_operation_two_wires_no_parameters(self, qubit_device_2_wires, tol, operation, input, expected_output):
+    def test_apply_operation_two_wires_no_parameters(
+        self, qubit_device_2_wires, tol, operation, input, expected_output
+    ):
         """Tests that applying an operation yields the expected output state for two wire
-           operations that have no parameters."""
-        qubit_device_2_wires._state = np.array(input).reshape(2 *[2]).astype(complex)
+        operations that have no parameters."""
+        qubit_device_2_wires._state = np.array(input).reshape(2 * [2]).astype(complex)
         qubit_device_2_wires.apply([operation(wires=[0, 1])])
 
         assert np.allclose(qubit_device_2_wires.state, np.array(expected_output), atol=tol, rtol=0)
@@ -146,29 +168,43 @@ class TestApply:
     ]
 
     @pytest.mark.parametrize("operation,input,expected_output", test_data_three_wires_no_parameters)
-    def test_apply_operation_three_wires_no_parameters(self, qubit_device_3_wires, tol, operation, input, expected_output):
+    def test_apply_operation_three_wires_no_parameters(
+        self, qubit_device_3_wires, tol, operation, input, expected_output
+    ):
         """Tests that applying an operation yields the expected output state for three wire
-           operations that have no parameters."""
+        operations that have no parameters."""
 
-        qubit_device_3_wires._state = np.array(input).reshape(3 *[2]).astype(complex)
+        qubit_device_3_wires._state = np.array(input).reshape(3 * [2]).astype(complex)
         qubit_device_3_wires.apply([operation(wires=[0, 1, 2])])
 
         assert np.allclose(qubit_device_3_wires.state, np.array(expected_output), atol=tol, rtol=0)
 
-
-    @pytest.mark.parametrize("operation,expected_output,par", [
-        (qml.BasisState, [0, 0, 1, 0], [1, 0]),
-        (qml.BasisState, [0, 0, 1, 0], [1, 0]),
-        (qml.BasisState, [0, 0, 0, 1], [1, 1]),
-        (qml.QubitStateVector, [0, 0, 1, 0], [0, 0, 1, 0]),
-        (qml.QubitStateVector, [0, 0, 1, 0], [0, 0, 1, 0]),
-        (qml.QubitStateVector, [0, 0, 0, 1], [0, 0, 0, 1]),
-        (qml.QubitStateVector, [1/math.sqrt(3), 0, 1/math.sqrt(3), 1/math.sqrt(3)], [1/math.sqrt(3), 0, 1/math.sqrt(3), 1/math.sqrt(3)]),
-        (qml.QubitStateVector, [1/math.sqrt(3), 0, -1/math.sqrt(3), 1/math.sqrt(3)], [1/math.sqrt(3), 0, -1/math.sqrt(3), 1/math.sqrt(3)]),
-    ])
-    def test_apply_operation_state_preparation(self, qubit_device_2_wires, tol, operation, expected_output, par):
+    @pytest.mark.parametrize(
+        "operation,expected_output,par",
+        [
+            (qml.BasisState, [0, 0, 1, 0], [1, 0]),
+            (qml.BasisState, [0, 0, 1, 0], [1, 0]),
+            (qml.BasisState, [0, 0, 0, 1], [1, 1]),
+            (qml.QubitStateVector, [0, 0, 1, 0], [0, 0, 1, 0]),
+            (qml.QubitStateVector, [0, 0, 1, 0], [0, 0, 1, 0]),
+            (qml.QubitStateVector, [0, 0, 0, 1], [0, 0, 0, 1]),
+            (
+                qml.QubitStateVector,
+                [1 / math.sqrt(3), 0, 1 / math.sqrt(3), 1 / math.sqrt(3)],
+                [1 / math.sqrt(3), 0, 1 / math.sqrt(3), 1 / math.sqrt(3)],
+            ),
+            (
+                qml.QubitStateVector,
+                [1 / math.sqrt(3), 0, -1 / math.sqrt(3), 1 / math.sqrt(3)],
+                [1 / math.sqrt(3), 0, -1 / math.sqrt(3), 1 / math.sqrt(3)],
+            ),
+        ],
+    )
+    def test_apply_operation_state_preparation(
+        self, qubit_device_2_wires, tol, operation, expected_output, par
+    ):
         """Tests that applying an operation yields the expected output state for single wire
-           operations that have no parameters."""
+        operations that have no parameters."""
 
         par = np.array(par)
         qubit_device_2_wires.reset()
@@ -179,29 +215,61 @@ class TestApply:
     test_data_single_wire_with_parameters = [
         (qml.PhaseShift, [1, 0], [1, 0], [math.pi / 2]),
         (qml.PhaseShift, [0, 1], [0, 1j], [math.pi / 2]),
-        (qml.PhaseShift, [1 / math.sqrt(2), 1 / math.sqrt(2)], [1 / math.sqrt(2), 1 / 2 + 1j / 2], [math.pi / 4]),
+        (
+            qml.PhaseShift,
+            [1 / math.sqrt(2), 1 / math.sqrt(2)],
+            [1 / math.sqrt(2), 1 / 2 + 1j / 2],
+            [math.pi / 4],
+        ),
         (qml.RX, [1, 0], [1 / math.sqrt(2), -1j * 1 / math.sqrt(2)], [math.pi / 2]),
         (qml.RX, [1, 0], [0, -1j], [math.pi]),
-        (qml.RX, [1 / math.sqrt(2), 1 / math.sqrt(2)], [1 / 2 - 1j / 2, 1 / 2 - 1j / 2], [math.pi / 2]),
+        (
+            qml.RX,
+            [1 / math.sqrt(2), 1 / math.sqrt(2)],
+            [1 / 2 - 1j / 2, 1 / 2 - 1j / 2],
+            [math.pi / 2],
+        ),
         (qml.RY, [1, 0], [1 / math.sqrt(2), 1 / math.sqrt(2)], [math.pi / 2]),
         (qml.RY, [1, 0], [0, 1], [math.pi]),
         (qml.RY, [1 / math.sqrt(2), 1 / math.sqrt(2)], [0, 1], [math.pi / 2]),
         (qml.RZ, [1, 0], [1 / math.sqrt(2) - 1j / math.sqrt(2), 0], [math.pi / 2]),
         (qml.RZ, [0, 1], [0, 1j], [math.pi]),
-        (qml.RZ, [1 / math.sqrt(2), 1 / math.sqrt(2)], [1 / 2 - 1j / 2, 1 / 2 + 1j / 2], [math.pi / 2]),
+        (
+            qml.RZ,
+            [1 / math.sqrt(2), 1 / math.sqrt(2)],
+            [1 / 2 - 1j / 2, 1 / 2 + 1j / 2],
+            [math.pi / 2],
+        ),
         (qml.Rot, [1, 0], [1 / math.sqrt(2) - 1j / math.sqrt(2), 0], [math.pi / 2, 0, 0]),
         (qml.Rot, [1, 0], [1 / math.sqrt(2), 1 / math.sqrt(2)], [0, math.pi / 2, 0]),
-        (qml.Rot, [1 / math.sqrt(2), 1 / math.sqrt(2)], [1 / 2 - 1j / 2, 1 / 2 + 1j / 2], [0, 0, math.pi / 2]),
-        (qml.Rot, [1, 0], [-1j / math.sqrt(2), -1 / math.sqrt(2)], [math.pi / 2, -math.pi / 2, math.pi / 2]),
-        (qml.Rot, [1 / math.sqrt(2), 1 / math.sqrt(2)], [1 / 2 + 1j / 2, -1 / 2 + 1j / 2],
-         [-math.pi / 2, math.pi, math.pi]),
+        (
+            qml.Rot,
+            [1 / math.sqrt(2), 1 / math.sqrt(2)],
+            [1 / 2 - 1j / 2, 1 / 2 + 1j / 2],
+            [0, 0, math.pi / 2],
+        ),
+        (
+            qml.Rot,
+            [1, 0],
+            [-1j / math.sqrt(2), -1 / math.sqrt(2)],
+            [math.pi / 2, -math.pi / 2, math.pi / 2],
+        ),
+        (
+            qml.Rot,
+            [1 / math.sqrt(2), 1 / math.sqrt(2)],
+            [1 / 2 + 1j / 2, -1 / 2 + 1j / 2],
+            [-math.pi / 2, math.pi, math.pi],
+        ),
     ]
 
-
-    @pytest.mark.parametrize("operation,input,expected_output,par", test_data_single_wire_with_parameters)
-    def test_apply_operation_single_wire_with_parameters(self, qubit_device_1_wire, tol, operation, input, expected_output, par):
+    @pytest.mark.parametrize(
+        "operation,input,expected_output,par", test_data_single_wire_with_parameters
+    )
+    def test_apply_operation_single_wire_with_parameters(
+        self, qubit_device_1_wire, tol, operation, input, expected_output, par
+    ):
         """Tests that applying an operation yields the expected output state for single wire
-           operations that have parameters."""
+        operations that have parameters."""
 
         qubit_device_1_wire._state = np.array(input).astype(complex)
 
@@ -212,109 +280,141 @@ class TestApply:
     test_data_two_wires_with_parameters = [
         (qml.CRX, [0, 1, 0, 0], [0, 1, 0, 0], [math.pi / 2]),
         (qml.CRX, [0, 0, 0, 1], [0, 0, -1j, 0], [math.pi]),
-        (qml.CRX, [0, 1 / math.sqrt(2), 1 / math.sqrt(2), 0], [0, 1 / math.sqrt(2), 1 / 2, -1j / 2], [math.pi / 2]),
+        (
+            qml.CRX,
+            [0, 1 / math.sqrt(2), 1 / math.sqrt(2), 0],
+            [0, 1 / math.sqrt(2), 1 / 2, -1j / 2],
+            [math.pi / 2],
+        ),
         (qml.CRY, [0, 0, 0, 1], [0, 0, -1 / math.sqrt(2), 1 / math.sqrt(2)], [math.pi / 2]),
         (qml.CRY, [0, 0, 0, 1], [0, 0, -1, 0], [math.pi]),
-        (qml.CRY, [1 / math.sqrt(2), 1 / math.sqrt(2), 0, 0], [1 / math.sqrt(2), 1 / math.sqrt(2), 0, 0], [math.pi / 2]),
+        (
+            qml.CRY,
+            [1 / math.sqrt(2), 1 / math.sqrt(2), 0, 0],
+            [1 / math.sqrt(2), 1 / math.sqrt(2), 0, 0],
+            [math.pi / 2],
+        ),
         (qml.CRZ, [0, 0, 0, 1], [0, 0, 0, 1 / math.sqrt(2) + 1j / math.sqrt(2)], [math.pi / 2]),
         (qml.CRZ, [0, 0, 0, 1], [0, 0, 0, 1j], [math.pi]),
-        (qml.CRZ, [1 / math.sqrt(2), 1 / math.sqrt(2), 0, 0], [1 / math.sqrt(2), 1 / math.sqrt(2), 0, 0], [math.pi / 2]),
-        (qml.CRot, [0, 0, 0, 1], [0, 0, 0, 1 / math.sqrt(2) + 1j / math.sqrt(2)], [math.pi / 2, 0, 0]),
+        (
+            qml.CRZ,
+            [1 / math.sqrt(2), 1 / math.sqrt(2), 0, 0],
+            [1 / math.sqrt(2), 1 / math.sqrt(2), 0, 0],
+            [math.pi / 2],
+        ),
+        (
+            qml.CRot,
+            [0, 0, 0, 1],
+            [0, 0, 0, 1 / math.sqrt(2) + 1j / math.sqrt(2)],
+            [math.pi / 2, 0, 0],
+        ),
         (qml.CRot, [0, 0, 0, 1], [0, 0, -1 / math.sqrt(2), 1 / math.sqrt(2)], [0, math.pi / 2, 0]),
-        (qml.CRot, [0, 0, 1 / math.sqrt(2), 1 / math.sqrt(2)], [0, 0, 1 / 2 - 1j / 2, 1 / 2 + 1j / 2],
-         [0, 0, math.pi / 2]),
-        (qml.CRot, [0, 0, 0, 1], [0, 0, 1 / math.sqrt(2), 1j / math.sqrt(2)], [math.pi / 2, -math.pi / 2, math.pi / 2]),
-        (qml.CRot, [0, 1 / math.sqrt(2), 1 / math.sqrt(2), 0], [0, 1 / math.sqrt(2), 0, -1 / 2 + 1j / 2],
-         [-math.pi / 2, math.pi, math.pi]),
+        (
+            qml.CRot,
+            [0, 0, 1 / math.sqrt(2), 1 / math.sqrt(2)],
+            [0, 0, 1 / 2 - 1j / 2, 1 / 2 + 1j / 2],
+            [0, 0, math.pi / 2],
+        ),
+        (
+            qml.CRot,
+            [0, 0, 0, 1],
+            [0, 0, 1 / math.sqrt(2), 1j / math.sqrt(2)],
+            [math.pi / 2, -math.pi / 2, math.pi / 2],
+        ),
+        (
+            qml.CRot,
+            [0, 1 / math.sqrt(2), 1 / math.sqrt(2), 0],
+            [0, 1 / math.sqrt(2), 0, -1 / 2 + 1j / 2],
+            [-math.pi / 2, math.pi, math.pi],
+        ),
     ]
 
-    @pytest.mark.parametrize("operation,input,expected_output,par", test_data_two_wires_with_parameters)
-    def test_apply_operation_two_wires_with_parameters(self, qubit_device_2_wires, tol, operation, input, expected_output, par):
+    @pytest.mark.parametrize(
+        "operation,input,expected_output,par", test_data_two_wires_with_parameters
+    )
+    def test_apply_operation_two_wires_with_parameters(
+        self, qubit_device_2_wires, tol, operation, input, expected_output, par
+    ):
         """Tests that applying an operation yields the expected output state for two wire
-           operations that have parameters."""
+        operations that have parameters."""
 
-        qubit_device_2_wires._state = np.array(input).reshape(2 *[2]).astype(complex)
+        qubit_device_2_wires._state = np.array(input).reshape(2 * [2]).astype(complex)
         qubit_device_2_wires.apply([operation(*par, wires=[0, 1])])
 
         assert np.allclose(qubit_device_2_wires.state, np.array(expected_output), atol=tol, rtol=0)
 
     def test_apply_errors_qubit_state_vector(self, qubit_device_2_wires):
         """Test that apply fails for incorrect state preparation, and > 2 qubit gates"""
-        with pytest.raises(
-            ValueError,
-            match="Sum of amplitudes-squared does not equal one."
-        ):
+        with pytest.raises(ValueError, match="Sum of amplitudes-squared does not equal one."):
             qubit_device_2_wires.apply([qml.QubitStateVector(np.array([1, -1]), wires=[0])])
 
-        with pytest.raises(
-            ValueError,
-            match=r"State vector must be of length 2\*\*wires."
-        ):
+        with pytest.raises(ValueError, match=r"State vector must be of length 2\*\*wires."):
             p = np.array([1, 0, 1, 1, 0]) / np.sqrt(3)
             qubit_device_2_wires.apply([qml.QubitStateVector(p, wires=[0, 1])])
 
         with pytest.raises(
             DeviceError,
-            match="Operation QubitStateVector cannot be used after other Operations have already been applied "
+            match="Operation QubitStateVector cannot be used after other Operations have already been applied ",
         ):
             qubit_device_2_wires.reset()
-            qubit_device_2_wires.apply([
-                qml.RZ(0.5, wires=[0]),
-                qml.QubitStateVector(np.array([0, 1, 0, 0]), wires=[0, 1])
-            ])
+            qubit_device_2_wires.apply(
+                [qml.RZ(0.5, wires=[0]), qml.QubitStateVector(np.array([0, 1, 0, 0]), wires=[0, 1])]
+            )
 
     def test_apply_errors_basis_state(self, qubit_device_2_wires):
         with pytest.raises(
-            ValueError,
-            match="BasisState parameter must consist of 0 or 1 integers."
+            ValueError, match="BasisState parameter must consist of 0 or 1 integers."
         ):
             qubit_device_2_wires.apply([qml.BasisState(np.array([-0.2, 4.2]), wires=[0, 1])])
 
         with pytest.raises(
-            ValueError,
-            match="BasisState parameter and wires must be of equal length."
+            ValueError, match="BasisState parameter and wires must be of equal length."
         ):
             qubit_device_2_wires.apply([qml.BasisState(np.array([0, 1]), wires=[0])])
 
         with pytest.raises(
             DeviceError,
-            match="Operation BasisState cannot be used after other Operations have already been applied "
+            match="Operation BasisState cannot be used after other Operations have already been applied ",
         ):
             qubit_device_2_wires.reset()
-            qubit_device_2_wires.apply([
-                qml.RZ(0.5, wires=[0]),
-                qml.BasisState(np.array([1, 1]), wires=[0, 1])
-            ])
+            qubit_device_2_wires.apply(
+                [qml.RZ(0.5, wires=[0]), qml.BasisState(np.array([1, 1]), wires=[0, 1])]
+            )
+
 
 class TestExpval:
     """Tests that expectation values are properly calculated or that the proper errors are raised."""
 
-    @pytest.mark.parametrize("operation,input,expected_output", [
-        (qml.PauliX, [1/math.sqrt(2), 1/math.sqrt(2)], 1),
-        (qml.PauliX, [1/math.sqrt(2), -1/math.sqrt(2)], -1),
-        (qml.PauliX, [1, 0], 0),
-        (qml.PauliY, [1/math.sqrt(2), 1j/math.sqrt(2)], 1),
-        (qml.PauliY, [1/math.sqrt(2), -1j/math.sqrt(2)], -1),
-        (qml.PauliY, [1, 0], 0),
-        (qml.PauliZ, [1, 0], 1),
-        (qml.PauliZ, [0, 1], -1),
-        (qml.PauliZ, [1/math.sqrt(2), 1/math.sqrt(2)], 0),
-        (qml.Hadamard, [1, 0], 1/math.sqrt(2)),
-        (qml.Hadamard, [0, 1], -1/math.sqrt(2)),
-        (qml.Hadamard, [1/math.sqrt(2), 1/math.sqrt(2)], 1/math.sqrt(2)),
-        (qml.Identity, [1, 0], 1),
-        (qml.Identity, [0, 1], 1),
-        (qml.Identity, [1/math.sqrt(2), -1/math.sqrt(2)], 1),
-    ])
-    def test_expval_single_wire_no_parameters(self, qubit_device_1_wire, tol, operation, input, expected_output):
+    @pytest.mark.parametrize(
+        "operation,input,expected_output",
+        [
+            (qml.PauliX, [1 / math.sqrt(2), 1 / math.sqrt(2)], 1),
+            (qml.PauliX, [1 / math.sqrt(2), -1 / math.sqrt(2)], -1),
+            (qml.PauliX, [1, 0], 0),
+            (qml.PauliY, [1 / math.sqrt(2), 1j / math.sqrt(2)], 1),
+            (qml.PauliY, [1 / math.sqrt(2), -1j / math.sqrt(2)], -1),
+            (qml.PauliY, [1, 0], 0),
+            (qml.PauliZ, [1, 0], 1),
+            (qml.PauliZ, [0, 1], -1),
+            (qml.PauliZ, [1 / math.sqrt(2), 1 / math.sqrt(2)], 0),
+            (qml.Hadamard, [1, 0], 1 / math.sqrt(2)),
+            (qml.Hadamard, [0, 1], -1 / math.sqrt(2)),
+            (qml.Hadamard, [1 / math.sqrt(2), 1 / math.sqrt(2)], 1 / math.sqrt(2)),
+            (qml.Identity, [1, 0], 1),
+            (qml.Identity, [0, 1], 1),
+            (qml.Identity, [1 / math.sqrt(2), -1 / math.sqrt(2)], 1),
+        ],
+    )
+    def test_expval_single_wire_no_parameters(
+        self, qubit_device_1_wire, tol, operation, input, expected_output
+    ):
         """Tests that expectation values are properly calculated for single-wire observables without parameters."""
 
         obs = operation(wires=[0])
 
         qubit_device_1_wire.reset()
         qubit_device_1_wire.apply(
-            [qml.QubitStateVector(np.array(input), wires=[0])],
-            obs.diagonalizing_gates()
+            [qml.QubitStateVector(np.array(input), wires=[0])], obs.diagonalizing_gates()
         )
         res = qubit_device_1_wire.expval(obs)
 
@@ -334,36 +434,40 @@ class TestExpval:
         # an estimated variance an an analytically calculated one
         assert expval != 0.0
 
+
 class TestVar:
     """Tests that variances are properly calculated."""
 
-    @pytest.mark.parametrize("operation,input,expected_output", [
-        (qml.PauliX, [1/math.sqrt(2), 1/math.sqrt(2)], 0),
-        (qml.PauliX, [1/math.sqrt(2), -1/math.sqrt(2)], 0),
-        (qml.PauliX, [1, 0], 1),
-        (qml.PauliY, [1/math.sqrt(2), 1j/math.sqrt(2)], 0),
-        (qml.PauliY, [1/math.sqrt(2), -1j/math.sqrt(2)], 0),
-        (qml.PauliY, [1, 0], 1),
-        (qml.PauliZ, [1, 0], 0),
-        (qml.PauliZ, [0, 1], 0),
-        (qml.PauliZ, [1/math.sqrt(2), 1/math.sqrt(2)], 1),
-        (qml.Hadamard, [1, 0], 1/2),
-        (qml.Hadamard, [0, 1], 1/2),
-        (qml.Hadamard, [1/math.sqrt(2), 1/math.sqrt(2)], 1/2),
-        (qml.Identity, [1, 0], 0),
-        (qml.Identity, [0, 1], 0),
-        (qml.Identity, [1/math.sqrt(2), -1/math.sqrt(2)], 0),
-
-    ])
-    def test_var_single_wire_no_parameters(self, qubit_device_1_wire, tol, operation, input, expected_output):
+    @pytest.mark.parametrize(
+        "operation,input,expected_output",
+        [
+            (qml.PauliX, [1 / math.sqrt(2), 1 / math.sqrt(2)], 0),
+            (qml.PauliX, [1 / math.sqrt(2), -1 / math.sqrt(2)], 0),
+            (qml.PauliX, [1, 0], 1),
+            (qml.PauliY, [1 / math.sqrt(2), 1j / math.sqrt(2)], 0),
+            (qml.PauliY, [1 / math.sqrt(2), -1j / math.sqrt(2)], 0),
+            (qml.PauliY, [1, 0], 1),
+            (qml.PauliZ, [1, 0], 0),
+            (qml.PauliZ, [0, 1], 0),
+            (qml.PauliZ, [1 / math.sqrt(2), 1 / math.sqrt(2)], 1),
+            (qml.Hadamard, [1, 0], 1 / 2),
+            (qml.Hadamard, [0, 1], 1 / 2),
+            (qml.Hadamard, [1 / math.sqrt(2), 1 / math.sqrt(2)], 1 / 2),
+            (qml.Identity, [1, 0], 0),
+            (qml.Identity, [0, 1], 0),
+            (qml.Identity, [1 / math.sqrt(2), -1 / math.sqrt(2)], 0),
+        ],
+    )
+    def test_var_single_wire_no_parameters(
+        self, qubit_device_1_wire, tol, operation, input, expected_output
+    ):
         """Tests that variances are properly calculated for single-wire observables without parameters."""
 
         obs = operation(wires=[0])
 
         qubit_device_1_wire.reset()
         qubit_device_1_wire.apply(
-            [qml.QubitStateVector(np.array(input), wires=[0])],
-            obs.diagonalizing_gates()
+            [qml.QubitStateVector(np.array(input), wires=[0])], obs.diagonalizing_gates()
         )
         res = qubit_device_1_wire.var(obs)
 
@@ -384,6 +488,7 @@ class TestVar:
         # an estimated variance and an analytically calculated one
         assert var != 1.0
 
+
 class TestSample:
     """Tests that samples are properly calculated."""
 
@@ -397,9 +502,7 @@ class TestSample:
         # initialized during reset
         qubit_device_2_wires.reset()
 
-        qubit_device_2_wires.apply(
-            [qml.RX(1.5708, wires=[0]), qml.RX(1.5708, wires=[1])]
-        )
+        qubit_device_2_wires.apply([qml.RX(1.5708, wires=[0]), qml.RX(1.5708, wires=[1])])
 
         qubit_device_2_wires.shots = 10
         qubit_device_2_wires._wires_measured = {0}
@@ -439,7 +542,8 @@ class TestSample:
 
         # s1 should only contain 1 and -1, which is guaranteed if
         # they square to 1
-        assert np.allclose(s1**2, 1, atol=tol, rtol=0)
+        assert np.allclose(s1 ** 2, 1, atol=tol, rtol=0)
+
 
 class TestLightningQubitIntegration:
     """Integration tests for lightning.qubit. This test ensures it integrates
@@ -457,9 +561,7 @@ class TestLightningQubitIntegration:
     def test_args(self):
         """Test that the plugin requires correct arguments"""
 
-        with pytest.raises(
-            TypeError, match="missing 1 required positional argument: 'wires'"
-        ):
+        with pytest.raises(TypeError, match="missing 1 required positional argument: 'wires'"):
             qml.device("lightning.qubit")
 
     def test_qubit_circuit(self, qubit_device_1_wire, tol):
@@ -510,13 +612,18 @@ class TestLightningQubitIntegration:
         assert np.isclose(np.mean(runs), -np.sin(p), atol=tol, rtol=0)
 
     # This test is ran against the state |0> with one Z expval
-    @pytest.mark.parametrize("name,expected_output", [
-        ("PauliX", -1),
-        ("PauliY", -1),
-        ("PauliZ", 1),
-        ("Hadamard", 0),
-    ])
-    def test_supported_gate_single_wire_no_parameters(self, qubit_device_1_wire, tol, name, expected_output):
+    @pytest.mark.parametrize(
+        "name,expected_output",
+        [
+            ("PauliX", -1),
+            ("PauliY", -1),
+            ("PauliZ", 1),
+            ("Hadamard", 0),
+        ],
+    )
+    def test_supported_gate_single_wire_no_parameters(
+        self, qubit_device_1_wire, tol, name, expected_output
+    ):
         """Tests supported gates that act on a single wire that are not parameterized"""
 
         op = getattr(qml.ops, name)
@@ -531,12 +638,17 @@ class TestLightningQubitIntegration:
         assert np.isclose(circuit(), expected_output, atol=tol, rtol=0)
 
     # This test is ran against the state |Phi+> with two Z expvals
-    @pytest.mark.parametrize("name,expected_output", [
-        ("CNOT", [-1/2, 1]),
-        ("SWAP", [-1/2, -1/2]),
-        ("CZ", [-1/2, -1/2]),
-    ])
-    def test_supported_gate_two_wires_no_parameters(self, qubit_device_2_wires, tol, name, expected_output):
+    @pytest.mark.parametrize(
+        "name,expected_output",
+        [
+            ("CNOT", [-1 / 2, 1]),
+            ("SWAP", [-1 / 2, -1 / 2]),
+            ("CZ", [-1 / 2, -1 / 2]),
+        ],
+    )
+    def test_supported_gate_two_wires_no_parameters(
+        self, qubit_device_2_wires, tol, name, expected_output
+    ):
         """Tests supported gates that act on two wires that are not parameterized"""
 
         op = getattr(qml.ops, name)
@@ -545,16 +657,21 @@ class TestLightningQubitIntegration:
 
         @qml.qnode(qubit_device_2_wires)
         def circuit():
-            qml.QubitStateVector(np.array([1/2, 0, 0, math.sqrt(3)/2]), wires=[0, 1])
+            qml.QubitStateVector(np.array([1 / 2, 0, 0, math.sqrt(3) / 2]), wires=[0, 1])
             op(wires=[0, 1])
             return qml.expval(qml.PauliZ(0)), qml.expval(qml.PauliZ(1))
 
         assert np.allclose(circuit(), expected_output, atol=tol, rtol=0)
 
-    @pytest.mark.parametrize("name,expected_output", [
-        ("CSWAP", [-1, -1, 1]),
-    ])
-    def test_supported_gate_three_wires_no_parameters(self, qubit_device_3_wires, tol, name, expected_output):
+    @pytest.mark.parametrize(
+        "name,expected_output",
+        [
+            ("CSWAP", [-1, -1, 1]),
+        ],
+    )
+    def test_supported_gate_three_wires_no_parameters(
+        self, qubit_device_3_wires, tol, name, expected_output
+    ):
         """Tests supported gates that act on three wires that are not parameterized"""
 
         op = getattr(qml.ops, name)
@@ -570,15 +687,20 @@ class TestLightningQubitIntegration:
         assert np.allclose(circuit(), expected_output, atol=tol, rtol=0)
 
     # This test is ran with two Z expvals
-    @pytest.mark.parametrize("name,par,expected_output", [
-        ("BasisState", [0, 0], [1, 1]),
-        ("BasisState", [1, 0], [-1, 1]),
-        ("BasisState", [0, 1], [1, -1]),
-        ("QubitStateVector", [1, 0, 0, 0], [1, 1]),
-        ("QubitStateVector", [0, 0, 1, 0], [-1, 1]),
-        ("QubitStateVector", [0, 1, 0, 0], [1, -1]),
-    ])
-    def test_supported_state_preparation(self, qubit_device_2_wires, tol, name, par, expected_output):
+    @pytest.mark.parametrize(
+        "name,par,expected_output",
+        [
+            ("BasisState", [0, 0], [1, 1]),
+            ("BasisState", [1, 0], [-1, 1]),
+            ("BasisState", [0, 1], [1, -1]),
+            ("QubitStateVector", [1, 0, 0, 0], [1, 1]),
+            ("QubitStateVector", [0, 0, 1, 0], [-1, 1]),
+            ("QubitStateVector", [0, 1, 0, 0], [1, -1]),
+        ],
+    )
+    def test_supported_state_preparation(
+        self, qubit_device_2_wires, tol, name, par, expected_output
+    ):
         """Tests supported state preparations"""
 
         op = getattr(qml.ops, name)
@@ -593,12 +715,17 @@ class TestLightningQubitIntegration:
         assert np.allclose(circuit(), expected_output, atol=tol, rtol=0)
 
     # This test is ran with two Z expvals
-    @pytest.mark.parametrize("name,par,wires,expected_output", [
-        ("BasisState", [1, 1], [0, 1], [-1, -1]),
-        ("BasisState", [1], [0], [-1, 1]),
-        ("BasisState", [1], [1], [1, -1])
-    ])
-    def test_basis_state_2_qubit_subset(self, qubit_device_2_wires, tol, name, par, wires, expected_output):
+    @pytest.mark.parametrize(
+        "name,par,wires,expected_output",
+        [
+            ("BasisState", [1, 1], [0, 1], [-1, -1]),
+            ("BasisState", [1], [0], [-1, 1]),
+            ("BasisState", [1], [1], [1, -1]),
+        ],
+    )
+    def test_basis_state_2_qubit_subset(
+        self, qubit_device_2_wires, tol, name, par, wires, expected_output
+    ):
         """Tests qubit basis state preparation on subsets of qubits"""
 
         op = getattr(qml.ops, name)
@@ -611,14 +738,19 @@ class TestLightningQubitIntegration:
         assert np.allclose(circuit(), expected_output, atol=tol, rtol=0)
 
     # This test is run with two expvals
-    @pytest.mark.parametrize("name,par,wires,expected_output", [
-        ("QubitStateVector", [0, 1], [1], [1, -1]),
-        ("QubitStateVector", [0, 1], [0], [-1, 1]),
-        ("QubitStateVector", [1./np.sqrt(2), 1./np.sqrt(2)], [1], [1, 0]),
-        ("QubitStateVector", [1j/2., np.sqrt(3)/2.], [1], [1, -0.5]),
-        ("QubitStateVector", [(2-1j)/3., 2j/3.], [0], [1/9., 1])
-    ])
-    def test_state_vector_2_qubit_subset(self, qubit_device_2_wires, tol, name, par, wires, expected_output):
+    @pytest.mark.parametrize(
+        "name,par,wires,expected_output",
+        [
+            ("QubitStateVector", [0, 1], [1], [1, -1]),
+            ("QubitStateVector", [0, 1], [0], [-1, 1]),
+            ("QubitStateVector", [1.0 / np.sqrt(2), 1.0 / np.sqrt(2)], [1], [1, 0]),
+            ("QubitStateVector", [1j / 2.0, np.sqrt(3) / 2.0], [1], [1, -0.5]),
+            ("QubitStateVector", [(2 - 1j) / 3.0, 2j / 3.0], [0], [1 / 9.0, 1]),
+        ],
+    )
+    def test_state_vector_2_qubit_subset(
+        self, qubit_device_2_wires, tol, name, par, wires, expected_output
+    ):
         """Tests qubit state vector preparation on subsets of 2 qubits"""
 
         op = getattr(qml.ops, name)
@@ -633,17 +765,26 @@ class TestLightningQubitIntegration:
         assert np.allclose(circuit(), expected_output, atol=tol, rtol=0)
 
     # This test is run with three expvals
-    @pytest.mark.parametrize("name,par,wires,expected_output", [
-        ("QubitStateVector", [1j/np.sqrt(10), (1-2j)/np.sqrt(10), 0, 0, 0, 2/np.sqrt(10), 0, 0],
-         [0, 1, 2], [1/5., 1., -4/5.]),
-        ("QubitStateVector", [1/np.sqrt(2), 0, 0, 1/np.sqrt(2)], [0, 2], [0., 1., 0.]),
-        ("QubitStateVector", [1 / np.sqrt(2), 0, 0, 1 / np.sqrt(2)], [0, 1], [0., 0., 1.]),
-        ("QubitStateVector", [0, 1, 0, 0, 0, 0, 0, 0], [2, 1, 0], [-1., 1., 1.]),
-        ("QubitStateVector", [0, 1j, 0, 0, 0, 0, 0, 0], [0, 2, 1], [1., -1., 1.]),
-        ("QubitStateVector", [0, 1/np.sqrt(2), 0, 1/np.sqrt(2)], [1, 0], [-1., 0., 1.]),
-        ("QubitStateVector", [0, 1 / np.sqrt(2), 0, 1 / np.sqrt(2)], [0, 1], [0., -1., 1.])
-    ])
-    def test_state_vector_3_qubit_subset(self, qubit_device_3_wires, tol, name, par, wires, expected_output):
+    @pytest.mark.parametrize(
+        "name,par,wires,expected_output",
+        [
+            (
+                "QubitStateVector",
+                [1j / np.sqrt(10), (1 - 2j) / np.sqrt(10), 0, 0, 0, 2 / np.sqrt(10), 0, 0],
+                [0, 1, 2],
+                [1 / 5.0, 1.0, -4 / 5.0],
+            ),
+            ("QubitStateVector", [1 / np.sqrt(2), 0, 0, 1 / np.sqrt(2)], [0, 2], [0.0, 1.0, 0.0]),
+            ("QubitStateVector", [1 / np.sqrt(2), 0, 0, 1 / np.sqrt(2)], [0, 1], [0.0, 0.0, 1.0]),
+            ("QubitStateVector", [0, 1, 0, 0, 0, 0, 0, 0], [2, 1, 0], [-1.0, 1.0, 1.0]),
+            ("QubitStateVector", [0, 1j, 0, 0, 0, 0, 0, 0], [0, 2, 1], [1.0, -1.0, 1.0]),
+            ("QubitStateVector", [0, 1 / np.sqrt(2), 0, 1 / np.sqrt(2)], [1, 0], [-1.0, 0.0, 1.0]),
+            ("QubitStateVector", [0, 1 / np.sqrt(2), 0, 1 / np.sqrt(2)], [0, 1], [0.0, -1.0, 1.0]),
+        ],
+    )
+    def test_state_vector_3_qubit_subset(
+        self, qubit_device_3_wires, tol, name, par, wires, expected_output
+    ):
         """Tests qubit state vector preparation on subsets of 3 qubits"""
 
         op = getattr(qml.ops, name)
@@ -658,23 +799,28 @@ class TestLightningQubitIntegration:
         assert np.allclose(circuit(), expected_output, atol=tol, rtol=0)
 
     # This test is ran on the state |0> with one Z expvals
-    @pytest.mark.parametrize("name,par,expected_output", [
-        ("PhaseShift", [math.pi/2], 1),
-        ("PhaseShift", [-math.pi/4], 1),
-        ("RX", [math.pi/2], 0),
-        ("RX", [-math.pi/4], 1/math.sqrt(2)),
-        ("RY", [math.pi/2], 0),
-        ("RY", [-math.pi/4], 1/math.sqrt(2)),
-        ("RZ", [math.pi/2], 1),
-        ("RZ", [-math.pi/4], 1),
-        ("Rot", [math.pi/2, 0, 0], 1),
-        ("Rot", [0, math.pi/2, 0], 0),
-        ("Rot", [0, 0, math.pi/2], 1),
-        ("Rot", [math.pi/2, -math.pi/4, -math.pi/4], 1/math.sqrt(2)),
-        ("Rot", [-math.pi/4, math.pi/2, math.pi/4], 0),
-        ("Rot", [-math.pi/4, math.pi/4, math.pi/2], 1/math.sqrt(2)),
-    ])
-    def test_supported_gate_single_wire_with_parameters(self, qubit_device_1_wire, tol, name, par, expected_output):
+    @pytest.mark.parametrize(
+        "name,par,expected_output",
+        [
+            ("PhaseShift", [math.pi / 2], 1),
+            ("PhaseShift", [-math.pi / 4], 1),
+            ("RX", [math.pi / 2], 0),
+            ("RX", [-math.pi / 4], 1 / math.sqrt(2)),
+            ("RY", [math.pi / 2], 0),
+            ("RY", [-math.pi / 4], 1 / math.sqrt(2)),
+            ("RZ", [math.pi / 2], 1),
+            ("RZ", [-math.pi / 4], 1),
+            ("Rot", [math.pi / 2, 0, 0], 1),
+            ("Rot", [0, math.pi / 2, 0], 0),
+            ("Rot", [0, 0, math.pi / 2], 1),
+            ("Rot", [math.pi / 2, -math.pi / 4, -math.pi / 4], 1 / math.sqrt(2)),
+            ("Rot", [-math.pi / 4, math.pi / 2, math.pi / 4], 0),
+            ("Rot", [-math.pi / 4, math.pi / 4, math.pi / 2], 1 / math.sqrt(2)),
+        ],
+    )
+    def test_supported_gate_single_wire_with_parameters(
+        self, qubit_device_1_wire, tol, name, par, expected_output
+    ):
         """Tests supported gates that act on a single wire that are parameterized"""
 
         op = getattr(qml.ops, name)
@@ -689,24 +835,29 @@ class TestLightningQubitIntegration:
         assert np.isclose(circuit(), expected_output, atol=tol, rtol=0)
 
     # This test is ran against the state 1/2|00>+sqrt(3)/2|11> with two Z expvals
-    @pytest.mark.parametrize("name,par,expected_output", [
-        ("CRX", [0], [-1/2, -1/2]),
-        ("CRX", [-math.pi], [-1/2, 1]),
-        ("CRX", [math.pi/2], [-1/2, 1/4]),
-        ("CRY", [0], [-1/2, -1/2]),
-        ("CRY", [-math.pi], [-1/2, 1]),
-        ("CRY", [math.pi/2], [-1/2, 1/4]),
-        ("CRZ", [0], [-1/2, -1/2]),
-        ("CRZ", [-math.pi], [-1/2, -1/2]),
-        ("CRZ", [math.pi/2], [-1/2, -1/2]),
-        ("CRot", [math.pi/2, 0, 0], [-1/2, -1/2]),
-        ("CRot", [0, math.pi/2, 0], [-1/2, 1/4]),
-        ("CRot", [0, 0, math.pi/2], [-1/2, -1/2]),
-        ("CRot", [math.pi/2, 0, -math.pi], [-1/2, -1/2]),
-        ("CRot", [0, math.pi/2, -math.pi], [-1/2, 1/4]),
-        ("CRot", [-math.pi, 0, math.pi/2], [-1/2, -1/2]),
-    ])
-    def test_supported_gate_two_wires_with_parameters(self, qubit_device_2_wires, tol, name, par, expected_output):
+    @pytest.mark.parametrize(
+        "name,par,expected_output",
+        [
+            ("CRX", [0], [-1 / 2, -1 / 2]),
+            ("CRX", [-math.pi], [-1 / 2, 1]),
+            ("CRX", [math.pi / 2], [-1 / 2, 1 / 4]),
+            ("CRY", [0], [-1 / 2, -1 / 2]),
+            ("CRY", [-math.pi], [-1 / 2, 1]),
+            ("CRY", [math.pi / 2], [-1 / 2, 1 / 4]),
+            ("CRZ", [0], [-1 / 2, -1 / 2]),
+            ("CRZ", [-math.pi], [-1 / 2, -1 / 2]),
+            ("CRZ", [math.pi / 2], [-1 / 2, -1 / 2]),
+            ("CRot", [math.pi / 2, 0, 0], [-1 / 2, -1 / 2]),
+            ("CRot", [0, math.pi / 2, 0], [-1 / 2, 1 / 4]),
+            ("CRot", [0, 0, math.pi / 2], [-1 / 2, -1 / 2]),
+            ("CRot", [math.pi / 2, 0, -math.pi], [-1 / 2, -1 / 2]),
+            ("CRot", [0, math.pi / 2, -math.pi], [-1 / 2, 1 / 4]),
+            ("CRot", [-math.pi, 0, math.pi / 2], [-1 / 2, -1 / 2]),
+        ],
+    )
+    def test_supported_gate_two_wires_with_parameters(
+        self, qubit_device_2_wires, tol, name, par, expected_output
+    ):
         """Tests supported gates that act on two wires wires that are parameterized"""
 
         op = getattr(qml.ops, name)
@@ -715,27 +866,32 @@ class TestLightningQubitIntegration:
 
         @qml.qnode(qubit_device_2_wires)
         def circuit():
-            qml.QubitStateVector(np.array([1/2, 0, 0, math.sqrt(3)/2]), wires=[0, 1])
+            qml.QubitStateVector(np.array([1 / 2, 0, 0, math.sqrt(3) / 2]), wires=[0, 1])
             op(*par, wires=[0, 1])
             return qml.expval(qml.PauliZ(0)), qml.expval(qml.PauliZ(1))
 
         assert np.allclose(circuit(), expected_output, atol=tol, rtol=0)
 
-    @pytest.mark.parametrize("name,state,expected_output", [
-        ("PauliX", [1/math.sqrt(2), 1/math.sqrt(2)], 1),
-        ("PauliX", [1/math.sqrt(2), -1/math.sqrt(2)], -1),
-        ("PauliX", [1, 0], 0),
-        ("PauliY", [1/math.sqrt(2), 1j/math.sqrt(2)], 1),
-        ("PauliY", [1/math.sqrt(2), -1j/math.sqrt(2)], -1),
-        ("PauliY", [1, 0], 0),
-        ("PauliZ", [1, 0], 1),
-        ("PauliZ", [0, 1], -1),
-        ("PauliZ", [1/math.sqrt(2), 1/math.sqrt(2)], 0),
-        ("Hadamard", [1, 0], 1/math.sqrt(2)),
-        ("Hadamard", [0, 1], -1/math.sqrt(2)),
-        ("Hadamard", [1/math.sqrt(2), 1/math.sqrt(2)], 1/math.sqrt(2)),
-    ])
-    def test_supported_observable_single_wire_no_parameters(self, qubit_device_1_wire, tol, name, state, expected_output):
+    @pytest.mark.parametrize(
+        "name,state,expected_output",
+        [
+            ("PauliX", [1 / math.sqrt(2), 1 / math.sqrt(2)], 1),
+            ("PauliX", [1 / math.sqrt(2), -1 / math.sqrt(2)], -1),
+            ("PauliX", [1, 0], 0),
+            ("PauliY", [1 / math.sqrt(2), 1j / math.sqrt(2)], 1),
+            ("PauliY", [1 / math.sqrt(2), -1j / math.sqrt(2)], -1),
+            ("PauliY", [1, 0], 0),
+            ("PauliZ", [1, 0], 1),
+            ("PauliZ", [0, 1], -1),
+            ("PauliZ", [1 / math.sqrt(2), 1 / math.sqrt(2)], 0),
+            ("Hadamard", [1, 0], 1 / math.sqrt(2)),
+            ("Hadamard", [0, 1], -1 / math.sqrt(2)),
+            ("Hadamard", [1 / math.sqrt(2), 1 / math.sqrt(2)], 1 / math.sqrt(2)),
+        ],
+    )
+    def test_supported_observable_single_wire_no_parameters(
+        self, qubit_device_1_wire, tol, name, state, expected_output
+    ):
         """Tests supported observables on single wires without parameters."""
 
         obs = getattr(qml.ops, name)
@@ -749,12 +905,17 @@ class TestLightningQubitIntegration:
 
         assert np.isclose(circuit(), expected_output, atol=tol, rtol=0)
 
-    @pytest.mark.parametrize("name,state,expected_output,par", [
-        ("Identity", [1, 0], 1, []),
-        ("Identity", [0, 1], 1, []),
-        ("Identity", [1/math.sqrt(2), -1/math.sqrt(2)], 1, []),
-    ])
-    def test_supported_observable_single_wire_with_parameters(self, qubit_device_1_wire, tol, name, state, expected_output, par):
+    @pytest.mark.parametrize(
+        "name,state,expected_output,par",
+        [
+            ("Identity", [1, 0], 1, []),
+            ("Identity", [0, 1], 1, []),
+            ("Identity", [1 / math.sqrt(2), -1 / math.sqrt(2)], 1, []),
+        ],
+    )
+    def test_supported_observable_single_wire_with_parameters(
+        self, qubit_device_1_wire, tol, name, state, expected_output, par
+    ):
         """Tests supported observables on single wires with parameters."""
 
         obs = getattr(qml.ops, name)
@@ -786,12 +947,14 @@ class TestLightningQubitIntegration:
         assert np.array_equal(outcomes[0], outcomes[1])
 
     @pytest.mark.parametrize("num_wires", [3, 4, 5, 6, 7, 8])
-    def test_multi_samples_return_correlated_results_more_wires_than_size_of_observable(self, num_wires):
+    def test_multi_samples_return_correlated_results_more_wires_than_size_of_observable(
+        self, num_wires
+    ):
         """Tests if the samples returned by the sample function have
         the correct dimensions
         """
 
-        dev = qml.device('lightning.qubit', wires=num_wires)
+        dev = qml.device("lightning.qubit", wires=num_wires)
 
         @qml.qnode(dev)
         def circuit():
@@ -802,6 +965,7 @@ class TestLightningQubitIntegration:
         outcomes = circuit()
 
         assert np.array_equal(outcomes[0], outcomes[1])
+
 
 @pytest.mark.parametrize("theta,phi,varphi", list(zip(THETA, PHI, VARPHI)))
 class TestTensorExpval:
@@ -820,9 +984,9 @@ class TestTensorExpval:
                 qml.RX(phi, wires=[1]),
                 qml.RX(varphi, wires=[2]),
                 qml.CNOT(wires=[0, 1]),
-                qml.CNOT(wires=[1, 2])
+                qml.CNOT(wires=[1, 2]),
             ],
-            obs.diagonalizing_gates()
+            obs.diagonalizing_gates(),
         )
 
         res = dev.expval(obs)
@@ -844,14 +1008,14 @@ class TestTensorExpval:
                 qml.RX(phi, wires=[1]),
                 qml.RX(varphi, wires=[2]),
                 qml.CNOT(wires=[0, 1]),
-                qml.CNOT(wires=[1, 2])
+                qml.CNOT(wires=[1, 2]),
             ],
-            obs.diagonalizing_gates()
+            obs.diagonalizing_gates(),
         )
 
         res = dev.expval(obs)
 
-        expected = np.cos(varphi)*np.cos(phi)
+        expected = np.cos(varphi) * np.cos(phi)
 
         assert np.allclose(res, expected, atol=tol, rtol=0)
 
@@ -867,9 +1031,9 @@ class TestTensorExpval:
                 qml.RX(phi, wires=[1]),
                 qml.RX(varphi, wires=[2]),
                 qml.CNOT(wires=[0, 1]),
-                qml.CNOT(wires=[1, 2])
+                qml.CNOT(wires=[1, 2]),
             ],
-            obs.diagonalizing_gates()
+            obs.diagonalizing_gates(),
         )
 
         res = dev.expval(obs)
@@ -877,6 +1041,7 @@ class TestTensorExpval:
         expected = -(np.cos(varphi) * np.sin(phi) + np.sin(varphi) * np.cos(theta)) / np.sqrt(2)
 
         assert np.allclose(res, expected, atol=tol, rtol=0)
+
 
 @pytest.mark.parametrize("theta, phi, varphi", list(zip(THETA, PHI, VARPHI)))
 class TestTensorVar:
@@ -894,9 +1059,9 @@ class TestTensorVar:
                 qml.RX(phi, wires=[1]),
                 qml.RX(varphi, wires=[2]),
                 qml.CNOT(wires=[0, 1]),
-                qml.CNOT(wires=[1, 2])
+                qml.CNOT(wires=[1, 2]),
             ],
-            obs.diagonalizing_gates()
+            obs.diagonalizing_gates(),
         )
 
         res = dev.var(obs)
@@ -924,9 +1089,9 @@ class TestTensorVar:
                 qml.RX(phi, wires=[1]),
                 qml.RX(varphi, wires=[2]),
                 qml.CNOT(wires=[0, 1]),
-                qml.CNOT(wires=[1, 2])
+                qml.CNOT(wires=[1, 2]),
             ],
-            obs.diagonalizing_gates()
+            obs.diagonalizing_gates(),
         )
 
         res = dev.var(obs)
@@ -939,6 +1104,7 @@ class TestTensorVar:
         ) / 4
 
         assert np.allclose(res, expected, atol=tol, rtol=0)
+
 
 @pytest.mark.parametrize("theta, phi, varphi", list(zip(THETA, PHI, VARPHI)))
 class TestTensorSample:
@@ -956,9 +1122,9 @@ class TestTensorSample:
                 qml.RX(phi, wires=[1]),
                 qml.RX(varphi, wires=[2]),
                 qml.CNOT(wires=[0, 1]),
-                qml.CNOT(wires=[1, 2])
+                qml.CNOT(wires=[1, 2]),
             ],
-            obs.diagonalizing_gates()
+            obs.diagonalizing_gates(),
         )
 
         dev._wires_measured = {0, 1, 2}
@@ -996,9 +1162,9 @@ class TestTensorSample:
                 qml.RX(phi, wires=[1]),
                 qml.RX(varphi, wires=[2]),
                 qml.CNOT(wires=[0, 1]),
-                qml.CNOT(wires=[1, 2])
+                qml.CNOT(wires=[1, 2]),
             ],
-            obs.diagonalizing_gates()
+            obs.diagonalizing_gates(),
         )
 
         dev._wires_measured = {0, 1, 2}
@@ -1042,9 +1208,15 @@ class TestTooManyQubits:
 
         with monkeypatch.context() as m:
             # Mock the DefaultQubit class to avoid an extensive memory allocation
-            m.setattr(pennylane_lightning.lightning_qubit.DefaultQubit, "__init__", MockDefaultQubit.__init__)
+            m.setattr(
+                pennylane_lightning.lightning_qubit.DefaultQubit,
+                "__init__",
+                MockDefaultQubit.__init__,
+            )
             with pytest.warns(UserWarning, match="The number of wires exceeds"):
-                pennylane_lightning.lightning_qubit.LightningQubit(wires=LightningQubit._MAX_WIRES + 1)
+                pennylane_lightning.lightning_qubit.LightningQubit(
+                    wires=LightningQubit._MAX_WIRES + 1
+                )
 
     def test_apply(self, mocker):
         """Test that the apply method uses the one in default.qubit when the number of wires


### PR DESCRIPTION
This PR adds in a new backend and some rudimentary performance comparisons between the new and old backend. If we elect to adopt the new backend, then we may just want to replace the old one altogether.

The old backend represents state vectors as a multi-dimensional tensor in Eigen and applies gates in the form of tensor contractions, which really limits the optimisations that can be performed. The long-term goal with the new backend is to write things in such a way that offers more flexibility when it comes to optimisation choices. For now, it implements gate operations as tensor contractions, so it does much the same work as the Eigen backend, but in future, we can write gate operations in ways that don't require the full matrix representation of a gate.

There's 4 commits in this:
1) Tone down warning levels: Compiling with Wall with MSVC floods the compilation with warning messages for the Eigen backend, so I toned down the warning levels for my own sanity.
2) Black reformatting: I integrated PyCharm with the black formatter, and it automatically reformats these files every single time I touch them, so I separated these out.
3) New backend + benchmark notebook: The main change, which adds in a separate backend and a notebook that plots the average execution time of both.
4) Add compilation for Eigen backend back in again: I turned off compilation of the Eigen backend during development because it literally takes minutes to compile; the new backend has no external dependencies (yet), so compilation is almost instantaneous.

Performance comparisons on my machine show about a x20-30 speedup relative to the old backend. For full disclosure, I doubt its from the backend itself--during development of the new backend, I found that the pybind11 bindings was the largest factor responsible for slowness, because it looked like it was returning a plain Python list instead of a numpy array, and then having to convert that into a numpy array. Its *possible* the old backend also has a similar problem, although I'm not that familiar with how pybind11 handles conversion between numpy arrays and Eigen vectors; if so, then perhaps a similar speedup can be achieved just using the old backend but reworking the pybind11 bindings. Even if that's the case, I still don't think its of much long-term value, just because of how representation using Eigen tensors inhibits future optimisation choices (there's a *lot* of low-hanging optimisation fruit for the new backend that remains to be picked).

On a much more minor note, the new backend also doesn't need template metaprogramming to have arbitrary rank tensors (although in theory, its hard limited to 64 bits, since indices only go up to unsigned 64-bit integers), which is a plus in my book :)

One caveat is that I haven't tested the results of the new backend extensively (beyond timing and inspecting a few state vectors by eye), so help validating the results would be appreciated.