### PR TITLE
Only upload artifacts on pushes to master

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,8 +37,10 @@ env:
 
   CIBW_TEST_REQUIRES: numpy scipy pytest pytest-cov pytest-mock flaky
 
+  # Note: breaking up tests so that no test cases hang on Windows, to be reverted
   CIBW_TEST_COMMAND: |
-    pl-device-test --device=lightning.qubit --skip-ops -x --tb=short --no-flaky-report
+    pl-device-test --device=lightning.qubit --skip-ops -x --tb=short --no-flaky-report -k "not test_four_qubit_random_circuit"
+    pl-device-test --device=lightning.qubit --skip-ops -x --tb=short --no-flaky-report -k "test_four_qubit_random_circuit"
 
 
 jobs:
@@ -83,11 +85,6 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           name: ${{ runner.os }}-wheels.zip
-          path: ./wheelhouse/*.whl
-
-      - uses: actions/upload-artifact@v2
-        with:
-          name: ${{ runner.os }}-wheels
           path: ./wheelhouse/*.whl
 
   upload-wheels:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -30,9 +30,6 @@ env:
 
   CIBW_ENVIRONMENT_WINDOWS: EIGEN_INCLUDE_DIR="C:\\eigen-3.3.7\\"
 
-#  CIBW_TEST_COMMAND_WINDOWS: |
-#    pytest "C:\\pennylane\\pennylane\\devices\\tests" --device=lightning.qubit --skip-ops -x --tb=short --no-flaky-report
-
   # Python build settings
 
   CIBW_BEFORE_BUILD: |
@@ -85,14 +82,12 @@ jobs:
           Invoke-WebRequest -Uri "https://gitlab.com/libeigen/eigen/-/archive/3.3.7/eigen-3.3.7.zip" -UseBasicParsing -OutFile C:\eigen3.zip
           & "C:\\Program Files\\7-Zip\\7z.exe" x C:\eigen3.zip -o"C:\" -y
 
-#          New-Item -ItemType directory -Path "C:\\pennylane"
-#          & git clone https://github.com/PennyLaneAI/pennylane.git "C:\\pennylane"
-
       - name: Build wheels
         run: |
           python -m cibuildwheel --output-dir wheelhouse
 
       - uses: actions/upload-artifact@v2
+        if: github.ref == 'refs/heads/master'
         with:
           name: ${{ runner.os }}-wheels.zip
           path: ./wheelhouse/*.whl


### PR DESCRIPTION
This PR makes the following CI changes:

* Ensures that `deploy` is up to date with the latest version of the `wheels` action
* Removes unused lines from `wheels`
* Modifies the artifact upload to only upload wheels when on the master branch. This will avoid using up storage for every commit in every PR.