### PR TITLE
Remove `qml.Snapshot` from fallback device

### DIFF
--- a/pennylane_lightning/_version.py
+++ b/pennylane_lightning/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.23.0-dev4"
+__version__ = "0.23.0-dev5"

--- a/pennylane_lightning/lightning_qubit.py
+++ b/pennylane_lightning/lightning_qubit.py
@@ -688,6 +688,7 @@ if not CPP_BINARY_AVAILABLE:
         version = __version__
         author = "Xanadu Inc."
         _CPP_BINARY_AVAILABLE = False
+        operations = _remove_snapshot_from_operations(DefaultQubit.operations)
 
         def __init__(self, *args, **kwargs):
             warn(


### PR DESCRIPTION
When the CI checks in the main PennyLane repo fail to install a correct wheel of Lightning from the PyPi test repo, some tests that expect the Snapshot operation to be unsupported fail because the operation is now suddenly supported due to the use of the fallback device (default.qubit).

This change makes the Snapshot operation unsupported on the fallback device.