### PR TITLE
Matrix utility functions for using `std::vector`

### DIFF
--- a/pennylane_lightning/src/Util.cpp
+++ b/pennylane_lightning/src/Util.cpp
@@ -1,0 +1,65 @@
+// Copyright 2021 Xanadu Quantum Technologies Inc.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+/**
+ * @file
+ * Contains uncategorised utility functions.
+ */
+#include "Util.hpp"
+#include <math.h> 
+
+void Pennylane::set_block(Pennylane::CplxType* mx, const size_t &dim, const size_t &start_ind, CplxType* block_mx, const size_t &block_dim){
+
+    auto row_of_start = floor(start_ind/dim);
+    auto col_of_start = start_ind % dim;
+
+    if (dim - row_of_start < block_dim || dim - col_of_start < block_dim)
+        throw std::invalid_argument(std::string("The block of the matrix determined by the start index needs to be greater than or equal to the dimension of the submatrix."));
+
+    size_t i = 0;
+    for(size_t j = 0; j<block_dim*block_dim; j+=block_dim){
+        for(size_t k = 0; k<block_dim; ++k){
+            mx[start_ind + i + k] = block_mx[k+j];
+        }
+        i += dim;
+    }
+}
+
+void Pennylane::swap_cols(CplxType* mx, const size_t &dim, const size_t column1, const size_t column2){
+
+    if (column1 >= dim || column2 >= dim)
+        throw std::invalid_argument(std::string("The indices of the columns need to be smaller than the dimension of the matrix."));
+
+    for(size_t i=0; i<dim; ++i){
+        auto row_num = i*dim;
+        std::swap(mx[row_num +column1], mx[row_num +column2]);
+    }
+}
+
+void Pennylane::swap_rows(CplxType* mx, const size_t &dim, const size_t row1, const size_t row2){
+    if (row1 >= dim || row2 >= dim)
+        throw std::invalid_argument(std::string("The indices of the rows need to be smaller than the dimension of the matrix."));
+
+    for(size_t i = 0; i<dim; ++i){
+        std::swap(mx[row1 * dim +i], mx[row2 * dim +i]);
+    }
+}
+
+std::vector<Pennylane::CplxType> Pennylane::create_identity(const size_t & dim){
+    std::vector<CplxType> identity(dim * dim);
+    for (size_t i = 0; i< identity.size(); i+=(dim+1)){
+        identity.at(i) = 1;
+    }
+    return identity;
+}
+

