### PR TITLE
Accept gate lists in benchmarking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ doc/code/
 *.so
 cpptests
 *.o
+
+.ycm_extra_conf.py
+.vscode

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,7 @@ option(ENABLE_BLAS "Enable BLAS" OFF)
 
 # Other build options
 option(BUILD_TESTS "Build cpp tests" OFF)
+option(BUILD_EXAMPLES "Build cpp examples" OFF)
 
 if(ENABLE_CLANG_TIDY)
     if(NOT DEFINED CLANG_TIDY_BINARY)
@@ -89,4 +90,8 @@ target_compile_definitions(lightning_qubit_ops PRIVATE VERSION_INFO=${VERSION_ST
 
 if(BUILD_TESTS)
     enable_testing()
+endif()
+
+if(BUILD_EXAMPLES)
+    add_subdirectory(examples)
 endif()

--- a/Makefile
+++ b/Makefile
@@ -79,9 +79,9 @@ test-cpp:
 .PHONY: format
 format:
 ifdef check
-	./bin/format --check pennylane_lightning/src/* tests
+	./bin/format --check pennylane_lightning/src/* examples tests 
 else
-	./bin/format pennylane_lightning/src/* tests
+	./bin/format pennylane_lightning/src/* examples tests
 endif
 
 .PHONY: check-tidy

--- a/cmake/process_options.cmake
+++ b/cmake/process_options.cmake
@@ -1,3 +1,6 @@
+# Include this file only once
+include_guard()
+
 # Set compile flags and library dependencies
 add_library(pennylane_lightning_compile_options INTERFACE)
 add_library(pennylane_lightning_external_libs INTERFACE)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -2,7 +2,7 @@
 ## I. Set project details
 #############################
 cmake_minimum_required(VERSION 3.14)
-set(CMAKE_POLICY_DEFAULT_CMP0127 NEW)
+#set(CMAKE_POLICY_DEFAULT_CMP0127 NEW)
 
 project("gate_benchmark"
         VERSION 0.1.0
@@ -10,7 +10,8 @@ project("gate_benchmark"
         LANGUAGES CXX
 )
 
-option(ENABLE_WARNINGS "Enable warnings" ON)
+set(CMAKE_CXX_STANDARD 17)
+
 option(ENABLE_CLANG_TIDY "Enable clang-tidy build checks" OFF)
 
 if(ENABLE_CLANG_TIDY)
@@ -22,25 +23,10 @@ if(ENABLE_CLANG_TIDY)
     )
 endif()
 
-#############################
-## II. Fetch project
-#############################
-
-Include(FetchContent)
-
-FetchContent_Declare(
-    Pennylane-lightning
-    GIT_REPOSITORY  https://github.com/PennyLaneAI/pennylane-lightning
-    GIT_TAG         master
-)
-FetchContent_MakeAvailable(Pennylane-lightning)
-
-#############################
-## III. Create project target
-#############################
-
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_FLAGS "-O3")
-
 add_executable(gate_benchmark gate_benchmark.cpp)
-target_link_libraries(gate_benchmark pennylane_lightning)
+target_link_libraries(gate_benchmark lightning_utils lightning_simulator lightning_algorithms
+    pennylane_lightning_compile_options pennylane_lightning_external_libs)
+
+add_executable(gate_benchmark_oplist gate_benchmark_oplist.cpp)
+target_link_libraries(gate_benchmark_oplist lightning_utils lightning_simulator lightning_algorithms
+    pennylane_lightning_compile_options pennylane_lightning_external_libs)

--- a/examples/gate_benchmark.cpp
+++ b/examples/gate_benchmark.cpp
@@ -5,79 +5,8 @@
 #include <random>
 #include <stdexcept>
 #include <string>
-#include <map>
 
 #include "StateVectorManaged.hpp"
-
-std::string_view strip(std::string_view str) {
-    auto start = str.find_first_not_of(" \t");
-    auto end = str.find_last_not_of(" \t");
-    return str.substr(start, end - start + 1);
-}
-
-std::vector<std::pair<std::string_view, size_t>> parseGateLists(std::string_view arg) {
-    const static std::map<std::string, size_t> available_gates_wires = {
-        /* Single-qubit gates */
-        {"PauliX", 1},
-        {"PauliY", 1},
-        {"PauliZ", 1},
-        {"Hadamard", 1},
-        {"S", 1},
-        {"T", 1},
-        {"RX", 1},
-        {"RY", 1},
-        {"RZ", 1},
-        {"Rot", 1},
-        {"PhaseShift", 1},
-        /* Two-qubit gates */
-        {"CNOT", 2},
-        {"SWAP", 2},
-        {"ControlledPhaseShift", 2},
-        {"CRX", 2},
-        {"CRY", 2},
-        {"CRZ", 2},
-        {"CRot", 2},
-        /* Three-qubit gates */
-        {"Toffoli", 3},
-        {"CSWAP", 3}
-    };
-
-    
-    if (arg.empty())
-        return std::vector<std::pair<std::string_view, size_t>>(available_gates_wires.begin(),
-                available_gates_wires.end());
-
-    std::vector<std::pair<std::string_view, size_t>> ops;
-
-    if (auto pos = arg.find_first_of("["); pos != std::string_view::npos)
-    {  
-        // arg is a list "[...]"
-        auto start = pos + 1;
-        auto end = arg.find_last_of("]");
-        if (end == std::string_view::npos) {
-            throw std::invalid_argument("Argument must contain operators within square brackets [].");
-        }
-        arg = arg.substr(start, end - start);
-    }
-        
-    size_t start;
-    size_t end = 0;
-    while ((start = arg.find_first_not_of(",", end)) != string::npos)
-    {
-        end = arg.find(",", start);
-        auto op_name = strip(arg.substr(start, end - start));
-
-        auto iter = available_gates_wires.find(std::string(op_name));
-
-        if (iter == available_gates_wires.end()) {
-            std::ostringstream ss;
-            ss << "Given gate " << op_name << " is not availabe"; // Change to std::format in C++20
-            throw std::invalid_argument(ss.str());
-        }
-        ops.emplace_back(*iter);
-    }
-    return ops;
-}
 
 /**
  * @brief Outputs wall-time for gate-benchmark.
@@ -90,51 +19,26 @@ int main(int argc, char *argv[]) {
     using TestType = double;
 
     // Handle input
-    if ((argc != 3) && (argc != 4)) {
-        std::cerr << "Wrong number of inputs. User provided " << argc - 1
+    try {
+        if (argc != 3) {
+            throw argc;
+        }
+    } catch (int e) {
+        std::cerr << "Wrong number of inputs. User provided " << e - 1
                   << " inputs. "
                   << "Usage: " + std::string(argv[0]) +
-                         " num_gate_reps num_qubits [gate_lists]"
-                  << std::endl; // Change to std::format in C++20
+                         " $num_gate_reps $num_qubits"
+                  << std::endl;
         return -1;
     }
-
-    size_t num_gate_reps;
-    size_t num_qubits;
-
-    try {
-        num_gate_reps = std::stoi(argv[1]);
-        num_qubits = std::stoi(argv[2]);
-    }
-    catch(std::exception& e) {
-        std::cerr << "Arguements num_gate_reps and num_qubits must be integers." << std::endl;
-        return -1;
-    }
-    
-    // Gate list is provided
-    std::string_view op_list_s;
-    if(argc == 3) {
-        op_list_s = "";
-    } else { // if argc == 4
-        op_list_s = argv[3];
-    }
-
-    auto op_list = parseGateLists(op_list_s);
-    for(const auto& [op_name, op_wire]: op_list) {
-        std::cout << op_name << "\t" << op_wire << std::endl;
-    }
-
+    const size_t num_gate_reps = std::stoi(argv[1]);
+    const size_t num_qubits = std::stoi(argv[2]);
 
     // Generate random values for parametric gates
     std::random_device rd;
     std::default_random_engine eng(rd());
     std::uniform_real_distribution<TestType> distr(0.0, 1.0);
-    std::vector<TestType> random_parameters(num_gate_reps);
-
-    for(uint32_t k = 0; k < num_gate_reps; ++k)
-    {
-    }
-
+    std::vector<std::vector<TestType>> random_parameter_vector(num_gate_reps);
     std::for_each(
         random_parameter_vector.begin(), random_parameter_vector.end(),
         [num_qubits, &eng, &distr](std::vector<TestType> &vec) {
@@ -187,5 +91,6 @@ int main(int argc, char *argv[]) {
                      .count());
     std::cout << num_qubits << ", "
               << walltime / static_cast<double>(num_gate_reps) << std::endl;
+
     return 0;
 }

--- a/examples/gate_benchmark_oplist.cpp
+++ b/examples/gate_benchmark_oplist.cpp
@@ -1,0 +1,188 @@
+#include <algorithm>
+#include <chrono>
+#include <cstdlib>
+#include <iostream>
+#include <map>
+#include <random>
+#include <stdexcept>
+#include <string>
+
+#include "StateVectorManaged.hpp"
+
+std::string_view strip(std::string_view str) {
+    auto start = str.find_first_not_of(" \t");
+    auto end = str.find_last_not_of(" \t");
+    return str.substr(start, end - start + 1);
+}
+
+struct GateDesc {
+    size_t n_wires;  // number of wires the gate applies to
+    size_t n_params; // number of parameters the gate requires
+};
+
+std::vector<std::pair<std::string_view, GateDesc>>
+parseGateLists(std::string_view arg) {
+    const static std::map<std::string, GateDesc> available_gates_wires = {
+        /* Single-qubit gates */
+        {"PauliX", {1, 0}},
+        {"PauliY", {1, 0}},
+        {"PauliZ", {1, 0}},
+        {"Hadamard", {1, 0}},
+        {"S", {1, 0}},
+        {"T", {1, 0}},
+        {"RX", {1, 1}},
+        {"RY", {1, 1}},
+        {"RZ", {1, 1}},
+        {"Rot", {1, 3}},
+        {"PhaseShift", {1, 1}},
+        /* Two-qubit gates */
+        {"CNOT", {2, 0}},
+        {"SWAP", {2, 0}},
+        {"ControlledPhaseShift", {2, 1}},
+        {"CRX", {2, 1}},
+        {"CRY", {2, 1}},
+        {"CRZ", {2, 1}},
+        {"CRot", {2, 3}},
+        /* Three-qubit gates */
+        {"Toffoli", {3, 0}},
+        {"CSWAP", {3, 0}}};
+
+    if (arg.empty())
+        return std::vector<std::pair<std::string_view, GateDesc>>(
+            available_gates_wires.begin(), available_gates_wires.end());
+
+    std::vector<std::pair<std::string_view, GateDesc>> ops;
+
+    if (auto pos = arg.find_first_of("["); pos != std::string_view::npos) {
+        // arg is a list "[...]"
+        auto start = pos + 1;
+        auto end = arg.find_last_of("]");
+        if (end == std::string_view::npos) {
+            throw std::invalid_argument(
+                "Argument must contain operators within square brackets [].");
+        }
+        arg = arg.substr(start, end - start);
+    }
+
+    size_t start;
+    size_t end = 0;
+    while ((start = arg.find_first_not_of(",", end)) != string::npos) {
+        end = arg.find(",", start);
+        auto op_name = strip(arg.substr(start, end - start));
+
+        auto iter = available_gates_wires.find(std::string(op_name));
+
+        if (iter == available_gates_wires.end()) {
+            std::ostringstream ss;
+            ss << "Given gate " << op_name
+               << " is not availabe"; // Change to std::format in C++20
+            throw std::invalid_argument(ss.str());
+        }
+        ops.emplace_back(*iter);
+    }
+    return ops;
+}
+
+template <typename RandomEngine>
+std::vector<size_t> generateDistinctWires(RandomEngine &re, size_t num_qubits,
+                                          size_t num_wires) {
+    std::vector<size_t> v(num_qubits, 0);
+    std::iota(v.begin(), v.end(), 0);
+    shuffle(v.begin(), v.end(), re);
+    return std::vector<size_t>(v.begin(), v.begin() + num_wires);
+}
+
+/**
+ * @brief Outputs wall-time for gate-benchmark.
+ * @param argc Number of arguments + 1 passed by user.
+ * @param argv Binary name followed by number of times gate is repeated and
+ * number of qubits.
+ * @return Returns 0 if completed successfully.
+ */
+int main(int argc, char *argv[]) {
+    using TestType = double;
+
+    // Handle input
+    if ((argc != 3) && (argc != 4)) {
+        std::cerr << "Wrong number of inputs. User provided " << argc - 1
+                  << " inputs. "
+                  << "Usage: " + std::string(argv[0]) +
+                         " num_gate_reps num_qubits [gate_lists]"
+                  << std::endl; // Change to std::format in C++20
+        return -1;
+    }
+
+    size_t num_gate_reps;
+    size_t num_qubits;
+
+    try {
+        num_gate_reps = std::stoi(argv[1]);
+        num_qubits = std::stoi(argv[2]);
+    } catch (std::exception &e) {
+        std::cerr << "Arguements num_gate_reps and num_qubits must be integers."
+                  << std::endl;
+        return -1;
+    }
+
+    // Gate list is provided
+    std::string_view op_list_s;
+    if (argc == 3) {
+        op_list_s = "";
+    } else { // if argc == 4
+        op_list_s = argv[3];
+    }
+
+    auto op_list = parseGateLists(op_list_s);
+
+    // Generate random gate sequences
+    std::random_device rd;
+    std::default_random_engine re(rd());
+
+    std::vector<std::string_view> random_gate_names;
+    std::vector<std::vector<size_t>> random_gate_wires;
+    std::vector<bool> random_inverses;
+    std::vector<std::vector<TestType>> random_gate_parameters;
+
+    std::uniform_int_distribution<size_t> gate_dist(0, op_list.size() - 1);
+    std::uniform_int_distribution<size_t> inverse_dist(0, 1);
+    std::uniform_real_distribution<TestType> param_dist(0.0, 2 * M_PI);
+    std::uniform_int_distribution<size_t> wire_dist(0, num_qubits - 1);
+
+    auto gen_param = [&param_dist, &re]() { return param_dist(re); };
+
+    for (uint32_t k = 0; k < num_gate_reps; ++k) {
+        auto [op_name, gate_desc] = op_list[gate_dist(re)];
+
+        std::vector<TestType> gate_params(gate_desc.n_params);
+        std::generate(gate_params.begin(), gate_params.end(), gen_param);
+
+        random_gate_names.emplace_back(op_name);
+        random_inverses.emplace_back(static_cast<bool>(inverse_dist(re)));
+        random_gate_wires.emplace_back(
+            generateDistinctWires(re, num_qubits, gate_desc.n_wires));
+        random_gate_parameters.emplace_back(std::move(gate_params));
+    }
+
+    // Run each gate specified number of times and measure walltime
+    Pennylane::StateVectorManaged<TestType> svdat{num_qubits};
+    std::chrono::time_point<std::chrono::high_resolution_clock> t_start, t_end;
+    t_start = std::chrono::high_resolution_clock::now();
+
+    for (size_t gate_rep = 0; gate_rep < num_gate_reps; gate_rep++) {
+        svdat.applyOperation(std::string(random_gate_names[gate_rep]),
+                             random_gate_wires[gate_rep],
+                             random_inverses[gate_rep],
+                             random_gate_parameters[gate_rep]);
+    }
+
+    t_end = std::chrono::high_resolution_clock::now();
+
+    // Output walltime in csv format (Num Qubits, Time (milliseconds))
+    const auto walltime =
+        0.001 * ((std::chrono::duration_cast<std::chrono::microseconds>(
+                      t_end - t_start))
+                     .count());
+    std::cout << num_qubits << ", "
+              << walltime / static_cast<double>(num_gate_reps) << std::endl;
+    return 0;
+}

