### PR TITLE
Fix Trans namespace in the Lightning Benchmark Suite

### DIFF
--- a/.github/workflows/tests_linux.yml
+++ b/.github/workflows/tests_linux.yml
@@ -132,6 +132,39 @@ jobs:
           file: ./BuildCov/coverage.info
           fail_ci_if_error: true
 
+  cppbenchmarksuite:
+    name: C++ Benchmark Suite (Linux, OpenBLAS)
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04]
+    steps:
+      - name: Cancel previous runs
+        uses: styfle/cancel-workflow-action@0.4.1
+        with:
+          access_token: ${{ github.token }}
+
+      - uses: actions/setup-python@v2
+        name: Install Python
+        with:
+          python-version: '3.7'
+
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get -y -q install cmake gcc g++ libopenblas-dev gcovr lcov
+
+      - name: Build and run gbenchmark
+        run: |
+            cmake . -BBuildGBench -DBUILD_BENCHMARKS=ON -DENABLE_BLAS=ON -DCMAKE_BUILD_TYPE=Release
+            cmake --build ./BuildGBench --target utils apply_operations apply_multirz
+            mkdir -p ./BuildGBench/benchmarks/results
+            ./BuildGBench/benchmarks/utils
+            ./BuildGBench/benchmarks/apply_operations
+            ./BuildGBench/benchmarks/apply_multirz
+
   pythontests:
     name: Python tests
     runs-on: ${{ matrix.os }}

--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,12 @@ benchmark:
 	cmake $(LIGHTNING_CPP_DIR) -BBuildBench -DBUILD_EXAMPLES=ON -DCMAKE_BUILD_TYPE=Release -DENABLE_AVX=ON
 	cmake --build ./BuildBench
 
+.PHONY: gbenchmark
+gbenchmark:
+	rm -rf ./BuildGBench
+	cmake $(LIGHTNING_CPP_DIR) -BBuildGBench -DBUILD_BENCHMARKS=ON -DENABLE_OPENMP=ON -DENABLE_BLAS=ON -DCMAKE_BUILD_TYPE=Release
+	cmake --build ./BuildGBench --target utils apply_operations apply_multirz
+
 .PHONY: format format-cpp format-python
 format: format-cpp format-python
 
@@ -120,9 +126,3 @@ check-tidy:
 	rm -rf ./Build
 	cmake . -BBuild -DENABLE_CLANG_TIDY=ON -DBUILD_TESTS=ON -DBUILD_EXAMPLES=ON
 	cmake --build ./Build
-
-.PHONY: gbenchmark
-gbenchmark:
-	rm -rf ./BuildGBench
-	cmake $(LIGHTNING_CPP_DIR) -BBuildGBench -DBUILD_BENCHMARKS=ON -DENABLE_OPENMP=ON -DENABLE_BLAS=ON -DCMAKE_BUILD_TYPE=Release
-	cmake --build ./BuildGBench --target utils apply_operations apply_multirz

--- a/pennylane_lightning/src/benchmarks/Bench_LinearAlgebra.cpp
+++ b/pennylane_lightning/src/benchmarks/Bench_LinearAlgebra.cpp
@@ -258,6 +258,7 @@ BENCHMARK(cf_transpose_cmplx<double, 32>)
  */
 template <class T>
 static void omp_matrixVecProd_cmplx(benchmark::State &state) {
+    using Pennylane::Util::Trans;
     std::random_device rd;
     std::mt19937_64 eng(rd());
     std::uniform_real_distribution<T> distr;
@@ -296,6 +297,7 @@ BENCHMARK(omp_matrixVecProd_cmplx<double>)
  */
 template <class T>
 static void blas_matrixVecProd_cmplx(benchmark::State &state) {
+    using Pennylane::Util::Trans;
     std::random_device rd;
     std::mt19937_64 eng(rd());
     std::uniform_real_distribution<T> distr;
@@ -348,6 +350,7 @@ BENCHMARK(blas_matrixVecProd_cmplx<double>)
  */
 template <class T>
 static void omp_matrixMatProd_cmplx(benchmark::State &state) {
+    using Pennylane::Util::Trans;
     std::random_device rd;
     std::mt19937_64 eng(rd());
     std::uniform_real_distribution<T> distr;
@@ -389,6 +392,7 @@ BENCHMARK(omp_matrixMatProd_cmplx<double>)
  */
 template <class T>
 static void blas_matrixMatProd_cmplx(benchmark::State &state) {
+    using Pennylane::Util::Trans;
     std::random_device rd;
     std::mt19937_64 eng(rd());
     std::uniform_real_distribution<T> distr;


### PR DESCRIPTION
**Context:**
`Trans`  is now moved into `Util` namespace; and so trying the Lightning benchmark suite would fail due to the following error,
```console
pennylane-lightning/pennylane_lightning/src/benchmarks/Bench_LinearAlgebra.cpp: error: ‘Trans’ has not been declared
``` 
This PR addresses this bug and adds `gbenchmark` to the CI.
