### PR TITLE
Update plugin by removing `analytic` argument for device creation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,5 +74,5 @@ jobs:
 
       - name: Run PennyLane shared test suite
         run: |
-          pl-device-test --device lightning.qubit --analytic False --skip-ops --shots=20000
-          pl-device-test --device lightning.qubit --analytic True --skip-ops
+          pl-device-test --device lightning.qubit --skip-ops --shots=20000
+          pl-device-test --device lightning.qubit --shots=None --skip-ops

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@
 
 This release contains contributions from (in alphabetical order):
 
-Thomas Bromley, Christina Lee, Thomas Loke, Antal Száva.
+Thomas Bromley, Theodor Isacsson, Christina Lee, Thomas Loke, Antal Száva.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,15 @@
-# Release 0.15.0-dev
+# Release 0.15.0
 
 ### New features since last release
 
 ### Breaking changes
 
 ### Improvements
+
+* For compatibility with PennyLane v0.15, the `analytic` keyword argument
+  has been removed. Statistics can still be computed analytically by setting
+  `shots=None`.
+  [(#93)](https://github.com/PennyLaneAI/pennylane-lightning/pull/93)
 
 * Inverse gates are now supported.
   [(#89)](https://github.com/PennyLaneAI/pennylane-lightning/pull/89)
@@ -14,8 +19,6 @@
 
 * Remove the previous Eigen-based backend.
   [(#67)](https://github.com/PennyLaneAI/pennylane-lightning/pull/67)
-
-### Documentation
 
 ### Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Release 0.15.0
 
-### New features since last release
-
-### Breaking changes
-
 ### Improvements
 
 * For compatibility with PennyLane v0.15, the `analytic` keyword argument

--- a/pennylane_lightning/_version.py
+++ b/pennylane_lightning/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.15.0-dev"
+__version__ = "0.15.0"

--- a/pennylane_lightning/lightning_qubit.py
+++ b/pennylane_lightning/lightning_qubit.py
@@ -42,7 +42,7 @@ class LightningQubit(DefaultQubit):
 
     name = "Lightning Qubit PennyLane plugin"
     short_name = "lightning.qubit"
-    pennylane_requires = ">=0.12"
+    pennylane_requires = ">=0.15"
     version = __version__
     author = "Xanadu Inc."
 

--- a/pennylane_lightning/lightning_qubit.py
+++ b/pennylane_lightning/lightning_qubit.py
@@ -35,12 +35,9 @@ class LightningQubit(DefaultQubit):
     Args:
         wires (int): the number of wires to initialize the device with
         shots (int): How many times the circuit should be evaluated (or sampled) to estimate
-            the expectation values. Defaults to 1000 if not specified.
-            If ``analytic == True``, then the number of shots is ignored
-            in the calculation of expectation values and variances, and only controls the number
-            of samples returned by ``sample``.
-        analytic (bool): indicates if the device should calculate expectations
-            and variances analytically
+            the expectation values. Defaults to 1000 if not specified. Setting
+            to ``None`` results in computing statistics like expectation values and
+            variances analytically.
     """
 
     name = "Lightning Qubit PennyLane plugin"
@@ -76,8 +73,8 @@ class LightningQubit(DefaultQubit):
 
     observables = {"PauliX", "PauliY", "PauliZ", "Hadamard", "Hermitian", "Identity"}
 
-    def __init__(self, wires, *, shots=1000, analytic=True):
-        super().__init__(wires, shots=shots, analytic=analytic)
+    def __init__(self, wires, *, shots=None):
+        super().__init__(wires, shots=shots)
 
     @classmethod
     def capabilities(cls):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 flaky
 numpy
-pennylane>=0.12
+git+https://github.com/PennyLaneAI/pennylane.git
 pybind11
 pytest
 pytest-cov

--- a/setup.py
+++ b/setup.py
@@ -173,7 +173,7 @@ else:
 
 requirements = [
     "numpy",
-    "git+https://github.com/PennyLaneAI/pennylane.git",
+    "pennylane @ git+https://github.com/PennyLaneAI/pennylane.git",
     "pybind11",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -173,7 +173,7 @@ else:
 
 requirements = [
     "numpy",
-    "pennylane>=0.12.0",
+    "git+https://github.com/PennyLaneAI/pennylane.git",
     "pybind11",
 ]
 

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -1128,13 +1128,19 @@ class TestTensorVar:
         assert np.allclose(res, expected, atol=tol, rtol=0)
 
 
-@pytest.mark.parametrize("theta, phi, varphi", list(zip(THETA, PHI, VARPHI)))
-class TestTensorSample:
-    """Test tensor expectation values"""
+# Tolerance for non-analytic tests
+TOL_STOCHASTIC = 0.05
 
-    def test_paulix_pauliy(self, theta, phi, varphi, monkeypatch, tol):
+
+@pytest.mark.parametrize("theta, phi, varphi", list(zip(THETA, PHI, VARPHI)))
+@pytest.mark.parametrize("shots", [None, 100000])
+class TestTensorSample:
+    """Test sampling tensor the tensor product of observables"""
+
+    def test_paulix_pauliy(self, theta, phi, varphi, shots, monkeypatch, tol):
         """Test that a tensor product involving PauliX and PauliY works correctly"""
-        dev = qml.device("lightning.qubit", wires=3, shots=None)
+        tolerance = tol if shots is None else TOL_STOCHASTIC
+        dev = qml.device("lightning.qubit", wires=3, shots=shots)
 
         obs = qml.PauliX(0) @ qml.PauliY(2)
 
@@ -1150,18 +1156,17 @@ class TestTensorSample:
         )
 
         dev._wires_measured = {0, 1, 2}
-        dev._samples = dev.generate_samples()
-        dev.sample(obs)
+        dev._samples = dev.generate_samples() if shots is not None else None
 
         s1 = obs.eigvals
         p = dev.probability(wires=obs.wires)
 
         # s1 should only contain 1 and -1
-        assert np.allclose(s1 ** 2, 1, atol=tol, rtol=0)
+        assert np.allclose(s1 ** 2, 1, atol=tolerance, rtol=0)
 
         mean = s1 @ p
         expected = np.sin(theta) * np.sin(phi) * np.sin(varphi)
-        assert np.allclose(mean, expected, atol=tol, rtol=0)
+        assert np.allclose(mean, expected, atol=tolerance, rtol=0)
 
         var = (s1 ** 2) @ p - (s1 @ p).real ** 2
         expected = (
@@ -1172,10 +1177,11 @@ class TestTensorSample:
             + 2 * np.cos(2 * phi)
             + 14
         ) / 16
-        assert np.allclose(var, expected, atol=tol, rtol=0)
+        assert np.allclose(var, expected, atol=tolerance, rtol=0)
 
-    def test_pauliz_hadamard(self, theta, phi, varphi, monkeypatch, qubit_device_3_wires, tol):
+    def test_pauliz_hadamard(self, theta, phi, varphi, monkeypatch, shots, qubit_device_3_wires, tol):
         """Test that a tensor product involving PauliZ and PauliY and hadamard works correctly"""
+        tolerance = tol if shots is None else TOL_STOCHASTIC
         dev = qubit_device_3_wires
         obs = qml.PauliZ(0) @ qml.Hadamard(1) @ qml.PauliY(2)
         dev.apply(
@@ -1190,8 +1196,7 @@ class TestTensorSample:
         )
 
         dev._wires_measured = {0, 1, 2}
-        dev._samples = dev.generate_samples()
-        dev.sample(obs)
+        dev._samples = dev.generate_samples() if shots is not None else None
 
         s1 = obs.eigvals
         p = dev.marginal_prob(dev.probability(), wires=obs.wires)
@@ -1210,4 +1215,4 @@ class TestTensorSample:
             - np.cos(2 * theta) * np.sin(varphi) ** 2
             - 2 * np.cos(theta) * np.sin(phi) * np.sin(2 * varphi)
         ) / 4
-        assert np.allclose(var, expected, atol=tol, rtol=0)
+        assert np.allclose(var, expected, atol=tolerance, rtol=0)

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -422,7 +422,7 @@ class TestExpval:
 
     def test_expval_estimate(self):
         """Test that the expectation value is not analytically calculated"""
-        dev = qml.device("lightning.qubit", wires=1, shots=3, analytic=False)
+        dev = qml.device("lightning.qubit", wires=1, shots=3)
 
         @qml.qnode(dev)
         def circuit():
@@ -476,7 +476,7 @@ class TestVar:
     def test_var_estimate(self):
         """Test that the variance is not analytically calculated"""
 
-        dev = qml.device("lightning.qubit", wires=1, shots=3, analytic=False)
+        dev = qml.device("lightning.qubit", wires=1, shots=3)
 
         @qml.qnode(dev)
         def circuit():
@@ -554,8 +554,7 @@ class TestLightningQubitIntegration:
 
         dev = qml.device("lightning.qubit", wires=2)
         assert dev.num_wires == 2
-        assert dev.shots == 1000
-        assert dev.analytic
+        assert dev.shots is None
         assert dev.short_name == "lightning.qubit"
 
     def test_no_backprop(self):
@@ -617,8 +616,8 @@ class TestLightningQubitIntegration:
     def test_nonzero_shots(self, tol):
         """Test that the default qubit plugin provides correct result for high shot number"""
 
-        shots = 10 ** 5
-        dev = qml.device("lightning.qubit", wires=1)
+        shots = 10 ** 4
+        dev = qml.device("lightning.qubit", wires=1, shots=shots)
 
         p = 0.543
 
@@ -632,7 +631,7 @@ class TestLightningQubitIntegration:
         for _ in range(100):
             runs.append(circuit(p))
 
-        assert np.isclose(np.mean(runs), -np.sin(p), atol=tol, rtol=0)
+        assert np.isclose(np.mean(runs), -np.sin(p), atol=1e-3, rtol=0)
 
     # This test is ran against the state |0> with one Z expval
     @pytest.mark.parametrize(
@@ -1135,7 +1134,7 @@ class TestTensorSample:
 
     def test_paulix_pauliy(self, theta, phi, varphi, monkeypatch, tol):
         """Test that a tensor product involving PauliX and PauliY works correctly"""
-        dev = qml.device("lightning.qubit", wires=3, shots=10000)
+        dev = qml.device("lightning.qubit", wires=3, shots=None)
 
         obs = qml.PauliX(0) @ qml.PauliY(2)
 

--- a/tests/test_expval.py
+++ b/tests/test_expval.py
@@ -129,7 +129,6 @@ class TestExpval:
 
 
 @pytest.mark.parametrize("theta,phi,varphi", list(zip(THETA, PHI, VARPHI)))
-@pytest.mark.parametrize("shots", [None])
 class TestTensorExpval:
     """Test tensor expectation values"""
 

--- a/tests/test_expval.py
+++ b/tests/test_expval.py
@@ -30,7 +30,7 @@ VARPHI = np.linspace(0.02, 1, 3)
 
 
 @pytest.mark.parametrize("theta, phi", list(zip(THETA, PHI)))
-@pytest.mark.parametrize("shots", [8192])
+@pytest.mark.parametrize("shots", [None])
 class TestExpval:
     """Test expectation values"""
 
@@ -130,7 +130,7 @@ class TestExpval:
 
 
 @pytest.mark.parametrize("theta,phi,varphi", list(zip(THETA, PHI, VARPHI)))
-@pytest.mark.parametrize("shots", [8192])
+@pytest.mark.parametrize("shots", [None])
 class TestTensorExpval:
     """Test tensor expectation values"""
 

--- a/tests/test_expval.py
+++ b/tests/test_expval.py
@@ -30,11 +30,10 @@ VARPHI = np.linspace(0.02, 1, 3)
 
 
 @pytest.mark.parametrize("theta, phi", list(zip(THETA, PHI)))
-@pytest.mark.parametrize("shots", [None])
 class TestExpval:
     """Test expectation values"""
 
-    def test_identity_expectation(self, theta, phi, shots, qubit_device_3_wires, tol):
+    def test_identity_expectation(self, theta, phi, qubit_device_3_wires, tol):
         """Test that identity expectation value (i.e. the trace) is 1"""
         dev = qubit_device_3_wires
 
@@ -53,7 +52,7 @@ class TestExpval:
         res = np.array([dev.expval(O1), dev.expval(O2)])
         assert np.allclose(res, np.array([1, 1]), tol)
 
-    def test_pauliz_expectation(self, theta, phi, shots, qubit_device_3_wires, tol):
+    def test_pauliz_expectation(self, theta, phi, qubit_device_3_wires, tol):
         """Test that PauliZ expectation value is correct"""
         dev = qubit_device_3_wires
         O1 = qml.PauliZ(wires=[0])
@@ -71,7 +70,7 @@ class TestExpval:
         res = np.array([dev.expval(O1), dev.expval(O2)])
         assert np.allclose(res, np.array([np.cos(theta), np.cos(theta) * np.cos(phi)]), tol)
 
-    def test_paulix_expectation(self, theta, phi, shots, qubit_device_3_wires, tol):
+    def test_paulix_expectation(self, theta, phi, qubit_device_3_wires, tol):
         """Test that PauliX expectation value is correct"""
         dev = qubit_device_3_wires
         O1 = qml.PauliX(wires=[0])
@@ -89,7 +88,7 @@ class TestExpval:
         res = np.array([dev.expval(O1), dev.expval(O2)])
         assert np.allclose(res, np.array([np.sin(theta) * np.sin(phi), np.sin(phi)]), tol)
 
-    def test_pauliy_expectation(self, theta, phi, shots, qubit_device_3_wires, tol):
+    def test_pauliy_expectation(self, theta, phi, qubit_device_3_wires, tol):
         """Test that PauliY expectation value is correct"""
         dev = qubit_device_3_wires
         O1 = qml.PauliY(wires=[0])
@@ -107,7 +106,7 @@ class TestExpval:
         res = np.array([dev.expval(O1), dev.expval(O2)])
         assert np.allclose(res, np.array([0, -np.cos(theta) * np.sin(phi)]), tol)
 
-    def test_hadamard_expectation(self, theta, phi, shots, qubit_device_3_wires, tol):
+    def test_hadamard_expectation(self, theta, phi, qubit_device_3_wires, tol):
         """Test that Hadamard expectation value is correct"""
         dev = qubit_device_3_wires
         O1 = qml.Hadamard(wires=[0])
@@ -134,7 +133,7 @@ class TestExpval:
 class TestTensorExpval:
     """Test tensor expectation values"""
 
-    def test_paulix_pauliy(self, theta, phi, varphi, shots, qubit_device_3_wires, tol):
+    def test_paulix_pauliy(self, theta, phi, varphi, qubit_device_3_wires, tol):
         """Test that a tensor product involving PauliX and PauliY works
         correctly"""
         dev = qubit_device_3_wires
@@ -156,7 +155,7 @@ class TestTensorExpval:
 
         assert np.allclose(res, expected, tol)
 
-    def test_pauliz_identity(self, theta, phi, varphi, shots, qubit_device_3_wires, tol):
+    def test_pauliz_identity(self, theta, phi, varphi, qubit_device_3_wires, tol):
         """Test that a tensor product involving PauliZ and Identity works
         correctly"""
         dev = qubit_device_3_wires
@@ -179,7 +178,7 @@ class TestTensorExpval:
 
         assert np.allclose(res, expected, tol)
 
-    def test_pauliz_hadamard_pauliy(self, theta, phi, varphi, shots, qubit_device_3_wires, tol):
+    def test_pauliz_hadamard_pauliy(self, theta, phi, varphi, qubit_device_3_wires, tol):
         """Test that a tensor product involving PauliZ and PauliY and hadamard
         works correctly"""
         dev = qubit_device_3_wires

--- a/tests/test_var.py
+++ b/tests/test_var.py
@@ -30,13 +30,12 @@ VARPHI = np.linspace(0.02, 1, 3)
 
 
 @pytest.mark.parametrize("theta, phi", list(zip(THETA, PHI)))
-@pytest.mark.parametrize("shots", [None])
 class TestVar:
     """Tests for the variance"""
 
-    def test_var(self, theta, phi, shots, tol):
+    def test_var(self, theta, phi, tol):
         """Tests for variance calculation"""
-        dev = qml.device("lightning.qubit", wires=3, shots=shots)
+        dev = qml.device("lightning.qubit", wires=3)
 
         # test correct variance for <Z> of a rotated state
         observable = qml.PauliZ(wires=[0])
@@ -56,13 +55,12 @@ class TestVar:
 
 
 @pytest.mark.parametrize("theta, phi, varphi", list(zip(THETA, PHI, VARPHI)))
-@pytest.mark.parametrize("shots", [None])
 class TestTensorVar:
     """Tests for variance of tensor observables"""
 
-    def test_paulix_pauliy(self, theta, phi, varphi, shots, tol):
+    def test_paulix_pauliy(self, theta, phi, varphi, tol):
         """Test that a tensor product involving PauliX and PauliY works correctly"""
-        dev = qml.device("lightning.qubit", wires=3, shots=shots)
+        dev = qml.device("lightning.qubit", wires=3)
         obs = qml.PauliX(0) @ qml.PauliY(2)
 
         dev.apply(
@@ -89,7 +87,7 @@ class TestTensorVar:
 
         assert np.allclose(res, expected, tol)
 
-    def test_pauliz_hadamard_pauliy(self, theta, phi, varphi, shots, tol):
+    def test_pauliz_hadamard_pauliy(self, theta, phi, varphi, tol):
         """Test that a tensor product involving PauliZ and PauliY and hadamard works correctly"""
         dev = qml.device("lightning.qubit", wires=3)
         obs = qml.PauliZ(0) @ qml.Hadamard(1) @ qml.PauliY(2)

--- a/tests/test_var.py
+++ b/tests/test_var.py
@@ -30,13 +30,13 @@ VARPHI = np.linspace(0.02, 1, 3)
 
 
 @pytest.mark.parametrize("theta, phi", list(zip(THETA, PHI)))
-@pytest.mark.parametrize("shots", [8192])
+@pytest.mark.parametrize("shots", [None])
 class TestVar:
     """Tests for the variance"""
 
     def test_var(self, theta, phi, shots, tol):
         """Tests for variance calculation"""
-        dev = qml.device("lightning.qubit", wires=3)
+        dev = qml.device("lightning.qubit", wires=3, shots=shots)
 
         # test correct variance for <Z> of a rotated state
         observable = qml.PauliZ(wires=[0])
@@ -56,13 +56,13 @@ class TestVar:
 
 
 @pytest.mark.parametrize("theta, phi, varphi", list(zip(THETA, PHI, VARPHI)))
-@pytest.mark.parametrize("shots", [8192])
+@pytest.mark.parametrize("shots", [None])
 class TestTensorVar:
     """Tests for variance of tensor observables"""
 
     def test_paulix_pauliy(self, theta, phi, varphi, shots, tol):
         """Test that a tensor product involving PauliX and PauliY works correctly"""
-        dev = qml.device("lightning.qubit", wires=3)
+        dev = qml.device("lightning.qubit", wires=3, shots=shots)
         obs = qml.PauliX(0) @ qml.PauliY(2)
 
         dev.apply(


### PR DESCRIPTION
Updates the plugin to cope with removing the `analytic` keyword argument as per https://github.com/PennyLaneAI/pennylane/pull/1079.