### PR TITLE
Split up device test cases for wheel build

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -43,7 +43,8 @@ env:
   CIBW_TEST_REQUIRES: numpy scipy pytest pytest-cov pytest-mock flaky
 
   CIBW_TEST_COMMAND: |
-    pl-device-test --device=lightning.qubit --skip-ops -x --tb=short --no-flaky-report
+    # Note: skipping a test that hangs on Win temporarily, to be reverted
+    pl-device-test --device=lightning.qubit --skip-ops -x --tb=short --no-flaky-report -k "not test_four_qubit_random_circuit"
 
 
 jobs:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -43,8 +43,9 @@ env:
   CIBW_TEST_REQUIRES: numpy scipy pytest pytest-cov pytest-mock flaky
 
   CIBW_TEST_COMMAND: |
-    # Note: skipping a test that hangs on Win temporarily, to be reverted
+    # Note: breaking up tests so that no test cases hang on Windows, to be reverted
     pl-device-test --device=lightning.qubit --skip-ops -x --tb=short --no-flaky-report -k "not test_four_qubit_random_circuit"
+    pl-device-test --device=lightning.qubit --skip-ops -x --tb=short --no-flaky-report -k "test_four_qubit_random_circuit"
 
 
 jobs:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -42,8 +42,8 @@ env:
 
   CIBW_TEST_REQUIRES: numpy scipy pytest pytest-cov pytest-mock flaky
 
+  # Note: breaking up tests so that no test cases hang on Windows, to be reverted
   CIBW_TEST_COMMAND: |
-    # Note: breaking up tests so that no test cases hang on Windows, to be reverted
     pl-device-test --device=lightning.qubit --skip-ops -x --tb=short --no-flaky-report -k "not test_four_qubit_random_circuit"
     pl-device-test --device=lightning.qubit --skip-ops -x --tb=short --no-flaky-report -k "test_four_qubit_random_circuit"
 


### PR DESCRIPTION
Splits up the test cases from the device test suite.

This is to avoid a test run behaviour that involves [tests hanging when run using `pytest` on Windows](https://github.com/PennyLaneAI/pennylane-lightning/runs/1813396596?check_suite_focus=true).