### PR TITLE
No backprop devices

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -44,7 +44,8 @@ env:
 
   # Note: breaking up tests so that no test cases hang on Windows, to be reverted
   CIBW_TEST_COMMAND: |
-    pl-device-test --device=lightning.qubit --skip-ops -x --tb=short --no-flaky-report
+    pl-device-test --device=lightning.qubit --skip-ops -x --tb=short --no-flaky-report -k "not test_four_qubit_random_circuit"
+    pl-device-test --device=lightning.qubit --skip-ops -x --tb=short --no-flaky-report -k "test_four_qubit_random_circuit"
 
 
 jobs:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -44,8 +44,7 @@ env:
 
   # Note: breaking up tests so that no test cases hang on Windows, to be reverted
   CIBW_TEST_COMMAND: |
-    pl-device-test --device=lightning.qubit --skip-ops -x --tb=short --no-flaky-report -k "not test_four_qubit_random_circuit"
-    pl-device-test --device=lightning.qubit --skip-ops -x --tb=short --no-flaky-report -k "test_four_qubit_random_circuit"
+    pl-device-test --device=lightning.qubit --skip-ops -x --tb=short --no-flaky-report
 
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,16 @@
 
 ### Bug fixes
 
+* Fixes a bug where the `QNode` would swap `LightningQubit` to
+  `DefaultQubitAutograd` on device execution due to the inherited
+  `passthru_devices` entry of the `capabilities` dictionary.
+  [(#61)](https://github.com/PennyLaneAI/pennylane-lightning/pull/61)
+
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
+
+Josh Izaac, Antal Száva
 
 ---
 

--- a/pennylane_lightning/lightning_qubit.py
+++ b/pennylane_lightning/lightning_qubit.py
@@ -17,15 +17,27 @@ interfaces with C++ for fast linear algebra calculations.
 """
 import warnings
 
-from pennylane.devices import DefaultQubit
-from .lightning_qubit_ops import apply
+from pennylane.devices import (
+    DefaultQubit,
+)
+from .lightning_qubit_ops import (
+    apply,
+)
 import numpy as np
-from pennylane import QubitStateVector, BasisState, DeviceError
+from pennylane import (
+    QubitStateVector,
+    BasisState,
+    DeviceError,
+)
 
-from ._version import __version__
+from ._version import (
+    __version__,
+)
 
 
-class LightningQubit(DefaultQubit):
+class LightningQubit(
+    DefaultQubit
+):
     """PennyLane Lightning device.
 
     An extension of PennyLane's built-in ``default.qubit`` device that interfaces with C++ to
@@ -82,24 +94,49 @@ class LightningQubit(DefaultQubit):
         "CRot",
     }
 
-    observables = {"PauliX", "PauliY", "PauliZ", "Hadamard", "Identity"}
+    observables = {
+        "PauliX",
+        "PauliY",
+        "PauliZ",
+        "Hadamard",
+        "Identity",
+    }
 
     _MAX_WIRES = 50
     """Maximum number of supported wires. Beyond this number, lightning.qubit behaves like 
     default.qubit."""
 
-    def __init__(self, wires, *, shots=1000, analytic=True):
-        super().__init__(wires, shots=shots, analytic=analytic)
+    def __init__(
+        self,
+        wires,
+        *,
+        shots=1000,
+        analytic=True,
+    ):
+        super().__init__(
+            wires,
+            shots=shots,
+            analytic=analytic,
+        )
 
-        if self.num_wires > self._MAX_WIRES:
+        if (
+            self.num_wires
+            > self._MAX_WIRES
+        ):
             warnings.warn(
                 f"The number of wires exceeds {self._MAX_WIRES}, reverting to NumPy-based evaluation.",
                 UserWarning,
             )
 
     @classmethod
-    def capabilities(cls):
-        capabilities = super().capabilities().copy()
+    def capabilities(
+        cls,
+    ):
+        capabilities = (
+            super()
+            .capabilities()
+            .copy()
+        )
         capabilities.update(
             model="qubit",
             supports_reversible_diff=False,
@@ -107,42 +144,103 @@ class LightningQubit(DefaultQubit):
             supports_analytic_computation=True,
             returns_state=True,
         )
-        capabilities.pop('passthru_devices', None)
+        capabilities.pop(
+            "passthru_devices",
+            None,
+        )
         return capabilities
 
-    def apply(self, operations, rotations=None, **kwargs):
+    def apply(
+        self,
+        operations,
+        rotations=None,
+        **kwargs,
+    ):
 
-        if self.num_wires > self._MAX_WIRES:
-            super().apply(operations, rotations=rotations, **kwargs)
+        if (
+            self.num_wires
+            > self._MAX_WIRES
+        ):
+            super().apply(
+                operations,
+                rotations=rotations,
+                **kwargs,
+            )
             return
 
-        for i, operation in enumerate(operations):  # State preparation is currently done in Python
-            if isinstance(operation, (QubitStateVector, BasisState)):
-                if i == 0:
+        for (
+            i,
+            operation,
+        ) in enumerate(
+            operations
+        ):  # State preparation is currently done in Python
+            if isinstance(
+                operation,
+                (
+                    QubitStateVector,
+                    BasisState,
+                ),
+            ):
+                if (
+                    i
+                    == 0
+                ):
 
-                    if isinstance(operation, QubitStateVector):
-                        self._apply_state_vector(operation.parameters[0], operation.wires)
+                    if isinstance(
+                        operation,
+                        QubitStateVector,
+                    ):
+                        self._apply_state_vector(
+                            operation.parameters[
+                                0
+                            ],
+                            operation.wires,
+                        )
                     else:
-                        self._apply_basis_state(operation.parameters[0], operation.wires)
+                        self._apply_basis_state(
+                            operation.parameters[
+                                0
+                            ],
+                            operation.wires,
+                        )
 
-                    del operations[0]
+                    del operations[
+                        0
+                    ]
                 else:
                     raise DeviceError(
                         "Operation {} cannot be used after other Operations have already been "
-                        "applied on a {} device.".format(operation.name, self.short_name)
+                        "applied on a {} device.".format(
+                            operation.name,
+                            self.short_name,
+                        )
                     )
 
         if operations:
-            self._pre_rotated_state = self.apply_lightning(self._state, operations)
+            self._pre_rotated_state = self.apply_lightning(
+                self._state,
+                operations,
+            )
         else:
-            self._pre_rotated_state = self._state
+            self._pre_rotated_state = (
+                self._state
+            )
 
         if rotations:
-            self._state = self.apply_lightning(self._pre_rotated_state, rotations)
+            self._state = self.apply_lightning(
+                self._pre_rotated_state,
+                rotations,
+            )
         else:
-            self._state = self._pre_rotated_state
+            self._state = (
+                self._pre_rotated_state
+            )
 
-    def apply_lightning(self, state, operations):
+    def apply_lightning(
+        self,
+        state,
+        operations,
+    ):
         """Apply a list of operations to the state tensor.
 
         Args:
@@ -152,10 +250,34 @@ class LightningQubit(DefaultQubit):
         Returns:
             array[complex]: the output state tensor
         """
-        op_names = [o.name for o in operations]
-        op_wires = [self.wires.indices(o.wires) for o in operations]
-        op_param = [o.parameters for o in operations]
+        op_names = [
+            o.name
+            for o in operations
+        ]
+        op_wires = [
+            self.wires.indices(
+                o.wires
+            )
+            for o in operations
+        ]
+        op_param = [
+            o.parameters
+            for o in operations
+        ]
 
-        state_vector = np.ravel(state, order="F")
-        state_vector_updated = apply(state_vector, op_names, op_wires, op_param, self.num_wires)
-        return np.reshape(state_vector_updated, state.shape, order="F")
+        state_vector = np.ravel(
+            state,
+            order="F",
+        )
+        state_vector_updated = apply(
+            state_vector,
+            op_names,
+            op_wires,
+            op_param,
+            self.num_wires,
+        )
+        return np.reshape(
+            state_vector_updated,
+            state.shape,
+            order="F",
+        )

--- a/pennylane_lightning/lightning_qubit.py
+++ b/pennylane_lightning/lightning_qubit.py
@@ -17,27 +17,15 @@ interfaces with C++ for fast linear algebra calculations.
 """
 import warnings
 
-from pennylane.devices import (
-    DefaultQubit,
-)
-from .lightning_qubit_ops import (
-    apply,
-)
+from pennylane.devices import DefaultQubit
+from .lightning_qubit_ops import apply
 import numpy as np
-from pennylane import (
-    QubitStateVector,
-    BasisState,
-    DeviceError,
-)
+from pennylane import QubitStateVector, BasisState, DeviceError
 
-from ._version import (
-    __version__,
-)
+from ._version import __version__
 
 
-class LightningQubit(
-    DefaultQubit
-):
+class LightningQubit(DefaultQubit):
     """PennyLane Lightning device.
 
     An extension of PennyLane's built-in ``default.qubit`` device that interfaces with C++ to
@@ -94,49 +82,24 @@ class LightningQubit(
         "CRot",
     }
 
-    observables = {
-        "PauliX",
-        "PauliY",
-        "PauliZ",
-        "Hadamard",
-        "Identity",
-    }
+    observables = {"PauliX", "PauliY", "PauliZ", "Hadamard", "Identity"}
 
     _MAX_WIRES = 50
     """Maximum number of supported wires. Beyond this number, lightning.qubit behaves like 
     default.qubit."""
 
-    def __init__(
-        self,
-        wires,
-        *,
-        shots=1000,
-        analytic=True,
-    ):
-        super().__init__(
-            wires,
-            shots=shots,
-            analytic=analytic,
-        )
+    def __init__(self, wires, *, shots=1000, analytic=True):
+        super().__init__(wires, shots=shots, analytic=analytic)
 
-        if (
-            self.num_wires
-            > self._MAX_WIRES
-        ):
+        if self.num_wires > self._MAX_WIRES:
             warnings.warn(
                 f"The number of wires exceeds {self._MAX_WIRES}, reverting to NumPy-based evaluation.",
                 UserWarning,
             )
 
     @classmethod
-    def capabilities(
-        cls,
-    ):
-        capabilities = (
-            super()
-            .capabilities()
-            .copy()
-        )
+    def capabilities(cls):
+        capabilities = super().capabilities().copy()
         capabilities.update(
             model="qubit",
             supports_reversible_diff=False,
@@ -144,103 +107,42 @@ class LightningQubit(
             supports_analytic_computation=True,
             returns_state=True,
         )
-        capabilities.pop(
-            "passthru_devices",
-            None,
-        )
+        capabilities.pop('passthru_devices', None)
         return capabilities
 
-    def apply(
-        self,
-        operations,
-        rotations=None,
-        **kwargs,
-    ):
+    def apply(self, operations, rotations=None, **kwargs):
 
-        if (
-            self.num_wires
-            > self._MAX_WIRES
-        ):
-            super().apply(
-                operations,
-                rotations=rotations,
-                **kwargs,
-            )
+        if self.num_wires > self._MAX_WIRES:
+            super().apply(operations, rotations=rotations, **kwargs)
             return
 
-        for (
-            i,
-            operation,
-        ) in enumerate(
-            operations
-        ):  # State preparation is currently done in Python
-            if isinstance(
-                operation,
-                (
-                    QubitStateVector,
-                    BasisState,
-                ),
-            ):
-                if (
-                    i
-                    == 0
-                ):
+        for i, operation in enumerate(operations):  # State preparation is currently done in Python
+            if isinstance(operation, (QubitStateVector, BasisState)):
+                if i == 0:
 
-                    if isinstance(
-                        operation,
-                        QubitStateVector,
-                    ):
-                        self._apply_state_vector(
-                            operation.parameters[
-                                0
-                            ],
-                            operation.wires,
-                        )
+                    if isinstance(operation, QubitStateVector):
+                        self._apply_state_vector(operation.parameters[0], operation.wires)
                     else:
-                        self._apply_basis_state(
-                            operation.parameters[
-                                0
-                            ],
-                            operation.wires,
-                        )
+                        self._apply_basis_state(operation.parameters[0], operation.wires)
 
-                    del operations[
-                        0
-                    ]
+                    del operations[0]
                 else:
                     raise DeviceError(
                         "Operation {} cannot be used after other Operations have already been "
-                        "applied on a {} device.".format(
-                            operation.name,
-                            self.short_name,
-                        )
+                        "applied on a {} device.".format(operation.name, self.short_name)
                     )
 
         if operations:
-            self._pre_rotated_state = self.apply_lightning(
-                self._state,
-                operations,
-            )
+            self._pre_rotated_state = self.apply_lightning(self._state, operations)
         else:
-            self._pre_rotated_state = (
-                self._state
-            )
+            self._pre_rotated_state = self._state
 
         if rotations:
-            self._state = self.apply_lightning(
-                self._pre_rotated_state,
-                rotations,
-            )
+            self._state = self.apply_lightning(self._pre_rotated_state, rotations)
         else:
-            self._state = (
-                self._pre_rotated_state
-            )
+            self._state = self._pre_rotated_state
 
-    def apply_lightning(
-        self,
-        state,
-        operations,
-    ):
+    def apply_lightning(self, state, operations):
         """Apply a list of operations to the state tensor.
 
         Args:
@@ -250,34 +152,10 @@ class LightningQubit(
         Returns:
             array[complex]: the output state tensor
         """
-        op_names = [
-            o.name
-            for o in operations
-        ]
-        op_wires = [
-            self.wires.indices(
-                o.wires
-            )
-            for o in operations
-        ]
-        op_param = [
-            o.parameters
-            for o in operations
-        ]
+        op_names = [o.name for o in operations]
+        op_wires = [self.wires.indices(o.wires) for o in operations]
+        op_param = [o.parameters for o in operations]
 
-        state_vector = np.ravel(
-            state,
-            order="F",
-        )
-        state_vector_updated = apply(
-            state_vector,
-            op_names,
-            op_wires,
-            op_param,
-            self.num_wires,
-        )
-        return np.reshape(
-            state_vector_updated,
-            state.shape,
-            order="F",
-        )
+        state_vector = np.ravel(state, order="F")
+        state_vector_updated = apply(state_vector, op_names, op_wires, op_param, self.num_wires)
+        return np.reshape(state_vector_updated, state.shape, order="F")

--- a/pennylane_lightning/lightning_qubit.py
+++ b/pennylane_lightning/lightning_qubit.py
@@ -107,6 +107,7 @@ class LightningQubit(DefaultQubit):
             supports_analytic_computation=True,
             returns_state=True,
         )
+        capabilities.pop('passthru_devices', None)
         return capabilities
 
     def apply(self, operations, rotations=None, **kwargs):

--- a/pennylane_lightning/lightning_qubit.py
+++ b/pennylane_lightning/lightning_qubit.py
@@ -107,7 +107,7 @@ class LightningQubit(DefaultQubit):
             supports_analytic_computation=True,
             returns_state=True,
         )
