### PR TITLE
Refactor the testing infrastructure for templated StateVector implementation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,24 +25,23 @@ jobs:
 
       - name: Build and run unit tests
         run: |
-            cd pennylane_lightning/src/tests
             cmake . -BBuild  -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=1
             cmake --build ./Build
-            ./Build/tests/runner --order lex --reporter junit --out Build/test/results/report.xml
+            ./Build/tests/runner --order lex --reporter junit --out Build/tests/results/report.xml
 
       - name: Upload test results
         uses: actions/upload-artifact@v2
         if: always()
         with:
           name: ubuntu-test-report
-          path: Build/test/results/report.xml
+          path: Build/tests/results/report.xml
 
       - name: Publish test results
         uses: EnricoMi/publish-unit-test-result-action@v1
         if: always()
         with:
           check_name: Test Report (C++) on Ubuntu
-          files: Build/test/results/report.xml
+          files: Build/tests/results/report.xml
 
   pythontests:
     name: Python tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Build and run unit tests
         run: |
             cd pennylane_lightning/src/tests
-            cmake . -BBuild  -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=1 
+            cmake . -BBuild  -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=1
             cmake --build ./Build
             ./Build/tests/runner --order lex --reporter junit --out Build/test/results/report.xml
 
@@ -36,7 +36,7 @@ jobs:
         with:
           name: ubuntu-test-report
           path: Build/test/results/report.xml
-    
+
       - name: Publish test results
         uses: EnricoMi/publish-unit-test-result-action@v1
         if: always()

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,21 +13,36 @@ jobs:
       matrix:
         os: [ubuntu-18.04]
     steps:
+      - name: Cancel previous runs
+        uses: styfle/cancel-workflow-action@0.4.1
+        with:
+          access_token: ${{ github.token }}
+
       - uses: actions/checkout@v2
 
       - name: Install dependencies
         run: sudo apt-get -y -q install cmake gcc
 
-      - name: Install Google Test
-        run: |
-            wget -qO - https://github.com/google/googletest/archive/release-1.10.0.tar.gz | tar -xz
-            cmake -D CMAKE_INSTALL_PREFIX:PATH=$HOME/googletest -D CMAKE_BUILD_TYPE=Release googletest-release-1.10.0
-            make install
-
       - name: Build and run unit tests
         run: |
             cd pennylane_lightning/src/tests
-            GOOGLETEST_DIR=$HOME/googletest make test
+            cmake . -BBuild  -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=1 
+            cmake --build ./Build
+            ./Build/tests/runner --order lex --reporter junit --out Build/test/results/report.xml
+
+      - name: Upload test results
+        uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: ubuntu-test-report
+          path: Build/test/results/report.xml
+    
+      - name: Publish test results
+        uses: EnricoMi/publish-unit-test-result-action@v1
+        if: always()
+        with:
+          check_name: Test Report (C++) on Ubuntu
+          files: Build/test/results/report.xml
 
   pythontests:
     name: Python tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,8 @@ jobs:
         run: |
             cmake . -BBuild  -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=1
             cmake --build ./Build
-            ./Build/tests/runner --order lex --reporter junit --out Build/tests/results/report.xml
+            mkdir -p ./Build/tests/results
+            ./Build/tests/runner --order lex --reporter junit --out ./Build/tests/results/report.xml
 
       - name: Upload test results
         uses: actions/upload-artifact@v2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,26 +35,27 @@ option(BUILD_TESTS "Build cpp tests" OFF)
 # Add pybind11
 include(FetchContent)
 FetchContent_Declare(
-	pybind11
-	GIT_REPOSITORY https://github.com/pybind/pybind11.git
-	GIT_TAG        v2.6.2
+    pybind11
+    GIT_REPOSITORY https://github.com/pybind/pybind11.git
+    GIT_TAG        v2.6.2
 )
 FetchContent_MakeAvailable(pybind11)
 
+add_library(pennylane_lightning SHARED "pennylane_lightning/src/StateVector.cpp")
+target_include_directories(pennylane_lightning INTERFACE "pennylane_lightning/src")
 
 add_library(external_dependency INTERFACE)
 
-
 if ("$ENV{USE_LAPACK}" OR "${USE_LAPACK}")
-	message(STATUS "Use LAPACKE")
-	target_link_libraries(external_dependency INTERFACE lapacke)
-	target_compile_options(external_dependency INTERFACE "-DLAPACKE=1")
+    message(STATUS "Use LAPACKE")
+    target_link_libraries(external_dependency INTERFACE lapacke)
+    target_compile_options(external_dependency INTERFACE "-DLAPACKE=1")
 endif()
 
 if ("$ENV{USE_OPENBLAS}" OR "${USE_OPENBLAS}")
