### PR TITLE
Ensure C++17 compiler builds wheel for MacOS

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,7 @@ env:
 
   CIBW_BEFORE_ALL_MACOS: |
     brew cask uninstall --force oclint
-    brew install gcc libomp
+    brew install clang libomp
 
   # Python build settings
   CIBW_BEFORE_BUILD: |
@@ -29,6 +29,11 @@ env:
   # Use Centos 7 wheel-builder for ARM
   CIBW_MANYLINUX_AARCH64_IMAGE: manylinux2014
   CIBW_MANYLINUX_PPC64LE_IMAGE: manylinux2014
+
+  # Ensure modern compiler available for MacOS wheelbuilding
+  CIBW_ENVIRONMENT_MACOS: |
+    CC=/usr/local/opt/llvm/bin/clang
+    CXX=/usr/local/opt/llvm/bin/clang++
 
 jobs:
   build-compiled-wheels:

--- a/.github/workflows/wheel_macos_arm64.yml
+++ b/.github/workflows/wheel_macos_arm64.yml
@@ -10,10 +10,7 @@ env:
   # MacOS specific build settings
   CIBW_BEFORE_ALL_MACOS: |
     brew uninstall --force oclint
-    brew install gcc libomp
-
-  # Required for C++17 support
-  CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=10.14 
+    brew install llvm libomp
 
   # Python build settings
   CIBW_BEFORE_BUILD: |
@@ -56,6 +53,8 @@ jobs:
 
         env:
           CIBW_ARCHS_MACOS: ${{ matrix.arch }}
+          CC: /usr/local/opt/llvm/bin/clang
+          CXX: /usr/local/opt/llvm/bin/clang++
 
       - uses: actions/upload-artifact@v2
         if: github.ref == 'refs/heads/master'

--- a/.github/workflows/wheel_macos_x86_64.yml
+++ b/.github/workflows/wheel_macos_x86_64.yml
@@ -57,7 +57,6 @@ jobs:
           CXX: /usr/local/opt/llvm/bin/clang++
 
       - uses: actions/upload-artifact@v2
-        if: github.ref == 'refs/heads/master'
         with:
           name: ${{ runner.os }}-wheels.zip
           path: ./wheelhouse/*.whl

--- a/.github/workflows/wheel_macos_x86_64.yml
+++ b/.github/workflows/wheel_macos_x86_64.yml
@@ -57,6 +57,7 @@ jobs:
           CXX: /usr/local/opt/llvm/bin/clang++
 
       - uses: actions/upload-artifact@v2
+        if: github.ref == 'refs/heads/master'
         with:
           name: ${{ runner.os }}-wheels.zip
           path: ./wheelhouse/*.whl

--- a/.github/workflows/wheel_macos_x86_64.yml
+++ b/.github/workflows/wheel_macos_x86_64.yml
@@ -13,9 +13,6 @@ env:
     brew uninstall --force oclint
     brew install llvm libomp
 
-  # Required for C++17 support
-  CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=10.14
-
   # Python build settings
   CIBW_BEFORE_BUILD: |
     pip install pybind11
@@ -56,6 +53,8 @@ jobs:
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
           CIBW_ARCHS_MACOS: ${{matrix.arch}}
+          CC: /usr/local/opt/llvm/bin/clang
+          CXX: /usr/local/opt/llvm/bin/clang++
 
       - uses: actions/upload-artifact@v2
         if: github.ref == 'refs/heads/master'


### PR DESCRIPTION
**Context:** This fixes issues with the MacOS wheelbuilder, requiring C++17 support that is unavailable within the default CI setup. We opt for an externally installed (brew) clang compiler, allowing both X86_64 and ARM64 wheels to be compiled.

**Description of the Change:** Uses brew clang as default compiler for MacOS.

**Benefits:** Enables Cpp17 features for MacOS under multiple architectures.

**Possible Drawbacks:** May have possible issues with older MacOS versions.

**Related GitHub Issues:**
