### PR TITLE
Update tests to remove JacobianTape

### DIFF
--- a/pennylane_lightning/_version.py
+++ b/pennylane_lightning/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.23.0-dev1"
+__version__ = "0.23.0-dev2"

--- a/tests/test_adjoint_jacobian.py
+++ b/tests/test_adjoint_jacobian.py
@@ -75,7 +75,7 @@ class TestAdjointJacobian:
         """Test if a QuantumFunctionError is raised for a tape with measurements that are not
         expectation values"""
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RX(0.1, wires=0)
             qml.var(qml.PauliZ(0))
 
@@ -87,7 +87,7 @@ class TestAdjointJacobian:
 
         dev = qml.device("lightning.qubit", wires=1, shots=1)
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.expval(qml.PauliZ(0))
 
         with pytest.warns(
@@ -100,7 +100,7 @@ class TestAdjointJacobian:
         """Test if a QuantumFunctionError is raised for an unsupported operation, i.e.,
         multi-parameter operations that are not qml.Rot"""
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.CRot(0.1, 0.2, 0.3, wires=[0, 1])
             qml.expval(qml.PauliZ(0))
 
@@ -109,7 +109,7 @@ class TestAdjointJacobian:
         ):
             dev.adjoint_jacobian(tape)
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.SingleExcitation(0.1, wires=[0, 1])
             qml.expval(qml.PauliZ(0))
 
@@ -122,7 +122,7 @@ class TestAdjointJacobian:
     @pytest.mark.skipif(not lq._CPP_BINARY_AVAILABLE, reason="Lightning binary required")
     def test_proj_unsupported(self, dev):
         """Test if a QuantumFunctionError is raised for a Projector observable"""
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.CRX(0.1, wires=[0, 1])
             qml.expval(qml.Projector([0, 1], wires=[0, 1]))
 
@@ -131,7 +131,7 @@ class TestAdjointJacobian:
         ):
             dev.adjoint_jacobian(tape)
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.CRX(0.1, wires=[0, 1])
             qml.expval(qml.Projector([0], wires=[0]) @ qml.PauliZ(0))
 
@@ -144,7 +144,7 @@ class TestAdjointJacobian:
     def test_unsupported_hermitian_expectation(self, dev):
         obs = np.array([[1, 0], [0, -1]], dtype=np.complex128, requires_grad=False)
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RY(0.1, wires=(0,))
             qml.expval(qml.Hermitian(obs, wires=(0,)))
 
@@ -153,7 +153,7 @@ class TestAdjointJacobian:
         ):
             dev.adjoint_jacobian(tape)
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RY(0.1, wires=(0,))
             qml.expval(qml.Hermitian(obs, wires=(0,)) @ qml.PauliZ(wires=1))
 
@@ -169,7 +169,7 @@ class TestAdjointJacobian:
     def test_unsupported_complex_type(self, dev):
         dev._state = dev._asarray(dev._state, np.complex256)
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.QubitStateVector(np.array([1.0, -1.0]) / np.sqrt(2), wires=0)
             qml.RX(0.3, wires=[0])
             qml.expval(qml.PauliZ(0))
@@ -187,7 +187,7 @@ class TestAdjointJacobian:
 
         dev._state = dev._asarray(dev._state, C)
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.QubitStateVector(np.array([1.0, -1.0]) / np.sqrt(2), wires=0)
             G(theta, wires=[0])
             qml.expval(qml.PauliZ(0))
@@ -210,7 +210,7 @@ class TestAdjointJacobian:
 
         dev._state = dev._state.astype(C)
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.QubitStateVector(np.array([1.0, -1.0]) / np.sqrt(2), wires=0)
             qml.Rot(*params, wires=[0])
             qml.expval(qml.PauliZ(0))
@@ -231,7 +231,7 @@ class TestAdjointJacobian:
 
         dev._state = dev._state.astype(C)
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RY(par, wires=[0])
             qml.expval(qml.PauliX(0))
 
@@ -239,11 +239,9 @@ class TestAdjointJacobian:
 
         # gradients
         exact = np.cos(par)
-        grad_F = tape.jacobian(dev, method="numeric")
         grad_A = dev.adjoint_jacobian(tape)
 
         # different methods must agree
-        assert np.allclose(grad_F, exact, atol=tol, rtol=0)
         assert np.allclose(grad_A, exact, atol=tol, rtol=0)
 
     @pytest.mark.parametrize("C", [np.complex64, np.complex128])
@@ -253,7 +251,7 @@ class TestAdjointJacobian:
 
         dev._state = dev._state.astype(C)
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RX(a, wires=0)
             qml.expval(qml.PauliZ(0))
 
@@ -270,7 +268,7 @@ class TestAdjointJacobian:
 
         dev._state = dev._state.astype(C)
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RX(params[0], wires=0)
             qml.RX(params[1], wires=1)
             qml.RX(params[2], wires=2)
@@ -307,7 +305,7 @@ class TestAdjointJacobian:
         dev._state = dev._state.astype(C)
 
         # op.num_wires and op.num_params must be initialized a priori
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.Hadamard(wires=0)
             qml.RX(0.543, wires=0)
             qml.CNOT(wires=[0, 1])
