### PR TITLE
Update PL-Lightning to support new features in PL

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -10,9 +10,14 @@
 
 ### Bug fixes
 
+* Update PL-Lightning to support new features in PL.
+[(#179)](https://github.com/PennyLaneAI/pennylane-lightning/pull/179)
+
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
+
+Ali Asadi
 
 ---
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -6,12 +6,12 @@
 
 ### Improvements
 
+* Update PL-Lightning to support new features in PL.
+[(#179)](https://github.com/PennyLaneAI/pennylane-lightning/pull/179)
+
 ### Documentation
 
 ### Bug fixes
-
-* Update PL-Lightning to support new features in PL.
-[(#179)](https://github.com/PennyLaneAI/pennylane-lightning/pull/179)
 
 ### Contributors
 

--- a/pennylane_lightning/lightning_qubit.py
+++ b/pennylane_lightning/lightning_qubit.py
@@ -18,6 +18,7 @@ interfaces with C++ for fast linear algebra calculations.
 from warnings import warn
 
 import numpy as np
+from numpy.core.fromnumeric import transpose
 from pennylane import (
     BasisState,
     DeviceError,
@@ -220,11 +221,12 @@ class LightningQubit(DefaultQubit):
 
         ops_serialized = adj.create_ops_list(*ops_serialized)
 
-        tape_trainable_params_set = set(tape.trainable_params)
+        # tape_trainable_params_set = set(tape.trainable_params)
+        trainable_params = sorted(tape.trainable_params)
+        first_elem = 1 if trainable_params[0] == 0 else 0
+
         tp_shift = (
-            tape_trainable_params_set
-            if not use_sp
-            else {i - 1 for i in tape_trainable_params_set.difference({0})}
+            trainable_params if not use_sp else [i - 1 for i in trainable_params[first_elem:]]
         )  # exclude first index if explicitly setting sv
 
         jac = adj.adjoint_jacobian(

--- a/pennylane_lightning/lightning_qubit.py
+++ b/pennylane_lightning/lightning_qubit.py
@@ -18,7 +18,6 @@ interfaces with C++ for fast linear algebra calculations.
 from warnings import warn
 
 import numpy as np
-from numpy.core.fromnumeric import transpose
 from pennylane import (
     BasisState,
     DeviceError,
@@ -221,7 +220,6 @@ class LightningQubit(DefaultQubit):
 
         ops_serialized = adj.create_ops_list(*ops_serialized)
 
-        # tape_trainable_params_set = set(tape.trainable_params)
         trainable_params = sorted(tape.trainable_params)
         first_elem = 1 if trainable_params[0] == 0 else 0
 

--- a/pennylane_lightning/lightning_qubit.py
+++ b/pennylane_lightning/lightning_qubit.py
@@ -220,10 +220,11 @@ class LightningQubit(DefaultQubit):
 
         ops_serialized = adj.create_ops_list(*ops_serialized)
 
+        tape_trainable_params_set = set(tape.trainable_params)
         tp_shift = (
-            tape.trainable_params
+            tape_trainable_params_set
             if not use_sp
-            else {i - 1 for i in tape.trainable_params.difference({0})}
+            else {i - 1 for i in tape_trainable_params_set.difference({0})}
         )  # exclude first index if explicitly setting sv
 
         jac = adj.adjoint_jacobian(

--- a/pennylane_lightning/src/algorithms/AdjointDiff.hpp
+++ b/pennylane_lightning/src/algorithms/AdjointDiff.hpp
@@ -16,7 +16,6 @@
 #include <complex>
 #include <cstring>
 #include <numeric>
-#include <set>
 #include <stdexcept>
 #include <type_traits>
 #include <unordered_map>
@@ -689,7 +688,7 @@ template <class T = double> class AdjointJacobian {
                          std::vector<std::vector<T>> &jac,
                          const std::vector<ObsDatum<T>> &observables,
                          const OpsData<T> &operations,
-                         const std::set<size_t> &trainableParams,
+                         const std::vector<size_t> &trainableParams,
                          bool apply_operations = false) {
         PL_ABORT_IF(trainableParams.empty(),
                     "No trainable parameters provided.");

--- a/pennylane_lightning/src/bindings/Bindings.cpp
+++ b/pennylane_lightning/src/bindings/Bindings.cpp
@@ -797,7 +797,7 @@ void lightning_class_bindings(py::module &m) {
                 const StateVecBinder<PrecisionT> &sv,
                 const std::vector<ObsDatum<PrecisionT>> &observables,
                 const OpsData<PrecisionT> &operations,
-                const set<size_t> &trainableParams, size_t num_params) {
+                const std::vector<size_t> &trainableParams, size_t num_params) {
                  std::vector<std::vector<PrecisionT>> jac(
                      observables.size(),
                      std::vector<PrecisionT>(num_params, 0));

--- a/pennylane_lightning/src/tests/Test_AdjDiff.cpp
+++ b/pennylane_lightning/src/tests/Test_AdjDiff.cpp
@@ -162,7 +162,7 @@ TEST_CASE("AdjointJacobian::adjointJacobian Op=[RX,RX,RX], Obs=[Z,Z,Z], "
         const size_t num_obs = 3;
         std::vector<std::vector<double>> jacobian(
             num_obs, std::vector<double>(num_params, 0));
-        std::set<size_t> t_params{0, 2};
+        std::vector<size_t> t_params{0, 2};
 
         std::vector<std::complex<double>> cdata(0b1 << num_qubits);
         StateVector<double> psi(cdata.data(), cdata.size());
@@ -316,7 +316,7 @@ TEST_CASE("AdjointJacobian::adjointJacobian Mixed Ops, Obs and TParams",
     std::vector<double> param{-M_PI / 7, M_PI / 5, 2 * M_PI / 3};
     {
         const size_t num_qubits = 2;
-        const std::set<size_t> t_params{1, 2, 3};
+        const std::vector<size_t> t_params{1, 2, 3};
         const size_t num_obs = 1;
 
         const auto thetas = Util::linspace(-2 * M_PI, 2 * M_PI, 8);

--- a/tests/test_adjoint_jacobian.py
+++ b/tests/test_adjoint_jacobian.py
@@ -259,14 +259,21 @@ class TestAdjointJacobian:
     @pytest.mark.parametrize("obs", [qml.PauliX, qml.PauliY])
     # @pytest.mark.parametrize("op", list(ops))
     @pytest.mark.parametrize(
-        "op", [qml.RX(0.4, wires=0), qml.RY(0.6, wires=0), qml.RZ(0.8, wires=0), 
-        qml.CRX(1.0, wires=[0, 1]), qml.CRY(2.0, wires=[0, 1]), qml.CRZ(3.0, wires=[0, 1]), 
-        qml.Rot(0.2, -0.1, 0.2, wires=0)]
+        "op",
+        [
+            qml.RX(0.4, wires=0),
+            qml.RY(0.6, wires=0),
+            qml.RZ(0.8, wires=0),
+            qml.CRX(1.0, wires=[0, 1]),
+            qml.CRY(2.0, wires=[0, 1]),
+            qml.CRZ(3.0, wires=[0, 1]),
+            qml.Rot(0.2, -0.1, 0.2, wires=0),
+        ],
     )
     def test_gradients(self, op, obs, tol, dev):
         """Tests that the gradients of circuits match between the finite difference and device
         methods."""
-        # op.num_params must be initialized a priori 
+        # op.num_params must be initialized a priori
         # args = np.linspace(0.2, 0.5, op.num_params)
 
         with qml.tape.JacobianTape() as tape:
@@ -274,7 +281,7 @@ class TestAdjointJacobian:
             qml.RX(0.543, wires=0)
             qml.CNOT(wires=[0, 1])
 
-            # op.num_wires must be initialized a priori 
+            # op.num_wires must be initialized a priori
             # op(*args, wires=range(op.num_wires))
             op
             qml.Rot(1.3, -2.3, 0.5, wires=[0])

--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -77,7 +77,6 @@ def op(op_name):
         "QubitCarry": qml.QubitCarry(wires=[0, 1, 2, 3]),
         "QubitUnitary": qml.QubitUnitary(np.eye(2) * 1j, wires=0),
     }
-    # return getattr(qml, op_name)
     return ops_list.get(op_name)
 
 

--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -43,13 +43,15 @@ def test_gate_unitary_correct(op, op_name):
     ):
         pytest.skip("Skipping operation.")  # These are tested in the device test-suite
 
-    wires = op.num_wires
+    # wires = op.num_wires
+    wires = 1
 
     if wires == -1:  # This occurs for operations that do not have a predefined number of wires
         wires = 4
 
     dev = qml.device("lightning.qubit", wires=wires)
-    num_params = op.num_params
+    # num_params = op.num_params
+    num_params = 1
     p = [0.1] * num_params
 
     @qml.qnode(dev)

--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -44,6 +44,7 @@ def op(op_name):
         "IsingXX": qml.IsingXX(0.123, wires=[0, 1]),
         "IsingYY": qml.IsingYY(0.123, wires=[0, 1]),
         "IsingZZ": qml.IsingZZ(0.123, wires=[0, 1]),
+        "Identity": qml.Identity(wires=0),
         "Rot": qml.Rot(0.123, 0.456, 0.789, wires=0),
         "Toffoli": qml.Toffoli(wires=[0, 1, 2]),
         "PhaseShift": qml.PhaseShift(2.133, wires=0),
@@ -55,10 +56,9 @@ def op(op_name):
         "CRZ": qml.CRZ(0.554, wires=[2, 3]),
         "Hadamard": qml.Hadamard(wires=0),
         "PauliX": qml.PauliX(wires=0),
-        "PauliZ": qml.PauliZ(wires=0),
         "PauliY": qml.PauliY(wires=0),
+        "PauliZ": qml.PauliZ(wires=0),
         "CRot": qml.CRot(0.123, 0.456, 0.789, wires=[0, 1]),
-        "QubitUnitary": qml.QubitUnitary(np.eye(2) * 1j, wires=0),
         "DiagonalQubitUnitary": qml.DiagonalQubitUnitary(np.array([1.0, 1.0j]), wires=1),
         "ControlledQubitUnitary": qml.ControlledQubitUnitary(
             np.eye(2) * 1j, wires=[0], control_wires=[2]
@@ -72,7 +72,10 @@ def op(op_name):
         "DoubleExcitation": qml.DoubleExcitation(0.123, wires=[0, 1, 2, 3]),
         "DoubleExcitationPlus": qml.DoubleExcitationPlus(0.123, wires=[0, 1, 2, 3]),
         "DoubleExcitationMinus": qml.DoubleExcitationMinus(0.123, wires=[0, 1, 2, 3]),
+        "QFT": qml.QFT(wires=0),
         "QubitSum": qml.QubitSum(wires=[0, 1, 2]),
+        "QubitCarry": qml.QubitCarry(wires=[0, 1, 2, 3]),
+        "QubitUnitary": qml.QubitUnitary(np.eye(2) * 1j, wires=0),
     }
     # return getattr(qml, op_name)
     return ops_list.get(op_name)

--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -25,7 +25,57 @@ from pennylane_lightning import LightningQubit
 
 @pytest.fixture
 def op(op_name):
-    return getattr(qml, op_name)
+    ops_list = {
+        "RX": qml.RX(0.123, wires=0),
+        "RY": qml.RY(1.434, wires=0),
+        "RZ": qml.RZ(2.774, wires=0),
+        "S": qml.S(wires=0),
+        "SX": qml.SX(wires=0),
+        "T": qml.T(wires=0),
+        "CNOT": qml.CNOT(wires=[0, 1]),
+        "CZ": qml.CZ(wires=[0, 1]),
+        "CY": qml.CY(wires=[0, 1]),
+        "SWAP": qml.SWAP(wires=[0, 1]),
+        "ISWAP": qml.ISWAP(wires=[0, 1]),
+        "SISWAP": qml.SISWAP(wires=[0, 1]),
+        "SQISW": qml.SQISW(wires=[0, 1]),
+        "CSWAP": qml.CSWAP(wires=[0, 1, 2]),
+        "PauliRot": qml.PauliRot(0.123, "Y", wires=0),
+        "IsingXX": qml.IsingXX(0.123, wires=[0, 1]),
+        "IsingYY": qml.IsingYY(0.123, wires=[0, 1]),
+        "IsingZZ": qml.IsingZZ(0.123, wires=[0, 1]),
+        "Rot": qml.Rot(0.123, 0.456, 0.789, wires=0),
+        "Toffoli": qml.Toffoli(wires=[0, 1, 2]),
+        "PhaseShift": qml.PhaseShift(2.133, wires=0),
+        "ControlledPhaseShift": qml.ControlledPhaseShift(1.777, wires=[0, 2]),
+        "CPhase": qml.CPhase(1.777, wires=[0, 2]),
+        "MultiRZ": qml.MultiRZ(0.112, wires=[1, 2, 3]),
+        "CRX": qml.CRX(0.836, wires=[2, 3]),
+        "CRY": qml.CRY(0.721, wires=[2, 3]),
+        "CRZ": qml.CRZ(0.554, wires=[2, 3]),
+        "Hadamard": qml.Hadamard(wires=0),
+        "PauliX": qml.PauliX(wires=0),
+        "PauliZ": qml.PauliZ(wires=0),
+        "PauliY": qml.PauliY(wires=0),
+        "CRot": qml.CRot(0.123, 0.456, 0.789, wires=[0, 1]),
+        "QubitUnitary": qml.QubitUnitary(np.eye(2) * 1j, wires=0),
+        "DiagonalQubitUnitary": qml.DiagonalQubitUnitary(np.array([1.0, 1.0j]), wires=1),
+        "ControlledQubitUnitary": qml.ControlledQubitUnitary(
+            np.eye(2) * 1j, wires=[0], control_wires=[2]
+        ),
+        "MultiControlledX": qml.MultiControlledX(
+            control_wires=[0, 1], wires=2, control_values="01"
+        ),
+        "SingleExcitation": qml.SingleExcitation(0.123, wires=[0, 3]),
+        "SingleExcitationPlus": qml.SingleExcitationPlus(0.123, wires=[0, 3]),
+        "SingleExcitationMinus": qml.SingleExcitationMinus(0.123, wires=[0, 3]),
+        "DoubleExcitation": qml.DoubleExcitation(0.123, wires=[0, 1, 2, 3]),
+        "DoubleExcitationPlus": qml.DoubleExcitationPlus(0.123, wires=[0, 1, 2, 3]),
+        "DoubleExcitationMinus": qml.DoubleExcitationMinus(0.123, wires=[0, 1, 2, 3]),
+        "QubitSum": qml.QubitSum(wires=[0, 1, 2]),
+    }
+    # return getattr(qml, op_name)
+    return ops_list.get(op_name)
 
 
 @pytest.mark.parametrize("op_name", LightningQubit.operations)
@@ -42,17 +92,19 @@ def test_gate_unitary_correct(op, op_name):
         "DiagonalQubitUnitary",
     ):
         pytest.skip("Skipping operation.")  # These are tested in the device test-suite
+    if op == None:
+        pytest.skip("Skipping operation.")
 
-    # wires = op.num_wires
-    wires = 1
+    wires = op.num_wires
 
     if wires == -1:  # This occurs for operations that do not have a predefined number of wires
         wires = 4
 
     dev = qml.device("lightning.qubit", wires=wires)
-    # num_params = op.num_params
-    num_params = 1
+    num_params = op.num_params
     p = [0.1] * num_params
+
+    op = getattr(qml, op_name)
 
     @qml.qnode(dev)
     def output(input):
@@ -85,6 +137,8 @@ def test_inverse_unitary_correct(op, op_name):
         "DiagonalQubitUnitary",
     ):
         pytest.skip("Skipping operation.")  # These are tested in the device test-suite
+    if op == None:
+        pytest.skip("Skipping operation.")
 
     wires = op.num_wires
 
@@ -94,6 +148,8 @@ def test_inverse_unitary_correct(op, op_name):
     dev = qml.device("lightning.qubit", wires=wires)
     num_params = op.num_params
     p = [0.1] * num_params
+
+    op = getattr(qml, op_name)
 
     @qml.qnode(dev)
     def output(input):


### PR DESCRIPTION
**Context:**
Current PL-Lightning is not compatible with new features in PL and as the result almost all `gates` and `adjoint_jacobian` tests are FAILED. This PR updates the PL-lightning along with all tests to support new features in PL. 

**Description of the Change:**
These files are mainly updated: 
- `lightning_qubit.py`
- `tests/test_gates.py`
- `tests/test_adjoint_jacobian.py`

**Benefits:**
PL-Lightning is compatible with new features in PL and there shouldn't be any failed tests 

**Related GitHub Issues:**
n/a