### PR TITLE
Get gtest 1.10.0 and parametrize tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,8 +21,8 @@ jobs:
 
       - name: Install Google Test
         run: |
-            wget -qO - https://github.com/google/googletest/archive/release-1.8.1.tar.gz | tar -xz
-            cmake -D CMAKE_INSTALL_PREFIX:PATH=$HOME/googletest -D CMAKE_BUILD_TYPE=Release googletest-release-1.8.1
+            wget -qO - https://github.com/google/googletest/archive/release-1.10.0.tar.gz | tar -xz
+            cmake -D CMAKE_INSTALL_PREFIX:PATH=$HOME/googletest -D CMAKE_BUILD_TYPE=Release googletest-release-1.10.0
             make install
 
       - name: Build and run unit tests

--- a/pennylane_lightning/src/tests/lightning_util_unittest.cpp
+++ b/pennylane_lightning/src/tests/lightning_util_unittest.cpp
@@ -19,7 +19,7 @@ namespace test_utils {
 class Exp2TestFixture :public ::testing::TestWithParam<std::tuple<int, int>> {
 };
 
-TEST_P(Exp2TestFixture, CheckPower) {
+TEST_P(Exp2TestFixture, CheckExp2Results) {
     int input = std::get<0>(GetParam());
     int expected = std::get<1>(GetParam());
     ASSERT_EQ(expected, Pennylane::exp2(input));

--- a/pennylane_lightning/src/tests/lightning_util_unittest.cpp
+++ b/pennylane_lightning/src/tests/lightning_util_unittest.cpp
@@ -14,6 +14,8 @@
 #include "gtest/gtest.h"
 #include "../rework/Util.hpp"
 
+#include <tuple>
+
 namespace test_utils {
 
 class Exp2TestFixture :public ::testing::TestWithParam<std::tuple<int, int>> {

--- a/pennylane_lightning/src/tests/lightning_util_unittest.cpp
+++ b/pennylane_lightning/src/tests/lightning_util_unittest.cpp
@@ -36,21 +36,25 @@ INSTANTIATE_TEST_SUITE_P (
                 std::make_tuple(5, 32),
                 std::make_tuple(8, 256)));
 
-TEST(maxDecimalForQubit, fixed_example) {
-    std::vector<std::vector<unsigned int>> inputs = {
-        {0, 3},
-        {1, 3},
-        {2, 3},
-        {0, 4},
-        {2, 4},
-        {2, 5},
-    };
-    std::vector<size_t> outputs = {4, 2, 1, 8, 2, 4};
+class maxDecimalForQubitTestFixture :public ::testing::TestWithParam<std::tuple<unsigned int, unsigned int, size_t>> {
+};
 
-    for (size_t i = 0; i < inputs.size(); i++) {
-        size_t result = Pennylane::maxDecimalForQubit(inputs[i][0], inputs[i][1]);
-        EXPECT_TRUE(result == outputs[i]);
-    }
+TEST_P(maxDecimalForQubitTestFixture, CheckMaxDecimalResults) {
+    unsigned int qubitIndex = std::get<0>(GetParam());
+    unsigned int qubits = std::get<1>(GetParam());
+    size_t expected = std::get<2>(GetParam());
+    ASSERT_EQ(expected, Pennylane::maxDecimalForQubit(qubitIndex, qubits));
 }
+
+INSTANTIATE_TEST_SUITE_P (
+        maxDecimalForQubitTests,
+        maxDecimalForQubitTestFixture,
+        ::testing::Values(
+                std::make_tuple(0, 3, 4),
+                std::make_tuple(1, 3, 2),
+                std::make_tuple(2, 3, 1),
+                std::make_tuple(0, 4, 8),
+                std::make_tuple(2, 4, 2),
+                std::make_tuple(2, 5, 4)));
 
 }

--- a/pennylane_lightning/src/tests/lightning_util_unittest.cpp
+++ b/pennylane_lightning/src/tests/lightning_util_unittest.cpp
@@ -27,7 +27,7 @@ TEST_P(Exp2TestFixture, CheckExp2Results) {
     ASSERT_EQ(expected, Pennylane::exp2(input));
 }
 
-INSTANTIATE_TEST_CASE_P (
+INSTANTIATE_TEST_SUITE_P (
         Exp2Tests,
         Exp2TestFixture,
         ::testing::Values(

--- a/pennylane_lightning/src/tests/lightning_util_unittest.cpp
+++ b/pennylane_lightning/src/tests/lightning_util_unittest.cpp
@@ -16,15 +16,23 @@
 
 namespace test_utils {
 
-TEST(exp2, fixed_example) {
-    std::vector<unsigned int> inputs = {1, 2, 5, 8};
-    std::vector<size_t> outputs = {2, 4, 32, 256};
+class Exp2TestFixture :public ::testing::TestWithParam<std::tuple<int, int>> {
+};
 
-    for (size_t i = 0; i < inputs.size(); i++) {
-        size_t result = Pennylane::exp2(inputs[i]);
-        EXPECT_TRUE(result == outputs[i]);
-    }
+TEST_P(Exp2TestFixture, CheckPower) {
+    int input = std::get<0>(GetParam());
+    int expected = std::get<1>(GetParam());
+    ASSERT_EQ(expected, Pennylane::exp2(input));
 }
+
+INSTANTIATE_TEST_SUITE_P (
+        Exp2Tests,
+        Exp2TestFixture,
+        ::testing::Values(
+                std::make_tuple(1, 2),
+                std::make_tuple(2, 4),
+                std::make_tuple(5, 32),
+                std::make_tuple(8, 256)));
 
 TEST(maxDecimalForQubit, fixed_example) {
     std::vector<std::vector<unsigned int>> inputs = {

--- a/pennylane_lightning/src/tests/lightning_util_unittest.cpp
+++ b/pennylane_lightning/src/tests/lightning_util_unittest.cpp
@@ -27,7 +27,7 @@ TEST_P(Exp2TestFixture, CheckExp2Results) {
     ASSERT_EQ(expected, Pennylane::exp2(input));
 }
 
-INSTANTIATE_TEST_SUITE_P (
+INSTANTIATE_TEST_CASE_P (
         Exp2Tests,
         Exp2TestFixture,
         ::testing::Values(


### PR DESCRIPTION
**Changes**

* Changes to CI to get the latest release of Google test available on GitHub (`v1.10.0`), [see release notes](https://github.com/google/googletest/releases/tag/release-1.10.0)
* Creates parametrized tests