### PR TITLE
CIbuildwheel and benchmark CIs use PL master for tests

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -32,6 +32,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install matplotlib
+          pip install git+https://github.com/PennyLaneAI/pennylane.git@master
 
       - name: Install lightning.qubit device (master)
         run: |

--- a/.github/workflows/wheel_linux_aarch64.yml
+++ b/.github/workflows/wheel_linux_aarch64.yml
@@ -5,7 +5,6 @@ on:
       - master
   release:
     types: [published]
-  pull_request: # need to be removed before merge
 
 env:
   CIBW_BUILD: 'cp37-* cp38-* cp39-* cp310-*'

--- a/.github/workflows/wheel_linux_aarch64.yml
+++ b/.github/workflows/wheel_linux_aarch64.yml
@@ -5,6 +5,7 @@ on:
       - master
   release:
     types: [published]
+  pull_request: # need to be removed before merge
 
 env:
   CIBW_BUILD: 'cp37-* cp38-* cp39-* cp310-*'
@@ -16,6 +17,8 @@ env:
 
   # Testing of built wheels
   CIBW_TEST_REQUIRES: numpy~=1.21 scipy pytest pytest-cov pytest-mock flaky
+
+  CIBW_BEFORE_TEST: pip install git+https://github.com/PennyLaneAI/pennylane.git@master
 
   CIBW_TEST_COMMAND: |
     pl-device-test --device=lightning.qubit --skip-ops -x --tb=short --no-flaky-report

--- a/.github/workflows/wheel_linux_ppc64le.yml
+++ b/.github/workflows/wheel_linux_ppc64le.yml
@@ -5,7 +5,6 @@ on:
       - master
   release:
     types: [published]
-  pull_request: # need to be removed before merge
 
 env:
   CIBW_BUILD: 'cp37-* cp38-* cp39-* cp310-*'

--- a/.github/workflows/wheel_linux_ppc64le.yml
+++ b/.github/workflows/wheel_linux_ppc64le.yml
@@ -5,6 +5,7 @@ on:
       - master
   release:
     types: [published]
+  pull_request: # need to be removed before merge
 
 env:
   CIBW_BUILD: 'cp37-* cp38-* cp39-* cp310-*'
@@ -16,6 +17,8 @@ env:
 
   # Skip PPC tests due to lack of numpy/scipy wheel support
   CIBW_TEST_SKIP: "*-manylinux_{ppc64le}"
+
+  CIBW_BEFORE_TEST: pip install git+https://github.com/PennyLaneAI/pennylane.git@master
 
   # Use CentOS 7 image for PPC
   CIBW_MANYLINUX_PPC64LE_IMAGE: manylinux2014

--- a/.github/workflows/wheel_linux_x86_64.yml
+++ b/.github/workflows/wheel_linux_x86_64.yml
@@ -18,6 +18,8 @@ env:
   # Testing of built wheels
   CIBW_TEST_REQUIRES: numpy~=1.21 scipy pytest pytest-cov pytest-mock flaky
 
+  CIBW_BEFORE_TEST: pip install git+https://github.com/PennyLaneAI/pennylane.git@master
+
   CIBW_TEST_COMMAND: |
     pl-device-test --device=lightning.qubit --skip-ops -x --tb=short --no-flaky-report
 

--- a/.github/workflows/wheel_macos_arm64.yml
+++ b/.github/workflows/wheel_macos_arm64.yml
@@ -21,6 +21,8 @@ env:
   # Testing of built wheels
   CIBW_TEST_REQUIRES: numpy~=1.21 scipy pytest pytest-cov pytest-mock flaky
 
+  CIBW_BEFORE_TEST: pip install git+https://github.com/PennyLaneAI/pennylane.git@master
+
   CIBW_TEST_COMMAND: |
     pl-device-test --device=lightning.qubit --skip-ops -x --tb=short --no-flaky-report
 

--- a/.github/workflows/wheel_macos_x86_64.yml
+++ b/.github/workflows/wheel_macos_x86_64.yml
@@ -22,6 +22,8 @@ env:
   # Testing of built wheels
   CIBW_TEST_REQUIRES: numpy~=1.21 scipy pytest pytest-cov pytest-mock flaky
 
+  CIBW_BEFORE_TEST: pip install git+https://github.com/PennyLaneAI/pennylane.git@master
+
   CIBW_TEST_COMMAND: |
     pl-device-test --device=lightning.qubit --skip-ops -x --tb=short --no-flaky-report
 

--- a/.github/workflows/wheel_win_x86_64.yml
+++ b/.github/workflows/wheel_win_x86_64.yml
@@ -20,6 +20,7 @@ env:
   CIBW_TEST_REQUIRES: numpy~=1.21 scipy pytest pytest-cov pytest-mock flaky
 
   CIBW_BEFORE_TEST: |
+    pip install git+https://github.com/PennyLaneAI/pennylane.git@master
     python -c "import sys; print(sys.path)"
 
   CIBW_TEST_COMMAND: |

--- a/pennylane_lightning/_version.py
+++ b/pennylane_lightning/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.24.0-dev5"
+__version__ = "0.24.0-dev6"


### PR DESCRIPTION
Update CIs to use `master` branch of PL instead of the latest release.