### PR TITLE
Create bug-fix release 0.22.1

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,3 +1,12 @@
+# Release 0.22.1
+
+### Bug fixes
+
+* Ensure `Identity ` kernel is registered to C++ dispatcher.
+[(#275)](https://github.com/PennyLaneAI/pennylane-lightning/pull/275)
+
+---
+
 # Release 0.22.0
 
 ### New features since last release

--- a/pennylane_lightning/_version.py
+++ b/pennylane_lightning/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.22.0"
+__version__ = "0.22.1"

--- a/pennylane_lightning/src/gates/Constant.hpp
+++ b/pennylane_lightning/src/gates/Constant.hpp
@@ -38,6 +38,8 @@ namespace Pennylane::Gates::Constant {
  * @brief Gate names
  */
 [[maybe_unused]] constexpr std::array gate_names = {
+    std::pair<GateOperation, std::string_view>{GateOperation::Identity,
+                                               "Identity"},
     std::pair<GateOperation, std::string_view>{GateOperation::PauliX, "PauliX"},
     std::pair<GateOperation, std::string_view>{GateOperation::PauliY, "PauliY"},
     std::pair<GateOperation, std::string_view>{GateOperation::PauliZ, "PauliZ"},
@@ -112,6 +114,7 @@ namespace Pennylane::Gates::Constant {
  * @brief Number of wires for gates besides multi-qubit gates
  */
 [[maybe_unused]] constexpr std::array gate_wires = {
+    std::pair<GateOperation, size_t>{GateOperation::Identity, 1},
     std::pair<GateOperation, size_t>{GateOperation::PauliX, 1},
     std::pair<GateOperation, size_t>{GateOperation::PauliY, 1},
     std::pair<GateOperation, size_t>{GateOperation::PauliZ, 1},
@@ -162,6 +165,7 @@ namespace Pennylane::Gates::Constant {
  * @brief Number of parameters for gates
  */
 [[maybe_unused]] constexpr std::array gate_num_params = {
+    std::pair<GateOperation, size_t>{GateOperation::Identity, 0},
     std::pair<GateOperation, size_t>{GateOperation::PauliX, 0},
     std::pair<GateOperation, size_t>{GateOperation::PauliY, 0},
     std::pair<GateOperation, size_t>{GateOperation::PauliZ, 0},
@@ -210,6 +214,7 @@ namespace Pennylane::Gates::Constant {
  * 3. For the Python binding.
  */
 [[maybe_unused]] constexpr std::array default_kernel_for_gates = {
+    std::pair{GateOperation::Identity, KernelType::LM},
     std::pair{GateOperation::PauliX, KernelType::LM},
     std::pair{GateOperation::PauliY, KernelType::LM},
     std::pair{GateOperation::PauliZ, KernelType::LM},

--- a/pennylane_lightning/src/gates/GateImplementationsLM.hpp
+++ b/pennylane_lightning/src/gates/GateImplementationsLM.hpp
@@ -44,18 +44,31 @@ class GateImplementationsLM : public PauliGenerator<GateImplementationsLM> {
     constexpr static uint32_t data_alignment_in_bytes = 1;
 
     constexpr static std::array implemented_gates = {
-        GateOperation::PauliX,  GateOperation::PauliY,
-        GateOperation::PauliZ,  GateOperation::Hadamard,
-        GateOperation::S,       GateOperation::T,
-        GateOperation::RX,      GateOperation::RY,
-        GateOperation::RZ,      GateOperation::PhaseShift,
-        GateOperation::Rot,     GateOperation::CY,
-        GateOperation::CZ,      GateOperation::CNOT,
-        GateOperation::SWAP,    GateOperation::ControlledPhaseShift,
-        GateOperation::CRX,     GateOperation::CRY,
-        GateOperation::CRZ,     GateOperation::IsingXX,
-        GateOperation::IsingYY, GateOperation::IsingZZ,
-        GateOperation::MultiRZ, GateOperation::Matrix};
+        GateOperation::Identity,
+        GateOperation::PauliX,
+        GateOperation::PauliY,
+        GateOperation::PauliZ,
+        GateOperation::Hadamard,
+        GateOperation::S,
+        GateOperation::T,
+        GateOperation::RX,
+        GateOperation::RY,
+        GateOperation::RZ,
+        GateOperation::PhaseShift,
+        GateOperation::Rot,
+        GateOperation::CY,
+        GateOperation::CZ,
+        GateOperation::CNOT,
+        GateOperation::SWAP,
+        GateOperation::ControlledPhaseShift,
+        GateOperation::CRX,
+        GateOperation::CRY,
+        GateOperation::CRZ,
+        GateOperation::IsingXX,
+        GateOperation::IsingYY,
+        GateOperation::IsingZZ,
+        GateOperation::MultiRZ,
+        GateOperation::Matrix};
 
     constexpr static std::array implemented_generators = {
         GeneratorOperation::RX,      GeneratorOperation::RY,
@@ -274,6 +287,17 @@ class GateImplementationsLM : public PauliGenerator<GateImplementationsLM> {
             }
         }
         }
+    }
+
+    template <class PrecisionT>
+    static void applyIdentity(std::complex<PrecisionT> *arr,
+                              const size_t num_qubits,
+                              const std::vector<size_t> &wires,
+                              [[maybe_unused]] bool inverse) {
+        assert(wires.size() == 1);
+        static_cast<void>(arr);        // No-op
+        static_cast<void>(num_qubits); // No-op
+        static_cast<void>(wires);      // No-op
     }
 
     template <class PrecisionT>

--- a/pennylane_lightning/src/gates/GateImplementationsPI.hpp
+++ b/pennylane_lightning/src/gates/GateImplementationsPI.hpp
@@ -51,19 +51,33 @@ class GateImplementationsPI : public PauliGenerator<GateImplementationsPI> {
     constexpr static uint32_t data_alignment_in_bytes = 1;
 
     constexpr static std::array implemented_gates = {
-        GateOperation::PauliX,  GateOperation::PauliY,
-        GateOperation::PauliZ,  GateOperation::Hadamard,
-        GateOperation::S,       GateOperation::T,
-        GateOperation::RX,      GateOperation::RY,
-        GateOperation::RZ,      GateOperation::PhaseShift,
-        GateOperation::Rot,     GateOperation::ControlledPhaseShift,
-        GateOperation::CNOT,    GateOperation::CY,
-        GateOperation::CZ,      GateOperation::SWAP,
-        GateOperation::IsingXX, GateOperation::IsingYY,
-        GateOperation::IsingZZ, GateOperation::CRX,
-        GateOperation::CRY,     GateOperation::CRZ,
-        GateOperation::CRot,    GateOperation::Toffoli,
-        GateOperation::CSWAP,   GateOperation::MultiRZ,
+        GateOperation::Identity,
+        GateOperation::PauliX,
+        GateOperation::PauliY,
+        GateOperation::PauliZ,
+        GateOperation::Hadamard,
+        GateOperation::S,
+        GateOperation::T,
+        GateOperation::RX,
+        GateOperation::RY,
+        GateOperation::RZ,
+        GateOperation::PhaseShift,
+        GateOperation::Rot,
+        GateOperation::ControlledPhaseShift,
+        GateOperation::CNOT,
+        GateOperation::CY,
+        GateOperation::CZ,
+        GateOperation::SWAP,
+        GateOperation::IsingXX,
+        GateOperation::IsingYY,
+        GateOperation::IsingZZ,
+        GateOperation::CRX,
+        GateOperation::CRY,
+        GateOperation::CRZ,
+        GateOperation::CRot,
+        GateOperation::Toffoli,
+        GateOperation::CSWAP,
+        GateOperation::MultiRZ,
         GateOperation::Matrix};
     constexpr static std::array implemented_generators = {
         GeneratorOperation::RX,  GeneratorOperation::RY,
@@ -144,6 +158,16 @@ class GateImplementationsPI : public PauliGenerator<GateImplementationsPI> {
     }
 
     /* Single qubit operators */
+    template <class PrecisionT>
+    static void applyIdentity(std::complex<PrecisionT> *arr, size_t num_qubits,
+                              const std::vector<size_t> &wires,
+                              [[maybe_unused]] bool inverse) {
+        assert(wires.size() == 1);
+        static_cast<void>(arr);        // No-op
+        static_cast<void>(num_qubits); // No-op
+        static_cast<void>(wires);      // No-op
+    }
+
     template <class PrecisionT>
     static void applyPauliX(std::complex<PrecisionT> *arr, size_t num_qubits,
                             const std::vector<size_t> &wires,

--- a/pennylane_lightning/src/gates/GateOperation.hpp
+++ b/pennylane_lightning/src/gates/GateOperation.hpp
@@ -27,7 +27,8 @@ namespace Pennylane::Gates {
 enum class GateOperation : uint32_t {
     BEGIN = 0,
     /* Single-qubit gates */
-    PauliX = 0,
+    Identity = 0,
+    PauliX,
     PauliY,
     PauliZ,
     Hadamard,

--- a/pennylane_lightning/src/gates/Gates.hpp
+++ b/pennylane_lightning/src/gates/Gates.hpp
@@ -9,6 +9,20 @@
 namespace Pennylane::Gates {
 
 /**
+ * @brief Create a matrix representation of the Identity gate data in row-major
+ * format.
+ *
+ * @tparam T Required precision of gate (`float` or `double`).
+ * @return constexpr std::vector<std::complex<T>> Return constant expression of
+ * Identity data.
+ */
+template <class T>
+static constexpr auto getIdentity() -> std::vector<std::complex<T>> {
+    using namespace Util;
+    return {ONE<T>(), ZERO<T>(), ZERO<T>(), ONE<T>()};
+}
+
+/**
  * @brief Create a matrix representation of the PauliX gate data in row-major
  * format.
  *

--- a/pennylane_lightning/src/gates/OpToMemberFuncPtr.hpp
+++ b/pennylane_lightning/src/gates/OpToMemberFuncPtr.hpp
@@ -47,6 +47,12 @@ struct GateOpToMemberFuncPtr {
 
 template <class PrecisionT, class ParamT, class GateImplementation>
 struct GateOpToMemberFuncPtr<PrecisionT, ParamT, GateImplementation,
+                             GateOperation::Identity> {
+    constexpr static auto value =
+        &GateImplementation::template applyIdentity<PrecisionT>;
+};
+template <class PrecisionT, class ParamT, class GateImplementation>
+struct GateOpToMemberFuncPtr<PrecisionT, ParamT, GateImplementation,
                              GateOperation::PauliX> {
     constexpr static auto value =
         &GateImplementation::template applyPauliX<PrecisionT>;

--- a/pennylane_lightning/src/simulator/StateVectorBase.hpp
+++ b/pennylane_lightning/src/simulator/StateVectorBase.hpp
@@ -327,6 +327,20 @@ template <class PrecisionT, class Derived> class StateVectorBase {
     }
 
     /**
+     * @brief Apply Identity gate operation to given indices of statevector.
+     *
+     * @param wires Wires to apply gate to.
+     * @param inverse Take adjoint of given operation.
+     */
+    PENNYLANE_STATEVECTOR_DEFINE_GATE(Identity)
+
+    /**
+     * @brief Apply Identity gate operation using a kernel given in
+     * default_kernel_for_gates
+     */
+    PENNYLANE_STATEVECTOR_DEFINE_DEFAULT_GATE(Identity)
+
+    /**
      * @brief Apply PauliX gate operation to given indices of statevector.
      *
      * @param wires Wires to apply gate to.

--- a/pennylane_lightning/src/tests/Test_GateImplementations_Nonparam.cpp
+++ b/pennylane_lightning/src/tests/Test_GateImplementations_Nonparam.cpp
@@ -69,6 +69,32 @@ using std::vector;
  * Single-qubit gates
  ******************************************************************************/
 template <typename PrecisionT, class GateImplementation>
+void testApplyIdentity() {
+    const size_t num_qubits = 3;
+    for (size_t index = 0; index < num_qubits; index++) {
+        auto st_pre = createZeroState<PrecisionT>(num_qubits);
+        auto st_post = createZeroState<PrecisionT>(num_qubits);
+
+        GateImplementation::applyIdentity(st_pre.data(), num_qubits, {index},
+                                          false);
+        CHECK(std::equal(st_pre.begin(), st_pre.end(), st_post.begin()));
+    }
+    for (size_t index = 0; index < num_qubits; index++) {
+        auto st_pre = createZeroState<PrecisionT>(num_qubits);
+        auto st_post = createZeroState<PrecisionT>(num_qubits);
+        GateImplementation::applyHadamard(st_pre.data(), num_qubits, {index},
+                                          false);
+        GateImplementation::applyHadamard(st_post.data(), num_qubits, {index},
+                                          false);
+
+        GateImplementation::applyIdentity(st_pre.data(), num_qubits, {index},
+                                          false);
+        CHECK(std::equal(st_pre.begin(), st_pre.end(), st_post.begin()));
+    }
+}
+PENNYLANE_RUN_TEST(Identity);
+
+template <typename PrecisionT, class GateImplementation>
 void testApplyPauliX() {
     const size_t num_qubits = 3;
     for (size_t index = 0; index < num_qubits; index++) {

--- a/pennylane_lightning/src/tests/Test_OpToMemberFuncPtr.cpp
+++ b/pennylane_lightning/src/tests/Test_OpToMemberFuncPtr.cpp
@@ -107,6 +107,7 @@ class DummyImplementation {
         static_cast<void>(inverse);
     }
 
+    PENNYLANE_TESTS_DEFINE_GATE_OP(Identity, 0)
     PENNYLANE_TESTS_DEFINE_GATE_OP(PauliX, 0)
     PENNYLANE_TESTS_DEFINE_GATE_OP(PauliY, 0)
     PENNYLANE_TESTS_DEFINE_GATE_OP(PauliZ, 0)


### PR DESCRIPTION
**Context:** Issues were observed with the identity gate in lightning & lightning GPU. This fix ensures the kernel is registered to C++ runtime.

**Description of the Change:** Adds Identity kernel as a no-op to dispatcher.

**Benefits:** Avoids runtime error of calling identity external to Python tooling.

**Possible Drawbacks:**

**Related GitHub Issues:**
