### PR TITLE
Add guidelines for lightning.qubit repository

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,46 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at research@xanadu.ai. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 Thank you for taking the time to contribute to PennyLane-Lightning!
 :confetti_ball: :tada: :fireworks: :balloon:
 
-For details on how to contribute, please see the (PennyLane contribution guide)[https://github.com/PennyLaneAI/pennylane/blob/master/.github/CONTRIBUTING.md].
+For details on how to contribute, please see the [PennyLane contribution guide](https://github.com/PennyLaneAI/pennylane/blob/master/.github/CONTRIBUTING.md).
 
 
 \- The PennyLane team

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,9 @@
+# Contributing to PennyLane-Lightning
+
+Thank you for taking the time to contribute to PennyLane-Lightning!
+:confetti_ball: :tada: :fireworks: :balloon:
+
+For details on how to contribute, please see the (PennyLane contribution guide)[https://github.com/PennyLaneAI/pennylane/blob/master/.github/CONTRIBUTING.md].
+
+
+\- The PennyLane team

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,38 @@
+#### Before posting an issue
+
+Search existing GitHub issues to make sure the issue does not already exist:
+https://github.com/xanaduai/pennylane-lightning/issues
+
+If posting a PennyLane-Lightning issue, delete everything above the dashed line, and fill
+in the template. If the issue is a bug, start the title of the issue with [BUG].
+
+If making a feature request, delete the following template and describe, in detail,
+the feature and why it is needed.
+
+For general technical details check out our documentation:
+https://pennylane-lightning.readthedocs.io/
+
+-------------------------------------------------------------------------------------------------------------
+
+#### Issue description
+
+Description of the issue - include code snippets and screenshots here
+if relevant. You may use the following template below
+
+* *Expected behavior:* (What you expect to happen)
+
+* *Actual behavior:* (What actually happens)
+
+* *Reproduces how often:* (What percentage of the time does it reproduce?)
+
+* *System information:* (post the output of `import pennylane as qml; qml.about()`)
+
+#### Source code and tracebacks
+
+Please include any additional code snippets and error tracebacks related
+to the issue here.
+
+#### Additional information
+
+Any additional information, configuration or data that might be necessary
+to reproduce the issue.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,33 @@
+### Before submitting
+
+Please complete the following checklist when submitting a PR:
+
+- [ ] All new features must include a unit test.
+      If you've fixed a bug or added code that should be tested, add a test to the
+      [`tests/`](tests/) directory!
+
+- [ ] All new functions and code must be clearly commented and documented.
+      If you do make documentation changes, make sure that the docs build and
+      render correctly by running `make docs`.
+
+- [ ] Ensure that the test suite passes, by running `make test`.
+
+- [ ] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
+      change, and including a link back to the PR.
+
+- [ ] Ensure that code is properly formatted by running `make format`. 
+
+When all the above are checked, delete everything above the dashed
+line and fill in the pull request template.
+
+------------------------------------------------------------------------------------------------------------
+
+**Context:**
+
+**Description of the Change:**
+
+**Benefits:**
+
+**Possible Drawbacks:**
+
+**Related GitHub Issues:**

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@ Please complete the following checklist when submitting a PR:
 
 - [ ] All new features must include a unit test.
       If you've fixed a bug or added code that should be tested, add a test to the
-      [`tests/`](../tests/) directory!
+      [`tests/`](../tests) directory!
 
 - [ ] All new functions and code must be clearly commented and documented.
       If you do make documentation changes, make sure that the docs build and

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@ Please complete the following checklist when submitting a PR:
 
 - [ ] All new features must include a unit test.
       If you've fixed a bug or added code that should be tested, add a test to the
-      [`tests/`](../tests) directory!
+      [`tests`](../tests) directory!
 
 - [ ] All new functions and code must be clearly commented and documented.
       If you do make documentation changes, make sure that the docs build and

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@ Please complete the following checklist when submitting a PR:
 
 - [ ] All new features must include a unit test.
       If you've fixed a bug or added code that should be tested, add a test to the
-      [`tests/`](tests/) directory!
+      [`tests/`](../tests/) directory!
 
 - [ ] All new functions and code must be clearly commented and documented.
       If you do make documentation changes, make sure that the docs build and


### PR DESCRIPTION
**Context:** Currently there are no repository guidelines for creating issues, PRs, or general contribution information. This PR will add support for this.

**Description of the Change:** Added `CODE_OF_CONDUCT.md`, `CONTRIBUTING.md` `ISSUE_TEMPLATE.md`  and  `PULL_REQUEST_TEMPLATE.md` modeled on main PennyLane repository.

**Benefits:** Enables users to contribute more easily, and adds guidelines for creating PRs.

**Possible Drawbacks:** None

**Related GitHub Issues:**
