### PR TITLE
Include test suite in coverage

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -7,6 +7,9 @@
 
 ### Improvements
 
+* The PennyLane device test suite is now included in coverage reports.
+  [(123)](https://github.com/PennyLaneAI/pennylane-lightning/pull/123)
+
 * Static versions of jQuery and Bootstrap are no longer included in the CSS theme. 
   [(118)](https://github.com/PennyLaneAI/pennylane-lightning/pull/118)
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -84,8 +84,8 @@ jobs:
         run: |
           cd main/
           pytest tests/ $COVERAGE_FLAGS
-          pl-device-test --device lightning.qubit --skip-ops --shots=20000 $COVERAGE_FLAGS
-          pl-device-test --device lightning.qubit --shots=None --skip-ops $COVERAGE_FLAGS
+          pl-device-test --device lightning.qubit --skip-ops --shots=20000 $COVERAGE_FLAGS --cov-append
+          pl-device-test --device lightning.qubit --shots=None --skip-ops $COVERAGE_FLAGS --cov-append
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1.0.12

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,9 @@ on:
       - master
   pull_request:
 
+env:
+  COVERAGE_FLAGS: "--cov=pennylane_lightning --cov-report=term-missing --cov-report=xml:../coverage.xml --no-flaky-report -p no:warnings --tb=native"
+
 jobs:
   cpptests:
     name: C++ tests
@@ -80,14 +83,11 @@ jobs:
       - name: Run PennyLane-Lightning unit tests
         run: |
           cd main/
-          pytest tests/ --cov=pennylane_lightning --cov-report term-missing --cov-report=xml:../coverage.xml
+          pytest tests/ $COVERAGE_FLAGS
+          pl-device-test --device lightning.qubit --skip-ops --shots=20000 $COVERAGE_FLAGS
+          pl-device-test --device lightning.qubit --shots=None --skip-ops $COVERAGE_FLAGS
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1.0.12
         with:
           file: coverage.xml
-
-      - name: Run PennyLane shared test suite
-        run: |
-          pl-device-test --device lightning.qubit --skip-ops --shots=20000
-          pl-device-test --device lightning.qubit --shots=None --skip-ops

--- a/Makefile
+++ b/Makefile
@@ -53,12 +53,22 @@ clean-docs:
 	rm -rf doc/code/api
 	make -C doc clean
 
-test:
+test-builtin:
 	$(PYTHON) -I $(TESTRUNNER)
+
+test-suite:
+	pl-device-test --device lightning.qubit --skip-ops --shots=20000
+	pl-device-test --device lightning.qubit --shots=None --skip-ops
+
+test-python: test-builtin test-suite
+	test-builtin
+	test-suite
 
 coverage:
 	@echo "Generating coverage report..."
 	$(PYTHON) $(TESTRUNNER) $(COVERAGE)
+	pl-device-test --device lightning.qubit --skip-ops --shots=20000 $(COVERAGE) --cov-append
+	pl-device-test --device lightning.qubit --shots=None --skip-ops $(COVERAGE) --cov-append
 
 test-cpp:
 	rm -rf ./BuildTests


### PR DESCRIPTION
The tests from PennyLane's device test suite will now be included when generating coverage reports. The makefile has also been updated to make using the test suite easier.

As we further modify some of the `default.qubit`-inherited methods in `lightning.qubit`, it'll be useful to harness the test suite tests for coverage so we don't have to replicated existing tests.