### PR TITLE
Update CI image before running tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04]
+        os: [ubuntu-20.04]
     steps:
       - uses: actions/checkout@v2
 
@@ -34,7 +34,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04]
+        os: [ubuntu-20.04]
 
     steps:
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install dependencies
-        run: sudo apt-get -y -q install cmake gcc
+        run: sudo apt-get update && sudo apt-get -y -q install cmake gcc
 
       - name: Install Google Test
         run: |
@@ -49,7 +49,7 @@ jobs:
           python-version: '3.7'
 
       - name: Install dependencies
-        run: sudo apt-get -y -q install cmake gcc
+        run: sudo apt-get update && sudo apt-get -y -q install cmake gcc
 
       - name: Get required Python packages
         run: |


### PR DESCRIPTION
**Context:** Github Actions fail to install packages for older Ubuntu 18.04 images, with error messages matching the following pattern:
```
E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/main/c/cmake/cmake-data_3.10.2-1ubuntu2.18.04.1_all.deb  404  Not Found [IP: 52.252.75.106 80]
```

It is necessary to update the base package list prior to installation of any dependencies.

**Description of the Change:** Add `sudo apt-get update` to Ubuntu 18.04 images.

**Benefits:** Github action fails no more.

**Possible Drawbacks:** None

**Related GitHub Issues:** None
