### PR TITLE
Add check-tidy to Makefile 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ help:
 	@echo "  test-cpp           to run the C++ test suite"
 	@echo "  coverage           to generate a coverage report"
 	@echo "  format [check=1]   to apply C++ formatter; use with 'check=1' to check instead of modify (requires clang-format)"
-	@echo "  check-tidy         to build PennyLane-Lightning with CLANG_TIDY=ON using clang-tidy-11"
+	@echo "  check-tidy         to build PennyLane-Lightning with ENABLE_CLANG_TIDY=ON"
 
 .PHONY: install
 install:
@@ -87,5 +87,5 @@ endif
 .PHONY: check-tidy
 check-tidy:
 	rm -rf ./Build
-	cmake . -BBuild -DENABLE_CLANG_TIDY=ON -DCLANG_TIDY_BINARY=clang-tidy-11
+	cmake . -BBuild -DENABLE_CLANG_TIDY=ON -DBUILD_TESTS=1
 	cmake --build ./Build

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ help:
 	@echo "  test-cpp           to run the C++ test suite"
 	@echo "  coverage           to generate a coverage report"
 	@echo "  format [check=1]   to apply C++ formatter; use with 'check=1' to check instead of modify (requires clang-format)"
+	@echo "  check-tidy         to build PennyLane-Lightning with CLANG_TIDY=ON using clang-tidy-11"
 
 .PHONY: install
 install:
@@ -82,3 +83,9 @@ ifdef check
 else
 	./bin/format pennylane_lightning/src/* tests
 endif
+
+.PHONY: check-tidy
+check-tidy:
+	rm -rf ./Build
+	cmake . -BBuild -DENABLE_CLANG_TIDY=ON -DCLANG_TIDY_BINARY=clang-tidy-11
+	cmake --build ./Build

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ help:
 	@echo "  test-cpp           to run the C++ test suite"
 	@echo "  coverage           to generate a coverage report"
 	@echo "  format [check=1]   to apply C++ formatter; use with 'check=1' to check instead of modify (requires clang-format)"
-	@echo "  check-tidy         to build PennyLane-Lightning with ENABLE_CLANG_TIDY=ON"
+	@echo "  check-tidy         to build PennyLane-Lightning with ENABLE_CLANG_TIDY=ON (requires clang-tidy & CMake)"
 
 .PHONY: install
 install:

--- a/README.rst
+++ b/README.rst
@@ -123,7 +123,7 @@ To test the C++ code:
     $ make test
 
 Other supported options are ``-DENABLE_NATIVE=ON`` (for ``-march=native``), ``-DUSE_LAPACK=ON``, ``-DUSE_OPENBLAS=ON``,
-``-DENABLE_CLANG_TIDY=ON``, and ``-DCLANG_TIDY_BINARY=clang-tidy-11``.
+and ``-DENABLE_CLANG_TIDY=ON``.
 
 
 .. installation-end-inclusion-marker-do-not-remove

--- a/README.rst
+++ b/README.rst
@@ -122,7 +122,8 @@ To test the C++ code:
     $ make cpptests
     $ make test
 
-Other supported options are ``-DENABLE_NATIVE=ON`` (for ``-march=native``), ``-DUSE_LAPACK=ON``, and ``-DUSE_OPENBLAS=ON``.
+Other supported options are ``-DENABLE_NATIVE=ON`` (for ``-march=native``), ``-DUSE_LAPACK=ON``, ``-DUSE_OPENBLAS=ON``,
+``-DENABLE_CLANG_TIDY=ON``, and ``-DCLANG_TIDY_BINARY=clang-tidy-11``.
 
 
 .. installation-end-inclusion-marker-do-not-remove

--- a/README.rst
+++ b/README.rst
@@ -34,6 +34,7 @@ learning, automatic differentiation, and optimization of hybrid quantum-classica
 
 .. header-end-inclusion-marker-do-not-remove
 
+
 Features
 ========
 
@@ -41,6 +42,7 @@ Features
   automatic differentiation and optimization.
 
 .. installation-start-inclusion-marker-do-not-remove
+
 
 Installation
 ============
@@ -122,16 +124,14 @@ To test the C++ code:
     $ make cpptests
     $ make test
 
-Other supported options are ``-DENABLE_NATIVE=ON`` (for ``-march=native``), ``-DUSE_LAPACK=ON``, ``-DUSE_OPENBLAS=ON``,
-and ``-DENABLE_CLANG_TIDY=ON``.
-
+Other supported options are ``-DENABLE_NATIVE=ON`` (for ``-march=native``),
+``-DUSE_LAPACK=ON``, ``-DUSE_OPENBLAS=ON``, and
+``-DENABLE_CLANG_TIDY=ON``.
 
 .. installation-end-inclusion-marker-do-not-remove
 
-
 Please refer to the `plugin documentation <https://pennylane-lightning.readthedocs.io/>`_ as
 well as to the `PennyLane documentation <https://pennylane.readthedocs.io/>`_ for further reference.
-
 
 
 Contributing
@@ -143,6 +143,7 @@ All contributers to this plugin will be listed as authors on the releases.
 
 We also encourage bug reports, suggestions for new features and enhancements, and even links to cool projects
 or applications built on PennyLane.
+
 
 Authors
 =======
@@ -158,6 +159,7 @@ If you are doing research using PennyLane and PennyLane-Lightning, please cite `
 
 .. support-start-inclusion-marker-do-not-remove
 
+
 Support
 =======
 
@@ -170,6 +172,7 @@ by asking a question in the forum.
 
 .. support-end-inclusion-marker-do-not-remove
 .. license-start-inclusion-marker-do-not-remove
+
 
 License
 =======


### PR DESCRIPTION
**Context:**
Add `make check-tidy` to PL-Lightning and update README

**Description of the Change:**
To ensure adherence to modern C++ standards, PR #153 added clang-tidy checks with selecting the following options: 

`clang-tidy -extra-arg=-std=c++17 -warnings-as-errors=* -header-filter=.* -checks=-*,-llvmlibc-*,clang-analyzer-*,modernize-*,clang-analyzer-cplusplus*,openmp-*,performance-*,portability-*,readability-*`

This PR is a minor update: 
-  Add `make check-tidy` option to build PL-Lightning with `ENABLE_CLANG_TIDY=ON`, and 
- Update README. 

**Benefits:**
Provide a simple Makefile command to ensure that new contributions follow modern C++ standards; see #153 for more details. 

**Possible Drawbacks:**

**Related GitHub Issues:**
