### PR TITLE
All_Of Identifier Not Found

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Add VJP support to PL-Lightning.
 [(#181)](https://github.com/PennyLaneAI/pennylane-lightning/pull/181)
 
+* Add complex64 support in PL-Lightning.
+[(#177)](https://github.com/PennyLaneAI/pennylane-lightning/pull/177)
+
 * Added examples folder containing aggregate gate performance test.
 [(#165)](https://github.com/PennyLaneAI/pennylane-lightning/pull/165)
 

--- a/doc/xanadu_theme/header.html
+++ b/doc/xanadu_theme/header.html
@@ -42,7 +42,7 @@
         <a class="nav-link" href="https://pennylane.ai/blog">Blog</a>
       </li>
       <li class="nav-item">
-        <a class="nav-link" href="https://pennylane.ai/carnival"><img src="https://pennylane.ai/img/carnival.png"></a>
+        <a class="nav-link" href="https://qhack.ai"><img src="https://pennylane.ai/img/qhack_plain_black.png"></a>
       </li>
     </ul>
     <!-- Links -->

--- a/pennylane_lightning/src/algorithms/JacobianProd.hpp
+++ b/pennylane_lightning/src/algorithms/JacobianProd.hpp
@@ -13,6 +13,8 @@
 // limitations under the License.
 #pragma once
 
+#include <algorithm>
+
 #include "AdjointDiff.hpp"
 
 namespace Pennylane {

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -87,6 +87,14 @@ class TestApply:
     that the proper errors are raised.
     """
 
+    def test_apply_operation_raise_type_error(self, qubit_device_1_wire):
+        """Tests that applying an operation yields the expected output state for single wire
+        operations that have no parameters."""
+
+        with pytest.raises(TypeError, match="Unsupported complex Type: complex256"):
+            qubit_device_1_wire._state = np.array([1, 0]).astype(np.complex256)
+            qubit_device_1_wire.apply([qml.PauliX(wires=[0])])
+
     test_data_no_parameters = [
         (qml.PauliX, [1, 0], np.array([0, 1])),
         (qml.PauliX, [1 / math.sqrt(2), 1 / math.sqrt(2)], [1 / math.sqrt(2), 1 / math.sqrt(2)]),
@@ -107,13 +115,14 @@ class TestApply:
     ]
 
     @pytest.mark.parametrize("operation,input,expected_output", test_data_no_parameters)
+    @pytest.mark.parametrize("C", [np.complex64, np.complex128])
     def test_apply_operation_single_wire_no_parameters(
-        self, qubit_device_1_wire, tol, operation, input, expected_output
+        self, qubit_device_1_wire, tol, operation, input, expected_output, C
     ):
         """Tests that applying an operation yields the expected output state for single wire
         operations that have no parameters."""
 
-        qubit_device_1_wire._state = np.array(input).astype(complex)
+        qubit_device_1_wire._state = np.array(input).astype(C)
         qubit_device_1_wire.apply([operation(wires=[0])])
 
         assert np.allclose(qubit_device_1_wire._state, np.array(expected_output), atol=tol, rtol=0)
@@ -143,12 +152,13 @@ class TestApply:
     ]
 
     @pytest.mark.parametrize("operation,input,expected_output", test_data_two_wires_no_parameters)
+    @pytest.mark.parametrize("C", [np.complex64, np.complex128])
     def test_apply_operation_two_wires_no_parameters(
-        self, qubit_device_2_wires, tol, operation, input, expected_output
+        self, qubit_device_2_wires, tol, operation, input, expected_output, C
     ):
         """Tests that applying an operation yields the expected output state for two wire
         operations that have no parameters."""
-        qubit_device_2_wires._state = np.array(input).reshape(2 * [2]).astype(complex)
+        qubit_device_2_wires._state = np.array(input).reshape(2 * [2]).astype(C)
         qubit_device_2_wires.apply([operation(wires=[0, 1])])
 
         assert np.allclose(qubit_device_2_wires.state, np.array(expected_output), atol=tol, rtol=0)
@@ -164,13 +174,14 @@ class TestApply:
     ]
 
     @pytest.mark.parametrize("operation,input,expected_output", test_data_three_wires_no_parameters)
+    @pytest.mark.parametrize("C", [np.complex64, np.complex128])
     def test_apply_operation_three_wires_no_parameters(
-        self, qubit_device_3_wires, tol, operation, input, expected_output
+        self, qubit_device_3_wires, tol, operation, input, expected_output, C
     ):
         """Tests that applying an operation yields the expected output state for three wire
         operations that have no parameters."""
 
-        qubit_device_3_wires._state = np.array(input).reshape(3 * [2]).astype(complex)
+        qubit_device_3_wires._state = np.array(input).reshape(3 * [2]).astype(C)
         qubit_device_3_wires.apply([operation(wires=[0, 1, 2])])
 
         assert np.allclose(qubit_device_3_wires.state, np.array(expected_output), atol=tol, rtol=0)
@@ -262,13 +273,14 @@ class TestApply:
     @pytest.mark.parametrize(
         "operation,input,expected_output,par", test_data_single_wire_with_parameters
     )
+    @pytest.mark.parametrize("C", [np.complex64, np.complex128])
     def test_apply_operation_single_wire_with_parameters(
-        self, qubit_device_1_wire, tol, operation, input, expected_output, par
+        self, qubit_device_1_wire, tol, operation, input, expected_output, par, C
     ):
         """Tests that applying an operation yields the expected output state for single wire
         operations that have parameters."""
 
-        qubit_device_1_wire._state = np.array(input).astype(complex)
+        qubit_device_1_wire._state = np.array(input).astype(C)
 
         qubit_device_1_wire.apply([operation(*par, wires=[0])])
 
@@ -360,13 +372,14 @@ class TestApply:
     @pytest.mark.parametrize(
         "operation,input,expected_output,par", test_data_two_wires_with_parameters
     )
+    @pytest.mark.parametrize("C", [np.complex64, np.complex128])
     def test_apply_operation_two_wires_with_parameters(
-        self, qubit_device_2_wires, tol, operation, input, expected_output, par
+        self, qubit_device_2_wires, tol, operation, input, expected_output, par, C
     ):
         """Tests that applying an operation yields the expected output state for two wire
         operations that have parameters."""
 
-        qubit_device_2_wires._state = np.array(input).reshape(2 * [2]).astype(complex)
+        qubit_device_2_wires._state = np.array(input).reshape(2 * [2]).astype(C)
         qubit_device_2_wires.apply([operation(*par, wires=[0, 1])])
 
         assert np.allclose(qubit_device_2_wires.state, np.array(expected_output), atol=tol, rtol=0)

--- a/tests/test_comparison.py
+++ b/tests/test_comparison.py
@@ -202,7 +202,7 @@ class TestComparison:
 
         vec = np.array([1] * (2 ** wires)) / np.sqrt(2 ** wires)
         shape = qml.StronglyEntanglingLayers.shape(2, wires)
-        w = np.random.uniform(high=2*np.pi, size=shape)
+        w = np.random.uniform(high=2 * np.pi, size=shape)
 
         def circuit():
             """Prepares the equal superposition state and then applies StronglyEntanglingLayers

--- a/tests/test_expval.py
+++ b/tests/test_expval.py
@@ -62,7 +62,8 @@ class TestExpval:
         res = np.array([dev.expval(O1), dev.expval(O2)])
         assert np.allclose(res, np.array([np.cos(theta), np.cos(theta) * np.cos(phi)]), tol)
 
-    def test_paulix_expectation(self, theta, phi, qubit_device_3_wires, tol):
+    @pytest.mark.parametrize("C", [np.complex64, np.complex128])
+    def test_paulix_expectation(self, theta, phi, qubit_device_3_wires, tol, C):
         """Test that PauliX expectation value is correct"""
         dev = qubit_device_3_wires
         O1 = qml.PauliX(wires=[0])
@@ -73,8 +74,8 @@ class TestExpval:
             rotations=[*O1.diagonalizing_gates(), *O2.diagonalizing_gates()],
         )
 
-        res = np.array([dev.expval(O1), dev.expval(O2)])
-        assert np.allclose(res, np.array([np.sin(theta) * np.sin(phi), np.sin(phi)]), tol)
+        res = np.array([dev.expval(O1), dev.expval(O2)], dtype=C)
+        assert np.allclose(res, np.array([np.sin(theta) * np.sin(phi), np.sin(phi)], dtype=C))
 
     def test_pauliy_expectation(self, theta, phi, qubit_device_3_wires, tol):
         """Test that PauliY expectation value is correct"""
@@ -132,7 +133,7 @@ class TestTensorExpval:
 
         expected = np.sin(theta) * np.sin(phi) * np.sin(varphi)
 
-        assert np.allclose(res, expected, tol)
+        assert np.allclose(res, expected)
 
     def test_pauliz_identity(self, theta, phi, varphi, qubit_device_3_wires, tol):
         """Test that a tensor product involving PauliZ and Identity works

--- a/tests/test_vector_jacobian_product.py
+++ b/tests/test_vector_jacobian_product.py
@@ -27,8 +27,20 @@ class TestComputeVJP:
     def dev(self):
         return qml.device("lightning.qubit", wires=2)
 
-    def test_computation(self, tol, dev):
+    def test_unsupported_complex_type(self, dev):
+        dev._state = dev._asarray(dev._state, np.complex256)
+
+        dy = np.array([[1.0, 2.0], [3.0, 4.0]])
+        jac = np.array([[[1.0, 0.1, 0.2], [0.2, 0.6, 0.1]], [[0.4, -0.7, 1.2], [-0.5, -0.6, 0.7]]])
+
+        with pytest.raises(TypeError, match="Unsupported complex Type: complex256"):
+            dev.compute_vjp(dy, jac)
+
+    @pytest.mark.parametrize("C", [np.complex64, np.complex128])
+    def test_computation(self, tol, dev, C):
         """Test that the correct VJP is returned"""
+        dev._state = dev._asarray(dev._state, C)
+
         dy = np.array([[1.0, 2.0], [3.0, 4.0]])
         jac = np.array([[[1.0, 0.1, 0.2], [0.2, 0.6, 0.1]], [[0.4, -0.7, 1.2], [-0.5, -0.6, 0.7]]])
 
@@ -38,8 +50,11 @@ class TestComputeVJP:
         assert vjp.shape == (3,)
         assert np.allclose(vjp, expected, atol=tol, rtol=0)
 
-    def test_computation_num(self, tol, dev):
+    @pytest.mark.parametrize("C", [np.complex64, np.complex128])
+    def test_computation_num(self, tol, dev, C):
         """Test that the correct VJP is returned"""
+        dev._state = dev._asarray(dev._state, C)
+
         dy = np.array([[1.0, 2.0], [3.0, 4.0]])
         jac = np.array([[[1.0, 0.1, 0.2], [0.2, 0.6, 0.1]], [[0.4, -0.7, 1.2], [-0.5, -0.6, 0.7]]])
 
@@ -49,16 +64,21 @@ class TestComputeVJP:
         assert vjp.shape == (3,)
         assert np.allclose(vjp, expected, atol=tol, rtol=0)
 
-    def test_computation_num_error(self, dev):
+    @pytest.mark.parametrize("C", [np.complex64, np.complex128])
+    def test_computation_num_error(self, dev, C):
         """Test that the correct VJP is returned"""
+        dev._state = dev._asarray(dev._state, C)
+
         dy = np.array([[1.0, 2.0], [3.0, 4.0]])
         jac = np.array([[[1.0, 0.1, 0.2], [0.2, 0.6, 0.1]], [[0.4, -0.7, 1.2], [-0.5, -0.6, 0.7]]])
 
         with pytest.raises(ValueError, match="Invalid size for the gradient-output vector"):
             dev.compute_vjp(dy, jac, num=3)
 
-    def test_jacobian_is_none(self, dev):
+    @pytest.mark.parametrize("C", [np.complex64, np.complex128])
+    def test_jacobian_is_none(self, dev, C):
         """A None Jacobian returns a None VJP"""
+        dev._state = dev._asarray(dev._state, C)
 
         dy = np.array([[1.0, 2.0], [3.0, 4.0]])
         jac = None
@@ -66,8 +86,11 @@ class TestComputeVJP:
         vjp = dev.compute_vjp(dy, jac)
         assert vjp is None
 
-    def test_zero_dy(self, dev):
+    @pytest.mark.parametrize("C", [np.complex64, np.complex128])
+    def test_zero_dy(self, dev, C):
         """A zero dy vector will return a zero matrix"""
+        dev._state = dev._asarray(dev._state, C)
+
         dy = np.zeros([2, 2])
         jac = np.array([[[1.0, 0.1, 0.2], [0.2, 0.6, 0.1]], [[0.4, -0.7, 1.2], [-0.5, -0.6, 0.7]]])
 
@@ -82,8 +105,28 @@ class TestVectorJacobianProduct:
     def dev(self):
         return qml.device("lightning.qubit", wires=2)
 
-    def test_use_device_state(self, tol, dev):
+    def test_unsupported_complex_type(self, dev):
+        dev._state = dev._asarray(dev._state, np.complex256)
+
+        x, y, z = [0.5, 0.3, -0.7]
+
+        with qml.tape.JacobianTape() as tape:
+            qml.RX(0.4, wires=[0])
+            qml.Rot(x, y, z, wires=[0])
+            qml.RY(-0.2, wires=[0])
+            qml.expval(qml.PauliZ(0))
+
+        tape.trainable_params = {1, 2, 3}
+
+        dy = np.array([1.0])
+
+        with pytest.raises(TypeError, match="Unsupported complex Type: complex256"):
+            dev.vector_jacobian_product(tape, dy)
+
+    @pytest.mark.parametrize("C", [np.complex64, np.complex128])
+    def test_use_device_state(self, tol, dev, C):
         """Tests that when using the device state, the correct answer is still returned."""
+        dev._state = dev._asarray(dev._state, C)
 
         x, y, z = [0.5, 0.3, -0.7]
 
@@ -105,8 +148,11 @@ class TestVectorJacobianProduct:
         assert np.allclose(vjp1, vjp2, atol=tol, rtol=0)
         assert np.allclose(jac1, jac2, atol=tol, rtol=0)
 
-    def test_provide_starting_state(self, tol, dev):
+    @pytest.mark.parametrize("C", [np.complex64, np.complex128])
+    def test_provide_starting_state(self, tol, dev, C):
         """Tests provides correct answer when provided starting state."""
+        dev._state = dev._asarray(dev._state, C)
+
         x, y, z = [0.5, 0.3, -0.7]
 
         with qml.tape.JacobianTape() as tape:
@@ -127,9 +173,11 @@ class TestVectorJacobianProduct:
         assert np.allclose(vjp1, vjp2, atol=tol, rtol=0)
         assert np.allclose(jac1, jac2, atol=tol, rtol=0)
 
-    def test_not_expval(self, dev):
+    @pytest.mark.parametrize("C", [np.complex64, np.complex128])
+    def test_not_expval(self, dev, C):
         """Test if a QuantumFunctionError is raised for a tape with measurements that are not
         expectation values"""
+        dev._state = dev._asarray(dev._state, C)
 
         with qml.tape.JacobianTape() as tape:
             qml.RX(0.1, wires=0)
@@ -140,10 +188,12 @@ class TestVectorJacobianProduct:
         with pytest.raises(qml.QuantumFunctionError, match="Adjoint differentiation method does"):
             dev.vector_jacobian_product(tape, dy)
 
-    def test_finite_shots_warns(self):
+    @pytest.mark.parametrize("C", [np.complex64, np.complex128])
+    def test_finite_shots_warns(self, C):
         """Tests warning raised when finite shots specified"""
 
         dev = qml.device("lightning.qubit", wires=1, shots=1)
+        dev._state = dev._asarray(dev._state, C)
 
         with qml.tape.JacobianTape() as tape:
             qml.expval(qml.PauliZ(0))
@@ -158,9 +208,11 @@ class TestVectorJacobianProduct:
     from pennylane_lightning import LightningQubit as lq
 
     @pytest.mark.skipif(not lq._CPP_BINARY_AVAILABLE, reason="Lightning binary required")
-    def test_unsupported_op(self, dev):
+    @pytest.mark.parametrize("C", [np.complex64, np.complex128])
+    def test_unsupported_op(self, dev, C):
         """Test if a QuantumFunctionError is raised for an unsupported operation, i.e.,
         multi-parameter operations that are not qml.Rot"""
+        dev._state = dev._asarray(dev._state, C)
 
         with qml.tape.JacobianTape() as tape:
             qml.CRot(0.1, 0.2, 0.3, wires=[0, 1])
@@ -184,8 +236,11 @@ class TestVectorJacobianProduct:
             dev.vector_jacobian_product(tape, dy)
 
     @pytest.mark.skipif(not lq._CPP_BINARY_AVAILABLE, reason="Lightning binary required")
-    def test_proj_unsupported(self, dev):
+    @pytest.mark.parametrize("C", [np.complex64, np.complex128])
+    def test_proj_unsupported(self, dev, C):
         """Test if a QuantumFunctionError is raised for a Projector observable"""
+        dev._state = dev._asarray(dev._state, C)
+
         with qml.tape.JacobianTape() as tape:
             qml.CRX(0.1, wires=[0, 1])
             qml.expval(qml.Projector([0, 1], wires=[0, 1]))
@@ -207,7 +262,10 @@ class TestVectorJacobianProduct:
             dev.vector_jacobian_product(tape, dy)
 
     @pytest.mark.skipif(not lq._CPP_BINARY_AVAILABLE, reason="Lightning binary required")
-    def test_unsupported_hermitian_expectation(self, dev):
+    @pytest.mark.parametrize("C", [np.complex64, np.complex128])
+    def test_unsupported_hermitian_expectation(self, dev, C):
+        dev._state = dev._asarray(dev._state, C)
+
         obs = np.array([[1, 0], [0, -1]], dtype=np.complex128, requires_grad=False)
 
         with qml.tape.JacobianTape() as tape:
@@ -230,8 +288,11 @@ class TestVectorJacobianProduct:
         ):
             dev.vector_jacobian_product(tape, dy)
 
-    def test_no_trainable_parameters(self, dev):
+    @pytest.mark.parametrize("C", [np.complex64, np.complex128])
+    def test_no_trainable_parameters(self, dev, C):
         """A tape with no trainable parameters will simply return None"""
+        dev._state = dev._asarray(dev._state, C)
+
         x = 0.4
 
         with qml.tape.QuantumTape() as tape:
@@ -246,8 +307,11 @@ class TestVectorJacobianProduct:
         assert vjp is None
         assert jac is None
 
-    def test_no_trainable_parameters_(self, dev):
+    @pytest.mark.parametrize("C", [np.complex64, np.complex128])
+    def test_no_trainable_parameters_(self, dev, C):
         """A tape with no trainable parameters will simply return None"""
+        dev._state = dev._asarray(dev._state, C)
+
         x = 0.4
 
         with qml.tape.QuantumTape() as tape:
@@ -262,8 +326,11 @@ class TestVectorJacobianProduct:
         assert vjp is None
         assert jac is None
 
-    def test_zero_dy(self, dev):
+    @pytest.mark.parametrize("C", [np.complex64, np.complex128])
+    def test_zero_dy(self, dev, C):
         """A zero dy vector will return no tapes and a zero matrix"""
+        dev._state = dev._asarray(dev._state, C)
+
         x = 0.4
         y = 0.6
 
@@ -280,9 +347,12 @@ class TestVectorJacobianProduct:
         assert np.all(vjp == np.zeros([len(tape.trainable_params)]))
         assert jac is None
 
-    def test_single_expectation_value(self, tol, dev):
+    @pytest.mark.parametrize("C", [np.complex64, np.complex128])
+    def test_single_expectation_value(self, tol, dev, C):
         """Tests correct output shape and evaluation for a tape
         with a single expval output"""
+        dev._state = dev._asarray(dev._state, C)
+
         x = 0.543
         y = -0.654
 
@@ -303,9 +373,12 @@ class TestVectorJacobianProduct:
         assert np.allclose(vjp, expected, atol=tol, rtol=0)
         assert np.allclose(jac1, jac2, atol=tol, rtol=0)
 
-    def test_multiple_expectation_values(self, tol, dev):
+    @pytest.mark.parametrize("C", [np.complex64, np.complex128])
+    def test_multiple_expectation_values(self, tol, dev, C):
         """Tests correct output shape and evaluation for a tape
         with multiple expval outputs"""
+        dev._state = dev._asarray(dev._state, C)
+
         x = 0.543
         y = -0.654
 
@@ -327,9 +400,12 @@ class TestVectorJacobianProduct:
         assert np.allclose(vjp, expected, atol=tol, rtol=0)
         assert np.allclose(jac1, jac2, atol=tol, rtol=0)
 
-    def test_prob_expectation_values(self, dev):
+    @pytest.mark.parametrize("C", [np.complex64, np.complex128])
+    def test_prob_expectation_values(self, dev, C):
         """Tests correct output shape and evaluation for a tape
         with prob and expval outputs"""
+        dev._state = dev._asarray(dev._state, C)
+
         x = 0.543
         y = -0.654
 
@@ -354,8 +430,33 @@ class TestBatchVectorJacobianProduct:
     def dev(self):
         return qml.device("lightning.qubit", wires=2)
 
-    def test_one_tape_no_trainable_parameters(self, dev):
+    def test_unsupported_complex_type(self, dev):
+        dev._state = dev._asarray(dev._state, np.complex256)
+
+        with qml.tape.QuantumTape() as tape1:
+            qml.RX(0.4, wires=0)
+            qml.CNOT(wires=[0, 1])
+            qml.expval(qml.PauliZ(0))
+
+        with qml.tape.JacobianTape() as tape2:
+            qml.RX(0.4, wires=0)
+            qml.RX(0.6, wires=0)
+            qml.CNOT(wires=[0, 1])
+            qml.expval(qml.PauliZ(0))
+
+        tape1.trainable_params = {0}
+        tape2.trainable_params = {0, 1}
+
+        tapes = [tape1, tape2]
+        dys = [np.array([1.0]), np.array([1.0])]
+
+        with pytest.raises(TypeError, match="Unsupported complex Type: complex256"):
+            dev.batch_vjp(tapes, dys)
+
+    @pytest.mark.parametrize("C", [np.complex64, np.complex128])
+    def test_one_tape_no_trainable_parameters(self, dev, C):
         """A tape with no trainable parameters will simply return None"""
+        dev._state = dev._asarray(dev._state, C)
 
         with qml.tape.QuantumTape() as tape1:
             qml.RX(0.4, wires=0)
@@ -382,8 +483,10 @@ class TestBatchVectorJacobianProduct:
         assert jacs[0] is None
         assert jacs[1] is not None
 
-    def test_all_tapes_no_trainable_parameters(self, dev):
+    @pytest.mark.parametrize("C", [np.complex64, np.complex128])
+    def test_all_tapes_no_trainable_parameters(self, dev, C):
         """If all tapes have no trainable parameters all outputs will be None"""
+        dev._state = dev._asarray(dev._state, C)
 
         with qml.tape.QuantumTape() as tape1:
             qml.RX(0.4, wires=0)
@@ -410,8 +513,10 @@ class TestBatchVectorJacobianProduct:
         assert jacs[0] is None
         assert jacs[1] is None
 
-    def test_zero_dy(self, dev):
+    @pytest.mark.parametrize("C", [np.complex64, np.complex128])
+    def test_zero_dy(self, dev, C):
         """A zero dy vector will return no tapes and a zero matrix"""
+        dev._state = dev._asarray(dev._state, C)
 
         with qml.tape.QuantumTape() as tape1:
             qml.RX(0.4, wires=0)
@@ -435,8 +540,10 @@ class TestBatchVectorJacobianProduct:
         assert np.allclose(vjps[0], 0)
         assert jacs[0] is None
 
-    def test_reduction_append(self, dev):
+    @pytest.mark.parametrize("C", [np.complex64, np.complex128])
+    def test_reduction_append(self, dev, C):
         """Test the 'append' reduction strategy"""
+        dev._state = dev._asarray(dev._state, C)
 
         with qml.tape.JacobianTape() as tape1:
             qml.RX(0.4, wires=0)
@@ -467,8 +574,10 @@ class TestBatchVectorJacobianProduct:
         assert np.allclose(jacs[0], jac0)
         assert np.allclose(jacs[1], jac1)
 
-    def test_reduction_append_callable(self, dev):
+    @pytest.mark.parametrize("C", [np.complex64, np.complex128])
+    def test_reduction_append_callable(self, dev, C):
         """Test the 'append' reduction strategy"""
+        dev._state = dev._asarray(dev._state, C)
 
         with qml.tape.JacobianTape() as tape1:
             qml.RX(0.4, wires=0)
@@ -499,8 +608,10 @@ class TestBatchVectorJacobianProduct:
         assert np.allclose(jacs[0], jac0)
         assert np.allclose(jacs[1], jac1)
 
-    def test_reduction_extend(self, dev):
+    @pytest.mark.parametrize("C", [np.complex64, np.complex128])
+    def test_reduction_extend(self, dev, C):
         """Test the 'extend' reduction strategy"""
+        dev._state = dev._asarray(dev._state, C)
 
         with qml.tape.JacobianTape() as tape1:
             qml.RX(0.4, wires=0)
@@ -529,8 +640,10 @@ class TestBatchVectorJacobianProduct:
         assert np.allclose(jacs[0], jac0)
         assert np.allclose(jacs[1], jac1)
 
-    def test_reduction_extend_callable(self, dev):
+    @pytest.mark.parametrize("C", [np.complex64, np.complex128])
+    def test_reduction_extend_callable(self, dev, C):
         """Test the 'extend' reduction strategy"""
+        dev._state = dev._asarray(dev._state, C)
 
         with qml.tape.JacobianTape() as tape1:
             qml.RX(0.4, wires=0)


### PR DESCRIPTION
**Context:**
Attempting to compile the `pennylane-lightning` with MSVC2022, `JacobianProd` is failed to complied. The compiler cites C3861 with the description that `error C3861: 'all_of': identifier not found`. This PR addresses this issue by adding the header `algorithm`.
 
**Related GitHub Issues:**
Compilation on Windows fails (#192) 