-        capabilities.pop('passthru_devices', None)
+        capabilities.pop("passthru_devices", None)
         return capabilities
 
     def apply(self, operations, rotations=None, **kwargs):

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -454,6 +454,18 @@ class TestLightningQubitIntegration:
         assert dev.analytic
         assert dev.short_name == "lightning.qubit"
 
+    def test_no_backprop(self):
+        """Test that lightning.qubit does not support the backprop
+        differentiation method."""
+
+        dev = qml.device("lightning.qubit", wires=2)
+        def circuit():
+            """Simply quantum function."""
+            return qml.expval(qml.PauliZ(0))
+
+        with pytest.raises(qml.QuantumFunctionError):
+            lightning = qml.QNode(circuit, dev, diff_method="backprop")
+
     def test_args(self):
         """Test that the plugin requires correct arguments"""
 

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -460,7 +460,7 @@ class TestLightningQubitIntegration:
 
         dev = qml.device("lightning.qubit", wires=2)
         def circuit():
-            """Simply quantum function."""
+            """Simple quantum function."""
             return qml.expval(qml.PauliZ(0))
 
         with pytest.raises(qml.QuantumFunctionError):

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -466,6 +466,17 @@ class TestLightningQubitIntegration:
         with pytest.raises(qml.QuantumFunctionError):
             qml.QNode(circuit, dev, diff_method="backprop")
 
