### PR TITLE
Fix the parameters' order in EXPECT_EQ macro

### DIFF
--- a/pennylane_lightning/src/tests/TestingUtils.hpp
+++ b/pennylane_lightning/src/tests/TestingUtils.hpp
@@ -18,7 +18,7 @@
         try { \
             stmt; \
         } catch (const etype& ex) { \
-            EXPECT_EQ(std::string(ex.what()), whatstring); \
+            EXPECT_EQ(whatstring, std::string(ex.what())); \
             throw; \
         } \
     , etype)


### PR DESCRIPTION
EXPECT_EQ is expecting "expected_value, actual_value". But it is having the parameters in reverse order.
