### PR TITLE
Modify pybind11 classes scope in modules

### DIFF
--- a/pennylane_lightning/_version.py
+++ b/pennylane_lightning/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.22.0-dev12"
+__version__ = "0.22.0-dev13"

--- a/pennylane_lightning/_version.py
+++ b/pennylane_lightning/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.22.0-dev13"
+__version__ = "0.22.0-dev14"

--- a/pennylane_lightning/src/bindings/Bindings.cpp
+++ b/pennylane_lightning/src/bindings/Bindings.cpp
@@ -55,8 +55,8 @@ void lightning_class_bindings(py::module &m) {
     //***********************************************************************//
 
     std::string class_name = "StateVectorC" + bitsize;
-    auto pyclass =
-        py::class_<StateVectorRaw<PrecisionT>>(m, class_name.c_str());
+    auto pyclass = py::class_<StateVectorRaw<PrecisionT>>(m, class_name.c_str(),
+                                                          py::module_local());
     pyclass.def(py::init(&create<PrecisionT>));
 
     registerKernelsToPyexport<PrecisionT, ParamT>(pyclass);
@@ -72,7 +72,7 @@ void lightning_class_bindings(py::module &m) {
         py::array_t<ParamT, py::array::c_style | py::array::forcecast>;
 
     using obs_data_var = std::variant<std::monostate, np_arr_r, np_arr_c>;
-    py::class_<ObsDatum<PrecisionT>>(m, class_name.c_str())
+    py::class_<ObsDatum<PrecisionT>>(m, class_name.c_str(), py::module_local())
         .def(py::init([](const std::vector<std::string> &names,
                          const std::vector<obs_data_var> &params,
                          const std::vector<std::vector<size_t>> &wires) {
@@ -157,7 +157,7 @@ void lightning_class_bindings(py::module &m) {
     //                              Operations
     //***********************************************************************//
     class_name = "OpsStructC" + bitsize;
-    py::class_<OpsData<PrecisionT>>(m, class_name.c_str())
+    py::class_<OpsData<PrecisionT>>(m, class_name.c_str(), py::module_local())
         .def(py::init<
              const std::vector<std::string> &,
              const std::vector<std::vector<ParamT>> &,
@@ -184,7 +184,8 @@ void lightning_class_bindings(py::module &m) {
     //***********************************************************************//
 
     class_name = "AdjointJacobianC" + bitsize;
-    py::class_<AdjointJacobian<PrecisionT>>(m, class_name.c_str())
+    py::class_<AdjointJacobian<PrecisionT>>(m, class_name.c_str(),
+                                            py::module_local())
         .def(py::init<>())
         .def("create_ops_list",
              [](AdjointJacobian<PrecisionT> &adj,
@@ -242,7 +243,8 @@ void lightning_class_bindings(py::module &m) {
     //***********************************************************************//
 
     class_name = "VectorJacobianProductC" + bitsize;
-    py::class_<VectorJacobianProduct<PrecisionT>>(m, class_name.c_str())
+    py::class_<VectorJacobianProduct<PrecisionT>>(m, class_name.c_str(),
+                                                  py::module_local())
         .def(py::init<>())
         .def("create_ops_list",
              [](VectorJacobianProduct<PrecisionT> &v,
@@ -308,7 +310,7 @@ void lightning_class_bindings(py::module &m) {
     //***********************************************************************//
 
     class_name = "MeasuresC" + bitsize;
-    py::class_<Measures<PrecisionT>>(m, class_name.c_str())
+    py::class_<Measures<PrecisionT>>(m, class_name.c_str(), py::module_local())
         .def(py::init<const StateVectorRaw<PrecisionT> &>())
         .def("probs",
              [](Measures<PrecisionT> &M, const std::vector<size_t> &wires) {


### PR DESCRIPTION
**Context:** When using Lightning as a library, having globally-exposed methods can cause issues when using the templated types with other external packages (see [here](https://github.com/pybind/pybind11/blob/master/docs/advanced/classes.rst#module-local-class-bindings) for details). In this case, ensuring the classes are exposed locally at the module level only helps avoid such issues as `ImportError: generic_type: type "MyType" is already registered!`. This PR helps to ensure such problems are avoided.

**Description of the Change:** Modifies Lightning bound classes to have local scope to Python modules only.

**Benefits:** Allows easier extensibility of the Lightning functionality for dependent classes and methods.

**Possible Drawbacks:** Disallows direct interoperability and conversion to Python types.

**Related GitHub Issues:**
