### PR TITLE
Update method signatures for bound class

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -7,6 +7,12 @@
 
 ### Improvements
 
+* The C++-backed Python bound methods can now be directly called with wires and supplied parameters.
+  [(125)](https://github.com/PennyLaneAI/pennylane-lightning/pull/125)
+
+* Lightning supports arbitrary unitary and non-unitary gate-calls from Python to C++ layer.
+  [(121)](https://github.com/PennyLaneAI/pennylane-lightning/pull/121)
+
 * The PennyLane device test suite is now included in coverage reports.
   [(123)](https://github.com/PennyLaneAI/pennylane-lightning/pull/123)
 

--- a/pennylane_lightning/src/Bindings.cpp
+++ b/pennylane_lightning/src/Bindings.cpp
@@ -215,6 +215,7 @@ template <class fp_t> class StateVecBinder : public StateVector<fp_t> {
             idx.internal, idx.external, inverse, params[0], params[1],
             params[2]);
     }
+
     template <class Param_t = fp_t>
     void applyCRot(const std::vector<size_t> &wires, bool inverse,
                    const std::vector<Param_t> &params) {
@@ -222,11 +223,13 @@ template <class fp_t> class StateVecBinder : public StateVector<fp_t> {
         StateVector<fp_t>::template applyCRot<Param_t>(
             idx.internal, idx.external, inverse, params[0], params[1],
             params[2]);
+    }
 
     void apply(const vector<string> &ops, const vector<vector<size_t>> &wires,
                const vector<bool> &inverse) {
         this->applyOperations(ops, wires, inverse);
     }
+
     /**
      * @brief Directly apply a given matrix to the specified wires. Matrix data
      * in 1D row-major format.
@@ -238,6 +241,7 @@ template <class fp_t> class StateVecBinder : public StateVector<fp_t> {
                           const vector<size_t> &wires, bool inverse = false) {
         this->applyOperation(matrix, wires, inverse);
     }
+
     /**
      * @brief Directly apply a given matrix to the specified wires. Data in 1/2D
      * numpy complex array format.
@@ -346,6 +350,7 @@ void lightning_class_bindings(py::module &m) {
                  const vector<string> &, const vector<vector<size_t>> &,
                  const vector<bool> &, const vector<vector<PrecisionT>> &>(
                  &StateVecBinder<PrecisionT>::apply))
+
         .def("apply", py::overload_cast<const vector<string> &,
                                         const vector<vector<size_t>> &,
                                         const vector<bool> &>(
@@ -412,8 +417,7 @@ void lightning_class_bindings(py::module &m) {
              py::overload_cast<const std::vector<size_t> &, bool,
                                const std::vector<Param_t> &>(
                  &StateVecBinder<PrecisionT>::template applyCRot<Param_t>),
-             "Apply the CRot gate.")
-        ;
+             "Apply the CRot gate.");
 }
 
 PYBIND11_MODULE(lightning_qubit_ops, m) {
@@ -422,7 +426,5 @@ PYBIND11_MODULE(lightning_qubit_ops, m) {
     m.def("apply", apply<float>, "lightning.qubit apply() method");
 
     lightning_class_bindings<float, float>(m);
-    lightning_class_bindings<float, double>(m);
-    lightning_class_bindings<double, float>(m);
     lightning_class_bindings<double, double>(m);
 }

--- a/pennylane_lightning/src/Bindings.cpp
+++ b/pennylane_lightning/src/Bindings.cpp
@@ -47,7 +47,29 @@ void apply(py::array_t<complex<T>> &stateNumpyArray, const vector<string> &ops,
     state.applyOperations(ops, wires, inverse, params);
 }
 
+/**
+ * @brief Binding class for exposing C++ methods to Python
+ *
+ * @tparam fp_t Floating point precision type.
+ */
 template <class fp_t> class StateVecBinder : public StateVector<fp_t> {
+  private:
+    /**
+     * @brief Internal utility struct to track indices of application.
+     *
+     */
+    struct GateIndices {
+        const std::vector<size_t> internal;
+        const std::vector<size_t> external;
+        GateIndices(const std::vector<size_t> &wires, size_t num_qubits)
+            : internal{std::move(
+                  StateVector<fp_t>::generateBitPatterns(wires, num_qubits))},
+              external{std::move(StateVector<fp_t>::generateBitPatterns(
+                  StateVector<fp_t>::getIndicesAfterExclusion(wires,
+                                                              num_qubits),
+                  num_qubits))} {}
+    };
+
   public:
     explicit StateVecBinder(const py::array_t<complex<fp_t>> &stateNumpyArray)
         : StateVector<fp_t>(
@@ -59,9 +81,151 @@ template <class fp_t> class StateVecBinder : public StateVector<fp_t> {
                const vector<vector<fp_t>> &params) {
         this->applyOperations(ops, wires, inverse, params);
     }
+
+    template <class Param_t = fp_t>
+    void applyPauliX(const std::vector<size_t> &wires, bool inverse,
+                     [[maybe_unused]] const std::vector<Param_t> params = {}) {
+        const GateIndices idx(wires, this->getNumQubits());
+        StateVector<fp_t>::applyPauliX(idx.internal, idx.external, inverse);
+    }
+    template <class Param_t = fp_t>
+    void applyPauliY(const std::vector<size_t> &wires, bool inverse,
+                     [[maybe_unused]] const std::vector<Param_t> params = {}) {
+        const GateIndices idx(wires, this->getNumQubits());
+        StateVector<fp_t>::applyPauliY(idx.internal, idx.external, inverse);
+    }
+    template <class Param_t = fp_t>
+    void applyPauliZ(const std::vector<size_t> &wires, bool inverse,
+                     [[maybe_unused]] const std::vector<Param_t> params = {}) {
+        const GateIndices idx(wires, this->getNumQubits());
+        StateVector<fp_t>::applyPauliZ(idx.internal, idx.external, inverse);
+    }
+    template <class Param_t = fp_t>
+    void
+    applyHadamard(const std::vector<size_t> &wires, bool inverse,
+                  [[maybe_unused]] const std::vector<Param_t> params = {}) {
+        const GateIndices idx(wires, this->getNumQubits());
+        StateVector<fp_t>::applyHadamard(idx.internal, idx.external, inverse);
+    }
+    template <class Param_t = fp_t>
+    void applyS(const std::vector<size_t> &wires, bool inverse,
+                [[maybe_unused]] const std::vector<Param_t> params = {}) {
+        const GateIndices idx(wires, this->getNumQubits());
+        StateVector<fp_t>::applyS(idx.internal, idx.external, inverse);
+    }
+    template <class Param_t = fp_t>
+    void applyT(const std::vector<size_t> &wires, bool inverse,
+                [[maybe_unused]] const std::vector<Param_t> params = {}) {
+        const GateIndices idx(wires, this->getNumQubits());
+        StateVector<fp_t>::applyT(idx.internal, idx.external, inverse);
+    }
+    template <class Param_t = fp_t>
+    void applyCNOT(const std::vector<size_t> &wires, bool inverse,
+                   [[maybe_unused]] const std::vector<Param_t> params = {}) {
+        const GateIndices idx(wires, this->getNumQubits());
+        StateVector<fp_t>::applyCNOT(idx.internal, idx.external, inverse);
+    }
+    template <class Param_t = fp_t>
+    void applySWAP(const std::vector<size_t> &wires, bool inverse,
+                   [[maybe_unused]] const std::vector<Param_t> params = {}) {
+        const GateIndices idx(wires, this->getNumQubits());
+        StateVector<fp_t>::applySWAP(idx.internal, idx.external, inverse);
+    }
+    template <class Param_t = fp_t>
+    void applyCZ(const std::vector<size_t> &wires, bool inverse,
+                 [[maybe_unused]] const std::vector<Param_t> params = {}) {
+        const GateIndices idx(wires, this->getNumQubits());
+        StateVector<fp_t>::applyCZ(idx.internal, idx.external, inverse);
+    }
+    template <class Param_t = fp_t>
+    void applyCSWAP(const std::vector<size_t> &wires, bool inverse,
+                    [[maybe_unused]] const std::vector<Param_t> params = {}) {
+        const GateIndices idx(wires, this->getNumQubits());
+        StateVector<fp_t>::applyCSWAP(idx.internal, idx.external, inverse);
+    }
+    template <class Param_t = fp_t>
+    void applyToffoli(const std::vector<size_t> &wires, bool inverse,
+                      [[maybe_unused]] const std::vector<Param_t> params = {}) {
+        const GateIndices idx(wires, this->getNumQubits());
+        StateVector<fp_t>::applyToffoli(idx.internal, idx.external, inverse);
+    }
+    template <class Param_t = fp_t>
+    void applyPhaseShift(const std::vector<size_t> &wires, bool inverse,
+                         const std::vector<Param_t> &params) {
+        const GateIndices idx(wires, this->getNumQubits());
+        StateVector<fp_t>::template applyPhaseShift<Param_t>(
+            idx.internal, idx.external, inverse, params[0]);
+    }
+    template <class Param_t = fp_t>
+    void applyControlledPhaseShift(const std::vector<size_t> &wires,
+                                   bool inverse,
+                                   const std::vector<Param_t> &params) {
+        const GateIndices idx(wires, this->getNumQubits());
+        StateVector<fp_t>::template applyControlledPhaseShift<Param_t>(
+            idx.internal, idx.external, inverse, params[0]);
+    }
+    template <class Param_t = fp_t>
+    void applyRX(const std::vector<size_t> &wires, bool inverse,
+                 const std::vector<Param_t> &params) {
+        const GateIndices idx(wires, this->getNumQubits());
+        StateVector<fp_t>::template applyRX<Param_t>(idx.internal, idx.external,
+                                                     inverse, params[0]);
+    }
+    template <class Param_t = fp_t>
+    void applyRY(const std::vector<size_t> &wires, bool inverse,
+                 const std::vector<Param_t> &params) {
+        const GateIndices idx(wires, this->getNumQubits());
+        StateVector<fp_t>::template applyRY<Param_t>(idx.internal, idx.external,
+                                                     inverse, params[0]);
+    }
+    template <class Param_t = fp_t>
+    void applyRZ(const std::vector<size_t> &wires, bool inverse,
+                 const std::vector<Param_t> &params) {
+        const GateIndices idx(wires, this->getNumQubits());
+        StateVector<fp_t>::template applyRZ<Param_t>(idx.internal, idx.external,
+                                                     inverse, params[0]);
+    }
+    template <class Param_t = fp_t>
+    void applyCRX(const std::vector<size_t> &wires, bool inverse,
+                  const std::vector<Param_t> &params) {
+        const GateIndices idx(wires, this->getNumQubits());
+        StateVector<fp_t>::template applyCRX<Param_t>(
+            idx.internal, idx.external, inverse, params[0]);
+    }
+    template <class Param_t = fp_t>
+    void applyCRY(const std::vector<size_t> &wires, bool inverse,
+                  const std::vector<Param_t> &params) {
+        const GateIndices idx(wires, this->getNumQubits());
+        StateVector<fp_t>::template applyCRY<Param_t>(
+            idx.internal, idx.external, inverse, params[0]);
+    }
+    template <class Param_t = fp_t>
+    void applyCRZ(const std::vector<size_t> &wires, bool inverse,
+                  const std::vector<Param_t> &params) {
+        const GateIndices idx(wires, this->getNumQubits());
+        StateVector<fp_t>::template applyCRZ<Param_t>(
+            idx.internal, idx.external, inverse, params[0]);
+    }
+    template <class Param_t = fp_t>
+    void applyRot(const std::vector<size_t> &wires, bool inverse,
+                  const std::vector<Param_t> &params) {
+        const GateIndices idx(wires, this->getNumQubits());
+        StateVector<fp_t>::template applyRot<Param_t>(
+            idx.internal, idx.external, inverse, params[0], params[1],
+            params[2]);
+    }
+    template <class Param_t = fp_t>
+    void applyCRot(const std::vector<size_t> &wires, bool inverse,
+                   const std::vector<Param_t> &params) {
+        const GateIndices idx(wires, this->getNumQubits());
+        StateVector<fp_t>::template applyCRot<Param_t>(
+            idx.internal, idx.external, inverse, params[0], params[1],
+            params[2]);
+    }
 };
 
-template <class PrecisionT> void lightning_class_bindings(py::module &m) {
+template <class PrecisionT, class Param_t>
+void lightning_class_bindings(py::module &m) {
     // Enable module name to be based on size of complex datatype
     const std::string bitsize = std::to_string(sizeof(PrecisionT) * 8 * 2);
     const std::string class_name = "StateVectorC" + bitsize;
@@ -70,43 +234,134 @@ template <class PrecisionT> void lightning_class_bindings(py::module &m) {
              py::array_t<complex<PrecisionT>,
                          py::array::c_style | py::array::forcecast> &>())
         .def("apply", &StateVecBinder<PrecisionT>::apply)
-        .def("PauliX", &StateVecBinder<PrecisionT>::applyPauliX)
-        .def("PauliY", &StateVecBinder<PrecisionT>::applyPauliY)
-        .def("PauliZ", &StateVecBinder<PrecisionT>::applyPauliZ)
-        .def("Hadamard", &StateVecBinder<PrecisionT>::applyHadamard)
-        .def("S", &StateVecBinder<PrecisionT>::applyS)
-        .def("T", &StateVecBinder<PrecisionT>::applyT)
-        .def("CNOT", &StateVecBinder<PrecisionT>::applyCNOT)
-        .def("SWAP", &StateVecBinder<PrecisionT>::applySWAP)
-        .def("CSWAP", &StateVecBinder<PrecisionT>::applyCSWAP)
-        .def("Toffoli", &StateVecBinder<PrecisionT>::applyToffoli)
-        .def("CZ", &StateVecBinder<PrecisionT>::applyCZ)
-        .def("PhaseShift",
-             &StateVecBinder<PrecisionT>::template applyPhaseShift<float>)
-        .def("PhaseShift",
-             &StateVecBinder<PrecisionT>::template applyPhaseShift<double>)
+        .def("PauliX",
+             py::overload_cast<const std::vector<size_t> &, bool,
+                               const std::vector<Param_t>>(
+                 &StateVecBinder<PrecisionT>::template applyPauliX<Param_t>),
+             "Apply the PauliX gate.")
+
+        .def("PauliY",
+             py::overload_cast<const std::vector<size_t> &, bool,
+                               const std::vector<Param_t>>(
+                 &StateVecBinder<PrecisionT>::template applyPauliY<Param_t>),
+             "Apply the PauliY gate.")
+
+        .def("PauliZ",
+             py::overload_cast<const std::vector<size_t> &, bool,
+                               const std::vector<Param_t>>(
+                 &StateVecBinder<PrecisionT>::template applyPauliZ<Param_t>),
+             "Apply the PauliZ gate.")
+
+        .def("Hadamard",
+             py::overload_cast<const std::vector<size_t> &, bool,
+                               const std::vector<Param_t>>(
+                 &StateVecBinder<PrecisionT>::template applyHadamard<Param_t>),
+             "Apply the Hadamard gate.")
+
+        .def("S",
+             py::overload_cast<const std::vector<size_t> &, bool,
+                               const std::vector<Param_t>>(
+                 &StateVecBinder<PrecisionT>::template applyS<Param_t>),
+             "Apply the S gate.")
+
+        .def("T",
+             py::overload_cast<const std::vector<size_t> &, bool,
+                               const std::vector<Param_t>>(
+                 &StateVecBinder<PrecisionT>::template applyT<Param_t>),
+             "Apply the T gate.")
+
+        .def("CNOT",
+             py::overload_cast<const std::vector<size_t> &, bool,
+                               const std::vector<Param_t>>(
+                 &StateVecBinder<PrecisionT>::template applyCNOT<Param_t>),
+             "Apply the CNOT gate.")
+
+        .def("SWAP",
+             py::overload_cast<const std::vector<size_t> &, bool,
+                               const std::vector<Param_t>>(
+                 &StateVecBinder<PrecisionT>::template applySWAP<Param_t>),
+             "Apply the SWAP gate.")
+
+        .def("CSWAP",
+             py::overload_cast<const std::vector<size_t> &, bool,
+                               const std::vector<Param_t>>(
+                 &StateVecBinder<PrecisionT>::template applyCSWAP<Param_t>),
+             "Apply the CSWAP gate.")
+
+        .def("Toffoli",
+             py::overload_cast<const std::vector<size_t> &, bool,
+                               const std::vector<Param_t>>(
+                 &StateVecBinder<PrecisionT>::template applyToffoli<Param_t>),
+             "Apply the Toffoli gate.")
+
+        .def("CZ",
+             py::overload_cast<const std::vector<size_t> &, bool,
+                               const std::vector<Param_t>>(
+                 &StateVecBinder<PrecisionT>::template applyCZ<Param_t>),
+             "Apply the CZ gate.")
+
+        .def(
+            "PhaseShift",
+            py::overload_cast<const std::vector<size_t> &, bool,
+                              const std::vector<Param_t> &>(
+                &StateVecBinder<PrecisionT>::template applyPhaseShift<Param_t>),
+            "Apply the PhaseShift gate.")
+
         .def("ControlledPhaseShift",
-             &StateVecBinder<PrecisionT>::template applyControlledPhaseShift<
-                 float>)
-        .def("ControlledPhaseShift",
-             &StateVecBinder<PrecisionT>::template applyControlledPhaseShift<
-                 double>)
-        .def("RX", &StateVecBinder<PrecisionT>::template applyRX<float>)
-        .def("RX", &StateVecBinder<PrecisionT>::template applyRX<double>)
-        .def("RY", &StateVecBinder<PrecisionT>::template applyRY<float>)
-        .def("RY", &StateVecBinder<PrecisionT>::template applyRY<double>)
-        .def("RZ", &StateVecBinder<PrecisionT>::template applyRZ<float>)
-        .def("RZ", &StateVecBinder<PrecisionT>::template applyRZ<double>)
-        .def("Rot", &StateVecBinder<PrecisionT>::template applyRot<float>)
-        .def("Rot", &StateVecBinder<PrecisionT>::template applyRot<double>)
-        .def("CRX", &StateVecBinder<PrecisionT>::template applyCRX<float>)
-        .def("CRX", &StateVecBinder<PrecisionT>::template applyCRX<double>)
-        .def("CRY", &StateVecBinder<PrecisionT>::template applyCRY<float>)
-        .def("CRY", &StateVecBinder<PrecisionT>::template applyCRY<double>)
-        .def("CRZ", &StateVecBinder<PrecisionT>::template applyCRZ<float>)
-        .def("CRZ", &StateVecBinder<PrecisionT>::template applyCRZ<double>)
-        .def("CRot", &StateVecBinder<PrecisionT>::template applyCRot<float>)
-        .def("CRot", &StateVecBinder<PrecisionT>::template applyCRot<double>);
+             py::overload_cast<const std::vector<size_t> &, bool,
+                               const std::vector<Param_t> &>(
+                 &StateVecBinder<
+                     PrecisionT>::template applyControlledPhaseShift<Param_t>),
+             "Apply the ControlledPhaseShift gate.")
+
+        .def("RX",
+             py::overload_cast<const std::vector<size_t> &, bool,
+                               const std::vector<Param_t> &>(
+                 &StateVecBinder<PrecisionT>::template applyRX<Param_t>),
+             "Apply the RX gate.")
+
+        .def("RY",
+             py::overload_cast<const std::vector<size_t> &, bool,
+                               const std::vector<Param_t> &>(
+                 &StateVecBinder<PrecisionT>::template applyRY<Param_t>),
+             "Apply the RY gate.")
+
+        .def("RZ",
+             py::overload_cast<const std::vector<size_t> &, bool,
+                               const std::vector<Param_t> &>(
+                 &StateVecBinder<PrecisionT>::template applyRZ<Param_t>),
+             "Apply the RZ gate.")
+
+        .def("Rot",
+             py::overload_cast<const std::vector<size_t> &, bool,
+                               const std::vector<Param_t> &>(
+                 &StateVecBinder<PrecisionT>::template applyRot<Param_t>),
+             "Apply the Rot gate.")
+
+        .def("CRX",
+             py::overload_cast<const std::vector<size_t> &, bool,
+                               const std::vector<Param_t> &>(
+                 &StateVecBinder<PrecisionT>::template applyCRX<Param_t>),
+             "Apply the CRX gate.")
+
+        .def("CRY",
+             py::overload_cast<const std::vector<size_t> &, bool,
+                               const std::vector<Param_t> &>(
+                 &StateVecBinder<PrecisionT>::template applyCRY<Param_t>),
+             "Apply the CRY gate.")
+
+        .def("CRZ",
+             py::overload_cast<const std::vector<size_t> &, bool,
+                               const std::vector<Param_t> &>(
+                 &StateVecBinder<PrecisionT>::template applyCRZ<Param_t>),
+             "Apply the CRZ gate.")
+
+        .def("CRot",
+             py::overload_cast<const std::vector<size_t> &, bool,
+                               const std::vector<Param_t> &>(
+                 &StateVecBinder<PrecisionT>::template applyCRot<Param_t>),
+             "Apply the CRot gate.")
+        ;
 }
 
 PYBIND11_MODULE(lightning_qubit_ops, m) {
@@ -114,6 +369,8 @@ PYBIND11_MODULE(lightning_qubit_ops, m) {
     m.def("apply", apply<double>, "lightning.qubit apply() method");
     m.def("apply", apply<float>, "lightning.qubit apply() method");
 
-    lightning_class_bindings<float>(m);
-    lightning_class_bindings<double>(m);
+    lightning_class_bindings<float, float>(m);
+    lightning_class_bindings<float, double>(m);
+    lightning_class_bindings<double, float>(m);
+    lightning_class_bindings<double, double>(m);
 }

--- a/pennylane_lightning/src/StateVector.hpp
+++ b/pennylane_lightning/src/StateVector.hpp
@@ -114,6 +114,7 @@ template <class fp_t = double> class StateVector {
 
     CFP_t *getData() { return arr_; }
     std::size_t getLength() { return length_; }
+    std::size_t getNumQubits() { return num_qubits_; }
 
     /**
      * @brief Apply a single gate to the state-vector.


### PR DESCRIPTION
**Context:** This PR enables direct call of the C++ backed methods with a given wire and parameter argument set. 

**Description of the Change:** Add overloads to Python bidings to allow direct call of the applicable gates without relying on the dispatch functionality.

**Benefits:** Simplifies the integration with PennyLane core.

**Possible Drawbacks:** May be less performant than directly using the C++ dispatcher.

**Related GitHub Issues:** #124 
