### PR TITLE
Fix column major data layout in bindings

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -47,6 +47,9 @@
 
 ### Bug fixes
 
+* Column-major data in numpy is now correctly converted to row-major upon pass to the C++ layer.
+  [(#126)](https://github.com/PennyLaneAI/pennylane-lightning/pull/126)
+
 * PowerPC wheel-builder now successfully compiles modules.
   [#120](https://github.com/PennyLaneAI/pennylane-lightning/pull/120)
 

--- a/pennylane_lightning/src/Bindings.cpp
+++ b/pennylane_lightning/src/Bindings.cpp
@@ -250,8 +250,10 @@ template <class fp_t> class StateVecBinder : public StateVector<fp_t> {
      * @param wires
      * @param inverse
      */
-    void applyMatrixWires(const py::array_t<complex<fp_t>> &matrix,
-                          const vector<size_t> &wires, bool inverse = false) {
+    void applyMatrixWires(
+        const py::array_t<complex<fp_t>,
+                          py::array::c_style | py::array::forcecast> &matrix,
+        const vector<size_t> &wires, bool inverse = false) {
         const vector<size_t> internalIndices = this->generateBitPatterns(wires);
         const vector<size_t> externalWires =
             this->getIndicesAfterExclusion(wires);
@@ -360,8 +362,10 @@ void lightning_class_bindings(py::module &m) {
                                const vector<size_t> &, bool>(
                  &StateVecBinder<PrecisionT>::applyMatrixWires))
         .def("applyMatrix",
-             py::overload_cast<const py::array_t<complex<PrecisionT>> &,
-                               const vector<size_t> &, bool>(
+             py::overload_cast<
+                 const py::array_t<complex<PrecisionT>,
+                                   py::array::c_style | py::array::forcecast> &,
+                 const vector<size_t> &, bool>(
                  &StateVecBinder<PrecisionT>::applyMatrixWires))
 
         .def("ControlledPhaseShift",


### PR DESCRIPTION
**Context:** This PR fixes issues observed when passing numpy data in column-major layout to the row-major backed C++ bindings.

**Description of the Change:** Numpy data is forced to C-style (row-major) layout when passing numpy arrays to the C++ backend.

**Benefits:** This ensures correctness for both row and column major data layouts.

**Possible Drawbacks:** Column major layout data will experience a small overhead (though we should be using row-major everything).

**Related GitHub Issues:** #124 
