### PR TITLE
`applyGenerator` method for gates

### DIFF
--- a/pennylane_lightning/src/Apply.cpp
+++ b/pennylane_lightning/src/Apply.cpp
@@ -68,6 +68,20 @@ void Pennylane::constructAndApplyOperation(
     gate->applyKernel(state, internalIndices, externalIndices, inverse);
 }
 
+void Pennylane::applyGateGenerator(
+    StateVector& state,
+    unique_ptr<AbstractGate> gate,
+    const vector<unsigned int>& opWires,
+    const unsigned int qubits
+) {
+    vector<size_t> internalIndices = generateBitPatterns(opWires, qubits);
+
+    vector<unsigned int> externalWires = getIndicesAfterExclusion(opWires, qubits);
+    vector<size_t> externalIndices = generateBitPatterns(externalWires, qubits);
+
+    gate->applyGenerator(state, internalIndices, externalIndices);
+}
+
 void Pennylane::apply(
     StateVector& state,
     const vector<string>& ops,

--- a/pennylane_lightning/src/Apply.hpp
+++ b/pennylane_lightning/src/Apply.hpp
@@ -76,11 +76,11 @@ namespace Pennylane {
     );
     
     /**
-     * Applies the generator to the gate to the state vector.
+     * Applies the generator of the gate to the state vector.
      * 
      * @param state state vector to which to apply the operation
-     * @param gate unique pointer to gate which is to be applied
-     * @param opWires index of qubits on which the gate acts
+     * @param gate unique pointer to the gate whose generator is to be applied
+     * @param opWires index of qubits on which the operation acts
      * @param qubits number of qubits
      */
     void applyGateGenerator(

--- a/pennylane_lightning/src/Apply.hpp
+++ b/pennylane_lightning/src/Apply.hpp
@@ -23,6 +23,7 @@
 #include <string>
 #include <vector>
 
+#include "Gates.hpp"
 #include "StateVector.hpp"
 #include "typedefs.hpp"
 
@@ -55,7 +56,7 @@ namespace Pennylane {
      */
     std::vector<size_t> generateBitPatterns(const std::vector<unsigned int>& qubitIndices, const unsigned int qubits);
 
-    /*
+    /**
      * Constructs the gate defined by the supplied parameters and applies it to the state vector.
      * 
      * @param state state vector to which to apply the operation
@@ -71,6 +72,21 @@ namespace Pennylane {
         const std::vector<unsigned int>& opWires,
         const std::vector<double>& opParams,
         bool inverse,
+        const unsigned int qubits
+    );
+    
+    /**
+     * Applies the generator to the gate to the state vector.
+     * 
+     * @param state state vector to which to apply the operation
+     * @param gate unique pointer to gate which is to be applied
+     * @param opWires index of qubits on which the gate acts
+     * @param qubits number of qubits
+     */
+    void Pennylane::applyGateGenerator(
+        StateVector& state,
+        std::unique_ptr<AbstractGate> gate,
+        const std::vector<unsigned int>& opWires,
         const unsigned int qubits
     );
 

--- a/pennylane_lightning/src/Apply.hpp
+++ b/pennylane_lightning/src/Apply.hpp
@@ -83,7 +83,7 @@ namespace Pennylane {
      * @param opWires index of qubits on which the gate acts
      * @param qubits number of qubits
      */
-    void Pennylane::applyGateGenerator(
+    void applyGateGenerator(
         StateVector& state,
         std::unique_ptr<AbstractGate> gate,
         const std::vector<unsigned int>& opWires,

--- a/pennylane_lightning/src/Gates.cpp
+++ b/pennylane_lightning/src/Gates.cpp
@@ -249,7 +249,8 @@ const double Pennylane::RotationXGate::generatorScalingFactor{ -0.5 };
 
 void Pennylane::RotationXGate::applyGenerator(const StateVector& state, const std::vector<size_t>& indices, const std::vector<size_t>& externalIndices) {
     unique_ptr<Pennylane::XGate> gate;
-    gate->applyKernel(state, indices, externalIndices);
+    gate->applyKernel(state, indices, externalIndices, false);
+}
 
 void Pennylane::RotationXGate::applyKernel(const StateVector& state, const std::vector<size_t>& indices, const std::vector<size_t>& externalIndices, bool inverse) {
     CplxType js_ = (inverse == true) ? -js : js;
@@ -284,7 +285,8 @@ const double Pennylane::RotationYGate::generatorScalingFactor{ -0.5 };
 
 void Pennylane::RotationYGate::applyGenerator(const StateVector& state, const std::vector<size_t>& indices, const std::vector<size_t>& externalIndices) {
     unique_ptr<Pennylane::YGate> gate;
-    gate->applyKernel(state, indices, externalIndices);
+    gate->applyKernel(state, indices, externalIndices, false);
+}
 
 void Pennylane::RotationYGate::applyKernel(const StateVector& state, const std::vector<size_t>& indices, const std::vector<size_t>& externalIndices, bool inverse) {
     CplxType s_ = (inverse == true) ? -s : s;
@@ -335,7 +337,7 @@ const double Pennylane::RotationZGate::generatorScalingFactor{ -0.5 };
 
 void Pennylane::RotationZGate::applyGenerator(const StateVector& state, const std::vector<size_t>& indices, const std::vector<size_t>& externalIndices) {
     unique_ptr<Pennylane::ZGate> gate;
-    gate->applyKernel(state, indices, externalIndices);
+    gate->applyKernel(state, indices, externalIndices, false);
 }
 
 

--- a/pennylane_lightning/src/Gates.cpp
+++ b/pennylane_lightning/src/Gates.cpp
@@ -321,7 +321,6 @@ void Pennylane::PhaseShiftGate::applyGenerator(const StateVector& state, const s
     for (const size_t& externalIndex : externalIndices) {
         CplxType* shiftedState = state.arr + externalIndex;
         shiftedState[indices[0]] = 0;
-        shiftedState[indices[1]] *= shift;
     }
 }
 
@@ -452,11 +451,8 @@ const double Pennylane::CRotationXGate::generatorScalingFactor{ -0.5 };
 void Pennylane::CRotationXGate::applyGenerator(const StateVector& state, const std::vector<size_t>& indices, const std::vector<size_t>& externalIndices) {
     for (const size_t& externalIndex : externalIndices) {
         CplxType* shiftedState = state.arr + externalIndex;
-        CplxType v0 = shiftedState[indices[2]];
-        CplxType v1 = shiftedState[indices[3]];
         shiftedState[indices[0]] = shiftedState[indices[1]] = 0;
-        shiftedState[indices[2]] = js * v0 + c * v1;
-        shiftedState[indices[3]] = c * v0 + js * v1;
+        swap(shiftedState[indices[2]], shiftedState[indices[3]]);
     }
 }
 
@@ -494,11 +490,10 @@ const double Pennylane::CRotationYGate::generatorScalingFactor{ -0.5 };
 void Pennylane::CRotationYGate::applyGenerator(const StateVector& state, const std::vector<size_t>& indices, const std::vector<size_t>& externalIndices) {
     for (const size_t& externalIndex : externalIndices) {
         CplxType* shiftedState = state.arr + externalIndex;
-        CplxType v0 = shiftedState[indices[2]];
-        CplxType v1 = shiftedState[indices[3]];
+        CplxType v0 = shiftedState[indices[0]];
         shiftedState[indices[0]] = shiftedState[indices[1]] = 0;
-        shiftedState[indices[2]] = - s * v0 - c * v1;
-        shiftedState[indices[3]] = c * v0 - s * v1;
+        shiftedState[indices[2]] = -IMAG * shiftedState[indices[3]];
+        shiftedState[indices[3]] = IMAG * v0;
     }
 }
 
@@ -534,11 +529,8 @@ const double Pennylane::CRotationZGate::generatorScalingFactor{ -0.5 };
 void Pennylane::CRotationZGate::applyGenerator(const StateVector& state, const std::vector<size_t>& indices, const std::vector<size_t>& externalIndices) {
     for (const size_t& externalIndex : externalIndices) {
         CplxType* shiftedState = state.arr + externalIndex;
-        CplxType v0 = shiftedState[indices[2]];
-        CplxType v1 = shiftedState[indices[3]];
         shiftedState[indices[0]] = shiftedState[indices[1]] = 0;
-        shiftedState[indices[2]] = first;
-        shiftedState[indices[3]] = -second;
+        shiftedState[indices[3]] *= -1;
     }
 }
 

--- a/pennylane_lightning/src/Gates.cpp
+++ b/pennylane_lightning/src/Gates.cpp
@@ -70,6 +70,14 @@ void Pennylane::AbstractGate::applyKernel(const StateVector& state, const std::v
     }
 }
 
+const double Pennylane::AbstractGate::generatorScalingFactor{};
+void Pennylane::AbstractGate::applyGenerator(const StateVector& state, const std::vector<size_t>& indices, const std::vector<size_t>& externalIndices) {
+    (void)state;
+    (void)indices;
+    (void)externalIndices;
+    throw NotImplementedException();
+}
+
 // -------------------------------------------------------------------------------------------------------------
 
 Pennylane::SingleQubitGate::SingleQubitGate()
@@ -220,6 +228,13 @@ Pennylane::RotationXGate::RotationXGate(double rotationAngle)
       js, c }
 {}
 
+const double Pennylane::RotationXGate::generatorScalingFactor{ -0.5 };
+
+void Pennylane::RotationXGate::applyGenerator(const StateVector& state, const std::vector<size_t>& indices, const std::vector<size_t>& externalIndices) {
+    unique_ptr<Pennylane::XGate> gate;
+    gate->applyKernel(state, indices, externalIndices);
+}
+
 // -------------------------------------------------------------------------------------------------------------
 
 const string Pennylane::RotationYGate::label = "RY";
@@ -236,6 +251,13 @@ Pennylane::RotationYGate::RotationYGate(double rotationAngle)
       c, -s,
       s, c }
 {}
+
+const double Pennylane::RotationYGate::generatorScalingFactor{ -0.5 };
+
+void Pennylane::RotationYGate::applyGenerator(const StateVector& state, const std::vector<size_t>& indices, const std::vector<size_t>& externalIndices) {
+    unique_ptr<Pennylane::YGate> gate;
+    gate->applyKernel(state, indices, externalIndices);
+}
 
 // -------------------------------------------------------------------------------------------------------------
 
@@ -262,6 +284,14 @@ void Pennylane::RotationZGate::applyKernel(const StateVector& state, const std::
     }
 }
 
+const double Pennylane::RotationZGate::generatorScalingFactor{ -0.5 };
+
+void Pennylane::RotationZGate::applyGenerator(const StateVector& state, const std::vector<size_t>& indices, const std::vector<size_t>& externalIndices) {
+    unique_ptr<Pennylane::ZGate> gate;
+    gate->applyKernel(state, indices, externalIndices);
+}
+
+
 // -------------------------------------------------------------------------------------------------------------
 
 const string Pennylane::PhaseShiftGate::label = "PhaseShift";
@@ -281,6 +311,16 @@ Pennylane::PhaseShiftGate::PhaseShiftGate(double rotationAngle)
 void Pennylane::PhaseShiftGate::applyKernel(const StateVector& state, const std::vector<size_t>& indices, const std::vector<size_t>& externalIndices) {
     for (const size_t& externalIndex : externalIndices) {
         CplxType* shiftedState = state.arr + externalIndex;
+        shiftedState[indices[1]] *= shift;
+    }
+}
+
+const double Pennylane::PhaseShiftGate::generatorScalingFactor{ 1.0 };
+
+void Pennylane::PhaseShiftGate::applyGenerator(const StateVector& state, const std::vector<size_t>& indices, const std::vector<size_t>& externalIndices) {
+    for (const size_t& externalIndex : externalIndices) {
+        CplxType* shiftedState = state.arr + externalIndex;
+        shiftedState[indices[0]] = 0;
         shiftedState[indices[1]] *= shift;
     }
 }
@@ -407,6 +447,19 @@ void Pennylane::CRotationXGate::applyKernel(const StateVector& state, const std:
     }
 }
 
+const double Pennylane::CRotationXGate::generatorScalingFactor{ -0.5 };
+
+void Pennylane::CRotationXGate::applyGenerator(const StateVector& state, const std::vector<size_t>& indices, const std::vector<size_t>& externalIndices) {
+    for (const size_t& externalIndex : externalIndices) {
+        CplxType* shiftedState = state.arr + externalIndex;
+        CplxType v0 = shiftedState[indices[2]];
+        CplxType v1 = shiftedState[indices[3]];
+        shiftedState[indices[0]] = shiftedState[indices[1]] = 0;
+        shiftedState[indices[2]] = js * v0 + c * v1;
+        shiftedState[indices[3]] = c * v0 + js * v1;
+    }
+}
+
 // -------------------------------------------------------------------------------------------------------------
 
 const string Pennylane::CRotationYGate::label = "CRY";
@@ -436,6 +489,19 @@ void Pennylane::CRotationYGate::applyKernel(const StateVector& state, const std:
     }
 }
 
+const double Pennylane::CRotationYGate::generatorScalingFactor{ -0.5 };
+
+void Pennylane::CRotationYGate::applyGenerator(const StateVector& state, const std::vector<size_t>& indices, const std::vector<size_t>& externalIndices) {
+    for (const size_t& externalIndex : externalIndices) {
+        CplxType* shiftedState = state.arr + externalIndex;
+        CplxType v0 = shiftedState[indices[2]];
+        CplxType v1 = shiftedState[indices[3]];
+        shiftedState[indices[0]] = shiftedState[indices[1]] = 0;
+        shiftedState[indices[2]] = - s * v0 - c * v1;
+        shiftedState[indices[3]] = c * v0 - s * v1;
+    }
+}
+
 // -------------------------------------------------------------------------------------------------------------
 
 const string Pennylane::CRotationZGate::label = "CRZ";
@@ -460,6 +526,19 @@ void Pennylane::CRotationZGate::applyKernel(const StateVector& state, const std:
         CplxType* shiftedState = state.arr + externalIndex;
         shiftedState[indices[2]] *= first;
         shiftedState[indices[3]] *= second;
+    }
+}
+
+const double Pennylane::CRotationZGate::generatorScalingFactor{ -0.5 };
+
+void Pennylane::CRotationZGate::applyGenerator(const StateVector& state, const std::vector<size_t>& indices, const std::vector<size_t>& externalIndices) {
+    for (const size_t& externalIndex : externalIndices) {
+        CplxType* shiftedState = state.arr + externalIndex;
+        CplxType v0 = shiftedState[indices[2]];
+        CplxType v1 = shiftedState[indices[3]];
+        shiftedState[indices[0]] = shiftedState[indices[1]] = 0;
+        shiftedState[indices[2]] = first;
+        shiftedState[indices[3]] = -second;
     }
 }
 

--- a/pennylane_lightning/src/Gates.cpp
+++ b/pennylane_lightning/src/Gates.cpp
@@ -80,10 +80,7 @@ void Pennylane::AbstractGate::applyKernel(const StateVector& state, const std::v
 }
 
 const double Pennylane::AbstractGate::generatorScalingFactor{};
-void Pennylane::AbstractGate::applyGenerator(const StateVector& state, const std::vector<size_t>& indices, const std::vector<size_t>& externalIndices) {
-    (void)state;
-    (void)indices;
-    (void)externalIndices;
+void Pennylane::AbstractGate::applyGenerator(const StateVector&, const std::vector<size_t>&, const std::vector<size_t>&) {
     throw NotImplementedException();
 }
 

--- a/pennylane_lightning/src/Gates.hpp
+++ b/pennylane_lightning/src/Gates.hpp
@@ -48,7 +48,7 @@ namespace Pennylane {
         virtual void applyKernel(const StateVector& state, const std::vector<size_t>& indices, const std::vector<size_t>& externalIndices, bool inverse);
 
         /**
-         * Generic matrix-multiplication kernel for applying the generator of an operation
+         * Kernel for applying the generator of an operation
          */
         void applyGenerator(const StateVector& state, const std::vector<size_t>& indices, const std::vector<size_t>& externalIndices);
 

--- a/pennylane_lightning/src/Gates.hpp
+++ b/pennylane_lightning/src/Gates.hpp
@@ -44,6 +44,16 @@ namespace Pennylane {
          * Generic matrix-multiplication kernel
          */
         virtual void applyKernel(const StateVector& state, const std::vector<size_t>& indices, const std::vector<size_t>& externalIndices);
+        
+        /**
+         * Generic matrix-multiplication kernel for applying the generator of an operation
+         */
+        virtual void applyGenerator(const StateVector& state, const std::vector<size_t>& indices, const std::vector<size_t>& externalIndices);
+
+        /**
+         * Scaling factor applied to the generator operation
+         */
+        static const double generatorScalingFactor;
     };
 
     // Single-qubit gates:
@@ -137,6 +147,8 @@ namespace Pennylane {
         inline const std::vector<CplxType>& asMatrix() {
             return matrix;
         }
+        virtual void applyGenerator(const StateVector& state, const std::vector<size_t>& indices, const std::vector<size_t>& externalIndices);
+        static const double generatorScalingFactor;
     };
 
     class RotationYGate : public SingleQubitGate {
@@ -150,6 +162,8 @@ namespace Pennylane {
         inline const std::vector<CplxType>& asMatrix() {
             return matrix;
         }
+        virtual void applyGenerator(const StateVector& state, const std::vector<size_t>& indices, const std::vector<size_t>& externalIndices);
+        static const double generatorScalingFactor;
     };
 
     class RotationZGate : public SingleQubitGate {
@@ -164,6 +178,8 @@ namespace Pennylane {
             return matrix;
         }
         void applyKernel(const StateVector& state, const std::vector<size_t>& indices, const std::vector<size_t>& externalIndices);
+        virtual void applyGenerator(const StateVector& state, const std::vector<size_t>& indices, const std::vector<size_t>& externalIndices);
+        static const double generatorScalingFactor;
     };
 
     class PhaseShiftGate : public SingleQubitGate {
@@ -178,6 +194,8 @@ namespace Pennylane {
             return matrix;
         }
         void applyKernel(const StateVector& state, const std::vector<size_t>& indices, const std::vector<size_t>& externalIndices);
+        virtual void applyGenerator(const StateVector& state, const std::vector<size_t>& indices, const std::vector<size_t>& externalIndices);
+        static const double generatorScalingFactor;
     };
 
     class GeneralRotationGate : public SingleQubitGate {
@@ -248,6 +266,8 @@ namespace Pennylane {
             return matrix;
         }
         void applyKernel(const StateVector& state, const std::vector<size_t>& indices, const std::vector<size_t>& externalIndices);
+        virtual void applyGenerator(const StateVector& state, const std::vector<size_t>& indices, const std::vector<size_t>& externalIndices);
+        static const double generatorScalingFactor;
     };
 
     class CRotationYGate : public TwoQubitGate {
@@ -262,6 +282,8 @@ namespace Pennylane {
             return matrix;
         }
         void applyKernel(const StateVector& state, const std::vector<size_t>& indices, const std::vector<size_t>& externalIndices);
+        virtual void applyGenerator(const StateVector& state, const std::vector<size_t>& indices, const std::vector<size_t>& externalIndices);
+        static const double generatorScalingFactor;
     };
 
     class CRotationZGate : public TwoQubitGate {
@@ -276,6 +298,8 @@ namespace Pennylane {
             return matrix;
         }
         void applyKernel(const StateVector& state, const std::vector<size_t>& indices, const std::vector<size_t>& externalIndices);
+        virtual void applyGenerator(const StateVector& state, const std::vector<size_t>& indices, const std::vector<size_t>& externalIndices);
+        static const double generatorScalingFactor;
     };
 
     class CGeneralRotationGate : public TwoQubitGate {

--- a/pennylane_lightning/src/Gates.hpp
+++ b/pennylane_lightning/src/Gates.hpp
@@ -32,8 +32,10 @@ namespace Pennylane {
     public:
         const int numQubits;
         const size_t length;
+
     protected:
         AbstractGate(int numQubits);
+
     public:
         /**
          * @return the matrix representation for the gate as a one-dimensional vector.
@@ -44,7 +46,7 @@ namespace Pennylane {
          * Generic matrix-multiplication kernel
          */
         virtual void applyKernel(const StateVector& state, const std::vector<size_t>& indices, const std::vector<size_t>& externalIndices, bool inverse);
-        
+
         /**
          * Generic matrix-multiplication kernel for applying the generator of an operation
          */
@@ -66,6 +68,7 @@ namespace Pennylane {
     class XGate : public SingleQubitGate {
     private:
         static const std::vector<CplxType> matrix;
+
     public:
         static const std::string label;
         static XGate create(const std::vector<double>& parameters);
@@ -78,6 +81,7 @@ namespace Pennylane {
     class YGate : public SingleQubitGate {
     private:
         static const std::vector<CplxType> matrix;
+
     public:
         static const std::string label;
         static YGate create(const std::vector<double>& parameters);
@@ -90,6 +94,7 @@ namespace Pennylane {
     class ZGate : public SingleQubitGate {
     private:
         static const std::vector<CplxType> matrix;
+
     public:
         static const std::string label;
         static ZGate create(const std::vector<double>& parameters);
@@ -102,6 +107,7 @@ namespace Pennylane {
     class HadamardGate : public SingleQubitGate {
     private:
         static const std::vector<CplxType> matrix;
+
     public:
         static const std::string label;
         static HadamardGate create(const std::vector<double>& parameters);
@@ -114,6 +120,7 @@ namespace Pennylane {
     class SGate : public SingleQubitGate {
     private:
         static const std::vector<CplxType> matrix;
+
     public:
         static const std::string label;
         static SGate create(const std::vector<double>& parameters);
@@ -127,6 +134,7 @@ namespace Pennylane {
     private:
         static const CplxType shift;
         static const std::vector<CplxType> matrix;
+
     public:
         static const std::string label;
         static TGate create(const std::vector<double>& parameters);
@@ -140,6 +148,7 @@ namespace Pennylane {
     private:
         const CplxType c, js;
         const std::vector<CplxType> matrix;
+
     public:
         static const std::string label;
         static RotationXGate create(const std::vector<double>& parameters);
@@ -156,6 +165,7 @@ namespace Pennylane {
     private:
         const CplxType c, s;
         const std::vector<CplxType> matrix;
+
     public:
         static const std::string label;
         static RotationYGate create(const std::vector<double>& parameters);
@@ -172,6 +182,7 @@ namespace Pennylane {
     private:
         const CplxType first, second;
         const std::vector<CplxType> matrix;
+
     public:
         static const std::string label;
         static RotationZGate create(const std::vector<double>& parameters);
@@ -188,6 +199,7 @@ namespace Pennylane {
     private:
         const CplxType shift;
         const std::vector<CplxType> matrix;
+
     public:
         static const std::string label;
         static PhaseShiftGate create(const std::vector<double>& parameters);
@@ -204,6 +216,7 @@ namespace Pennylane {
     private:
         const CplxType c, s, r1, r2, r3, r4;
         const std::vector<CplxType> matrix;
+
     public:
         static const std::string label;
         static GeneralRotationGate create(const std::vector<double>& parameters);
@@ -224,6 +237,7 @@ namespace Pennylane {
     class CNOTGate : public TwoQubitGate {
     private:
         static const std::vector<CplxType> matrix;
+
     public:
         static const std::string label;
         static CNOTGate create(const std::vector<double>& parameters);
@@ -236,6 +250,7 @@ namespace Pennylane {
     class SWAPGate : public TwoQubitGate {
     private:
         static const std::vector<CplxType> matrix;
+
     public:
         static const std::string label;
         static SWAPGate create(const std::vector<double>& parameters);
@@ -248,6 +263,7 @@ namespace Pennylane {
     class CZGate : public TwoQubitGate {
     private:
         static const std::vector<CplxType> matrix;
+
     public:
         static const std::string label;
         static CZGate create(const std::vector<double>& parameters);
@@ -261,6 +277,7 @@ namespace Pennylane {
     private:
         const CplxType c, js;
         const std::vector<CplxType> matrix;
+
     public:
         static const std::string label;
         static CRotationXGate create(const std::vector<double>& parameters);
@@ -277,6 +294,7 @@ namespace Pennylane {
     private:
         const CplxType c, s;
         const std::vector<CplxType> matrix;
+
     public:
         static const std::string label;
         static CRotationYGate create(const std::vector<double>& parameters);
@@ -293,6 +311,7 @@ namespace Pennylane {
     private:
         const CplxType first, second;
         const std::vector<CplxType> matrix;
+
     public:
         static const std::string label;
         static CRotationZGate create(const std::vector<double>& parameters);
@@ -309,6 +328,7 @@ namespace Pennylane {
     private:
         const CplxType c, s, r1, r2, r3, r4;
         const std::vector<CplxType> matrix;
+
     public:
         static const std::string label;
         static CGeneralRotationGate create(const std::vector<double>& parameters);
@@ -329,6 +349,7 @@ namespace Pennylane {
     class ToffoliGate : public ThreeQubitGate {
     private:
         static const std::vector<CplxType> matrix;
+
     public:
         static const std::string label;
         static ToffoliGate create(const std::vector<double>& parameters);
@@ -341,6 +362,7 @@ namespace Pennylane {
     class CSWAPGate : public ThreeQubitGate {
     private:
         static const std::vector<CplxType> matrix;
+
     public:
         static const std::string label;
         static CSWAPGate create(const std::vector<double>& parameters);

--- a/pennylane_lightning/src/Gates.hpp
+++ b/pennylane_lightning/src/Gates.hpp
@@ -48,7 +48,7 @@ namespace Pennylane {
         /**
          * Generic matrix-multiplication kernel for applying the generator of an operation
          */
-        virtual void applyGenerator(const StateVector& state, const std::vector<size_t>& indices, const std::vector<size_t>& externalIndices);
+        void applyGenerator(const StateVector& state, const std::vector<size_t>& indices, const std::vector<size_t>& externalIndices);
 
         /**
          * Scaling factor applied to the generator operation
@@ -147,7 +147,7 @@ namespace Pennylane {
         inline const std::vector<CplxType>& asMatrix() {
             return matrix;
         }
-        virtual void applyGenerator(const StateVector& state, const std::vector<size_t>& indices, const std::vector<size_t>& externalIndices);
+        void applyGenerator(const StateVector& state, const std::vector<size_t>& indices, const std::vector<size_t>& externalIndices);
         static const double generatorScalingFactor;
     };
 
@@ -162,7 +162,7 @@ namespace Pennylane {
         inline const std::vector<CplxType>& asMatrix() {
             return matrix;
         }
-        virtual void applyGenerator(const StateVector& state, const std::vector<size_t>& indices, const std::vector<size_t>& externalIndices);
+        void applyGenerator(const StateVector& state, const std::vector<size_t>& indices, const std::vector<size_t>& externalIndices);
         static const double generatorScalingFactor;
     };
 
@@ -178,7 +178,7 @@ namespace Pennylane {
             return matrix;
         }
         void applyKernel(const StateVector& state, const std::vector<size_t>& indices, const std::vector<size_t>& externalIndices);
-        virtual void applyGenerator(const StateVector& state, const std::vector<size_t>& indices, const std::vector<size_t>& externalIndices);
+        void applyGenerator(const StateVector& state, const std::vector<size_t>& indices, const std::vector<size_t>& externalIndices);
         static const double generatorScalingFactor;
     };
 
@@ -194,7 +194,7 @@ namespace Pennylane {
             return matrix;
         }
         void applyKernel(const StateVector& state, const std::vector<size_t>& indices, const std::vector<size_t>& externalIndices);
-        virtual void applyGenerator(const StateVector& state, const std::vector<size_t>& indices, const std::vector<size_t>& externalIndices);
+        void applyGenerator(const StateVector& state, const std::vector<size_t>& indices, const std::vector<size_t>& externalIndices);
         static const double generatorScalingFactor;
     };
 
@@ -266,7 +266,7 @@ namespace Pennylane {
             return matrix;
         }
         void applyKernel(const StateVector& state, const std::vector<size_t>& indices, const std::vector<size_t>& externalIndices);
-        virtual void applyGenerator(const StateVector& state, const std::vector<size_t>& indices, const std::vector<size_t>& externalIndices);
+        void applyGenerator(const StateVector& state, const std::vector<size_t>& indices, const std::vector<size_t>& externalIndices);
         static const double generatorScalingFactor;
     };
 
@@ -282,7 +282,7 @@ namespace Pennylane {
             return matrix;
         }
         void applyKernel(const StateVector& state, const std::vector<size_t>& indices, const std::vector<size_t>& externalIndices);
-        virtual void applyGenerator(const StateVector& state, const std::vector<size_t>& indices, const std::vector<size_t>& externalIndices);
+        void applyGenerator(const StateVector& state, const std::vector<size_t>& indices, const std::vector<size_t>& externalIndices);
         static const double generatorScalingFactor;
     };
 
@@ -298,7 +298,7 @@ namespace Pennylane {
             return matrix;
         }
         void applyKernel(const StateVector& state, const std::vector<size_t>& indices, const std::vector<size_t>& externalIndices);
-        virtual void applyGenerator(const StateVector& state, const std::vector<size_t>& indices, const std::vector<size_t>& externalIndices);
+        void applyGenerator(const StateVector& state, const std::vector<size_t>& indices, const std::vector<size_t>& externalIndices);
         static const double generatorScalingFactor;
     };
 

--- a/pennylane_lightning/src/Gates.hpp
+++ b/pennylane_lightning/src/Gates.hpp
@@ -50,7 +50,7 @@ namespace Pennylane {
         /**
          * Kernel for applying the generator of an operation
          */
-        void applyGenerator(const StateVector& state, const std::vector<size_t>& indices, const std::vector<size_t>& externalIndices);
+        virtual void applyGenerator(const StateVector& state, const std::vector<size_t>& indices, const std::vector<size_t>& externalIndices);
 
         /**
          * Scaling factor applied to the generator operation

--- a/pennylane_lightning/src/Util.hpp
+++ b/pennylane_lightning/src/Util.hpp
@@ -55,5 +55,5 @@ std::unique_ptr<T> make_unique(Args&&... args) {
 class NotImplementedException : public std::logic_error
 {
 public:
-    NotImplementedException() : std::logic_error("Function not yet implemented") { };
+    NotImplementedException() : std::logic_error("Function is not implemented.") { };
 };

--- a/pennylane_lightning/src/Util.hpp
+++ b/pennylane_lightning/src/Util.hpp
@@ -51,7 +51,7 @@ std::unique_ptr<T> make_unique(Args&&... args) {
     return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
 }
 
-// Exception for functions that arent't implemented
+// Exception for functions that aren't implemented
 class NotImplementedException : public std::logic_error
 {
 public:

--- a/pennylane_lightning/src/Util.hpp
+++ b/pennylane_lightning/src/Util.hpp
@@ -50,3 +50,10 @@ template<typename T, typename... Args>
 std::unique_ptr<T> make_unique(Args&&... args) {
     return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
 }
+
+// Exception for functions that arent't implemented
+class NotImplementedException : public std::logic_error
+{
+public:
+    NotImplementedException() : std::logic_error("Function not yet implemented") { };
+};


### PR DESCRIPTION
Adds an `applyGenerator` method for all supported gates, which applied the corresponding generator to a state, and a `generatorScalingFactor` that returns the shift for the particular gate, for use in the adjoint method.