### PR TITLE
Fix for maybe uninitiailized warning/error with GCC11

### DIFF
--- a/pennylane_lightning/_version.py
+++ b/pennylane_lightning/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.25.0-dev0"
+__version__ = "0.25.0-dev1"

--- a/pennylane_lightning/src/bindings/Bindings.hpp
+++ b/pennylane_lightning/src/bindings/Bindings.hpp
@@ -141,13 +141,13 @@ auto alignedNumpyArray(CPUMemoryModel memory_model, size_t size)
         auto capsule = pybind11::capsule(ptr, &Util::alignedFree);
         return pybind11::array{
             pybind11::dtype::of<T>(), {size}, {sizeof(T)}, ptr, capsule};
-    } // else
-    void *ptr = malloc(sizeof(T) * size);
-    auto capsule = pybind11::capsule(ptr, free);
+    }
+    void *ptr = static_cast<void *>(new T[size]);
+    auto capsule =
+        pybind11::capsule(ptr, [](void *p) { delete static_cast<T *>(p); });
     return pybind11::array{
         pybind11::dtype::of<T>(), {size}, {sizeof(T)}, ptr, capsule};
 }
-
 /**
  * @brief Create a numpy array whose underlying data is allocated by
  * lightning.


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [ ] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [ ] Ensure that the test suite passes, by running `make test`.

- [ ] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [x] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:** This fixes the issue observed with GCC/G++11.x where the warning-as-errors would cause failed compilation, requiring a downgrade to GCC10.y

**Description of the Change:** Move the `malloc` and `free` calls to `new` and a lambda-bound `delete` with the Pybind11 capsule creation.

**Benefits:** Allows use of GCC 11.x

**Possible Drawbacks:** Validation of allocated memory block may require some checking.

**Related GitHub Issues:**