@@ -326,7 +324,8 @@ class TestAdjointJacobian:
 
         tape.trainable_params = set(range(1, 1 + op.num_params))
 
-        grad_F = tape.jacobian(dev, method="numeric")
+        tapes, fn = qml.gradients.finite_diff(tape)
+        grad_F = fn(qml.execute(tapes, dev, None))
         grad_D = dev.adjoint_jacobian(tape)
 
         assert np.allclose(grad_D, grad_F, atol=tol, rtol=0)
@@ -338,7 +337,7 @@ class TestAdjointJacobian:
 
         dev._state = dev._state.astype(C)
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RX(0.4, wires=[0])
             qml.Rot(x, y, z, wires=[0])
             qml.RY(-0.2, wires=[0])
@@ -347,7 +346,8 @@ class TestAdjointJacobian:
         tape.trainable_params = {1, 2, 3}
 
         grad_D = dev.adjoint_jacobian(tape)
-        grad_F = tape.jacobian(dev, method="numeric")
+        tapes, fn = qml.gradients.finite_diff(tape)
+        grad_F = fn(qml.execute(tapes, dev, None))
 
         # gradient has the correct shape and every element is nonzero
         assert grad_D.shape == (1, 3)
@@ -363,7 +363,7 @@ class TestAdjointJacobian:
 
         dev._state = dev._state.astype(C)
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RX(0.4, wires=[0])
             qml.Rot(x, y, z, wires=[0])
             qml.RY(-0.2, wires=[0])
@@ -385,7 +385,7 @@ class TestAdjointJacobian:
 
         dev._state = dev._state.astype(C)
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RX(0.4, wires=[0])
             qml.Rot(x, y, z, wires=[0])
             qml.RY(-0.2, wires=[0])

--- a/tests/test_vjp.py
+++ b/tests/test_vjp.py
@@ -161,7 +161,7 @@ class TestVectorJacobianProduct:
 
         x, y, z = [0.5, 0.3, -0.7]
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RX(0.4, wires=[0])
             qml.Rot(x, y, z, wires=[0])
             qml.RY(-0.2, wires=[0])
@@ -181,7 +181,7 @@ class TestVectorJacobianProduct:
 
         x, y, z = [0.5, 0.3, -0.7]
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RX(0.4, wires=[0])
             qml.Rot(x, y, z, wires=[0])
             qml.RY(-0.2, wires=[0])
@@ -207,7 +207,7 @@ class TestVectorJacobianProduct:
 
         x, y, z = [0.5, 0.3, -0.7]
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RX(0.4, wires=[0])
             qml.Rot(x, y, z, wires=[0])
             qml.RY(-0.2, wires=[0])
@@ -232,7 +232,7 @@ class TestVectorJacobianProduct:
         expectation values"""
         dev._state = dev._asarray(dev._state, C)
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RX(0.1, wires=0)
             qml.var(qml.PauliZ(0))
 
@@ -248,7 +248,7 @@ class TestVectorJacobianProduct:
         dev = qml.device("lightning.qubit", wires=1, shots=1)
         dev._state = dev._asarray(dev._state, C)
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.expval(qml.PauliZ(0))
 
         dy = np.array([1.0])
@@ -267,7 +267,7 @@ class TestVectorJacobianProduct:
         multi-parameter operations that are not qml.Rot"""
         dev._state = dev._asarray(dev._state, C)
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.CRot(0.1, 0.2, 0.3, wires=[0, 1])
             qml.expval(qml.PauliZ(0))
 
@@ -278,7 +278,7 @@ class TestVectorJacobianProduct:
         ):
             dev.vjp(tape, dy)(tape)
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.SingleExcitation(0.1, wires=[0, 1])
             qml.expval(qml.PauliZ(0))
 
@@ -294,7 +294,7 @@ class TestVectorJacobianProduct:
         """Test if a QuantumFunctionError is raised for a Projector observable"""
         dev._state = dev._asarray(dev._state, C)
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.CRX(0.1, wires=[0, 1])
             qml.expval(qml.Projector([0, 1], wires=[0, 1]))
 
@@ -305,7 +305,7 @@ class TestVectorJacobianProduct:
         ):
             dev.vjp(tape, dy)(tape)
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.CRX(0.1, wires=[0, 1])
             qml.expval(qml.Projector([0], wires=[0]) @ qml.PauliZ(0))
 
@@ -321,7 +321,7 @@ class TestVectorJacobianProduct:
 
         obs = np.array([[1, 0], [0, -1]], dtype=np.complex128, requires_grad=False)
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RY(0.1, wires=(0,))
             qml.expval(qml.Hermitian(obs, wires=(0,)))
 
@@ -332,7 +332,7 @@ class TestVectorJacobianProduct:
         ):
             dev.vjp(tape, dy)(tape)
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RY(0.1, wires=(0,))
             qml.expval(qml.Hermitian(obs, wires=(0,)) @ qml.PauliZ(wires=1))
 
@@ -431,7 +431,7 @@ class TestVectorJacobianProduct:
         x = 0.543
         y = -0.654
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RX(x, wires=[0])
             qml.RY(y, wires=[1])
             qml.CNOT(wires=[0, 1])
