### PR TITLE
Enable clang-tidy in CI checks

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -44,13 +44,14 @@ jobs:
 
       - name: Install dependencies
         run: sudo apt update && sudo apt -y install clang-tidy-11 python3 cmake g++
+        env: DEBIAN_FRONTEND=noninteractive
 
       - name: Checkout code
         uses: actions/checkout@v2
 
       - name: Run clang-tidy compilation
         run: |
-          cmake -BBuild -DENABLE_CLANG_TIDY=on . 
+          cmake -BBuild -DENABLE_CLANG_TIDY=on -DCLANT_TIDY_BINARY=clang-tidy-11 .
           cmake --build ./Build
 
   format-cpp:

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -32,6 +32,27 @@ jobs:
       - name: Run Black
         run: black -l 100 pennylane_lightning/ --check
 
+  tidy-cpp:
+    name: Tidy (C++)
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Cancel previous runs
+        uses: styfle/cancel-workflow-action@0.4.1
+        with:
+          access_token: ${{ github.token }}
+
+      - name: Install dependencies
+        run: sudo apt update && sudo apt -y install clang-tidy-11 python3 cmake g++
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Run clang-tidy compilation
+        run: |
+          cmake -BBuild -DENABLE_CLANG_TIDY=on . 
+          cmake --build ./Build
+
   format-cpp:
     name: Format (C++)
     runs-on: ubuntu-20.04

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,15 +1,9 @@
 name: Formatting check
 on:
   pull_request:
-    paths:
-      - "pennylane_lightning/**"
-      - "tests/**"
   push:
     branches:
       - master
-    paths:
-      - "pennylane_lightning/**"
-      - "tests/**"
 
 jobs:
   black:

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,12 +1,15 @@
 name: Formatting check
 on:
   pull_request:
-    push:
-      branches:
-        - master
-      paths:
-        - "pennylane_lightning/**"
-        - "tests/**"
+    paths:
+      - "pennylane_lightning/**"
+      - "tests/**"
+  push:
+    branches:
+      - master
+    paths:
+      - "pennylane_lightning/**"
+      - "tests/**"
 
 jobs:
   black:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,10 @@ option(ENABLE_WARNINGS "Enable warnings" ON)
 option(ENABLE_CLANG_TIDY "Enable clang-tidy build checks" OFF)
 
 if(ENABLE_CLANG_TIDY)
-    set(CMAKE_CXX_CLANG_TIDY clang-tidy;
+    if (NOT DEFINED CLANG_TIDY_BINARY)
+        set(CLANG_TIDY_BINARY clang-tidy)
+    endif()
+    set(CMAKE_CXX_CLANG_TIDY ${CLANG_TIDY_BINARY};
                             -extra-arg=-std=c++17;
                             -warnings-as-errors=*;
                             -header-filter=.*;

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,16 @@ endif()
 option(ENABLE_NATIVE "Enable native CPU build tuning" OFF)
 option(BUILD_TESTS "Build cpp tests" OFF)
 option(ENABLE_WARNINGS "Enable warnings" ON)
+option(ENABLE_CLANG_TIDY "Enable clang-tidy build checks" OFF)
+
+if(ENABLE_CLANG_TIDY)
+    set(CMAKE_CXX_CLANG_TIDY clang-tidy;
+                            -extra-arg=-std=c++17;
+                            -warnings-as-errors=*;
+                            -header-filter=.*;
+                            -checks=-*,-llvmlibc-*,modernize-*,clang-analyzer-cplusplus*,openmp-*,performance-*,portability-*,readability-*;
+    )
+endif()
 
 # Add pybind11
 include(FetchContent)


### PR DESCRIPTION
**Context:** To ensure modern C++ standards, we require testing of newly added code to ensure it is standards-conforming with all newly supported features. This PR enables clang-tidy with warnings-as-errors support for a variety of tidy options as defined from [here](https://clang.llvm.org/extra/clang-tidy/)

**Description of the Change:** Add CI-enabled checking of code-base builds with clang-tidy for the following options:
```
clang-tidy \
-extra-arg=-std=c++17 \
-warnings-as-errors=* \
-header-filter=.* \
-checks=-*,-llvmlibc-*,clang-analyzer-*,modernize-*,clang-analyzer-cplusplus*,openmp-*,performance-*,portability-*,readability-*
```

**Benefits:** This will ensure our codebase uses non-legacy and/or deprecated language features, as well as ensuring strict conformance to the modern C++ standard (currently C++17). In addition, this can prevent compiler-specific bugs being uncaught, which can be difficult to find between compiler versions.

**Possible Drawbacks:** May add additional development time to new features as developer become comfortable with the requirements of the standard.

**Related GitHub Issues:**