--- a/pennylane_lightning/src/Util.cpp
+++ b/pennylane_lightning/src/Util.cpp
@@ -19,7 +19,6 @@
 #include <math.h> 
 
 void Pennylane::set_block(Pennylane::CplxType* mx, const size_t &dim, const size_t &start_ind, CplxType* block_mx, const size_t &block_dim){
-
     auto row_of_start = floor(start_ind/dim);
     auto col_of_start = start_ind % dim;
 
@@ -36,7 +35,6 @@ void Pennylane::set_block(Pennylane::CplxType* mx, const size_t &dim, const size
 }
 
 void Pennylane::swap_cols(CplxType* mx, const size_t &dim, const size_t column1, const size_t column2){
-
     if (column1 >= dim || column2 >= dim)
         throw std::invalid_argument(std::string("The indices of the columns need to be smaller than the dimension of the matrix."));
 

--- a/pennylane_lightning/src/Util.hpp
+++ b/pennylane_lightning/src/Util.hpp
@@ -57,6 +57,26 @@ namespace Pennylane {
      * @param block_dim the dimension of the submatrix
      */
     void set_block(Pennylane::CplxType* mx, const size_t &dim, const size_t &start_ind, CplxType* block_mx, const size_t &block_dim);
+
+    /**
+     * In-place swaps two columns of a matrix.
+     *
+     * @param mx pointer to the complex-typed matrix in a row-major vector representation
+     * @param dim the dimension of the matrix
+     * @param column1 the index of the first column
+     * @param column2 the index of the second column
+     */
+    void swap_cols(CplxType* mx, const size_t &dim, const size_t column1, const size_t column2);
+
+    /**
+     * In-place swaps two rows of a matrix.
+     *
+     * @param mx pointer to the complex-typed matrix in a row-major vector representation
+     * @param dim the dimension of the matrix
+     * @param row1 the index of the first row
+     * @param row2 the index of the second row
+     */
+    void swap_rows(CplxType* mx, const size_t &dim, const size_t row1, const size_t row2);
 }
 
 // Helper similar to std::make_unique from c++14

--- a/pennylane_lightning/src/Util.hpp
+++ b/pennylane_lightning/src/Util.hpp
@@ -19,7 +19,7 @@
 
 #include <assert.h>
 #include <memory>
-#include <iostream>
+#include <vector>
 
 #include "typedefs.hpp"
 
@@ -46,6 +46,14 @@ namespace Pennylane {
         assert(qubitIndex < qubits);
         return exp2(qubits - qubitIndex - 1);
     }
+
+    /**
+     * Creates the identity matrix with a specific dimension.
+     *
+     * @param dim the dimension of the matrix
+     * @return the identity matrix of size dim
+     */
+    std::vector<CplxType> create_identity(const size_t & dim);
 
     /**
      * Sets a matrix block with the defined submatrix in-place.

--- a/pennylane_lightning/src/Util.hpp
+++ b/pennylane_lightning/src/Util.hpp
@@ -18,12 +18,16 @@
 #pragma once
 
 #include <assert.h>
+#include <memory>
+#include <iostream>
+
+#include "typedefs.hpp"
 
 namespace Pennylane {
 
     /**
      * Calculates 2^n for some integer n > 0 using bitshifts.
-     * 
+     *
      * @param n the exponent
      * @return value of 2^n
      */
@@ -33,7 +37,7 @@ namespace Pennylane {
 
     /**
      * Calculates the decimal value for a qubit, assuming a big-endian convention.
-     * 
+     *
      * @param qubitIndex the index of the qubit in the range [0, qubits)
      * @param qubits the number of qubits in the circuit
      * @return decimal value for the qubit at specified index
@@ -43,6 +47,16 @@ namespace Pennylane {
         return exp2(qubits - qubitIndex - 1);
     }
 
+    /**
+     * Sets a matrix block with the defined submatrix in-place.
+     *
+     * @param mx pointer to the complex-typed matrix in a row-major vector representation
+     * @param dim the dimension of the matrix
+     * @param start_ind the index from which we set the matrix block
+     * @param block_mx the submatrix to use when setting the block
+     * @param block_dim the dimension of the submatrix
+     */
+    void set_block(Pennylane::CplxType* mx, const size_t &dim, const size_t &start_ind, CplxType* block_mx, const size_t &block_dim);
 }
 
 // Helper similar to std::make_unique from c++14

--- a/pennylane_lightning/src/tests/Makefile
+++ b/pennylane_lightning/src/tests/Makefile
@@ -13,8 +13,7 @@
 # limitations under the License.
 CC = g++
 CFLAGS = -std=c++11 -g -Wall -fopenmp -fPIC -I/usr/include \
-	-I../include -I$(GOOGLETEST_DIR)/include \
-	-march=native
+	-I../include -I$(GOOGLETEST_DIR)/include
 
 LFLAGS = -fopenmp -L$(GOOGLETEST_DIR)/lib -lgtest
 
@@ -29,6 +28,9 @@ Gates.o: ../Gates.cpp
 Apply.o: ../Apply.cpp
 	$(CC) $^ $(CFLAGS) -c
 
+Util.o: ../Util.cpp
+	$(CC) $^ $(CFLAGS) -c
+
 lightning_gates_unittest.o: lightning_gates_unittest.cpp
 	$(CC) $^ $(CFLAGS) -c
 
@@ -38,7 +40,7 @@ lightning_apply_unittest.o: lightning_apply_unittest.cpp
 gtest_main.o: gtest_main.cpp
 	$(CC) $^ $(CFLAGS) -c
 
-cpptests: gtest_main.o lightning_util_unittest.o lightning_gates_unittest.o Gates.o lightning_apply_unittest.o Apply.o
+cpptests: gtest_main.o lightning_util_unittest.o Util.o lightning_gates_unittest.o Gates.o lightning_apply_unittest.o Apply.o
 	$(CC) $^ -o $@ $(LFLAGS)
 
 test: cpptests

--- a/pennylane_lightning/src/tests/lightning_util_unittest.cpp
+++ b/pennylane_lightning/src/tests/lightning_util_unittest.cpp
@@ -171,3 +171,106 @@ INSTANTIATE_TEST_SUITE_P (
                 std::make_tuple(vector<CplxType>{0,0,0,0}, 2, 2, vector<CplxType>{1,0,0,1}, 2),
                 std::make_tuple(vector<CplxType>{0,0,0,0}, 2, 4, vector<CplxType>{1}, 1)
                 ));
+
+class SwapCols : public ::testing::TestWithParam<std::tuple<vector<CplxType>, size_t, size_t, size_t, vector<CplxType> > > {
+};
+
+TEST_P(SwapCols, SwapCols) {
+    auto mx = std::get<0>(GetParam());
+    auto dim = std::get<1>(GetParam());
+
+    auto col1 = std::get<2>(GetParam());
+    auto col2 = std::get<3>(GetParam());
+
+    auto expected = std::get<4>(GetParam());
+
+    Pennylane::swap_cols(mx.data(), dim, col1, col2);
+    ASSERT_EQ(mx, expected);
+}
+
+INSTANTIATE_TEST_SUITE_P (
+        SwapColsTests,
+        SwapCols,
+        ::testing::Values(
+                std::make_tuple(vector<CplxType>{1,2,
+                                                 3,4},
+                                                 2, 0, 1,
+                                vector<CplxType>{2,1,
+                                                 4,3}),
+
+
+                std::make_tuple(vector<CplxType>{1,2,
+                                                 3,4},
+                                                 2, 1, 0,
+                                vector<CplxType>{2,1,
+                                                 4,3}),
+
+
+                std::make_tuple(vector<CplxType>{1,2,3,
+                                                 4,5,6,
+                                                 7,8,9},
+                                                 3, 0, 2,
+                                vector<CplxType>{3,2,1,
+                                                 6,5,4,
+                                                 9,8,7}),
+
+
+                std::make_tuple(vector<CplxType>{1,2,3,
+                                                 4,5,6,
+                                                 7,8,9},
+                                                 3, 2, 1,
+                                vector<CplxType>{1,3,2,
+                                                 4,6,5,
+                                                 7,9,8})
+    ));
+
+class SwapRows : public ::testing::TestWithParam<std::tuple<vector<CplxType>, size_t, size_t, size_t, vector<CplxType> > > {
+};
+
+TEST_P(SwapRows, SwapRows) {
+    auto mx = std::get<0>(GetParam());
+    auto dim = std::get<1>(GetParam());
+
+    auto row1 = std::get<2>(GetParam());
+    auto row2 = std::get<3>(GetParam());
+
+    auto expected = std::get<4>(GetParam());
+
+    Pennylane::swap_rows(mx.data(), dim, row1, row2);
+    ASSERT_EQ(mx, expected);
+}
+
+INSTANTIATE_TEST_SUITE_P (
+        SwapRowsTests,
+        SwapRows,
+        ::testing::Values(
+                std::make_tuple(vector<CplxType>{1,2,
+                                                 3,4},
+                                                 2, 0, 1,
+                                vector<CplxType>{3,4,
+                                                 1,2}),
+
+
+                std::make_tuple(vector<CplxType>{1,2,
+                                                 3,4},
+                                                 2, 1, 0,
+                                vector<CplxType>{3,4,
+                                                 1,2}),
+
+
+                std::make_tuple(vector<CplxType>{1,2,3,
+                                                 4,5,6,
+                                                 7,8,9},
+                                                 3, 0, 2,
+                                vector<CplxType>{7,8,9,
+                                                 4,5,6,
+                                                 1,2,3}),
+
+                std::make_tuple(vector<CplxType>{1,2,3,
+                                                 4,5,6,
+                                                 7,8,9},
+                                                 3, 2, 1,
+                                vector<CplxType>{1,2,3,
+                                                 7,8,9,
+                                                 4,5,6})
+    ));

--- a/pennylane_lightning/src/tests/lightning_util_unittest.cpp
+++ b/pennylane_lightning/src/tests/lightning_util_unittest.cpp
@@ -63,6 +63,29 @@ INSTANTIATE_TEST_SUITE_P (
 
 }
 
+class CreateIdentity : public ::testing::TestWithParam<std::tuple<unsigned int, vector<CplxType> > > {
+};
+
+TEST_P(CreateIdentity, CreateIdentity) {
+    const unsigned int dim = std::get<0>(GetParam());
+    const vector<CplxType> expected =std::get<1>(GetParam());
+
+    vector<CplxType> mx = Pennylane::create_identity(dim);
+
+    ASSERT_EQ(mx, expected);
+}
+
+INSTANTIATE_TEST_SUITE_P (
+        IdentityTests,
+        CreateIdentity,
+        ::testing::Values(
+                std::make_tuple(2, vector<CplxType>{1,0,0,1}),
+                std::make_tuple(4, vector<CplxType>{1,0,0,0,
+                                                    0,1,0,0,
+                                                    0,0,1,0,
+                                                    0,0,0,1})
+    ));
+
 class SetBlock : public ::testing::TestWithParam<std::tuple<vector<CplxType>, size_t, size_t, vector<CplxType>, size_t, vector<CplxType> > > {
 };
 


### PR DESCRIPTION
PennyLane-Lightning uses a row-major storage approach to represent matrices in a `std::vector`.

This PR adds 4 utility functions for dealing with matrices stored in a `std::vector`:
* `set_block`: sets the block of a matrix with a submatrix,
* `swap_cols`: swaps two columns of a matrix,
* `swap_rows`: swaps two columns of a matrix,
* `create_identity`: creates the identity matrix with the specified dimension.

These functions can be used as a convenience. This PR reduces some of the new functionality added in #88.