### PR TITLE
Fix OpenMP library issues on M1 Macs

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -18,6 +18,12 @@
 * Linux users on `x86_64` must have a CPU supporting AVX.
   [(#157)](https://github.com/PennyLaneAI/pennylane-lightning/pull/157)
 
+### Bug fixes
+
+* OpenMP built with Intel MacOS CI runners causes failures on M1 Macs. OpenMP is currently
+  disabled in the built wheels until this can be resolved with Github Actions runners.
+  [(#)]
+
 ### Contributors
 
 This release contains contributions from (in alphabetical order):

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -22,7 +22,7 @@
 
 * OpenMP built with Intel MacOS CI runners causes failures on M1 Macs. OpenMP is currently
   disabled in the built wheels until this can be resolved with Github Actions runners.
-  [(#)]
+  [(#166)](https://github.com/PennyLaneAI/pennylane-lightning/pull/166)
 
 ### Contributors
 

--- a/.github/workflows/wheel_macos_arm64.yml
+++ b/.github/workflows/wheel_macos_arm64.yml
@@ -10,7 +10,6 @@ env:
   # MacOS specific build settings
   CIBW_BEFORE_ALL_MACOS: |
     brew uninstall --force oclint
-    brew install libomp
 
   # Python build settings
   CIBW_BEFORE_BUILD: |

--- a/.github/workflows/wheel_macos_x86_64.yml
+++ b/.github/workflows/wheel_macos_x86_64.yml
@@ -57,6 +57,7 @@ jobs:
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
           CIBW_ARCHS_MACOS: ${{matrix.arch}}
+          USE_OMP: 1
 
       - uses: actions/upload-artifact@v2
         if: github.ref == 'refs/heads/master'

--- a/setup.py
+++ b/setup.py
@@ -91,11 +91,16 @@ class BuildExt(build_ext):
             opts["unix"].remove("-fopenmp")
             opts["unix"].remove("-shared")
 
-        darwin_opts = [
-            "-stdlib=libc++",
-            "-Xpreprocessor",
-            "-fopenmp",
-        ]
+        darwin_opts = ["-stdlib=libc++"]
+
+        # Used to enable OpenMP only on Intel 
+        # Macs due to CI available of M1
+        if os.environ.get("USE_OMP"):
+            darwin_opts.extend([
+                "-Xpreprocessor",
+                "-fopenmp",
+            ])
+
         darwin_opts.append("-mmacosx-version-min=10.14")
         
         c_opts["unix"] += darwin_opts


### PR DESCRIPTION
**Context:** This PR disables OpenMP for lightning on M1 Macs due the lack of M1 support on Github Actions.

**Description of the Change:** OpenMP is disabled for wheels built targeting M1 Macs.

**Benefits:** No issues with missing symbols.

**Possible Drawbacks:** OpenMP support would add performance benefits when fully utilised.

**Related GitHub Issues:** https://github.com/PennyLaneAI/pennylane-lightning/issues/151
