### PR TITLE
Add GPU support to lightning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -121,6 +121,7 @@ info = {
     else [],
     "cmdclass": {"build_ext": CMakeBuild},
     "ext_package": "pennylane_lightning",
+    "extras_require": {"gpu" : ["pennylane-lightning-gpu"]}
 }
 
 classifiers = [


### PR DESCRIPTION
This adds GPU support to lightning, and is installable using the optional tag 
```bash
pip install pennylane-lightning[gpu]
```

Note: this package works only with Linux on x64