### PR TITLE
Disable AVX default for PPC and ARM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ option(ENABLE_CLANG_TIDY "Enable clang-tidy build checks" OFF)
 # Compile options
 option(ENABLE_WARNINGS "Enable warnings" ON)
 option(ENABLE_NATIVE "Enable native CPU build tuning" OFF)
-option(ENABLE_AVX "Enable AVX support" ON)
+option(ENABLE_AVX "Enable AVX support" OFF)
 option(ENABLE_OPENMP "Enable OpenMP" ON)
 option(ENABLE_BLAS "Enable BLAS" OFF)
 


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [ ] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [ ] Ensure that the test suite passes, by running `make test`.

- [ ] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [ ] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:** Wheelbuilder does not work for PPC and ARM in 19a8a85 as AVX is enabled by default in CMake.

**Description of the Change:** Turned it off.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
