### PR TITLE
Removes support for Python 3.6 and adds support for Python 3.9

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -42,6 +42,9 @@
 
 ### Breaking changes
 
+* Removes support for Python 3.6 and adds support for Python 3.9.
+  [#128](https://github.com/PennyLaneAI/pennylane-lightning/pull/128)
+
 * Compilers with C++17 support are now required to build C++ module.
   [#113](https://github.com/PennyLaneAI/pennylane-lightning/pull/113)
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,7 +4,7 @@ sphinx:
   configuration: doc/conf.py
 
 python:
-  version: 3.6
+  version: 3.9
   install:
     - requirements: doc/requirements.txt
     - requirements: requirements.txt

--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,7 @@ Features
 Installation
 ============
 
-PennyLane-Lightning requires Python version 3.6 and above. It can be installed using ``pip``:
+PennyLane-Lightning requires Python version 3.7 and above. It can be installed using ``pip``:
 
 .. code-block:: console
 

--- a/setup.py
+++ b/setup.py
@@ -208,9 +208,9 @@ classifiers = [
     "Operating System :: Microsoft :: Windows",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Scientific/Engineering :: Physics",
 ]


### PR DESCRIPTION
The [deploy](https://github.com/PennyLaneAI/pennylane-lightning/blob/master/.github/workflows/deploy.yml) workflow is already set up for 3.7 - 3.9, so hopefully on the next release we'll have the 3.9 binaries!

Closes https://github.com/PennyLaneAI/pennylane-lightning/issues/96
Closes https://github.com/PennyLaneAI/pennylane-lightning/issues/116