-	message(STATUS "Use OPENBLAS")
-	target_link_libraries(external_dependency INTERFACE openblas)
-	target_compile_options(external_dependency INTERFACE "-DOPENBLAS=1")
+    message(STATUS "Use OPENBLAS")
+    target_link_libraries(external_dependency INTERFACE openblas)
+    target_compile_options(external_dependency INTERFACE "-DOPENBLAS=1")
 endif()
 
 pybind11_add_module(lightning_qubit_ops "pennylane_lightning/src/StateVector.cpp"
@@ -68,12 +69,12 @@ target_compile_options(lightning_qubit_ops PRIVATE "$<$<CONFIG:DEBUG>:-Wall>")
 target_compile_definitions(lightning_qubit_ops PRIVATE VERSION_INFO=${VERSION_STRING})
 
 if(ENABLE_NATIVE)
-	message(STATUS "ENABLE_NATIVE is ON. Use -march=native for lightning_qubit_ops.")
-	target_compile_options(lightning_qubit_ops PRIVATE -march=native)
+    message(STATUS "ENABLE_NATIVE is ON. Use -march=native for lightning_qubit_ops.")
+    target_compile_options(pennylane_lightning PRIVATE -march=native)
+    target_compile_options(lightning_qubit_ops PRIVATE -march=native)
 endif()
 
-
 if (BUILD_TESTS)
-	enable_testing()
-	add_subdirectory("pennylane_lightning/src/tests" "tests")
+    enable_testing()
+    add_subdirectory("pennylane_lightning/src/tests" "tests")
 endif()

--- a/pennylane_lightning/lightning_qubit.py
+++ b/pennylane_lightning/lightning_qubit.py
@@ -94,14 +94,10 @@ class LightningQubit(DefaultQubit):
         # State preparation is currently done in Python
         if operations:  # make sure operations[0] exists
             if isinstance(operations[0], QubitStateVector):
-                self._apply_state_vector(
-                    operations[0].parameters[0].copy(), operations[0].wires
-                )
+                self._apply_state_vector(operations[0].parameters[0].copy(), operations[0].wires)
                 del operations[0]
             elif isinstance(operations[0], BasisState):
-                self._apply_basis_state(
-                    operations[0].parameters[0], operations[0].wires
-                )
+                self._apply_basis_state(operations[0].parameters[0], operations[0].wires)
                 del operations[0]
 
         for operation in operations:
@@ -120,9 +116,7 @@ class LightningQubit(DefaultQubit):
             if any(isinstance(r, QubitUnitary) for r in rotations):
                 super().apply(operations=[], rotations=rotations)
             else:
-                self._state = self.apply_lightning(
-                    np.copy(self._pre_rotated_state), rotations
-                )
+                self._state = self.apply_lightning(np.copy(self._pre_rotated_state), rotations)
         else:
             self._state = self._pre_rotated_state
 

--- a/pennylane_lightning/src/Bindings.cpp
+++ b/pennylane_lightning/src/Bindings.cpp
@@ -65,7 +65,7 @@ template <class fp_t> class StateVecBinder : public StateVector<fp_t> {
 
 template <class PrecisionT> void lightning_class_bindings(py::module &m) {
     // Enable module name to be based on size of complex datatype
-    const std::string bitsize = std::to_string(sizeof(PrecisionT) * 8 * 2 );
+    const std::string bitsize = std::to_string(sizeof(PrecisionT) * 8 * 2);
     const std::string class_name = "StateVectorC" + bitsize;
     py::class_<StateVecBinder<PrecisionT>>(m, class_name.c_str())
         .def(py::init<

--- a/pennylane_lightning/src/StateVector.hpp
+++ b/pennylane_lightning/src/StateVector.hpp
@@ -311,8 +311,8 @@ template <class fp_t = double> class StateVector {
     template <typename Param_t = fp_t>
     static const vector<CFP_t> getRot(Param_t phi, Param_t theta,
                                       Param_t omega) {
-        const CFP_t c{std::cos(theta / 2), 0}, s{std::sin(theta / 2), 0};
-        const fp_t p{phi + omega}, m{phi - omega};
+        const CFP_t c(std::cos(theta / 2), 0), s(std::sin(theta / 2), 0);
+        const fp_t p(phi + omega), m(phi - omega);
         return vector<CFP_t>{
             std::exp(-IMAG * (p / 2)) * c, -std::exp(IMAG * (m / 2)) * s,
             std::exp(-IMAG * (m / 2)) * s, std::exp(IMAG * (p / 2)) * c};
@@ -449,8 +449,8 @@ template <class fp_t = double> class StateVector {
                 const vector<size_t> &externalIndices, bool inverse) {
 
         const CFP_t shift = (inverse == true)
-                                ? std::conj(std::exp(CFP_t{0, M_PI / 4}))
-                                : std::exp(CFP_t{0, M_PI / 4});
+                                ? std::conj(std::exp(CFP_t(0, M_PI / 4)))
+                                : std::exp(CFP_t(0, M_PI / 4));
 
         for (const size_t &externalIndex : externalIndices) {
             CFP_t *shiftedState = arr_ + externalIndex;
@@ -464,8 +464,8 @@ template <class fp_t = double> class StateVector {
                  Param_t angle) {
         const CFP_t c(std::cos(angle / 2), 0);
 
-        const CFP_t js = (inverse == true) ? CFP_t{0, -std::sin(-angle / 2)}
-                                           : CFP_t{0, std::sin(-angle / 2)};
+        const CFP_t js = (inverse == true) ? CFP_t(0, -std::sin(-angle / 2))
+                                           : CFP_t(0, std::sin(-angle / 2));
 
         for (const size_t &externalIndex : externalIndices) {
             CFP_t *shiftedState = arr_ + externalIndex;
@@ -481,8 +481,8 @@ template <class fp_t = double> class StateVector {
                  const vector<size_t> &externalIndices, bool inverse,
                  Param_t angle) {
         const CFP_t c(std::cos(angle / 2), 0);
-        const CFP_t s = (inverse == true) ? CFP_t{-std::sin(angle / 2), 0}
-                                          : CFP_t{std::sin(angle / 2), 0};
+        const CFP_t s = (inverse == true) ? CFP_t(-std::sin(angle / 2), 0)
+                                          : CFP_t(std::sin(angle / 2), 0);
 
         for (const size_t &externalIndex : externalIndices) {
             CFP_t *shiftedState = arr_ + externalIndex;
@@ -497,8 +497,8 @@ template <class fp_t = double> class StateVector {
     void applyRZ(const vector<size_t> &indices,
                  const vector<size_t> &externalIndices, bool inverse,
                  Param_t angle) {
-        const CFP_t first = std::exp(CFP_t{0, -angle / 2});
-        const CFP_t second = std::exp(CFP_t{0, angle / 2});
+        const CFP_t first = std::exp(CFP_t(0, -angle / 2));
+        const CFP_t second = std::exp(CFP_t(0, angle / 2));
         const CFP_t shift1 = (inverse == true) ? std::conj(first) : first;
         const CFP_t shift2 = (inverse == true) ? std::conj(second) : second;
 
@@ -513,8 +513,8 @@ template <class fp_t = double> class StateVector {
     void applyPhaseShift(const vector<size_t> &indices,
                          const vector<size_t> &externalIndices, bool inverse,
                          Param_t angle) {
-        const CFP_t s = (inverse == true) ? conj(std::exp(CFP_t{0, angle}))
-                                          : std::exp(CFP_t{0, angle});
+        const CFP_t s = (inverse == true) ? conj(std::exp(CFP_t(0, angle)))
+                                          : std::exp(CFP_t(0, angle));
 
         for (const size_t &externalIndex : externalIndices) {
             CFP_t *shiftedState = arr_ + externalIndex;
@@ -569,9 +569,9 @@ template <class fp_t = double> class StateVector {
     void applyCRX(const vector<size_t> &indices,
                   const vector<size_t> &externalIndices, bool inverse,
                   Param_t angle) {
-        const CFP_t c{std::cos(angle / 2), 0};
-        const CFP_t js = (inverse == true) ? CFP_t{0, -std::sin(-angle / 2)}
-                                           : CFP_t{0, std::sin(-angle / 2)};
+        const CFP_t c(std::cos(angle / 2), 0);
+        const CFP_t js = (inverse == true) ? CFP_t(0, -std::sin(-angle / 2))
+                                           : CFP_t(0, std::sin(-angle / 2));
 
         for (const size_t &externalIndex : externalIndices) {
             CFP_t *shiftedState = arr_ + externalIndex;
@@ -586,9 +586,9 @@ template <class fp_t = double> class StateVector {
     void applyCRY(const vector<size_t> &indices,
                   const vector<size_t> &externalIndices, bool inverse,
                   Param_t angle) {
-        const CFP_t c{std::cos(angle / 2), 0};
-        const CFP_t s = (inverse == true) ? CFP_t{-std::sin(angle / 2), 0}
-                                          : CFP_t{std::sin(angle / 2), 0};
+        const CFP_t c(std::cos(angle / 2), 0);
+        const CFP_t s = (inverse == true) ? CFP_t(-std::sin(angle / 2), 0)
+                                          : CFP_t(std::sin(angle / 2), 0);
 
         for (const size_t &externalIndex : externalIndices) {
             CFP_t *shiftedState = arr_ + externalIndex;
@@ -604,11 +604,11 @@ template <class fp_t = double> class StateVector {
                   const vector<size_t> &externalIndices, bool inverse,
                   Param_t angle) {
         const CFP_t m00 = (inverse == true)
-                              ? std::conj(std::exp(CFP_t{0, -angle / 2}))
-                              : std::exp(CFP_t{0, -angle / 2});
+                              ? std::conj(std::exp(CFP_t(0, -angle / 2)))
+                              : std::exp(CFP_t(0, -angle / 2));
         const CFP_t m11 = (inverse == true)
-                              ? std::conj(std::exp(CFP_t{0, angle / 2}))
-                              : std::exp(CFP_t{0, angle / 2});
+                              ? std::conj(std::exp(CFP_t(0, angle / 2)))
+                              : std::exp(CFP_t(0, angle / 2));
         for (const size_t &externalIndex : externalIndices) {
             CFP_t *shiftedState = arr_ + externalIndex;
             shiftedState[indices[2]] *= m00;

--- a/pennylane_lightning/src/StateVector.hpp
+++ b/pennylane_lightning/src/StateVector.hpp
@@ -428,7 +428,6 @@ template <class fp_t = double> class StateVector {
 
     void applyHadamard(const vector<size_t> &indices,
                        const vector<size_t> &externalIndices, bool inverse) {
-
         for (const size_t &externalIndex : externalIndices) {
             CFP_t *shiftedState = arr_ + externalIndex;
 

--- a/pennylane_lightning/src/StateVector.hpp
+++ b/pennylane_lightning/src/StateVector.hpp
@@ -55,9 +55,10 @@ template <class fp_t = double> class StateVector {
     static constexpr CFP_t ONE = {1, 0};
     static constexpr CFP_t ZERO = {0, 0};
     static constexpr CFP_t IMAG = {0, 1};
-    inline static const CFP_t SQRT2 = {static_cast<fp_t>(std::sqrt(2)), 0};
-    inline static const CFP_t INVSQRT2 = {static_cast<fp_t>(1 / std::sqrt(2)),
-                                          0};
+    inline static const fp_t SQRT2 = {static_cast<fp_t>(std::sqrt(2))};
+    inline static const fp_t INVSQRT2 = {
+        static_cast<fp_t>(1 / std::sqrt(2)),
+    };
 
     const FMap gates_;
     const std::unordered_map<string, size_t> gate_wires_;
@@ -427,6 +428,7 @@ template <class fp_t = double> class StateVector {
 
     void applyHadamard(const vector<size_t> &indices,
                        const vector<size_t> &externalIndices, bool inverse) {
+
         for (const size_t &externalIndex : externalIndices) {
             CFP_t *shiftedState = arr_ + externalIndex;
 

--- a/pennylane_lightning/src/StateVector.hpp
+++ b/pennylane_lightning/src/StateVector.hpp
@@ -170,8 +170,7 @@ template <class fp_t = double> class StateVector {
      */
     void applyOperations(const vector<string> &ops,
                          const vector<vector<size_t>> &wires,
-                         const vector<bool> &inverse
-                         ) {
+                         const vector<bool> &inverse) {
         const size_t numOperations = ops.size();
         if (numOperations != wires.size())
             throw std::invalid_argument(
@@ -179,7 +178,7 @@ template <class fp_t = double> class StateVector {
                 "parameters must all be equal");
 
         for (size_t i = 0; i < numOperations; i++) {
-            applyOperation(ops[i], wires[i], inverse[i] );
+            applyOperation(ops[i], wires[i], inverse[i]);
         }
     }
 

--- a/pennylane_lightning/src/StateVector.hpp
+++ b/pennylane_lightning/src/StateVector.hpp
@@ -149,7 +149,7 @@ template <class fp_t = double> class StateVector {
     void applyOperations(const vector<string> &ops,
                          const vector<vector<size_t>> &wires,
                          const vector<bool> &inverse,
-                         const vector<vector<fp_t>> &params = {{}}) {
+                         const vector<vector<fp_t>> &params) {
         const size_t numOperations = ops.size();
         if (numOperations != wires.size() || numOperations != params.size())
             throw std::invalid_argument(
@@ -158,6 +158,28 @@ template <class fp_t = double> class StateVector {
 
         for (size_t i = 0; i < numOperations; i++) {
             applyOperation(ops[i], wires[i], inverse[i], params[i]);
+        }
+    }
+    /**
+     * @brief Apply multiple gates to the state-vector.
+     *
+     * @param ops Vector of gate names to be applied in order.
+     * @param wires Vector of wires on which to apply index-matched gate name.
+     * @param inverse Indicates whether gate at matched index is to be inverted.
+     * @param params Optional parameter data for index matched gates.
+     */
+    void applyOperations(const vector<string> &ops,
+                         const vector<vector<size_t>> &wires,
+                         const vector<bool> &inverse
+                         ) {
+        const size_t numOperations = ops.size();
+        if (numOperations != wires.size())
+            throw std::invalid_argument(
+                "Invalid arguments: number of operations, wires, and "
+                "parameters must all be equal");
+
+        for (size_t i = 0; i < numOperations; i++) {
+            applyOperation(ops[i], wires[i], inverse[i] );
         }
     }
 

--- a/pennylane_lightning/src/StateVector.hpp
+++ b/pennylane_lightning/src/StateVector.hpp
@@ -188,16 +188,20 @@ template <class fp_t = double> class StateVector {
      * @param indicesToExclude
      * @return vector<size_t>
      */
-    vector<size_t>
-    getIndicesAfterExclusion(const vector<size_t> &indicesToExclude) {
+    vector<size_t> static getIndicesAfterExclusion(
+        const vector<size_t> &indicesToExclude, size_t num_qubits) {
         std::set<size_t> indices;
-        for (size_t i = 0; i < num_qubits_; i++) {
+        for (size_t i = 0; i < num_qubits; i++) {
             indices.emplace(i);
         }
         for (const size_t &excludedIndex : indicesToExclude) {
             indices.erase(excludedIndex);
         }
         return {indices.begin(), indices.end()};
+    }
+    vector<size_t>
+    getIndicesAfterExclusion(const vector<size_t> &indicesToExclude) {
+        return getIndicesAfterExclusion(indicesToExclude, num_qubits_);
     }
 
     /**
@@ -206,19 +210,26 @@ template <class fp_t = double> class StateVector {
      * @param qubitIndices Indices of the qubits to apply operations.
      * @return vector<size_t>
      */
-    vector<size_t> generateBitPatterns(const vector<size_t> &qubitIndices) {
+    static vector<size_t>
+    generateBitPatterns(const vector<size_t> &qubitIndices, size_t num_qubits) {
         vector<size_t> indices;
         indices.reserve(Util::exp2(qubitIndices.size()));
         indices.emplace_back(0);
-        for (int i = qubitIndices.size() - 1; i >= 0; i--) {
-            size_t value =
-                Util::maxDecimalForQubit(qubitIndices[i], num_qubits_);
-            size_t currentSize = indices.size();
+
+        for (auto index_it = qubitIndices.rbegin();
+             index_it != qubitIndices.rend(); index_it++) {
+            const size_t value =
+                Util::maxDecimalForQubit(*index_it, num_qubits);
+            const size_t currentSize = indices.size();
             for (size_t j = 0; j < currentSize; j++) {
                 indices.emplace_back(indices[j] + value);
             }
         }
         return indices;
+    }
+
+    vector<size_t> generateBitPatterns(const vector<size_t> &qubitIndices) {
+        return generateBitPatterns(qubitIndices, num_qubits_);
     }
 
     static constexpr vector<CFP_t> getPauliX() {

--- a/pennylane_lightning/src/StateVector.hpp
+++ b/pennylane_lightning/src/StateVector.hpp
@@ -18,6 +18,9 @@
 
 #pragma once
 
+// Required for compilation with MSVC
+#define _USE_MATH_DEFINES
+
 #include <cmath>
 #include <complex>
 #include <functional>

--- a/pennylane_lightning/src/StateVector.hpp
+++ b/pennylane_lightning/src/StateVector.hpp
@@ -135,8 +135,7 @@ template <class fp_t = double> class StateVector {
               {"CRZ",
                bind(&StateVector<fp_t>::applyCRZ_, this, _1, _2, _3, _4)},
               {"CRot",
-               bind(&StateVector<fp_t>::applyCRot_, this, _1, _2, _3, _4)}} {
-    };
+               bind(&StateVector<fp_t>::applyCRot_, this, _1, _2, _3, _4)}} {};
 
     CFP_t *getData() { return arr_; }
     std::size_t getLength() { return length_; }
@@ -617,31 +616,37 @@ template <class fp_t = double> class StateVector {
     inline void applyPauliX_(const vector<size_t> &indices,
                              const vector<size_t> &externalIndices,
                              bool inverse, const vector<fp_t> &params) {
+        static_cast<void>(params);
         applyPauliX(indices, externalIndices, inverse);
     }
     inline void applyPauliY_(const vector<size_t> &indices,
                              const vector<size_t> &externalIndices,
                              bool inverse, const vector<fp_t> &params) {
+        static_cast<void>(params);
         applyPauliY(indices, externalIndices, inverse);
     }
     inline void applyPauliZ_(const vector<size_t> &indices,
                              const vector<size_t> &externalIndices,
                              bool inverse, const vector<fp_t> &params) {
+        static_cast<void>(params);
         applyPauliZ(indices, externalIndices, inverse);
     }
     inline void applyHadamard_(const vector<size_t> &indices,
                                const vector<size_t> &externalIndices,
                                bool inverse, const vector<fp_t> &params) {
+        static_cast<void>(params);
         applyHadamard(indices, externalIndices, inverse);
     }
     inline void applyS_(const vector<size_t> &indices,
                         const vector<size_t> &externalIndices, bool inverse,
                         const vector<fp_t> &params) {
+        static_cast<void>(params);
         applyS(indices, externalIndices, inverse);
     }
     inline void applyT_(const vector<size_t> &indices,
                         const vector<size_t> &externalIndices, bool inverse,
                         const vector<fp_t> &params) {
+        static_cast<void>(params);
         applyT(indices, externalIndices, inverse);
     }
     inline void applyRX_(const vector<size_t> &indices,
@@ -673,16 +678,19 @@ template <class fp_t = double> class StateVector {
     inline void applyCNOT_(const vector<size_t> &indices,
                            const vector<size_t> &externalIndices, bool inverse,
                            const vector<fp_t> &params) {
+        static_cast<void>(params);
         applyCNOT(indices, externalIndices, inverse);
     }
     inline void applySWAP_(const vector<size_t> &indices,
                            const vector<size_t> &externalIndices, bool inverse,
                            const vector<fp_t> &params) {
+        static_cast<void>(params);
         applySWAP(indices, externalIndices, inverse);
     }
     inline void applyCZ_(const vector<size_t> &indices,
                          const vector<size_t> &externalIndices, bool inverse,
                          const vector<fp_t> &params) {
+        static_cast<void>(params);
         applyCZ(indices, externalIndices, inverse);
     }
     inline void applyCRX_(const vector<size_t> &indices,
@@ -709,11 +717,13 @@ template <class fp_t = double> class StateVector {
     inline void applyToffoli_(const vector<size_t> &indices,
                               const vector<size_t> &externalIndices,
                               bool inverse, const vector<fp_t> &params) {
+        static_cast<void>(params);
         applyToffoli(indices, externalIndices, inverse);
     }
     inline void applyCSWAP_(const vector<size_t> &indices,
                             const vector<size_t> &externalIndices, bool inverse,
                             const vector<fp_t> &params) {
+        static_cast<void>(params);
         applyCSWAP(indices, externalIndices, inverse);
     }
 };

--- a/pennylane_lightning/src/Util.hpp
+++ b/pennylane_lightning/src/Util.hpp
@@ -37,7 +37,9 @@ namespace Util {
  */
 inline size_t exp2(const size_t &n) { return static_cast<size_t>(1) << n; }
 
-constexpr inline size_t log2(size_t value) { return static_cast<size_t>(std::log2(value) ); }
+inline size_t log2(size_t value) {
+    return static_cast<size_t>(std::log2(value));
+}
 
 /**
  * Calculates the decimal value for a qubit, assuming a big-endian convention.

--- a/pennylane_lightning/src/tests/CMakeLists.txt
+++ b/pennylane_lightning/src/tests/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.14)
 project(pennylane_lightning_tests)
 
 set(CMAKE_CXX_STANDARD 17)

--- a/pennylane_lightning/src/tests/CMakeLists.txt
+++ b/pennylane_lightning/src/tests/CMakeLists.txt
@@ -1,8 +1,6 @@
-cmake_minimum_required(VERSION 3.14)
-
 project(pennylane_lightning_tests)
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
 find_package(OpenMP)
 
 # Default build type for test code is Debug
@@ -10,39 +8,36 @@ if(NOT CMAKE_BUILD_TYPE)
 	set(CMAKE_BUILD_TYPE Debug)
 endif()
 
-
 option(ENABLE_NATIVE "Enable native CPU build tuning" OFF)
 
+Include(FetchContent)
 
-include(FetchContent)
 FetchContent_Declare(
-  googletest
-  GIT_REPOSITORY https://github.com/google/googletest.git 
-  GIT_TAG release-1.11.0
+  Catch2
+  GIT_REPOSITORY https://github.com/catchorg/Catch2.git
+  GIT_TAG        v2.13.1
 )
-# For Windows: Prevent overriding the parent project's compiler/linker settings
-set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
-FetchContent_MakeAvailable(googletest)
-enable_testing()
 
-add_executable(cpptests lightning_apply_unittest.cpp
-                        lightning_gates_unittest.cpp
-                        lightning_util_unittest.cpp
-                        "../Apply.cpp"
-                        "../Gates.cpp")
+FetchContent_MakeAvailable(Catch2)
 
-target_link_libraries(cpptests PRIVATE gtest_main)
-if(OpenMP_CXX_FOUND)
-	target_link_libraries(cpptests PRIVATE OpenMP::OpenMP_CXX)
-endif()
+# Required for catch_discover_tests().
+list(APPEND CMAKE_MODULE_PATH ${catch2_SOURCE_DIR}/contrib)
 
-target_compile_options(cpptests PRIVATE "$<$<CONFIG:DEBUG>:-Wall>")
+# Modify `ctest` to only run the supported subset of tests.
+include(CTest)
+include(Catch)
+
+add_executable(runner runner_main.cpp)
+target_link_libraries(runner pennylane_lightning Catch2::Catch2)
+
+target_sources(runner PRIVATE Test_StateVector.cpp
+                              Test_Bindings.cpp)
+
+target_compile_options(runner PRIVATE "$<$<CONFIG:DEBUG>:-Wall>")
 
 if(ENABLE_NATIVE)
-	message(STATUS "ENABLE_NATIVE is ON. Use -march=native for cpptests.")
-	target_compile_options(cpptests PRIVATE -march=native)
+    message(STATUS "ENABLE_NATIVE is ON. Use -march=native for cpptests.")
+    target_compile_options(runner PRIVATE -march=native)
 endif()
 
-
-include(GoogleTest)
-gtest_discover_tests(cpptests)
+catch_discover_tests(runner)

--- a/pennylane_lightning/src/tests/Test_StateVector.cpp
+++ b/pennylane_lightning/src/tests/Test_StateVector.cpp
@@ -1,0 +1,79 @@
+#include <algorithm>
+#include <complex>
+#include <iostream>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include <catch2/catch.hpp>
+
+#include "StateVector.hpp"
+#include "Util.hpp"
+
+using namespace Pennylane;
+
+TEMPLATE_TEST_CASE("StateVector::StateVector", "[StateVector]", float, double) {
+    SECTION("StateVector") {
+        REQUIRE(std::is_constructible<StateVector<>>::value);
+    }
+    SECTION("StateVector<TestType> {}") {
+        REQUIRE(std::is_constructible<StateVector<TestType>>::value);
+    }
+    SECTION("StateVector<TestType> {std::complex<TestType>, size_t}") {
+        REQUIRE(std::is_constructible<StateVector<TestType>,
+                                      std::complex<TestType>, size_t>::value);
+    }
+    SECTION("StateVector<TestType> cross types") {
+        if constexpr (!std::is_same_v<TestType, double>) {
+            REQUIRE_FALSE(
+                std::is_constructible<StateVector<TestType>,
+                                      std::complex<double>, size_t>::value);
+            REQUIRE_FALSE(
+                std::is_constructible<StateVector<double>,
+                                      std::complex<TestType>, size_t>::value);
+        } else if constexpr (!std::is_same_v<TestType, float>) {
+            REQUIRE_FALSE(
+                std::is_constructible<StateVector<TestType>,
+                                      std::complex<float>, size_t>::value);
+            REQUIRE_FALSE(
+                std::is_constructible<StateVector<float>,
+                                      std::complex<TestType>, size_t>::value);
+        }
+    }
+}
+
+template <typename fp_t> struct SVData {
+    size_t num_qubits;
+    std::vector<size_t> qubit_indices;
+    std::vector<std::complex<fp_t>> cdata;
+    StateVector<fp_t> sv;
+
+    SVData(size_t num_qubits)
+        : num_qubits{num_qubits}, qubit_indices{num_qubits},
+          cdata(0b1 << num_qubits), sv{cdata.data(), cdata.size()} {
+        std::iota(qubit_indices.begin(), qubit_indices.end(), 0);
+        cdata[0] = std::complex<fp_t>{1, 0};
+    }
+};
+
+TEMPLATE_TEST_CASE("StateVector::applyPauliX", "[StateVector]", float, double) {
+
+    SVData<TestType> svdat{3};
+
+    vector<size_t> internalIndices =
+        svdat.sv.generateBitPatterns(svdat.qubit_indices);
+    vector<size_t> externalWires =
+        svdat.sv.getIndicesAfterExclusion(svdat.qubit_indices);
+    vector<size_t> externalIndices =
+        svdat.sv.generateBitPatterns(externalWires);
+
+    SECTION("XII|000> -> |100>") {}
+}
+TEMPLATE_TEST_CASE("StateVector::applyPauliY", "[StateVector]", float, double) {
+
+}
+TEMPLATE_TEST_CASE("StateVector::applyPauliZ", "[StateVector]", float, double) {
+
+}
+TEMPLATE_TEST_CASE("StateVector::applyHadamard", "[StateVector]", float,
+                   double) {}

--- a/pennylane_lightning/src/tests/Test_StateVector.cpp
+++ b/pennylane_lightning/src/tests/Test_StateVector.cpp
@@ -12,6 +12,34 @@
 
 using namespace Pennylane;
 
+/**
+ * @brief Utility function to compare complex statevector data.
+ *
+ * @tparam Data_t Floating point data-type.
+ * @param data1 StateVector data 1.
+ * @param data2 StateVector data 2.
+ * @return true Data are approximately equal.
+ * @return false Data are not approximately equal.
+ */
+template <class Data_t>
+inline bool isApproxEqual(const std::vector<Data_t> &data1,
+                          const std::vector<Data_t> &data2) {
+    if (data1.size() != data2.size())
+        return false;
+
+    for (size_t i = 0; i < data1.size(); i++) {
+        if (data1[i].real() != Approx(data2[i].real()) ||
+            data1[i].imag() != Approx(data2[i].imag())) {
+            return false;
+        }
+    }
+    return true;
+}
+
+/**
+ * @brief Tests the constructability of the StateVector class.
+ *
+ */
 TEMPLATE_TEST_CASE("StateVector::StateVector", "[StateVector]", float, double) {
     SECTION("StateVector") {
         REQUIRE(std::is_constructible<StateVector<>>::value);
@@ -42,38 +70,188 @@ TEMPLATE_TEST_CASE("StateVector::StateVector", "[StateVector]", float, double) {
     }
 }
 
+/**
+ * @brief Utility data-structure to assist with testing StateVector class
+ *
+ * @tparam fp_t Floating-point type. Supported options: float, double
+ */
 template <typename fp_t> struct SVData {
     size_t num_qubits;
-    std::vector<size_t> qubit_indices;
     std::vector<std::complex<fp_t>> cdata;
     StateVector<fp_t> sv;
 
     SVData(size_t num_qubits)
-        : num_qubits{num_qubits}, qubit_indices{num_qubits},
+        : num_qubits{num_qubits}, // qubit_indices{num_qubits},
           cdata(0b1 << num_qubits), sv{cdata.data(), cdata.size()} {
-        std::iota(qubit_indices.begin(), qubit_indices.end(), 0);
         cdata[0] = std::complex<fp_t>{1, 0};
     }
+    SVData(size_t num_qubits,
+           const std::vector<std::complex<fp_t>> &cdata_input)
+        : num_qubits{num_qubits}, // qubit_indices{num_qubits},
+          cdata(cdata_input), sv{cdata.data(), cdata.size()} {}
+    vector<size_t>
+    getInternalIndices(const std::vector<size_t> &qubit_indices) {
+        return sv.generateBitPatterns(qubit_indices);
+    }
+    vector<size_t>
+    getExternalIndices(const std::vector<size_t> &qubit_indices) {
+        vector<size_t> externalWires =
+            sv.getIndicesAfterExclusion(qubit_indices);
+        vector<size_t> externalIndices = sv.generateBitPatterns(externalWires);
+        return externalIndices;
+    }
 };
+TEMPLATE_TEST_CASE("StateVector::applyHadamard", "[StateVector]", float,
+                   double) {
+    using cp_t = std::complex<TestType>;
+    const size_t num_qubits = 3;
+    SECTION("Apply directly") {
+        for (size_t index = 0; index < num_qubits; index++) {
+            SVData<TestType> svdat{num_qubits};
+
+            auto int_idx = svdat.getInternalIndices({index});
+            auto ext_idx = svdat.getExternalIndices({index});
+            CHECK(svdat.cdata[0] == cp_t{1, 0});
+            svdat.sv.applyHadamard(int_idx, ext_idx, false);
+
+            cp_t expected = {1 / std::sqrt(2), 0};
+            CHECK(expected.real() == Approx(svdat.cdata[0].real()));
+            CHECK(expected.imag() == Approx(svdat.cdata[0].imag()));
+
+            CHECK(
+                expected.real() ==
+                Approx(
+                    svdat.cdata[0b1 << (svdat.num_qubits - index - 1)].real()));
+            CHECK(
+                expected.imag() ==
+                Approx(
+                    svdat.cdata[0b1 << (svdat.num_qubits - index - 1)].imag()));
+        }
+    }
+    SECTION("Apply using dispatcher") {
+        for (size_t index = 0; index < num_qubits; index++) {
+            SVData<TestType> svdat{num_qubits};
+            CHECK(svdat.cdata[0] == cp_t{1, 0});
+            svdat.sv.applyOperation("Hadamard", {index}, false);
+
+            cp_t expected = {1 / std::sqrt(2), 0};
+
+            CHECK(expected.real() == Approx(svdat.cdata[0].real()));
+            CHECK(expected.imag() == Approx(svdat.cdata[0].imag()));
+
+            CHECK(
+                expected.real() ==
+                Approx(
+                    svdat.cdata[0b1 << (svdat.num_qubits - index - 1)].real()));
+            CHECK(
+                expected.imag() ==
+                Approx(
+                    svdat.cdata[0b1 << (svdat.num_qubits - index - 1)].imag()));
+        }
+    }
+}
 
 TEMPLATE_TEST_CASE("StateVector::applyPauliX", "[StateVector]", float, double) {
-
-    SVData<TestType> svdat{3};
-
-    vector<size_t> internalIndices =
-        svdat.sv.generateBitPatterns(svdat.qubit_indices);
-    vector<size_t> externalWires =
-        svdat.sv.getIndicesAfterExclusion(svdat.qubit_indices);
-    vector<size_t> externalIndices =
-        svdat.sv.generateBitPatterns(externalWires);
-
-    SECTION("XII|000> -> |100>") {}
+    using cp_t = std::complex<TestType>;
+    const size_t num_qubits = 3;
+    SECTION("Apply directly") {
+        for (size_t index = 0; index < num_qubits; index++) {
+            SVData<TestType> svdat{num_qubits};
+            auto int_idx = svdat.getInternalIndices({index});
+            auto ext_idx = svdat.getExternalIndices({index});
+            CHECK(svdat.cdata[0] == cp_t{1, 0});
+            svdat.sv.applyPauliX(int_idx, ext_idx, false);
+            CHECK(svdat.cdata[0] == cp_t{0, 0});
+            CHECK(svdat.cdata[0b1 << (svdat.num_qubits - index - 1)] ==
+                  cp_t{1, 0});
+        }
+    }
+    SECTION("Apply using dispatcher") {
+        for (size_t index = 0; index < num_qubits; index++) {
+            SVData<TestType> svdat{num_qubits};
+            CHECK(svdat.cdata[0] == cp_t{1, 0});
+            svdat.sv.applyOperation("PauliX", {index}, false);
+            CHECK(svdat.cdata[0] == cp_t{0, 0});
+            CHECK(svdat.cdata[0b1 << (svdat.num_qubits - index - 1)] ==
+                  cp_t{1, 0});
+        }
+    }
 }
+
 TEMPLATE_TEST_CASE("StateVector::applyPauliY", "[StateVector]", float, double) {
+    using cp_t = std::complex<TestType>;
+    const size_t num_qubits = 3;
+    SVData<TestType> svdat{num_qubits};
+    // Test using |+++> state
+    svdat.sv.applyOperations({{"Hadamard"}, {"Hadamard"}, {"Hadamard"}},
+                             {{0}, {1}, {2}}, {{false}, {false}, {false}});
 
+    cp_t p = {0, 1 / (2 * std::sqrt(2))};
+    cp_t m = {0, -1 / (2 * std::sqrt(2))};
+
+    const std::vector<std::vector<cp_t>> expected_results = {
+        {m, m, m, m, p, p, p, p},
+        {m, m, p, p, m, m, p, p},
+        {m, p, m, p, m, p, m, p}};
+
+    const auto init_state = svdat.cdata;
+    SECTION("Apply directly") {
+        for (size_t index = 0; index < num_qubits; index++) {
+            SVData<TestType> svdat{num_qubits, init_state};
+            auto int_idx = svdat.getInternalIndices({index});
+            auto ext_idx = svdat.getExternalIndices({index});
+
+            CHECK(svdat.cdata == init_state);
+            svdat.sv.applyPauliY(int_idx, ext_idx, false);
+
+            CHECK(isApproxEqual(svdat.cdata, expected_results[index]));
+        }
+    }
+    SECTION("Apply using dispatcher") {
+        for (size_t index = 0; index < num_qubits; index++) {
+            SVData<TestType> svdat{num_qubits, init_state};
+            CHECK(svdat.cdata == init_state);
+            svdat.sv.applyOperation("PauliY", {index}, false);
+            CHECK(isApproxEqual(svdat.cdata, expected_results[index]));
+        }
+    }
 }
+
 TEMPLATE_TEST_CASE("StateVector::applyPauliZ", "[StateVector]", float, double) {
+    using cp_t = std::complex<TestType>;
+    const size_t num_qubits = 3;
+    SVData<TestType> svdat{num_qubits};
+    // Test using |+++> state
+    svdat.sv.applyOperations({{"Hadamard"}, {"Hadamard"}, {"Hadamard"}},
+                             {{0}, {1}, {2}}, {{false}, {false}, {false}});
 
+    cp_t p = {1 / (2 * std::sqrt(2)), 0};
+    cp_t m = {-1 / (2 * std::sqrt(2)), 0};
+
+    const std::vector<std::vector<cp_t>> expected_results = {
+        {p, p, p, p, m, m, m, m},
+        {p, p, m, m, p, p, m, m},
+        {p, m, p, m, p, m, p, m}};
+
+    const auto init_state = svdat.cdata;
+    SECTION("Apply directly") {
+        for (size_t index = 0; index < num_qubits; index++) {
+            SVData<TestType> svdat{num_qubits, init_state};
+            auto int_idx = svdat.getInternalIndices({index});
+            auto ext_idx = svdat.getExternalIndices({index});
+
+            CHECK(svdat.cdata == init_state);
+            svdat.sv.applyPauliZ(int_idx, ext_idx, false);
+
+            CHECK(isApproxEqual(svdat.cdata, expected_results[index]));
+        }
+    }
+    SECTION("Apply using dispatcher") {
+        for (size_t index = 0; index < num_qubits; index++) {
+            SVData<TestType> svdat{num_qubits, init_state};
+            CHECK(svdat.cdata == init_state);
+            svdat.sv.applyOperation("PauliZ", {index}, false);
+            CHECK(isApproxEqual(svdat.cdata, expected_results[index]));
+        }
+    }
 }
-TEMPLATE_TEST_CASE("StateVector::applyHadamard", "[StateVector]", float,
-                   double) {}

--- a/pennylane_lightning/src/tests/Test_StateVector.cpp
+++ b/pennylane_lightning/src/tests/Test_StateVector.cpp
@@ -101,23 +101,23 @@ TEMPLATE_TEST_CASE("StateVector::StateVector", "[StateVector]", float, double) {
     }
     SECTION("StateVector<TestType> {std::complex<TestType>, size_t}") {
         REQUIRE(std::is_constructible<StateVector<TestType>,
-                                      std::complex<TestType>*, size_t>::value);
+                                      std::complex<TestType> *, size_t>::value);
     }
     SECTION("StateVector<TestType> cross types") {
         if constexpr (!std::is_same_v<TestType, double>) {
             REQUIRE_FALSE(
                 std::is_constructible<StateVector<TestType>,
-                                      std::complex<double>*, size_t>::value);
+                                      std::complex<double> *, size_t>::value);
             REQUIRE_FALSE(
                 std::is_constructible<StateVector<double>,
-                                      std::complex<TestType>*, size_t>::value);
+                                      std::complex<TestType> *, size_t>::value);
         } else if constexpr (!std::is_same_v<TestType, float>) {
             REQUIRE_FALSE(
                 std::is_constructible<StateVector<TestType>,
-                                      std::complex<float>*, size_t>::value);
+                                      std::complex<float> *, size_t>::value);
             REQUIRE_FALSE(
                 std::is_constructible<StateVector<float>,
-                                      std::complex<TestType>*, size_t>::value);
+                                      std::complex<TestType> *, size_t>::value);
         }
     }
 }
@@ -197,14 +197,14 @@ TEST_CASE("StateVector::generateBitPatterns", "[StateVector]") {
 TEST_CASE("StateVector::getIndicesAfterExclusion", "[StateVector]") {
     const size_t num_qubits = 4;
     SECTION("Qubit indices {}") {
-        std::vector<size_t> expected{0,1,2,3};
+        std::vector<size_t> expected{0, 1, 2, 3};
         auto indices = StateVector<>::getIndicesAfterExclusion({}, num_qubits);
         CHECK(indices == expected);
     }
     SECTION("Qubit indices {i}") {
         for (size_t i = 0; i < num_qubits; i++) {
-            std::vector<size_t> expected{0,1,2,3};
-            expected.erase(expected.begin()+i);
+            std::vector<size_t> expected{0, 1, 2, 3};
+            expected.erase(expected.begin() + i);
 
             auto indices =
                 StateVector<>::getIndicesAfterExclusion({i}, num_qubits);

--- a/pennylane_lightning/src/tests/Test_StateVector.cpp
+++ b/pennylane_lightning/src/tests/Test_StateVector.cpp
@@ -101,23 +101,23 @@ TEMPLATE_TEST_CASE("StateVector::StateVector", "[StateVector]", float, double) {
     }
     SECTION("StateVector<TestType> {std::complex<TestType>, size_t}") {
         REQUIRE(std::is_constructible<StateVector<TestType>,
-                                      std::complex<TestType>, size_t>::value);
+                                      std::complex<TestType>*, size_t>::value);
     }
     SECTION("StateVector<TestType> cross types") {
         if constexpr (!std::is_same_v<TestType, double>) {
             REQUIRE_FALSE(
                 std::is_constructible<StateVector<TestType>,
-                                      std::complex<double>, size_t>::value);
+                                      std::complex<double>*, size_t>::value);
             REQUIRE_FALSE(
                 std::is_constructible<StateVector<double>,
-                                      std::complex<TestType>, size_t>::value);
+                                      std::complex<TestType>*, size_t>::value);
         } else if constexpr (!std::is_same_v<TestType, float>) {
             REQUIRE_FALSE(
                 std::is_constructible<StateVector<TestType>,
-                                      std::complex<float>, size_t>::value);
+                                      std::complex<float>*, size_t>::value);
             REQUIRE_FALSE(
                 std::is_constructible<StateVector<float>,
-                                      std::complex<TestType>, size_t>::value);
+                                      std::complex<TestType>*, size_t>::value);
         }
     }
 }
@@ -153,6 +153,91 @@ template <typename fp_t> struct SVData {
         return externalIndices;
     }
 };
+
+TEST_CASE("StateVector::generateBitPatterns", "[StateVector]") {
+    const size_t num_qubits = 4;
+    SECTION("Qubit indices {}") {
+        auto bit_pattern = StateVector<>::generateBitPatterns({}, num_qubits);
+        CHECK(bit_pattern == std::vector<size_t>{0});
+    }
+    SECTION("Qubit indices {i}") {
+        for (size_t i = 0; i < num_qubits; i++) {
+            std::vector<size_t> expected{0, 0b1UL << (num_qubits - i - 1)};
+            auto bit_pattern =
+                StateVector<>::generateBitPatterns({i}, num_qubits);
+            CHECK(bit_pattern == expected);
+        }
+    }
+    SECTION("Qubit indices {i,i+1,i+2}") {
+        std::vector<size_t> expected_123{0, 1, 2, 3, 4, 5, 6, 7};
+        std::vector<size_t> expected_012{0, 2, 4, 6, 8, 10, 12, 14};
+        auto bit_pattern_123 =
+            StateVector<>::generateBitPatterns({1, 2, 3}, num_qubits);
+        auto bit_pattern_012 =
+            StateVector<>::generateBitPatterns({0, 1, 2}, num_qubits);
+
+        CHECK(bit_pattern_123 == expected_123);
+        CHECK(bit_pattern_012 == expected_012);
+    }
+    SECTION("Qubit indices {0,2,3}") {
+        std::vector<size_t> expected{0, 1, 2, 3, 8, 9, 10, 11};
+        auto bit_pattern =
+            StateVector<>::generateBitPatterns({0, 2, 3}, num_qubits);
+
+        CHECK(bit_pattern == expected);
+    }
+    SECTION("Qubit indices {3,1,0}") {
+        std::vector<size_t> expected{0, 8, 4, 12, 1, 9, 5, 13};
+        auto bit_pattern =
+            StateVector<>::generateBitPatterns({3, 1, 0}, num_qubits);
+        CHECK(bit_pattern == expected);
+    }
+}
+
+TEST_CASE("StateVector::getIndicesAfterExclusion", "[StateVector]") {
+    const size_t num_qubits = 4;
+    SECTION("Qubit indices {}") {
+        std::vector<size_t> expected{0,1,2,3};
+        auto indices = StateVector<>::getIndicesAfterExclusion({}, num_qubits);
+        CHECK(indices == expected);
+    }
+    SECTION("Qubit indices {i}") {
+        for (size_t i = 0; i < num_qubits; i++) {
+            std::vector<size_t> expected{0,1,2,3};
+            expected.erase(expected.begin()+i);
+
+            auto indices =
+                StateVector<>::getIndicesAfterExclusion({i}, num_qubits);
+            CHECK(indices == expected);
+        }
+    }
+    SECTION("Qubit indices {i,i+1,i+2}") {
+        std::vector<size_t> expected_123{0};
+        std::vector<size_t> expected_012{3};
+        auto indices_123 =
+            StateVector<>::getIndicesAfterExclusion({1, 2, 3}, num_qubits);
+        auto indices_012 =
+            StateVector<>::getIndicesAfterExclusion({0, 1, 2}, num_qubits);
+
+        CHECK(indices_123 == expected_123);
+        CHECK(indices_012 == expected_012);
+    }
+    SECTION("Qubit indices {0,2,3}") {
+        std::vector<size_t> expected{1};
+        auto indices =
+            StateVector<>::getIndicesAfterExclusion({0, 2, 3}, num_qubits);
+
+        CHECK(indices == expected);
+    }
+    SECTION("Qubit indices {3,1,0}") {
+        std::vector<size_t> expected{2};
+        auto indices =
+            StateVector<>::getIndicesAfterExclusion({3, 1, 0}, num_qubits);
+
+        CHECK(indices == expected);
+    }
+}
+
 TEMPLATE_TEST_CASE("StateVector::applyHadamard", "[StateVector]", float,
                    double) {
     using cp_t = std::complex<TestType>;

--- a/pennylane_lightning/src/tests/Test_StateVector.cpp
+++ b/pennylane_lightning/src/tests/Test_StateVector.cpp
@@ -255,3 +255,81 @@ TEMPLATE_TEST_CASE("StateVector::applyPauliZ", "[StateVector]", float, double) {
         }
     }
 }
+
+TEMPLATE_TEST_CASE("StateVector::applyS", "[StateVector]", float, double) {
+    using cp_t = std::complex<TestType>;
+    const size_t num_qubits = 3;
+    SVData<TestType> svdat{num_qubits};
+    // Test using |+++> state
+    svdat.sv.applyOperations({{"Hadamard"}, {"Hadamard"}, {"Hadamard"}},
+                             {{0}, {1}, {2}}, {{false}, {false}, {false}});
+
+    cp_t r = {1 / (2 * std::sqrt(2)), 0};
+    cp_t i = {0, 1 / (2 * std::sqrt(2))};
+
+    const std::vector<std::vector<cp_t>> expected_results = {
+        {r, r, r, r, i, i, i, i},
+        {r, r, i, i, r, r, i, i},
+        {r, i, r, i, r, i, r, i}};
+
+    const auto init_state = svdat.cdata;
+    SECTION("Apply directly") {
+        for (size_t index = 0; index < num_qubits; index++) {
+            SVData<TestType> svdat{num_qubits, init_state};
+            auto int_idx = svdat.getInternalIndices({index});
+            auto ext_idx = svdat.getExternalIndices({index});
+
+            CHECK(svdat.cdata == init_state);
+            svdat.sv.applyS(int_idx, ext_idx, false);
+
+            CHECK(isApproxEqual(svdat.cdata, expected_results[index]));
+        }
+    }
+    SECTION("Apply using dispatcher") {
+        for (size_t index = 0; index < num_qubits; index++) {
+            SVData<TestType> svdat{num_qubits, init_state};
+            CHECK(svdat.cdata == init_state);
+            svdat.sv.applyOperation("S", {index}, false);
+            CHECK(isApproxEqual(svdat.cdata, expected_results[index]));
+        }
+    }
+}
+
+TEMPLATE_TEST_CASE("StateVector::applyT", "[StateVector]", float, double) {
+    using cp_t = std::complex<TestType>;
+    const size_t num_qubits = 3;
+    SVData<TestType> svdat{num_qubits};
+    // Test using |+++> state
+    svdat.sv.applyOperations({{"Hadamard"}, {"Hadamard"}, {"Hadamard"}},
+                             {{0}, {1}, {2}}, {{false}, {false}, {false}});
+
+    cp_t r = {1 / (2 * std::sqrt(2)), 0};
+    cp_t i = {1.0 / 4, 1.0 / 4};
+
+    const std::vector<std::vector<cp_t>> expected_results = {
+        {r, r, r, r, i, i, i, i},
+        {r, r, i, i, r, r, i, i},
+        {r, i, r, i, r, i, r, i}};
+
+    const auto init_state = svdat.cdata;
+    SECTION("Apply directly") {
+        for (size_t index = 0; index < num_qubits; index++) {
+            SVData<TestType> svdat{num_qubits, init_state};
+            auto int_idx = svdat.getInternalIndices({index});
+            auto ext_idx = svdat.getExternalIndices({index});
+
+            CHECK(svdat.cdata == init_state);
+            svdat.sv.applyT(int_idx, ext_idx, false);
+
+            CHECK(isApproxEqual(svdat.cdata, expected_results[index]));
+        }
+    }
+    SECTION("Apply using dispatcher") {
+        for (size_t index = 0; index < num_qubits; index++) {
+            SVData<TestType> svdat{num_qubits, init_state};
+            CHECK(svdat.cdata == init_state);
+            svdat.sv.applyOperation("T", {index}, false);
+            CHECK(isApproxEqual(svdat.cdata, expected_results[index]));
+        }
+    }
+}

--- a/pennylane_lightning/src/tests/Test_StateVector.cpp
+++ b/pennylane_lightning/src/tests/Test_StateVector.cpp
@@ -720,7 +720,6 @@ TEMPLATE_TEST_CASE("StateVector::applySWAP", "[StateVector]", float, double) {
     }
     SECTION("Apply using dispatcher") {
         SECTION("SWAP0,1 |+10> -> |1+0>") {
-
             std::vector<cp_t> expected{
                 {0, 0},           {0, 0}, {0, 0},           {0, 0},
                 {1 / sqrt(2), 0}, {0, 0}, {1 / sqrt(2), 0}, {0, 0}};
@@ -833,7 +832,6 @@ TEMPLATE_TEST_CASE("StateVector::applyCZ", "[StateVector]", float, double) {
     }
     SECTION("Apply using dispatcher") {
         SECTION("CZ0,1 |+10> -> |1+0>") {
-
             std::vector<cp_t> expected{
                 {0, 0}, {0, 0}, {1 / sqrt(2), 0},  {0, 0},
                 {0, 0}, {0, 0}, {-1 / sqrt(2), 0}, {0, 0}};
@@ -994,7 +992,6 @@ TEMPLATE_TEST_CASE("StateVector::applyCSWAP", "[StateVector]", float, double) {
             std::vector<cp_t> expected{{0, 0}, {0, 0}, {1 / sqrt(2), 0},
                                        {0, 0}, {0, 0}, {1 / sqrt(2), 0},
                                        {0, 0}, {0, 0}};
-
             SVData<TestType> svdat012{num_qubits, init_state};
 
             svdat012.sv.applyCSWAP(svdat.getInternalIndices({0, 1, 2}),
@@ -1032,7 +1029,6 @@ TEMPLATE_TEST_CASE("StateVector::applyCSWAP", "[StateVector]", float, double) {
             std::vector<cp_t> expected{{0, 0}, {0, 0}, {1 / sqrt(2), 0},
                                        {0, 0}, {0, 0}, {1 / sqrt(2), 0},
                                        {0, 0}, {0, 0}};
-
             SVData<TestType> svdat012{num_qubits, init_state};
 
             svdat012.sv.applyOperation("CSWAP", {0, 1, 2});

--- a/pennylane_lightning/src/tests/runner_main.cpp
+++ b/pennylane_lightning/src/tests/runner_main.cpp
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>


### PR DESCRIPTION
**Context:** With the refactor of the `StateVector` implementation in PR #113 the existing test-suite and tooling required an overhaul. This PR replaces the previous C++ test suite using googletest, with a more maintainable version written using Catch2. These new tests leverage CMake, and will auto-install the Catch2 library and make it available at build-time. 

**Description of the Change:** The files located at `pennylane_lightning/src/tests` have been largely replaced by a Catch2 implementation, which tests the newly refactored `StateVector` class and all contained operations. Explicit tests are added for each supported gate-type, and test with both `complex<float>` and `complex<double>` statevector backend data.

**Benefits:** This allows for a more streamlined testing process, and more easily extensible with additional modules that may be added to the package later. Reporting via CI is also provided. The testing will also be more thorough than the previous googletest version.

**Possible Drawbacks:** The testing file is large, and may incur more overhead than previous testing.

**Related GitHub Issues:** #113 
