### PR TITLE
Add prelim CUDA class support to Lightning shared library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,22 @@
+##########################
+## Set Project version
+##########################
 cmake_minimum_required(VERSION 3.14)
+set(LIGHTNING_LOGO "
+░█░░░▀█▀░█▀▀░█░█░▀█▀░█▀█░▀█▀░█▀█░█▀▀░
+░█░░░░█░░█░█░█▀█░░█░░█░█░░█░░█░█░█░█░
+░▀▀▀░▀▀▀░▀▀▀░▀░▀░░▀░░▀░▀░▀▀▀░▀░▀░▀▀▀░
+")
+message(${LIGHTNING_LOGO})
 
-project(pennylane_lightning)
+project(pennylane_lightning
+    DESCRIPTION "A C++ backed statevector device for PennyLane"
+    LANGUAGES CXX C
+)
+
+##########################
+## Utility methods
+##########################
 
 # Read and set pennylane_lightning version
 function(set_pennylane_lightning_version VERSION_FILE_PATH)
@@ -20,16 +36,27 @@ set_pennylane_lightning_version(${PROJECT_SOURCE_DIR}/pennylane_lightning/_versi
 message(STATUS "pennylane_lightning version ${VERSION_STRING}")
 set(PROJECT_VERSION ${VERSION_STRING})
 
-set(CMAKE_CXX_STANDARD 17) # At least C++17 is required
+##########################
+## Enfore C++ Standard
+##########################
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-if(NOT CMAKE_BUILD_TYPE)
-    set(CMAKE_BUILD_TYPE Release)
-endif()
-
+##########################
+## Set Default Options
+##########################
+# Compiler options
 option(ENABLE_NATIVE "Enable native CPU build tuning" OFF)
 option(BUILD_TESTS "Build cpp tests" OFF)
 option(ENABLE_WARNINGS "Enable warnings" ON)
 option(ENABLE_CLANG_TIDY "Enable clang-tidy build checks" OFF)
+option(ENABLE_CUDA "Build with CUDA GPU support" OFF)
+option(DISABLE_CUDA_SAFETY "Build without CUDA call safety checks" OFF)
+
+# Build options
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE Release)
+endif()
 
 if(ENABLE_CLANG_TIDY)
     if (NOT DEFINED CLANG_TIDY_BINARY)
@@ -40,6 +67,9 @@ if(ENABLE_CLANG_TIDY)
     )
 endif()
 
+##########################
+## Fetch dependencies
+##########################
 # Add pybind11
 include(FetchContent)
 FetchContent_Declare(
@@ -49,31 +79,42 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(pybind11)
 
-add_subdirectory(pennylane_lightning/src)
+if(ENABLE_CUDA)
+    SET(CUDA_SEPARABLE_COMPILATION ON)
+    enable_language(CUDA)
+    if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
+        set(CMAKE_CUDA_ARCHITECTURES 60)
+    endif()
 
+    find_package(CUDA REQUIRED)
+endif()
+
+############################
+## Create Lightning bindings
+############################
+add_subdirectory(pennylane_lightning/src)
 add_library(pennylane_lightning INTERFACE)
 target_link_libraries(pennylane_lightning INTERFACE     lightning_utils 
                                                         lightning_simulator 
                                                         lightning_algorithms)
 target_include_directories(pennylane_lightning INTERFACE "pennylane_lightning/src")
 
+# Create binding module
 add_library(external_dependency INTERFACE)
-
-if ("$ENV{USE_OPENBLAS}" OR "${USE_OPENBLAS}")
-    message(STATUS "Use OPENBLAS")
-    target_link_libraries(external_dependency INTERFACE openblas)
-    target_compile_options(external_dependency INTERFACE "-DOPENBLAS=1")
-endif()
-
 pybind11_add_module(lightning_qubit_ops     "pennylane_lightning/src/bindings/Bindings.cpp")
 target_link_libraries(lightning_qubit_ops PRIVATE pennylane_lightning external_dependency)
 set_target_properties(lightning_qubit_ops PROPERTIES CXX_VISIBILITY_PRESET hidden)
-
 target_compile_options(lightning_qubit_ops PRIVATE "$<$<CONFIG:RELEASE>:-W>")
 target_compile_definitions(lightning_qubit_ops PRIVATE VERSION_INFO=${VERSION_STRING})
 
+##########################
+## Compile options
+##########################
+
 if(ENABLE_WARNINGS)
-  target_compile_options(pennylane_lightning INTERFACE $<$<COMPILE_LANGUAGE:CXX>:-Wall;-Wextra;-Werror>)
+    target_compile_options(pennylane_lightning INTERFACE 
+        $<$<COMPILE_LANGUAGE:CXX>:-Wall;-Wextra;-Werror>
+    )
 endif()
 
 if(ENABLE_NATIVE)
@@ -81,6 +122,16 @@ if(ENABLE_NATIVE)
     add_compile_options(-march=native)
     target_compile_options(pennylane_lightning INTERFACE -march=native)
     target_compile_options(lightning_qubit_ops PRIVATE -march=native)
+endif()
+
+if (ENABLE_CUDA)
+    # Avoid DSO errors on platforms preferring static linkage
+    string(REPLACE "libcudart_static.a" "libcudart.so" CUDA_SHARED_RT "${CUDA_LIBRARIES}")
+    target_include_directories(pennylane_lightning INTERFACE ${CUDA_TOOLKIT_ROOT_DIR}/include)
+    target_link_libraries(pennylane_lightning INTERFACE ${CUDA_SHARED_RT})
+    if(DISABLE_CUDA_SAFETY)
+        target_compile_options(pennylane_lightning INTERFACE $<$<COMPILE_LANGUAGE:CXX>:-DCUDA_UNSAFE>)
+    endif()
 endif()
 
 if (BUILD_TESTS)

--- a/pennylane_lightning/src/simulator/CMakeLists.txt
+++ b/pennylane_lightning/src/simulator/CMakeLists.txt
@@ -7,6 +7,17 @@ add_library(lightning_simulator STATIC ${SIMULATOR_FILES})
 find_package(OpenMP)
 
 target_include_directories(lightning_simulator PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} )
