### PR TITLE
Add virtual destructors to StateVector classes

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -4,7 +4,8 @@
 * Direct support to probability, expectation value and variance calculation in PL-Lightning.
 [(#185)](https://github.com/PennyLaneAI/pennylane-lightning/pull/185)
 
-* Add C++ only benchmark for a given list of gates ([#199](https://github.com/PennyLaneAI/pennylane-lightning/pull/199))
+* Add C++ only benchmark for a given list of gates.
+[(#199)](https://github.com/PennyLaneAI/pennylane-lightning/pull/199)
 
 ### Breaking changes
 
@@ -13,6 +14,9 @@
 ### Documentation
 
 ### Bug fixes
+
+* Add virtual destructor to C++ state-vector classes.
+[(#200)](https://github.com/PennyLaneAI/pennylane-lightning/pull/200)
 
 ### Contributors
 

--- a/pennylane_lightning/src/simulator/StateVector.hpp
+++ b/pennylane_lightning/src/simulator/StateVector.hpp
@@ -270,6 +270,8 @@ template <class fp_t = double> class StateVector {
                               std::forward<decltype(PH4)>(PH4));
                }}} {};
 
+    virtual ~StateVector() = default;
+
     /**
      * @brief Get the underlying data pointer.
      *

--- a/pennylane_lightning/src/simulator/StateVectorManaged.hpp
+++ b/pennylane_lightning/src/simulator/StateVectorManaged.hpp
@@ -57,7 +57,7 @@ class StateVectorManaged : public StateVector<fp_t> {
         StateVector<fp_t>::setData(data_.data());
     }
 
-    virtual ~StateVectorManaged() = default;
+    ~StateVectorManaged() = default;
 
     auto operator=(const StateVectorManaged<fp_t> &other)
         -> StateVectorManaged & {

--- a/pennylane_lightning/src/simulator/StateVectorManaged.hpp
+++ b/pennylane_lightning/src/simulator/StateVectorManaged.hpp
@@ -57,6 +57,8 @@ class StateVectorManaged : public StateVector<fp_t> {
         StateVector<fp_t>::setData(data_.data());
     }
 
+    virtual ~StateVectorManaged() = default;
+
     auto operator=(const StateVectorManaged<fp_t> &other)
         -> StateVectorManaged & {
         if (this != &other) {

--- a/pennylane_lightning/src/simulator/StateVectorManaged.hpp
+++ b/pennylane_lightning/src/simulator/StateVectorManaged.hpp
@@ -57,7 +57,7 @@ class StateVectorManaged : public StateVector<fp_t> {
         StateVector<fp_t>::setData(data_.data());
     }
 
-    ~StateVectorManaged() = default;
+    ~StateVectorManaged() override = default;
 
     auto operator=(const StateVectorManaged<fp_t> &other)
         -> StateVectorManaged & {


### PR DESCRIPTION
**Context:** Fixes https://github.com/PennyLaneAI/pennylane-lightning/issues/188

**Description of the Change:** Add virtual destructors to `StateVector` and derived types.

**Benefits:** Prevents issues with destructor order calls.

**Possible Drawbacks:** None.

**Related GitHub Issues:** https://github.com/PennyLaneAI/pennylane-lightning/issues/188
