### PR TITLE
Fix a bug in Python tests with `matrix` calls

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -23,6 +23,7 @@
 ### Bug fixes
 
 * Fix a bug in Python tests with operations' `matrix` calls.
+[(#238)](https://github.com/PennyLaneAI/pennylane-lightning/pull/238)
 
 * Refactor utility header and fix a bug in linear algebra function with CBLAS.
 [(#228)](https://github.com/PennyLaneAI/pennylane-lightning/pull/228)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -22,6 +22,8 @@
 
 ### Bug fixes
 
+* Fix a bug in Python tests with operations' `matrix` calls.
+
 * Refactor utility header and fix a bug in linear algebra function with CBLAS.
 [(#228)](https://github.com/PennyLaneAI/pennylane-lightning/pull/228)
 

--- a/pennylane_lightning/lightning_qubit.py
+++ b/pennylane_lightning/lightning_qubit.py
@@ -322,13 +322,13 @@ class LightningQubit(DefaultQubit):
         if jac is None:
             return None
 
-        if not isinstance(dy, np.ndarray) or not isinstance(jac, np.ndarray):
-            return qml.gradients.compute_vjp(dy, jac)
-
         dy_row = math.reshape(dy, [-1])
 
         if num is None:
             num = math.shape(dy_row)[0]
+
+        if not isinstance(dy_row, np.ndarray):
+            jac = math.convert_like(jac, dy_row)
 
         jac = math.reshape(jac, [num, -1])
         num_params = jac.shape[1]
@@ -634,8 +634,7 @@ class LightningQubit(DefaultQubit):
 
 if not CPP_BINARY_AVAILABLE:
 
-    class LightningQubit(DefaultQubit):
-
+    class LightningQubit(DefaultQubit):  # pragma: no cover
         name = "Lightning Qubit PennyLane plugin"
         short_name = "lightning.qubit"
         pennylane_requires = ">=0.15"

--- a/pennylane_lightning/lightning_qubit.py
+++ b/pennylane_lightning/lightning_qubit.py
@@ -322,13 +322,13 @@ class LightningQubit(DefaultQubit):
         if jac is None:
             return None
 
+        if not isinstance(dy, np.ndarray) or not isinstance(jac, np.ndarray):
+            return qml.gradients.compute_vjp(dy, jac)
+
         dy_row = math.reshape(dy, [-1])
 
         if num is None:
             num = math.shape(dy_row)[0]
-
-        if not isinstance(dy_row, np.ndarray):
-            jac = math.convert_like(jac, dy_row)
 
         jac = math.reshape(jac, [num, -1])
         num_params = jac.shape[1]

--- a/tests/test_adjoint_jacobian.py
+++ b/tests/test_adjoint_jacobian.py
@@ -23,7 +23,12 @@ from pennylane import QNode, qnode
 from scipy.stats import unitary_group
 
 
-I, X, Y, Z = np.eye(2), qml.PauliX.matrix, qml.PauliY.matrix, qml.PauliZ.matrix
+I, X, Y, Z = (
+    np.eye(2),
+    qml.PauliX.compute_matrix(),
+    qml.PauliY.compute_matrix(),
+    qml.PauliZ.compute_matrix(),
+)
 
 
 def Rx(theta):

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -301,9 +301,9 @@ class TestSerializeObs:
         """Test for a comprehensive range of returns"""
         wires_dict = {"a": 0, 1: 1, "b": 2, -1: 3, 3.141: 4, "five": 5, 6: 6, 77: 7, 9: 8}
         I = np.eye(2).astype(np.complex64)
-        X = qml.PauliX.matrix.astype(np.complex64)
-        Y = qml.PauliY.matrix.astype(np.complex64)
-        Z = qml.PauliZ.matrix.astype(np.complex64)
+        X = qml.PauliX.compute_matrix().astype(np.complex64)
+        Y = qml.PauliY.compute_matrix().astype(np.complex64)
+        Z = qml.PauliZ.compute_matrix().astype(np.complex64)
 
         mock_obs = mock.MagicMock()
 
@@ -347,9 +347,9 @@ class TestSerializeObs:
         """Test for a comprehensive range of returns"""
         wires_dict = {"a": 0, 1: 1, "b": 2, -1: 3, 3.141: 4, "five": 5, 6: 6, 77: 7, 9: 8}
         I = np.eye(2).astype(np.complex128)
-        X = qml.PauliX.matrix.astype(np.complex128)
-        Y = qml.PauliY.matrix.astype(np.complex128)
-        Z = qml.PauliZ.matrix.astype(np.complex128)
+        X = qml.PauliX.compute_matrix().astype(np.complex128)
+        Y = qml.PauliY.compute_matrix().astype(np.complex128)
+        Z = qml.PauliZ.compute_matrix().astype(np.complex128)
 
         mock_obs = mock.MagicMock()
 

--- a/tests/test_vjp.py
+++ b/tests/test_vjp.py
@@ -108,34 +108,6 @@ class TestComputeVJP:
         vjp = dev.compute_vjp(dy, jac)
         assert np.all(vjp == np.zeros([3]))
 
-    @pytest.mark.parametrize("dtype1, dtype2", [("float32", "float64"), ("float64", "float32")])
-    def test_dtype_torch(self, dev, dtype1, dtype2):
-        """Test that using the Torch interface the dtype of the result is
-        determined by the dtype of the dy."""
-        torch = pytest.importorskip("torch")
-
-        dtype1 = getattr(torch, dtype1)
-        dtype2 = getattr(torch, dtype2)
-
-        dy = torch.ones(4, dtype=dtype1)
-        jac = torch.ones((4, 4), dtype=dtype2)
-
-        assert dev.compute_vjp(dy, jac).dtype == dtype1
-
-    @pytest.mark.parametrize("dtype1,dtype2", [("float32", "float64"), ("float64", "float32")])
-    def test_dtype_tf(self, dev, dtype1, dtype2):
-        """Test that using the TensorFlow interface the dtype of the result is
-        determined by the dtype of the dy."""
-        tf = pytest.importorskip("tensorflow")
-
-        dtype1 = getattr(tf, dtype1)
-        dtype2 = getattr(tf, dtype2)
-
-        dy = tf.ones(4, dtype=dtype1)
-        jac = tf.ones((4, 4), dtype=dtype2)
-
-        assert dev.compute_vjp(dy, jac).dtype == dtype1
-
 
 class TestVectorJacobianProduct:
     """Tests for the `vjp` function"""

--- a/tests/test_vjp.py
+++ b/tests/test_vjp.py
@@ -108,6 +108,34 @@ class TestComputeVJP:
         vjp = dev.compute_vjp(dy, jac)
         assert np.all(vjp == np.zeros([3]))
 
+    @pytest.mark.parametrize("dtype1, dtype2", [("float32", "float64"), ("float64", "float32")])
+    def test_dtype_torch(self, dev, dtype1, dtype2):
+        """Test that using the Torch interface the dtype of the result is
+        determined by the dtype of the dy."""
+        torch = pytest.importorskip("torch")
+
+        dtype1 = getattr(torch, dtype1)
+        dtype2 = getattr(torch, dtype2)
+
+        dy = torch.ones(4, dtype=dtype1)
+        jac = torch.ones((4, 4), dtype=dtype2)
+
+        assert dev.compute_vjp(dy, jac).dtype == dtype1
+
+    @pytest.mark.parametrize("dtype1,dtype2", [("float32", "float64"), ("float64", "float32")])
+    def test_dtype_tf(self, dev, dtype1, dtype2):
+        """Test that using the TensorFlow interface the dtype of the result is
+        determined by the dtype of the dy."""
+        tf = pytest.importorskip("tensorflow")
+
+        dtype1 = getattr(tf, dtype1)
+        dtype2 = getattr(tf, dtype2)
+
+        dy = tf.ones(4, dtype=dtype1)
+        jac = tf.ones((4, 4), dtype=dtype2)
+
+        assert dev.compute_vjp(dy, jac).dtype == dtype1
+
 
 class TestVectorJacobianProduct:
     """Tests for the `vjp` function"""


### PR DESCRIPTION
**Context:**
A few tests in `test_adjoint_jacobian.py` and `test_serialize.py` are failed due to the operation refactor in PennyLane (PR [#2023](https://github.com/PennyLaneAI/pennylane/pull/2023)). 

**Description of the Change:**
Replace `op.matrix` by `op.compute_matrix()` in `test_adjoint_jacobian.py` and `test_serialize.py` to fix the failed tests.