### PR TITLE
No init module use for the tests

### DIFF
--- a/tests/test_comparison.py
+++ b/tests/test_comparison.py
@@ -201,13 +201,14 @@ class TestComparison:
         """Test an n-qubit circuit"""
 
         vec = np.array([1] * (2 ** wires)) / np.sqrt(2 ** wires)
-        w = qml.init.strong_ent_layers_uniform(2, wires)
+        shape = qml.StronglyEntanglingLayers.shape(2, wires)
+        w = np.random.uniform(high=2*np.pi, size=shape)
 
         def circuit():
             """Prepares the equal superposition state and then applies StronglyEntanglingLayers
             and concludes with a simple PauliZ measurement"""
             qml.QubitStateVector(vec, wires=range(wires))
-            qml.templates.StronglyEntanglingLayers(w, wires=range(wires))
+            qml.StronglyEntanglingLayers(w, wires=range(wires))
             return qml.expval(qml.PauliZ(0))
 
         lightning = qml.QNode(circuit, lightning_qubit_dev)


### PR DESCRIPTION
Changes a test that used `qml.init` and [caused failures in the device test suite](https://github.com/PennyLaneAI/plugin-test-matrix/runs/4402546181?check_suite_focus=true#step:9:40). The `init` module has been removed from PennyLane (https://github.com/PennyLaneAI/pennylane/pull/1963).