### PR TITLE
Fixes a bug in state preparation

### DIFF
--- a/pennylane_lightning/lightning_qubit_new.py
+++ b/pennylane_lightning/lightning_qubit_new.py
@@ -98,11 +98,11 @@ class LightningQubitNew(DefaultQubit):
         for i, operation in enumerate(operations):  # State preparation is currently done in Python
             if isinstance(operation, (QubitStateVector, BasisState)):
                 if i == 0:
-
+                    input_state = operation.parameters[0].copy()
                     if isinstance(operation, QubitStateVector):
-                        self._apply_state_vector(operation.parameters[0], operation.wires)
+                        self._apply_state_vector(input_state, operation.wires)
                     else:
-                        self._apply_basis_state(operation.parameters[0], operation.wires)
+                        self._apply_basis_state(input_state, operation.wires)
 
                     del operations[0]
                 else:


### PR DESCRIPTION
Because `lightning.qubit.new` modifies the system state _in-place_, it is possible for it to change the input state specified by the user. This can be quite a sneaky side effect, and caused us to fail the device integration test suite in a very sneaky way!

For example, consider the following code:
```python
import pennylane as qml
import numpy as np

dev = qml.device("lightning.qubit", wires=1)

def init_state(n):
    state = np.random.random([2 ** n]) + np.random.random([2 ** n]) * 1j
    state /= np.linalg.norm(state)
    return state

rnd_state = init_state(1)
rnd_state_copy = rnd_state.copy()

print("input state:              ", rnd_state)

@qml.qnode(dev)
def circuit():
    qml.QubitStateVector(rnd_state, wires=[0])
    qml.PauliX([0])
    return qml.probs(wires=[0])

circuit()
print("input state after circuit:", rnd_state)

assert np.allclose(rnd_state_copy, rnd_state)
```

We are changing the `rnd_state` of the user! I think we shouldn't, as the user will be surprised (as I was!) to find their state changing, or they may not notice and get wrong results.