### PR TITLE
Move `Expectation` import

### DIFF
--- a/pennylane_lightning/_version.py
+++ b/pennylane_lightning/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.23.0-dev0"
+__version__ = "0.23.0-dev1"

--- a/pennylane_lightning/lightning_qubit.py
+++ b/pennylane_lightning/lightning_qubit.py
@@ -34,7 +34,8 @@ from pennylane import (
     DeviceError,
 )
 from pennylane.devices import DefaultQubit
-from pennylane.operation import Expectation, Tensor
+from pennylane.operation import Tensor
+from pennylane.measurements import Expectation
 from pennylane.wires import Wires
 
 # Remove after the next release of PL


### PR DESCRIPTION
See PennyLane PR #2329 : https://github.com/PennyLaneAI/pennylane/pull/2329

The `ObservableReturnTypes`, including `Expectation` are being moved to the `measurements` module from the `operation` module, as they are about the measurements.

This PR updates lightning to reflect that change.  This PR and #2329 will have to be performed together.