+
+if(ENABLE_CUDA)
+    enable_language(CUDA)
+    add_library(lightning_simulator_gpu OBJECT StateVectorGPU.cu )
+    target_include_directories(lightning_simulator_gpu PUBLIC ${CUDA_INCLUDE_DIRS} ${CMAKE_CURRENT_SOURCE_DIR})
+    target_link_libraries(lightning_simulator_gpu PRIVATE lightning_utils)
+    set_target_properties(lightning_simulator_gpu PROPERTIES POSITION_INDEPENDENT_CODE ON)
+    set_target_properties(lightning_simulator_gpu PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
+    target_link_libraries(lightning_simulator PRIVATE lightning_simulator_gpu ${CUDA_LIBRARIES})
+endif()
+
 target_link_libraries(lightning_simulator PRIVATE lightning_utils)
 
 if(OpenMP_FOUND)

--- a/pennylane_lightning/src/simulator/StateVectorGPU.cu
+++ b/pennylane_lightning/src/simulator/StateVectorGPU.cu
@@ -1,0 +1,19 @@
+// Copyright 2021 Xanadu Quantum Technologies Inc.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "StateVectorGPU.cuh"
+
+// explicit instantiation
+template class Pennylane::StateVectorGPU<float>;
+template class Pennylane::StateVectorGPU<double>;

--- a/pennylane_lightning/src/simulator/StateVectorGPU.cuh
+++ b/pennylane_lightning/src/simulator/StateVectorGPU.cuh
@@ -1,0 +1,89 @@
+// Copyright 2021 Xanadu Quantum Technologies Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include <cuComplex.h>
+#include <cuda.h>
+
+#include "StateVector.hpp"
+
+namespace {
+cuDoubleComplex getCudaType(const double &t) {
+    static_cast<void>(t);
+    return {};
+}
+cuComplex getCudaType(const float &t) {
+    static_cast<void>(t);
+    return {};
+}
+} // namespace
+
+namespace Pennylane {
+
+/**
+ * @brief GPU managed memory version of StateVector class.
+ *
+ * @tparam fp_t
+ */
+template <class fp_t = double> class StateVectorGPU : public StateVector<fp_t> {
+  private:
+    using CFP_t = decltype(getCudaType(fp_t{}));
+    CFP_t *arr_;
+
+    inline void CopyHostDataToGpu(const StateVector<fp_t> &sv) {
+        cudaMemcpy(arr_, sv.getData(), sizeof(CFP_t) * sv.getLength(),
+                   cudaMemcpyHostToDevice);
+    }
+    inline void CopyGpuDataToHost(StateVector<fp_t> &sv) const {
+        cudaMemcpy(sv.getData(), arr_, sizeof(CFP_t) * this->getLength(),
+                   cudaMemcpyDeviceToHost);
+    }
+    inline void CopyGpuDataToGpu(StateVectorGPU<fp_t> &sv) {
+        cudaMemcpy(sv.getData(), arr_, sizeof(CFP_t) * this->getLength(),
+                   cudaMemcpyDeviceToDevice);
+    }
+    inline void AsyncCopyHostDataToGpu(const StateVector<fp_t> &sv,
+                                       cudaStream_t stream = 0) {
+        cudaMemcpyAsync(arr_, sv.getData(), sizeof(CFP_t) * sv.getLength(),
+                        cudaMemcpyHostToDevice, stream);
+    }
+    inline void AsyncCopyGpuDataToHost(StateVector<fp_t> &sv,
+                                       cudaStream_t stream = 0) {
+        cudaMemcpyAsync(sv.getData(), arr_, sizeof(CFP_t) * this->getLength(),
+                        cudaMemcpyDeviceToHost, stream);
+    }
+
+  public:
+    StateVectorGPU() : StateVector<fp_t>(), arr_{nullptr} {}
+    StateVectorGPU(CFP_t *arr, size_t length)
+        : StateVector<fp_t>(nullptr, length) {
+        cudaMalloc(reinterpret_cast<void **>(&arr_), sizeof(CFP_t));
+    }
+    ~StateVectorGPU() { cudaFree(arr_); }
+
+    template <class CPUData>
+    StateVectorGPU &operator=(const StateVector<CPUData> &other) {
+        static_assert(sizeof(CPUData) == sizeof(fp_t),
+                      "Size of CPU and GPU data types do not match.");
+        CopyHostDataToGpu(other);
+        return *this;
+    }
+
+    auto getDataVector() -> std::vector<std::complex<fp_t>> {
+        std::vector<std::complex<fp_t>> host_data_buffer(this->getLength());
+        auto ptr = reinterpret_cast<CFP_t *>(host_data_buffer.data());
+        cudaMemcpy(ptr, arr_, sizeof(CFP_t) * this->getLength(),
+                   cudaMemcpyDeviceToHost);
+        return host_data_buffer;
+    }
+};
+
+} // namespace Pennylane


### PR DESCRIPTION
**Context:** This PR adds compilation support for CUDA to Lightning. 

**Description of the Change:** A CUDA-enabled class `StateVectorGPU` is added, with necessary built and tooling changes. The CUDA runtime libraries are linked during compilation, allowing a user/developer to build CUDA supported methods into Lightning.

**Benefits:** Lightning can support CUDA kernels.

**Possible Drawbacks:** CUDA adds additional compilation and configuration complexity.

**Related GitHub Issues:**
