### PR TITLE
Fix missing header for dependent packages

### DIFF
--- a/pennylane_lightning/src/util/Util.hpp
+++ b/pennylane_lightning/src/util/Util.hpp
@@ -30,7 +30,6 @@
 #include <type_traits>
 #include <vector>
 
-
 /// @cond DEV
 #if __has_include(<cblas.h>) && defined _ENABLE_BLAS
 #include <cblas.h>

--- a/pennylane_lightning/src/util/Util.hpp
+++ b/pennylane_lightning/src/util/Util.hpp
@@ -21,14 +21,15 @@
 #include <cmath>
 #include <complex>
 #include <cstddef>
+#include <iostream>
 #include <limits>
 #include <memory>
 #include <numeric>
 #include <set>
 #include <stdexcept>
 #include <type_traits>
+#include <vector>
 
-#include <iostream>
 
 /// @cond DEV
 #if __has_include(<cblas.h>) && defined _ENABLE_BLAS


### PR DESCRIPTION
### Before submitting

**Context:** `Util.hpp` is missing the `vector` header, which causes problems with packages using this header from outside Lightning.

**Description of the Change:** Added the `vector` STL to `Util.hpp`.

**Benefits:** Fixes compilation issues on dependent packages.

**Possible Drawbacks:** None.

**Related GitHub Issues:**
