### PR TITLE
Skip Python 3.6 for wheel build & deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,7 @@ on:
     types: [published]
 
 env:
-  CIBW_SKIP: "cp27-* cp34-* cp35-* *i686 pp* *win32"
+  CIBW_SKIP: "cp27-* cp34-* cp35-* cp36-* *i686 pp* *win32"
 
   # MacOS specific build settings
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 env:
-  CIBW_SKIP: "cp27-* cp34-* cp35-* *i686 pp* *win32"
+  CIBW_SKIP: "cp27-* cp34-* cp35-* cp36-* *i686 pp* *win32"
 
   # MacOS specific build settings
 


### PR DESCRIPTION
**Context**

Python 3.6 has been deprecated with the release of PennyLane 0.16.0. The `master` version of PennyLane-Lightning may still use Python 3.6, as `pennylane>=0.15` is the dependence.

Nonetheless, the CI that builds the wheel fails with the latest changes of PennyLane in version 0.16.0 when using Python 3.6.

**Changes**

Removes Python 3.6 runs from the wheel build.

**Related issues**

Closes #105.