+    def test_best_gets_lightning(self):
+        """Test that the best differentiation method returns lightning
+        qubit."""
+        dev = qml.device("lightning.qubit", wires=2)
+        def circuit():
+            """Simple quantum function."""
+            return qml.expval(qml.PauliZ(0))
+
+        qnode = qml.QNode(circuit, dev, diff_method="best")
+        assert isinstance(qnode.device, LightningQubit)
+
     def test_args(self):
         """Test that the plugin requires correct arguments"""
 

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -464,7 +464,7 @@ class TestLightningQubitIntegration:
             return qml.expval(qml.PauliZ(0))
 
         with pytest.raises(qml.QuantumFunctionError):
-            lightning = qml.QNode(circuit, dev, diff_method="backprop")
+            qml.QNode(circuit, dev, diff_method="backprop")
 
     def test_args(self):
         """Test that the plugin requires correct arguments"""


### PR DESCRIPTION
**Context**

As `lighting.qubit` inherits from `default.qubit`, it also inherits the `passthru_devices` entry of the `device.capabilities` dictionary.

This, however, may lead to unexpected behaviour, as the QNode in PennyLane attempts to get a device with the best differentiation method available. Therefore, even without specifying a differentiation method, we may get a `default.qubit.autograd` device.

**Changes**

Removes the `passthru_devices` entry of `device.capabilities`.