--- a/examples/gate_benchmark_oplist.cpp
+++ b/examples/gate_benchmark_oplist.cpp
@@ -101,7 +101,8 @@ int main(int argc, char *argv[]) {
                   << " inputs. "
                   << "Usage: " + std::string(argv[0]) +
                          " num_gate_reps num_qubits [gate_lists]\n"
-                         "\tExample: " << argv[0] << " 1000 10 [PauliX, CNOT]"
+                         "\tExample: "
+                  << argv[0] << " 1000 10 [PauliX, CNOT]"
                   << std::endl; // Change to std::format in C++20
         return -1;
     }
@@ -122,8 +123,7 @@ int main(int argc, char *argv[]) {
     std::string op_list_s;
     {
         std::ostringstream ss;
-        for (int idx = 3; idx < argc; ++idx)
-        {
+        for (int idx = 3; idx < argc; ++idx) {
             ss << argv[idx] << " ";
         }
         op_list_s = ss.str();
@@ -161,17 +161,16 @@ int main(int argc, char *argv[]) {
     }
 
     // Log genereated sequence if LOG is turned on
-    const char* env_p = std::getenv("LOG");
+    const char *env_p = std::getenv("LOG");
     try {
-        if(env_p && std::stoi(env_p) != 0) {
+        if (env_p && std::stoi(env_p) != 0) {
             for (size_t gate_rep = 0; gate_rep < num_gate_reps; gate_rep++) {
-                std::cerr << random_gate_names[gate_rep] << ", " << 
-                    random_gate_wires[gate_rep] << ", " << 
-                    random_gate_parameters[gate_rep] << std::endl;
+                std::cerr << random_gate_names[gate_rep] << ", "
+                          << random_gate_wires[gate_rep] << ", "
+                          << random_gate_parameters[gate_rep] << std::endl;
             }
         }
-    } catch (std::exception& e)
-    {
+    } catch (std::exception &e) {
         // Just do not pring log
     }
 


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [ ] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [ ] Ensure that the test suite passes, by running `make test`.

- [ ] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [ ] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:** As a step to add an alternative implementation of kernel, it is good to have a benchmark code testing a given list of gates.

**Description of the Change:** Examples submodule is now under the main `cmake`; Benchmark code for a given list of gates added. 

**Benefits:** We can now benchmark some gate operations we give.

**Possible Drawbacks:** I don't aware.

**Related GitHub Issues:** 
