### PR TITLE
Add implementations for optimised gate kernels

### DIFF
--- a/pennylane_lightning/src/Apply.cpp
+++ b/pennylane_lightning/src/Apply.cpp
@@ -64,11 +64,7 @@ void Pennylane::constructAndApplyOperation(
     vector<unsigned int> externalWires = getIndicesAfterExclusion(opWires, qubits);
     vector<size_t> externalIndices = generateBitPatterns(externalWires, qubits);
 
-    vector<CplxType> inputVector(internalIndices.size());
-    for (const size_t& externalIndex : externalIndices) {
-        CplxType* shiftedStatePtr = state.arr + externalIndex;
-        gate->applyKernel(shiftedStatePtr, internalIndices, inputVector);
-    }
+    gate->applyKernel(state, internalIndices, externalIndices);
 }
 
 void Pennylane::apply(

--- a/pennylane_lightning/src/Apply.cpp
+++ b/pennylane_lightning/src/Apply.cpp
@@ -58,8 +58,6 @@ void Pennylane::constructAndApplyOperation(
     unique_ptr<AbstractGate> gate = constructGate(opLabel, opParams);
     if (gate->numQubits != opWires.size())
         throw std::invalid_argument(string("The gate of type ") + opLabel + " requires " + std::to_string(gate->numQubits) + " wires, but " + std::to_string(opWires.size()) + " were supplied");
-
-    const vector<CplxType>& matrix = gate->asMatrix();
     
     vector<size_t> internalIndices = generateBitPatterns(opWires, qubits);
 
@@ -69,23 +67,7 @@ void Pennylane::constructAndApplyOperation(
     vector<CplxType> inputVector(internalIndices.size());
     for (const size_t& externalIndex : externalIndices) {
         CplxType* shiftedStatePtr = state.arr + externalIndex;
-
-        // Gather
-        size_t pos = 0;
-        for (const size_t& internalIndex : internalIndices) {
-            inputVector[pos] = shiftedStatePtr[internalIndex];
-            pos++;
-        }
-
-        // Apply + scatter
-        for (size_t i = 0; i < internalIndices.size(); i++) {
-            size_t internalIndex = internalIndices[i];
-            shiftedStatePtr[internalIndex] = 0;
-            size_t baseIndex = i * internalIndices.size();
-            for (size_t j = 0; j < internalIndices.size(); j++) {
-                shiftedStatePtr[internalIndex] += matrix[baseIndex + j] * inputVector[j];
-            }
-        }
+        gate->applyKernel(shiftedStatePtr, internalIndices, inputVector);
     }
 }
 

--- a/pennylane_lightning/src/Gates.cpp
+++ b/pennylane_lightning/src/Gates.cpp
@@ -116,10 +116,6 @@ void Pennylane::YGate::applyKernel(const StateVector& state, const std::vector<s
         shiftedState[indices[0]] = -IMAG * shiftedState[indices[1]];
         shiftedState[indices[1]] = IMAG * v0;
     }
-    for (const size_t& externalIndex : externalIndices) {
-        CplxType* shiftedState = state.arr + externalIndex;
-
-    }
 }
 
 // -------------------------------------------------------------------------------------------------------------

--- a/pennylane_lightning/src/Gates.cpp
+++ b/pennylane_lightning/src/Gates.cpp
@@ -42,6 +42,28 @@ Pennylane::AbstractGate::AbstractGate(int numQubits)
     , length(exp2(numQubits))
 {}
 
+void Pennylane::AbstractGate::applyKernel(CplxType* state, vector<size_t>& indices, vector<CplxType>& v) {
+    const vector<CplxType>& matrix = asMatrix();
+    assert(indices.size() == length && v.size() == length);
+
+    // Gather
+    size_t pos = 0;
+    for (const size_t& index : indices) {
+        v[pos] = state[index];
+        pos++;
+    }
+
+    // Apply + scatter
+    for (size_t i = 0; i < indices.size(); i++) {
+        size_t index = indices[i];
+        state[index] = 0;
+        size_t baseIndex = i * indices.size();
+        for (size_t j = 0; j < indices.size(); j++) {
+            state[index] += matrix[baseIndex + j] * v[j];
+        }
+    }
+}
+
 // -------------------------------------------------------------------------------------------------------------
 
 Pennylane::SingleQubitGate::SingleQubitGate()

--- a/pennylane_lightning/src/Gates.cpp
+++ b/pennylane_lightning/src/Gates.cpp
@@ -46,7 +46,7 @@ Pennylane::AbstractGate::AbstractGate(int numQubits)
 
 void Pennylane::AbstractGate::applyKernel(const StateVector& state, const std::vector<size_t>& indices, const std::vector<size_t>& externalIndices) {
     const vector<CplxType>& matrix = asMatrix();
-    assert(indices.size() == length && v.size() == length);
+    assert(indices.size() == length);
 
     vector<CplxType> v(indices.size());
     for (const size_t& externalIndex : externalIndices) {

--- a/pennylane_lightning/src/Gates.hpp
+++ b/pennylane_lightning/src/Gates.hpp
@@ -20,6 +20,7 @@
 #include <memory>
 #include <vector>
 
+#include "StateVector.hpp"
 #include "typedefs.hpp"
 
 namespace Pennylane {
@@ -42,7 +43,7 @@ namespace Pennylane {
         /**
          * Generic matrix-multiplication kernel
          */
-        virtual void applyKernel(CplxType* state, std::vector<size_t>& gateIndices, std::vector<CplxType>& v);
+        virtual void applyKernel(const StateVector& state, const std::vector<size_t>& indices, const std::vector<size_t>& externalIndices);
     };
 
     // Single-qubit gates:
@@ -61,7 +62,7 @@ namespace Pennylane {
         inline const std::vector<CplxType>& asMatrix() {
             return matrix;
         }
-        void applyKernel(CplxType* state, std::vector<size_t>& indices, std::vector<CplxType>& v);
+        void applyKernel(const StateVector& state, const std::vector<size_t>& indices, const std::vector<size_t>& externalIndices);
     };
 
     class YGate : public SingleQubitGate {
@@ -73,7 +74,7 @@ namespace Pennylane {
         inline const std::vector<CplxType>& asMatrix() {
             return matrix;
         }
-        void applyKernel(CplxType* state, std::vector<size_t>& indices, std::vector<CplxType>& v);
+        void applyKernel(const StateVector& state, const std::vector<size_t>& indices, const std::vector<size_t>& externalIndices);
     };
 
     class ZGate : public SingleQubitGate {
@@ -85,7 +86,7 @@ namespace Pennylane {
         inline const std::vector<CplxType>& asMatrix() {
             return matrix;
         }
-        void applyKernel(CplxType* state, std::vector<size_t>& indices, std::vector<CplxType>& v);
+        void applyKernel(const StateVector& state, const std::vector<size_t>& indices, const std::vector<size_t>& externalIndices);
     };
 
     class HadamardGate : public SingleQubitGate {
@@ -97,7 +98,7 @@ namespace Pennylane {
         inline const std::vector<CplxType>& asMatrix() {
             return matrix;
         }
-        void applyKernel(CplxType* state, std::vector<size_t>& indices, std::vector<CplxType>& v);
+        void applyKernel(const StateVector& state, const std::vector<size_t>& indices, const std::vector<size_t>& externalIndices);
     };
 
     class SGate : public SingleQubitGate {
@@ -109,7 +110,7 @@ namespace Pennylane {
         inline const std::vector<CplxType>& asMatrix() {
             return matrix;
         }
-        void applyKernel(CplxType* state, std::vector<size_t>& indices, std::vector<CplxType>& v);
+        void applyKernel(const StateVector& state, const std::vector<size_t>& indices, const std::vector<size_t>& externalIndices);
     };
 
     class TGate : public SingleQubitGate {
@@ -122,7 +123,7 @@ namespace Pennylane {
         inline const std::vector<CplxType>& asMatrix() {
             return matrix;
         }
-        void applyKernel(CplxType* state, std::vector<size_t>& indices, std::vector<CplxType>& v);
+        void applyKernel(const StateVector& state, const std::vector<size_t>& indices, const std::vector<size_t>& externalIndices);
     };
 
     class RotationXGate : public SingleQubitGate {
@@ -162,7 +163,7 @@ namespace Pennylane {
         inline const std::vector<CplxType>& asMatrix() {
             return matrix;
         }
-        void applyKernel(CplxType* state, std::vector<size_t>& indices, std::vector<CplxType>& v);
+        void applyKernel(const StateVector& state, const std::vector<size_t>& indices, const std::vector<size_t>& externalIndices);
     };
 
     class PhaseShiftGate : public SingleQubitGate {
@@ -176,7 +177,7 @@ namespace Pennylane {
         inline const std::vector<CplxType>& asMatrix() {
             return matrix;
         }
-        void applyKernel(CplxType* state, std::vector<size_t>& indices, std::vector<CplxType>& v);
+        void applyKernel(const StateVector& state, const std::vector<size_t>& indices, const std::vector<size_t>& externalIndices);
     };
 
     class GeneralRotationGate : public SingleQubitGate {
@@ -208,7 +209,7 @@ namespace Pennylane {
         inline const std::vector<CplxType>& asMatrix() {
             return matrix;
         }
-        void applyKernel(CplxType* state, std::vector<size_t>& indices, std::vector<CplxType>& v);
+        void applyKernel(const StateVector& state, const std::vector<size_t>& indices, const std::vector<size_t>& externalIndices);
     };
 
     class SWAPGate : public TwoQubitGate {
@@ -220,7 +221,7 @@ namespace Pennylane {
         inline const std::vector<CplxType>& asMatrix() {
             return matrix;
         }
-        void applyKernel(CplxType* state, std::vector<size_t>& indices, std::vector<CplxType>& v);
+        void applyKernel(const StateVector& state, const std::vector<size_t>& indices, const std::vector<size_t>& externalIndices);
     };
 
     class CZGate : public TwoQubitGate {
@@ -232,7 +233,7 @@ namespace Pennylane {
         inline const std::vector<CplxType>& asMatrix() {
             return matrix;
         }
-        void applyKernel(CplxType* state, std::vector<size_t>& indices, std::vector<CplxType>& v);
+        void applyKernel(const StateVector& state, const std::vector<size_t>& indices, const std::vector<size_t>& externalIndices);
     };
 
     class CRotationXGate : public TwoQubitGate {
@@ -246,7 +247,7 @@ namespace Pennylane {
         inline const std::vector<CplxType>& asMatrix() {
             return matrix;
         }
-        void applyKernel(CplxType* state, std::vector<size_t>& indices, std::vector<CplxType>& v);
+        void applyKernel(const StateVector& state, const std::vector<size_t>& indices, const std::vector<size_t>& externalIndices);
     };
 
     class CRotationYGate : public TwoQubitGate {
@@ -260,7 +261,7 @@ namespace Pennylane {
         inline const std::vector<CplxType>& asMatrix() {
             return matrix;
         }
-        void applyKernel(CplxType* state, std::vector<size_t>& indices, std::vector<CplxType>& v);
+        void applyKernel(const StateVector& state, const std::vector<size_t>& indices, const std::vector<size_t>& externalIndices);
     };
 
     class CRotationZGate : public TwoQubitGate {
@@ -274,7 +275,7 @@ namespace Pennylane {
         inline const std::vector<CplxType>& asMatrix() {
             return matrix;
         }
-        void applyKernel(CplxType* state, std::vector<size_t>& indices, std::vector<CplxType>& v);
+        void applyKernel(const StateVector& state, const std::vector<size_t>& indices, const std::vector<size_t>& externalIndices);
     };
 
     class CGeneralRotationGate : public TwoQubitGate {
@@ -288,7 +289,7 @@ namespace Pennylane {
         inline const std::vector<CplxType>& asMatrix() {
             return matrix;
         }
-        void applyKernel(CplxType* state, std::vector<size_t>& indices, std::vector<CplxType>& v);
+        void applyKernel(const StateVector& state, const std::vector<size_t>& indices, const std::vector<size_t>& externalIndices);
     };
 
     // Three-qubit gates
@@ -307,7 +308,7 @@ namespace Pennylane {
         inline const std::vector<CplxType>& asMatrix() {
             return matrix;
         }
-        void applyKernel(CplxType* state, std::vector<size_t>& indices, std::vector<CplxType>& v);
+        void applyKernel(const StateVector& state, const std::vector<size_t>& indices, const std::vector<size_t>& externalIndices);
     };
 
     class CSWAPGate : public ThreeQubitGate {
@@ -319,7 +320,7 @@ namespace Pennylane {
         inline const std::vector<CplxType>& asMatrix() {
             return matrix;
         }
-        void applyKernel(CplxType* state, std::vector<size_t>& indices, std::vector<CplxType>& v);
+        void applyKernel(const StateVector& state, const std::vector<size_t>& indices, const std::vector<size_t>& externalIndices);
     };
 
     /**

--- a/pennylane_lightning/src/Gates.hpp
+++ b/pennylane_lightning/src/Gates.hpp
@@ -61,6 +61,7 @@ namespace Pennylane {
         inline const std::vector<CplxType>& asMatrix() {
             return matrix;
         }
+        void applyKernel(CplxType* state, std::vector<size_t>& indices, std::vector<CplxType>& v);
     };
 
     class YGate : public SingleQubitGate {
@@ -72,6 +73,7 @@ namespace Pennylane {
         inline const std::vector<CplxType>& asMatrix() {
             return matrix;
         }
+        void applyKernel(CplxType* state, std::vector<size_t>& indices, std::vector<CplxType>& v);
     };
 
     class ZGate : public SingleQubitGate {
@@ -83,6 +85,7 @@ namespace Pennylane {
         inline const std::vector<CplxType>& asMatrix() {
             return matrix;
         }
+        void applyKernel(CplxType* state, std::vector<size_t>& indices, std::vector<CplxType>& v);
     };
 
     class HadamardGate : public SingleQubitGate {
@@ -94,6 +97,7 @@ namespace Pennylane {
         inline const std::vector<CplxType>& asMatrix() {
             return matrix;
         }
+        void applyKernel(CplxType* state, std::vector<size_t>& indices, std::vector<CplxType>& v);
     };
 
     class SGate : public SingleQubitGate {
@@ -105,10 +109,12 @@ namespace Pennylane {
         inline const std::vector<CplxType>& asMatrix() {
             return matrix;
         }
+        void applyKernel(CplxType* state, std::vector<size_t>& indices, std::vector<CplxType>& v);
     };
 
     class TGate : public SingleQubitGate {
     private:
+        static const CplxType shift;
         static const std::vector<CplxType> matrix;
     public:
         static const std::string label;
@@ -116,6 +122,7 @@ namespace Pennylane {
         inline const std::vector<CplxType>& asMatrix() {
             return matrix;
         }
+        void applyKernel(CplxType* state, std::vector<size_t>& indices, std::vector<CplxType>& v);
     };
 
     class RotationXGate : public SingleQubitGate {
@@ -155,6 +162,7 @@ namespace Pennylane {
         inline const std::vector<CplxType>& asMatrix() {
             return matrix;
         }
+        void applyKernel(CplxType* state, std::vector<size_t>& indices, std::vector<CplxType>& v);
     };
 
     class PhaseShiftGate : public SingleQubitGate {
@@ -168,11 +176,12 @@ namespace Pennylane {
         inline const std::vector<CplxType>& asMatrix() {
             return matrix;
         }
+        void applyKernel(CplxType* state, std::vector<size_t>& indices, std::vector<CplxType>& v);
     };
 
     class GeneralRotationGate : public SingleQubitGate {
     private:
-        const CplxType c, s;
+        const CplxType c, s, r1, r2, r3, r4;
         const std::vector<CplxType> matrix;
     public:
         static const std::string label;
@@ -199,6 +208,7 @@ namespace Pennylane {
         inline const std::vector<CplxType>& asMatrix() {
             return matrix;
         }
+        void applyKernel(CplxType* state, std::vector<size_t>& indices, std::vector<CplxType>& v);
     };
 
     class SWAPGate : public TwoQubitGate {
@@ -210,6 +220,7 @@ namespace Pennylane {
         inline const std::vector<CplxType>& asMatrix() {
             return matrix;
         }
+        void applyKernel(CplxType* state, std::vector<size_t>& indices, std::vector<CplxType>& v);
     };
 
     class CZGate : public TwoQubitGate {
@@ -221,6 +232,7 @@ namespace Pennylane {
         inline const std::vector<CplxType>& asMatrix() {
             return matrix;
         }
+        void applyKernel(CplxType* state, std::vector<size_t>& indices, std::vector<CplxType>& v);
     };
 
     class CRotationXGate : public TwoQubitGate {
@@ -234,6 +246,7 @@ namespace Pennylane {
         inline const std::vector<CplxType>& asMatrix() {
             return matrix;
         }
+        void applyKernel(CplxType* state, std::vector<size_t>& indices, std::vector<CplxType>& v);
     };
 
     class CRotationYGate : public TwoQubitGate {
@@ -247,6 +260,7 @@ namespace Pennylane {
         inline const std::vector<CplxType>& asMatrix() {
             return matrix;
         }
+        void applyKernel(CplxType* state, std::vector<size_t>& indices, std::vector<CplxType>& v);
     };
 
     class CRotationZGate : public TwoQubitGate {
@@ -260,11 +274,12 @@ namespace Pennylane {
         inline const std::vector<CplxType>& asMatrix() {
             return matrix;
         }
+        void applyKernel(CplxType* state, std::vector<size_t>& indices, std::vector<CplxType>& v);
     };
 
     class CGeneralRotationGate : public TwoQubitGate {
     private:
-        const CplxType c, s;
+        const CplxType c, s, r1, r2, r3, r4;
         const std::vector<CplxType> matrix;
     public:
         static const std::string label;
@@ -273,6 +288,7 @@ namespace Pennylane {
         inline const std::vector<CplxType>& asMatrix() {
             return matrix;
         }
+        void applyKernel(CplxType* state, std::vector<size_t>& indices, std::vector<CplxType>& v);
     };
 
     // Three-qubit gates
@@ -291,6 +307,7 @@ namespace Pennylane {
         inline const std::vector<CplxType>& asMatrix() {
             return matrix;
         }
+        void applyKernel(CplxType* state, std::vector<size_t>& indices, std::vector<CplxType>& v);
     };
 
     class CSWAPGate : public ThreeQubitGate {
@@ -302,6 +319,7 @@ namespace Pennylane {
         inline const std::vector<CplxType>& asMatrix() {
             return matrix;
         }
+        void applyKernel(CplxType* state, std::vector<size_t>& indices, std::vector<CplxType>& v);
     };
 
     /**

--- a/pennylane_lightning/src/Gates.hpp
+++ b/pennylane_lightning/src/Gates.hpp
@@ -38,6 +38,11 @@ namespace Pennylane {
          * @return the matrix representation for the gate as a one-dimensional vector.
          */
         virtual const std::vector<CplxType>& asMatrix() = 0;
+
+        /**
+         * Generic matrix-multiplication kernel
+         */
+        virtual void applyKernel(CplxType* state, std::vector<size_t>& gateIndices, std::vector<CplxType>& v);
     };
 
     // Single-qubit gates:


### PR DESCRIPTION
I'm still mulling over the most natural API, but this is one attempt at it. This is comprised of two commits:

1. A refactoring commit that simply moves the core of the gate application (matrix multiplication) into the base `AbstractGate` class.
2. Adds optimised kernels for most gates that overrides the default base class implementation. Some gates (e.g. fully populated 2-by-2 matrices for single-qubit gates) have little (if any?) benefit from not using the default kernel, so I left them as-is.

A word of caution: I've yet to test this extensively. In order to eliminate the function call overhead (especially for the single qubit gates), I think what needs to happen is to move the outer loop over `applyKernel` into said function (unfortunately, I don't think runtime polymorphism works with inline functions unless the concrete class can be statically determined). It may be a worthwhile exercise anyway for when we start vectorising, but again, I've not really tested much.