### PR TITLE
Allow lightning.qubit to skip C++ compilation and provide a Python-only binary

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -12,9 +12,9 @@
 
 * PennyLane-Lightning can now be installed without compiling its C++ binaries and will fall back
   to using the `default.qubit` implementation. Skipping compilation is achieved by setting the
-  `SKIP_COMPILATION` environment variable, e.g., Linux/MacOS: `export SKIP_COMPILATION=True`, Windows: `set SKIP_COMPILATION=True`. This feature
-  is intended for building a pure-Python wheel of PennyLane-Lightning as a backup for platforms
-  without a dedicated wheel.
+  `SKIP_COMPILATION` environment variable, e.g., Linux/MacOS: `export SKIP_COMPILATION=True`,
+  Windows: `set SKIP_COMPILATION=True`. This feature is intended for building a pure-Python wheel of
+  PennyLane-Lightning as a backup for platforms without a dedicated wheel.
   [(129)](https://github.com/PennyLaneAI/pennylane-lightning/pull/129)
 
 * The C++-backed Python bound methods can now be directly called with wires and supplied parameters.

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -10,6 +10,13 @@
 
 ### Improvements
 
+* PennyLane-Lightning can now be installed without compiling its C++ binaries and will fall back
+  to using the `default.qubit` implementation. Skipping compilation is achieved by setting the
+  `SKIP_COMPILATION` environment variable, e.g., `export SKIP_COMPILATION=True`. This feature
+  is intended for building a pure-Python wheel of PennyLane-Lightning as a backup for platforms
+  without a dedicated wheel.
+  [(129)](https://github.com/PennyLaneAI/pennylane-lightning/pull/129)
+
 * The C++-backed Python bound methods can now be directly called with wires and supplied parameters.
   [(125)](https://github.com/PennyLaneAI/pennylane-lightning/pull/125)
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 * PennyLane-Lightning can now be installed without compiling its C++ binaries and will fall back
   to using the `default.qubit` implementation. Skipping compilation is achieved by setting the
-  `SKIP_COMPILATION` environment variable, e.g., `export SKIP_COMPILATION=True`. This feature
+  `SKIP_COMPILATION` environment variable, e.g., Linux/MacOS: `export SKIP_COMPILATION=True`, Windows: `set SKIP_COMPILATION=True`. This feature
   is intended for building a pure-Python wheel of PennyLane-Lightning as a backup for platforms
   without a dedicated wheel.
   [(129)](https://github.com/PennyLaneAI/pennylane-lightning/pull/129)

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,7 @@
 name: Deploy
 on:
-  push:
-    branches:
-      - master
-  pull_request:
+  release:
+    types: [published]
 
 env:
   CIBW_BUILD: 'cp37-* cp38-* cp39-*'
@@ -28,37 +26,37 @@ env:
 
 jobs:
 
-#  build-wheels:
-#    name: ${{ matrix.os }}
-#    runs-on: ${{ matrix.os }}
-#    strategy:
-#      matrix:
-#        os: [ubuntu-latest, macos-latest, windows-latest]
-#    steps:
-#      - name: Cancel Previous Runs
-#        uses: styfle/cancel-workflow-action@0.4.1
-#        with:
-#          access_token: ${{ github.token }}
-#
-#      - uses: actions/checkout@v2
-#
-#      - uses: actions/setup-python@v2
-#        with:
-#          python-version: '3.7'
-#
-#      - name: Install cibuildwheel
-#        run: |
-#          python -m pip install --upgrade pip
-#          python -m pip install cibuildwheel==1.5.5
-#
-#      - name: Build wheels
-#        run: |
-#          python -m cibuildwheel --output-dir wheelhouse
-#
-#      - uses: actions/upload-artifact@v2
-#        with:
-#          name: ${{ runner.os }}-wheels.zip
-#          path: ./wheelhouse/*.whl
+  build-wheels:
+    name: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.4.1
+        with:
+          access_token: ${{ github.token }}
+
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.7'
+
+      - name: Install cibuildwheel
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install cibuildwheel==1.5.5
+
+      - name: Build wheels
+        run: |
+          python -m cibuildwheel --output-dir wheelhouse
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: ${{ runner.os }}-wheels.zip
+          path: ./wheelhouse/*.whl
 
   build-pure-python-wheel:
     runs-on: ubuntu-latest
@@ -74,7 +72,7 @@ jobs:
 
       - name: Build wheels
         run: |
-          pip install wheel
+          python -m pip install --upgrade pip wheel
           cd main
           python setup.py bdist_wheel
         env:
@@ -84,3 +82,39 @@ jobs:
         with:
           name: pure-python-wheels.zip
           path: main/dist/*.whl
+
+  upload-wheels:
+    runs-on: ubuntu-latest
+    needs: [build-wheels, build-pure-python-wheel]
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          path: dist/
+
+      - name: Publish
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI }}
+
+  upload-source:
+    runs-on: ubuntu-latest
+    needs: [build-wheels, build-pure-python-wheel]
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+
+      - name: Build and install Plugin
+        run: |
+          python -m pip install --upgrade pip wheel
+          python setup.py sdist
+
+      - name: Publish
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -83,4 +83,4 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           name: pure-python-wheels.zip
-          path: ./dist/*.whl
+          path: main/dist/*.whl

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,7 +1,9 @@
 name: Deploy
 on:
-  release:
-    types: [published]
+  push:
+    branches:
+      - master
+  pull_request:
 
 env:
   CIBW_BUILD: 'cp37-* cp38-* cp39-*'
@@ -26,70 +28,54 @@ env:
 
 jobs:
 
-  build-wheels:
-    name: ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-    steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.4.1
-        with:
-          access_token: ${{ github.token }}
+#  build-wheels:
+#    name: ${{ matrix.os }}
+#    runs-on: ${{ matrix.os }}
+#    strategy:
+#      matrix:
+#        os: [ubuntu-latest, macos-latest, windows-latest]
+#    steps:
+#      - name: Cancel Previous Runs
+#        uses: styfle/cancel-workflow-action@0.4.1
+#        with:
+#          access_token: ${{ github.token }}
+#
+#      - uses: actions/checkout@v2
+#
+#      - uses: actions/setup-python@v2
+#        with:
+#          python-version: '3.7'
+#
+#      - name: Install cibuildwheel
+#        run: |
+#          python -m pip install --upgrade pip
+#          python -m pip install cibuildwheel==1.5.5
+#
+#      - name: Build wheels
+#        run: |
+#          python -m cibuildwheel --output-dir wheelhouse
+#
+#      - uses: actions/upload-artifact@v2
+#        with:
+#          name: ${{ runner.os }}-wheels.zip
+#          path: ./wheelhouse/*.whl
 
+  build-pure-python-wheel:
+    runs-on: ubuntu-latest
+    steps:
       - uses: actions/checkout@v2
 
       - uses: actions/setup-python@v2
         with:
           python-version: '3.7'
 
-      - name: Install cibuildwheel
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install cibuildwheel==1.5.5
-
       - name: Build wheels
         run: |
-          python -m cibuildwheel --output-dir wheelhouse
+          python setup.py bdist_wheel
+        env:
+          SKIP_COMPILATION: True
 
       - uses: actions/upload-artifact@v2
         with:
-          name: ${{ runner.os }}-wheels.zip
-          path: ./wheelhouse/*.whl
-
-  upload-wheels:
-    runs-on: ubuntu-latest
-    needs: [build-wheels]
-    steps:
-      - uses: actions/download-artifact@v2
-        with:
-          path: dist/
-
-      - name: Publish
-        uses: pypa/gh-action-pypi-publish@master
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI }}
-
-  upload-source:
-    runs-on: ubuntu-latest
-    needs: [build-wheels]
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.7
-
-      - name: Build and install Plugin
-        run: |
-          python -m pip install --upgrade pip wheel
-          python setup.py sdist
-
-      - name: Publish
-        uses: pypa/gh-action-pypi-publish@master
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI }}
+          name: pure-python-wheels.zip
+          path: ./dist/*.whl

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -74,6 +74,7 @@ jobs:
 
       - name: Build wheels
         run: |
+          pip install wheel
           cd main
           python setup.py bdist_wheel
         env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,7 +63,10 @@ jobs:
   build-pure-python-wheel:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout PennyLane-Lightning
+        uses: actions/checkout@v2
+        with:
+          path: main
 
       - uses: actions/setup-python@v2
         with:
@@ -71,6 +74,7 @@ jobs:
 
       - name: Build wheels
         run: |
+          cd main
           python setup.py bdist_wheel
         env:
           SKIP_COMPILATION: True

--- a/.github/workflows/tests_without_binary.yml
+++ b/.github/workflows/tests_without_binary.yml
@@ -1,4 +1,4 @@
-name: Testing
+name: Testing without binary
 on:
   push:
     branches:

--- a/.github/workflows/tests_without_binary.yml
+++ b/.github/workflows/tests_without_binary.yml
@@ -1,0 +1,58 @@
+name: Testing
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+env:
+  COVERAGE_FLAGS: "--cov=pennylane_lightning --cov-report=term-missing --cov-report=xml:../coverage.xml --no-flaky-report -p no:warnings --tb=native"
+
+jobs:
+  pythontests:
+    name: Python tests
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04]
+
+    steps:
+      - name: Cancel previous runs
+        uses: styfle/cancel-workflow-action@0.4.1
+        with:
+          access_token: ${{ github.token }}
+
+      - name: Checkout PennyLane-Lightning
+        uses: actions/checkout@v2
+        with:
+          path: main
+
+      - uses: actions/setup-python@v2
+        name: Install Python
+        with:
+          python-version: '3.7'
+
+      - name: Get required Python packages
+        run: |
+          cd main
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Install lightning.qubit device
+        run: |
+          cd main
+          pip install -e .
+        env:
+          SKIP_COMPILATION: True
+
+      - name: Run PennyLane-Lightning unit tests
+        run: |
+          cd main/
+          pytest tests/ $COVERAGE_FLAGS
+          pl-device-test --device lightning.qubit --skip-ops --shots=20000 $COVERAGE_FLAGS --cov-append
+          pl-device-test --device lightning.qubit --shots=None --skip-ops $COVERAGE_FLAGS --cov-append
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1.0.12
+        with:
+          file: coverage.xml

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,7 +4,7 @@ sphinx:
   configuration: doc/conf.py
 
 python:
-  version: 3.9
+  version: 3.8
   install:
     - requirements: doc/requirements.txt
     - requirements: requirements.txt

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ clean:
 	rm -rf .coverage coverage_html_report/
 	rm -rf tmp
 	rm -rf *.dat
+	rm pennylane_lightning/lightning_qubit_ops*
 
 docs:
 	make -C doc html

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ clean:
 	rm -rf .coverage coverage_html_report/
 	rm -rf tmp
 	rm -rf *.dat
-	rm pennylane_lightning/lightning_qubit_ops*
+	rm -rf pennylane_lightning/lightning_qubit_ops*
 
 docs:
 	make -C doc html

--- a/README.rst
+++ b/README.rst
@@ -57,6 +57,7 @@ Alternatively, to build PennyLane-Lightning from source you can run
 
     $ git clone https://github.com/XanaduAI/pennylane-lightning.git
     $ cd pennylane-lightning
+    $ pip install -r requirements.txt
     $ pip install -e .
 
 Note that subsequent calls to ``pip install -e .`` will use cached binaries stored in the

--- a/README.rst
+++ b/README.rst
@@ -51,7 +51,23 @@ PennyLane-Lightning requires Python version 3.6 and above. It can be installed u
 
     $ pip install pennylane-lightning
 
-Alternatively, to build PennyLane-Lightning from source you can run
+To build PennyLane-Lightning from source you can run
+
+.. code-block:: console
+
+    $ pip install pybind11 pennylane-lightning --no-binary :all:
+
+A C++ compiler such as ``g++``, ``clang``, or ``MSVC`` is required. On Debian-based systems, this
+can be installed via ``apt``:
+
+.. code-block:: console
+
+    $ sudo apt install g++
+
+The `pybind11 <https://pybind11.readthedocs.io/en/stable/>`_ library is also used for binding the
+C++ functionality to Python.
+
+Alternatively, for development and testing, you can install by cloning the repository:
 
 .. code-block:: console
 
@@ -62,19 +78,6 @@ Alternatively, to build PennyLane-Lightning from source you can run
 
 Note that subsequent calls to ``pip install -e .`` will use cached binaries stored in the
 ``build`` folder. Run ``make clean`` if you would like to recompile.
-
-The following dependencies are required to install PennyLane-Lightning:
-
-* A C++ compiler, such as ``g++``, ``clang``, or ``MSVC``.
-* `pybind11 <https://pybind11.readthedocs.io/en/stable/>`_ a library for binding C++
-  functionality to Python.
-
-On Debian-based systems, these can be installed via ``apt`` and ``pip``:
-
-.. code-block:: console
-
-    $ sudo apt install g++
-    $ pip install pybind11
 
 Testing
 -------

--- a/pennylane_lightning/lightning_qubit.py
+++ b/pennylane_lightning/lightning_qubit.py
@@ -15,10 +15,17 @@ r"""
 This module contains the :class:`~.LightningQubit` class, a PennyLane simulator device that
 interfaces with C++ for fast linear algebra calculations.
 """
+from warnings import warn
+
 from pennylane.devices import DefaultQubit
 import numpy as np
 from pennylane import QubitStateVector, BasisState, DeviceError, QubitUnitary
-from .lightning_qubit_ops import apply, StateVectorC64, StateVectorC128
+
+try:
+    from .lightning_qubit_ops import apply, StateVectorC64, StateVectorC128
+    BINARY_AVAILABLE = True
+except ModuleNotFoundError:
+    BINARY_AVAILABLE = False
 
 from ._version import __version__
 
@@ -122,3 +129,20 @@ class LightningQubit(DefaultQubit):
                 method(wires, inv, param)
 
         return np.reshape(state_vector, state.shape)
+
+
+if not BINARY_AVAILABLE:
+    class LightningQubit(DefaultQubit):
+
+        name = "Lightning Qubit PennyLane plugin"
+        short_name = "lightning.qubit"
+        pennylane_requires = ">=0.15"
+        version = __version__
+        author = "Xanadu Inc."
+
+        def __init__(self, *args, **kwargs):
+            warn("Pre-compiled binaries for lightning.qubit are not available. Falling back to "
+                 "using the Python-based default.qubit implementation. To manually compile from"
+                 "source, follow the instructions at "
+                 "https://pennylane-lightning.readthedocs.io/en/latest/installation.html.")
+            super().__init__(*args, **kwargs)

--- a/pennylane_lightning/lightning_qubit.py
+++ b/pennylane_lightning/lightning_qubit.py
@@ -24,9 +24,9 @@ from pennylane import QubitStateVector, BasisState, DeviceError, QubitUnitary
 try:
     from .lightning_qubit_ops import apply, StateVectorC64, StateVectorC128
 
-    BINARY_AVAILABLE = True
+    CPP_BINARY_AVAILABLE = True
 except ModuleNotFoundError:
-    BINARY_AVAILABLE = False
+    CPP_BINARY_AVAILABLE = False
 
 from ._version import __version__
 
@@ -132,7 +132,7 @@ class LightningQubit(DefaultQubit):
         return np.reshape(state_vector, state.shape)
 
 
-if not BINARY_AVAILABLE:
+if not CPP_BINARY_AVAILABLE:
 
     class LightningQubit(DefaultQubit):
 

--- a/pennylane_lightning/lightning_qubit.py
+++ b/pennylane_lightning/lightning_qubit.py
@@ -23,6 +23,7 @@ from pennylane import QubitStateVector, BasisState, DeviceError, QubitUnitary
 
 try:
     from .lightning_qubit_ops import apply, StateVectorC64, StateVectorC128
+
     BINARY_AVAILABLE = True
 except ModuleNotFoundError:
     BINARY_AVAILABLE = False
@@ -132,6 +133,7 @@ class LightningQubit(DefaultQubit):
 
 
 if not BINARY_AVAILABLE:
+
     class LightningQubit(DefaultQubit):
 
         name = "Lightning Qubit PennyLane plugin"
@@ -141,8 +143,11 @@ if not BINARY_AVAILABLE:
         author = "Xanadu Inc."
 
         def __init__(self, *args, **kwargs):
-            warn("Pre-compiled binaries for lightning.qubit are not available. Falling back to "
-                 "using the Python-based default.qubit implementation. To manually compile from"
-                 "source, follow the instructions at "
-                 "https://pennylane-lightning.readthedocs.io/en/latest/installation.html.")
+            warn(
+                "Pre-compiled binaries for lightning.qubit are not available. Falling back to "
+                "using the Python-based default.qubit implementation. To manually compile from "
+                "source, follow the instructions at "
+                "https://pennylane-lightning.readthedocs.io/en/latest/installation.html.",
+                UserWarning,
+            )
             super().__init__(*args, **kwargs)

--- a/setup.py
+++ b/setup.py
@@ -168,7 +168,6 @@ else:
 requirements = [
     "numpy",
     "pennylane>=0.15",
-    "pybind11",
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -116,7 +116,7 @@ class BuildExt(build_ext):
         build_ext.build_extensions(self)
 
 
-if not os.environ.get("MOCK_DOCS", False):
+if not os.environ.get("SKIP_COMPILATION", False):
 
     include_dirs = [
         get_pybind_include(),

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -14,18 +14,13 @@
 """
 Unit tests for the :mod:`pennylane_lightning.LightningQubit` device.
 """
-import cmath
-import math
-
 # pylint: disable=protected-access,cell-var-from-loop
-from unittest import mock
+import math
 
 import numpy as np
 import pennylane as qml
-import pennylane_lightning
 import pytest
 from pennylane import DeviceError
-from pennylane.devices.default_qubit import DefaultQubit
 
 from pennylane_lightning import LightningQubit
 

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -23,7 +23,7 @@ import pytest
 from pennylane import DeviceError
 
 from pennylane_lightning import LightningQubit
-from pennylane_lightning.lightning_qubit import BINARY_AVAILABLE
+from pennylane_lightning.lightning_qubit import CPP_BINARY_AVAILABLE
 
 U2 = np.array(
     [
@@ -588,7 +588,7 @@ class TestLightningQubitIntegration:
     def test_no_backprop(self):
         """Test that lightning.qubit does not support the backprop
         differentiation method."""
-        if not BINARY_AVAILABLE:
+        if not CPP_BINARY_AVAILABLE:
             pytest.skip("Skipping test because lightning.qubit is behaving like default.qubit")
 
         dev = qml.device("lightning.qubit", wires=2)
@@ -603,7 +603,7 @@ class TestLightningQubitIntegration:
     def test_best_gets_lightning(self):
         """Test that the best differentiation method returns lightning
         qubit."""
-        if not BINARY_AVAILABLE:
+        if not CPP_BINARY_AVAILABLE:
             pytest.skip("Skipping test because lightning.qubit is behaving like default.qubit")
 
         dev = qml.device("lightning.qubit", wires=2)
@@ -1261,7 +1261,7 @@ class TestTensorSample:
 
 def test_warning():
     """Tests if a warning is raised when lightning.qubit binaries are not available"""
-    if BINARY_AVAILABLE:
+    if CPP_BINARY_AVAILABLE:
         pytest.skip("Test only applies when binaries are unavailable")
 
     with pytest.warns(UserWarning, match="Pre-compiled binaries for lightning.qubit"):

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -666,7 +666,7 @@ class TestLightningQubitIntegration:
         for _ in range(100):
             runs.append(circuit(p))
 
-        assert np.isclose(np.mean(runs), -np.sin(p), atol=1e-3, rtol=0)
+        assert np.isclose(np.mean(runs), -np.sin(p), atol=1e-2, rtol=0)
 
     # This test is ran against the state |0> with one Z expval
     @pytest.mark.parametrize(
@@ -1257,3 +1257,12 @@ class TestTensorSample:
             - 2 * np.cos(theta) * np.sin(phi) * np.sin(2 * varphi)
         ) / 4
         assert np.allclose(var, expected, atol=tolerance, rtol=0)
+
+
+def test_warning():
+    """Tests if a warning is raised when lightning.qubit binaries are not available"""
+    if BINARY_AVAILABLE:
+        pytest.skip("Test only applies when binaries are unavailable")
+
+    with pytest.warns(UserWarning, match="Pre-compiled binaries for lightning.qubit"):
+        qml.device("lightning.qubit", wires=1)

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -23,6 +23,7 @@ import pytest
 from pennylane import DeviceError
 
 from pennylane_lightning import LightningQubit
+from pennylane_lightning.lightning_qubit import BINARY_AVAILABLE
 
 U2 = np.array(
     [
@@ -587,6 +588,8 @@ class TestLightningQubitIntegration:
     def test_no_backprop(self):
         """Test that lightning.qubit does not support the backprop
         differentiation method."""
+        if not BINARY_AVAILABLE:
+            pytest.skip("Skipping test because lightning.qubit is behaving like default.qubit")
 
         dev = qml.device("lightning.qubit", wires=2)
 
@@ -600,6 +603,9 @@ class TestLightningQubitIntegration:
     def test_best_gets_lightning(self):
         """Test that the best differentiation method returns lightning
         qubit."""
+        if not BINARY_AVAILABLE:
+            pytest.skip("Skipping test because lightning.qubit is behaving like default.qubit")
+
         dev = qml.device("lightning.qubit", wires=2)
 
         def circuit():


### PR DESCRIPTION
**Context:**

PennyLane-Lightning can now be installed without compiling its C++ binaries and will fall back
  to using the `default.qubit` implementation. Skipping compilation is achieved by setting the
  `SKIP_COMPILATION` environment variable, e.g., `export SKIP_COMPILATION=True`. This feature
  is intended for building a pure-Python wheel of PennyLane-Lightning as a backup for platforms
  without a dedicated wheel.

**Possible Drawbacks:**

Users installing the non-compiled version will obviously have a device that is as fast as `default.qubit`. A warning has been added for this eventuality.