### PR TITLE
Modify Release to RelWithDebInfo for built wheels

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -10,6 +10,9 @@
 
 ### Improvements
 
+* Ensure debug info is built into dynamic libraries.
+[(#201)](https://github.com/PennyLaneAI/pennylane-lightning/pull/201)
+
 ### Documentation
 
 ### Bug fixes

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ set(PROJECT_VERSION ${VERSION_STRING})
 set(CMAKE_CXX_STANDARD 17) # At least C++17 is required
 
 if(NOT CMAKE_BUILD_TYPE)
-    set(CMAKE_BUILD_TYPE Release)
+    set(CMAKE_BUILD_TYPE RelWithDebInfo)
 endif()
 
 # Clang-tidy


### PR DESCRIPTION
**Context:** Debugging with pypi supplied wheels is currently difficult due to the missing debug info. This PR ensure deub info is returned to the dynamic libraries by setting `Release` to `RelWithDebInfo`. This allows use of Lightning through debuggers, such as gdb, and lldb.

**Description of the Change:**  `Release` build type defaults to `RelWithDebInfo`.

**Benefits:** Allows debugging symbols to be included in distributed binaries.

**Possible Drawbacks:** Larger wheel sizes.

**Related GitHub Issues:**