@@ -455,7 +455,7 @@ class TestVectorJacobianProduct:
         x = 0.543
         y = -0.654
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RX(x, wires=[0])
             qml.RY(y, wires=[1])
             qml.CNOT(wires=[0, 1])
@@ -480,7 +480,7 @@ class TestVectorJacobianProduct:
         x = 0.543
         y = -0.654
 
-        with qml.tape.JacobianTape() as tape:
+        with qml.tape.QuantumTape() as tape:
             qml.RX(x, wires=[0])
             qml.RY(y, wires=[1])
             qml.CNOT(wires=[0, 1])
@@ -512,7 +512,7 @@ class TestBatchVectorJacobianProduct:
             qml.CNOT(wires=[0, 1])
             qml.expval(qml.PauliZ(0))
 
-        with qml.tape.JacobianTape() as tape2:
+        with qml.tape.QuantumTape() as tape2:
             qml.RX(0.4, wires=0)
             qml.RX(0.6, wires=0)
             qml.CNOT(wires=[0, 1])
@@ -537,7 +537,7 @@ class TestBatchVectorJacobianProduct:
             qml.CNOT(wires=[0, 1])
             qml.expval(qml.PauliZ(0))
 
-        with qml.tape.JacobianTape() as tape2:
+        with qml.tape.QuantumTape() as tape2:
             qml.RX(0.4, wires=0)
             qml.RX(0.6, wires=0)
             qml.CNOT(wires=[0, 1])
@@ -593,7 +593,7 @@ class TestBatchVectorJacobianProduct:
             qml.CNOT(wires=[0, 1])
             qml.expval(qml.PauliZ(0))
 
-        with qml.tape.JacobianTape() as tape2:
+        with qml.tape.QuantumTape() as tape2:
             qml.RX(0.4, wires=0)
             qml.RX(0.6, wires=0)
             qml.CNOT(wires=[0, 1])
@@ -615,12 +615,12 @@ class TestBatchVectorJacobianProduct:
         """Test the 'append' reduction strategy"""
         dev._state = dev._asarray(dev._state, C)
 
-        with qml.tape.JacobianTape() as tape1:
+        with qml.tape.QuantumTape() as tape1:
             qml.RX(0.4, wires=0)
             qml.CNOT(wires=[0, 1])
             qml.expval(qml.PauliZ(0))
 
-        with qml.tape.JacobianTape() as tape2:
+        with qml.tape.QuantumTape() as tape2:
             qml.RX(0.4, wires=0)
             qml.RX(0.6, wires=0)
             qml.CNOT(wires=[0, 1])
@@ -644,12 +644,12 @@ class TestBatchVectorJacobianProduct:
         """Test the 'append' reduction strategy"""
         dev._state = dev._asarray(dev._state, C)
 
-        with qml.tape.JacobianTape() as tape1:
+        with qml.tape.QuantumTape() as tape1:
             qml.RX(0.4, wires=0)
             qml.CNOT(wires=[0, 1])
             qml.expval(qml.PauliZ(0))
 
-        with qml.tape.JacobianTape() as tape2:
+        with qml.tape.QuantumTape() as tape2:
             qml.RX(0.4, wires=0)
             qml.RX(0.6, wires=0)
             qml.CNOT(wires=[0, 1])
@@ -673,12 +673,12 @@ class TestBatchVectorJacobianProduct:
         """Test the 'extend' reduction strategy"""
         dev._state = dev._asarray(dev._state, C)
 
-        with qml.tape.JacobianTape() as tape1:
+        with qml.tape.QuantumTape() as tape1:
             qml.RX(0.4, wires=0)
             qml.CNOT(wires=[0, 1])
             qml.expval(qml.PauliZ(0))
 
-        with qml.tape.JacobianTape() as tape2:
+        with qml.tape.QuantumTape() as tape2:
             qml.RX(0.4, wires=0)
             qml.RX(0.6, wires=0)
             qml.CNOT(wires=[0, 1])
@@ -700,12 +700,12 @@ class TestBatchVectorJacobianProduct:
         """Test the 'extend' reduction strategy"""
         dev._state = dev._asarray(dev._state, C)
 
-        with qml.tape.JacobianTape() as tape1:
+        with qml.tape.QuantumTape() as tape1:
             qml.RX(0.4, wires=0)
             qml.CNOT(wires=[0, 1])
             qml.expval(qml.PauliZ(0))
 
-        with qml.tape.JacobianTape() as tape2:
+        with qml.tape.QuantumTape() as tape2:
             qml.RX(0.4, wires=0)
             qml.RX(0.6, wires=0)
             qml.CNOT(wires=[0, 1])


### PR DESCRIPTION
**Context:** With https://github.com/PennyLaneAI/pennylane/pull/2336 deprecated functions in PennyLane were removed. Some of these functions were still in use in Lightning and needed replacement.

**Description of the Change:** Removes `JacobianTape` from the Lightning Python test suite and updates the support for new syntax.

**Benefits:** Passing tests

**Possible Drawbacks:**

**Related GitHub Issues:**
