### PR TITLE
[WIP] Prebuild and cache Kokkos libs for each target platform

### DIFF
--- a/.github/workflows/build_cached_libs.yml
+++ b/.github/workflows/build_cached_libs.yml
@@ -9,11 +9,13 @@ jobs:
   kokkos_libs:
     name: Kokkos core & kernels
     runs-on: ${{ matrix.os }}
+    container: ${{ matrix.container_img }}
     strategy:
       matrix:
-        os: ["ubuntu-20.04", "quay.io/pypa/manylinux2014_x86_64"]
+        os: [ubuntu-20.04]
         exec_model: [SERIAL, OPENMP, THREADS]
         kokkos_version: ["3.6.00"]
+        container_img: [ubuntu:20.04, quay.io/pypa/manylinux2014_x86_64]
     steps:
       - name: Cancel previous runs
         uses: styfle/cancel-workflow-action@0.4.1
@@ -21,7 +23,7 @@ jobs:
           access_token: ${{ github.token }}
 
       - name: Install dependencies (Ubuntu)
-        if: ${{ matrix.os == "ubuntu-20.04" }}
+        if: ${{ matrix.container_img == "ubuntu-20.04" }}
         run: sudo apt-get update && sudo apt-get -y -q install cmake gcc-10 g++-10 ccache ninja-build
 
       - name: Install dependencies (CentOS)

--- a/.github/workflows/build_cached_libs.yml
+++ b/.github/workflows/build_cached_libs.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Install dependencies (Ubuntu)
         if: ${{ matrix.container_img == 'ubuntu:20.04' }}
-        run: apt-get update && apt-get -y -q install cmake gcc-10 g++-10 ccache ninja-build
+        run: apt-get update && apt-get -y -q install cmake gcc-10 g++-10 ccache ninja-build git
 
       - name: Install dependencies (CentOS)
         if: ${{ matrix.container_img == 'quay.io/pypa/manylinux2014_x86_64' }}
@@ -32,17 +32,16 @@ jobs:
 
       - name: Clone Kokkos libs
         run: |
-          pushd . &> /dev/null
           git clone https://github.com/kokkos/kokkos.git
           cd kokkos 
           git checkout ${{ matrix.kokkos_version }}
-          popd &> /dev/null
+          cd -
 
           pushd . &> /dev/null
           git clone https://github.com/kokkos/kokkos-kernels.git
           cd kokkos-kernels
           git checkout ${{ matrix.kokkos_version }}
-          popd &> /dev/null
+          cd -
 
       - name: Cache installation directories
         id: kokkos-cache

--- a/.github/workflows/build_cached_libs.yml
+++ b/.github/workflows/build_cached_libs.yml
@@ -22,6 +22,15 @@ jobs:
         with:
           access_token: ${{ github.token }}
 
+      - name: Cache installation directories
+        id: kokkos-cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ${{ github.workspace }}/install_dir/${{ matrix.exec_model }}
+            $HOME/.ccache
+          key: ${{ matrix.container_img }}-kokkos${{ matrix.kokkos_version }}-${{ matrix.exec_model }}
+
       - name: Install dependencies (Ubuntu)
         if: ${{ matrix.container_img == 'ubuntu:20.04' }}
         run: |
@@ -46,15 +55,6 @@ jobs:
           cd kokkos-kernels
           git checkout ${{ matrix.kokkos_version }}
           cd -
-
-      - name: Cache installation directories
-        id: kokkos-cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            ${{ github.workspace }}/install_dir/${{ matrix.exec_model }}
-            $HOME/.ccache
-          key: ${{ matrix.container_img }}-kokkos${{ matrix.kokkos_version }}-${{ matrix.exec_model }}
 
       - name: Build Kokkos core library
         if: steps.kokkos-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/build_cached_libs.yml
+++ b/.github/workflows/build_cached_libs.yml
@@ -59,7 +59,6 @@ jobs:
       - name: Build Kokkos core library
         if: steps.kokkos-cache.outputs.cache-hit != 'true'
         run: |
-          pushd . &> /dev/null
           mkdir -p /root/install_dir/${{ matrix.exec_model }}
           cd kokkos
           cmake -BBuild . -DCMAKE_INSTALL_PREFIX=/root/install_dir/${{ matrix.exec_model }} \
@@ -72,12 +71,11 @@ jobs:
 
           cmake --build ./Build --verbose
           cmake --install ./Build
-          popd &> /dev/null
+          cd -
 
       - name: Build Kokkos kernels library
         if: steps.kokkos-cache.outputs.cache-hit != 'true'
         run: |
-          pushd . &> /dev/null
           mkdir -p /root/install_dir/${{ matrix.exec_model }}
           cd kokkos-kernels
           cmake -BBuild . -DCMAKE_INSTALL_PREFIX=/root/install_dir/${{ matrix.exec_model }} \
@@ -89,5 +87,4 @@ jobs:
                           -G Ninja
           cmake --build ./Build --verbose
           cmake --install ./Build
-          popd &> /dev/null
 

--- a/.github/workflows/build_cached_libs.yml
+++ b/.github/workflows/build_cached_libs.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04] #, quay.io/pypa/manylinux2014_x86_64]
-        exec_model: [SERIAL] #[OPENMP, THREADS, SERIAL]
+        os: [ubuntu-20.04, quay.io/pypa/manylinux2014_x86_64]
+        exec_model: [SERIAL, OPENMP, THREADS]
         kokkos_version: ["3.6.00"]
     steps:
       - name: Cancel previous runs
@@ -20,8 +20,13 @@ jobs:
         with:
           access_token: ${{ github.token }}
 
-      - name: Install dependencies
+      - name: Install dependencies (Ubuntu)
+        if: ${{ matrix.os == "ubuntu-20.04" }}
         run: sudo apt-get update && sudo apt-get -y -q install cmake gcc-10 g++-10 ccache ninja-build
+
+      - name: Install dependencies (CentOS)
+        if: ${{ matrix.os == "quay.io/pypa/manylinux2014_x86_64" }}
+        run: sudo yum update && sudo yum install -y cmake ccache ninja-build
 
       - name: Clone Kokkos libs
         run: |

--- a/.github/workflows/build_cached_libs.yml
+++ b/.github/workflows/build_cached_libs.yml
@@ -23,11 +23,11 @@ jobs:
           access_token: ${{ github.token }}
 
       - name: Install dependencies (Ubuntu)
-        if: ${{ matrix.container_img }} == "ubuntu-20.04"
+        if: ${{ matrix.container_img == 'ubuntu:20.04' }}
         run: apt-get update && apt-get -y -q install cmake gcc-10 g++-10 ccache ninja-build
 
       - name: Install dependencies (CentOS)
-        if: ${{ matrix.container_img}} == "quay.io/pypa/manylinux2014_x86_64"
+        if: ${{ matrix.container_img == 'quay.io/pypa/manylinux2014_x86_64' }}
         run: yum update && yum install -y cmake ccache ninja-build
 
       - name: Clone Kokkos libs

--- a/.github/workflows/build_cached_libs.yml
+++ b/.github/workflows/build_cached_libs.yml
@@ -56,7 +56,7 @@ jobs:
                           -DKokkos_ENABLE_${{ matrix.exec_model }}=ON \
                           -DCMAKE_CXX_COMPILER=g++-10 \
                           -DCMAKE_CXX_STANDARD=20 \
-                          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+                          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
                           -G Ninja
           cmake --build ./Build --verbose
           cmake --install ./Build
@@ -73,7 +73,7 @@ jobs:
                           -DCMAKE_CXX_COMPILER=g++-10 \
                           -DCMAKE_CXX_STANDARD=20 \
                           -DKokkos_DIR=$PWD/../install_dir/${{ matrix.exec_model }} \
-                          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+                          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
                           -G Ninja
           cmake --build ./Build --verbose
           cmake --install ./Build

--- a/.github/workflows/build_cached_libs.yml
+++ b/.github/workflows/build_cached_libs.yml
@@ -24,11 +24,11 @@ jobs:
 
       - name: Install dependencies (Ubuntu)
         if: ${{ matrix.container_img }} == "ubuntu-20.04"
-        run: sudo apt-get update && sudo apt-get -y -q install cmake gcc-10 g++-10 ccache ninja-build
+        run: apt-get update && apt-get -y -q install cmake gcc-10 g++-10 ccache ninja-build
 
       - name: Install dependencies (CentOS)
         if: ${{ matrix.container_img}} == "quay.io/pypa/manylinux2014_x86_64"
-        run: sudo yum update && sudo yum install -y cmake ccache ninja-build
+        run: yum update && yum install -y cmake ccache ninja-build
 
       - name: Clone Kokkos libs
         run: |

--- a/.github/workflows/build_cached_libs.yml
+++ b/.github/workflows/build_cached_libs.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: |
-            ${{ github.workspace }}/install_dir/${{ matrix.exec_model }}
+            $HOME/install_dir/${{ matrix.exec_model }}
             $HOME/.ccache
           key: ${{ matrix.container_img }}-kokkos${{ matrix.kokkos_version }}-${{ matrix.exec_model }}
 
@@ -60,9 +60,9 @@ jobs:
         if: steps.kokkos-cache.outputs.cache-hit != 'true'
         run: |
           pushd . &> /dev/null
-          mkdir -p ${{ github.workspace }}/install_dir/${{ matrix.exec_model }}
+          mkdir -p $HOME/install_dir/${{ matrix.exec_model }}
           cd kokkos
-          cmake -BBuild . -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/install_dir/${{ matrix.exec_model }} \
+          cmake -BBuild . -DCMAKE_INSTALL_PREFIX=$HOME/install_dir/${{ matrix.exec_model }} \
                           -DKokkos_ENABLE_COMPLEX_ALIGN=off \
                           -DKokkos_ENABLE_${{ matrix.exec_model }}=ON \
                           -DCMAKE_CXX_COMPILER=${{ env.COMPILER }} \
@@ -78,9 +78,9 @@ jobs:
         if: steps.kokkos-cache.outputs.cache-hit != 'true'
         run: |
           pushd . &> /dev/null
-          mkdir -p ${{ github.workspace }}/install_dir/${{ matrix.exec_model }}
+          mkdir -p $HOME/install_dir/${{ matrix.exec_model }}
           cd kokkos-kernels
-          cmake -BBuild . -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/install_dir/${{ matrix.exec_model }} \
+          cmake -BBuild . -DCMAKE_INSTALL_PREFIX=$HOME/install_dir/${{ matrix.exec_model }} \
                           -DKokkos_ENABLE_${{ matrix.exec_model }}=ON \
                           -DCMAKE_CXX_COMPILER=${{ env.COMPILER }} \
                           -DCMAKE_CXX_STANDARD=20 \

--- a/.github/workflows/build_cached_libs.yml
+++ b/.github/workflows/build_cached_libs.yml
@@ -1,0 +1,68 @@
+name: Build cached libs
+
+jobs:
+  kokkos_libs:
+    name: Kokkos core & kernels
+    runs-on: ubuntu-20.04 # ubuntu-20.04 ${{ matrix.os }}
+    strategy:
+      matrix:
+        exec_model: [OPENMP, THREADS, SERIAL]
+    steps:
+      #- name: Cancel previous runs
+      #  uses: styfle/cancel-workflow-action@0.4.1
+      #  with:
+      #    access_token: ${{ github.token }}
+
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get -y -q install cmake gcc-10 g++-10
+
+      - name: Clone Kokkos libs
+        run: |
+          pushd . &> /dev/null
+          git clone https://github.com/kokkos/kokkos.git
+          cd kokkos 
+          git checkout 3.6.00
+          popd &> /dev/null
+
+          pushd . &> /dev/null
+          git clone https://github.com/kokkos/kokkos-kernels.git
+          cd kokkos-kernels
+          git checkout 3.6.00
+          popd &> /dev/null
+
+      - name: Build Kokkos core library
+        run: |
+          pushd . &> /dev/null
+          mkdir -p install_dir/${{ matrix.exec_model }}
+          cd kokkos
+          cmake -BBuild . -DCMAKE_INSTALL_PREFIX=$PWD/../install_dir/${{ matrix.exec_model }} \
+                          -DKokkos_ENABLE_COMPLEX_ALIGN=off \
+                          -DKokkos_ENABLE_${{ matrix.exec_model }}=ON \
+                          -DCMAKE_CXX_COMPILER=g++-10 \
+                          -DCMAKE_CXX_STANDARD=20
+          cmake --build ./Build --verbose
+          cmake --install ./Build
+          popd . &> /dev/null
+
+      - name: Build Kokkos kernels library
+        run: |
+          pushd . &> /dev/null
+          mkdir -p install_dir/${{ matrix.exec_model }}
+          cd kokkos-kernels
+          cmake -BBuild . -DCMAKE_INSTALL_PREFIX=$PWD/../install_dir/${{ matrix.exec_model }} \
+                          -DKokkos_ENABLE_COMPLEX_ALIGN=off \
+                          -DKokkos_ENABLE_${{ matrix.exec_model }}=ON \
+                          -DCMAKE_CXX_COMPILER=g++-10 \
+                          -DCMAKE_CXX_STANDARD=20 \
+                          -DKokkos_DIR=$PWD/../install_dir/${{ matrix.exec_model }}
+
+          cmake --build ./Build --verbose
+          cmake --install ./Build
+          popd . &> /dev/null
+
+      - name: Cache installation directories
+        uses: actions/cache@v3
+        with:
+          path: |
+            install_dir/${{ matrix.exec_model }}
+          key: ${{ runner.os }}-kokkos-${{ matrix.exec_model }}

--- a/.github/workflows/build_cached_libs.yml
+++ b/.github/workflows/build_cached_libs.yml
@@ -1,17 +1,23 @@
 name: Build cached libs
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   kokkos_libs:
     name: Kokkos core & kernels
-    runs-on: ubuntu-20.04 # ubuntu-20.04 ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [ubuntu-20.04] #, quay.io/pypa/manylinux2014_x86_64]
         exec_model: [OPENMP, THREADS, SERIAL]
     steps:
-      #- name: Cancel previous runs
-      #  uses: styfle/cancel-workflow-action@0.4.1
-      #  with:
-      #    access_token: ${{ github.token }}
+      - name: Cancel previous runs
+        uses: styfle/cancel-workflow-action@0.4.1
+        with:
+          access_token: ${{ github.token }}
 
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get -y -q install cmake gcc-10 g++-10
@@ -65,4 +71,4 @@ jobs:
         with:
           path: |
             install_dir/${{ matrix.exec_model }}
-          key: ${{ runner.os }}-kokkos-${{ matrix.exec_model }}
+          key: ${{ matrix.os }}-kokkos-${{ matrix.exec_model }}

--- a/.github/workflows/build_cached_libs.yml
+++ b/.github/workflows/build_cached_libs.yml
@@ -38,6 +38,7 @@ jobs:
           popd &> /dev/null
 
       - name: Cache installation directories
+        id: kokkos-cache
         uses: actions/cache@v3
         with:
           path: |
@@ -46,7 +47,7 @@ jobs:
           key: ${{ matrix.os }}-kokkos${{ matrix.kokkos_version }}-${{ matrix.exec_model }}
 
       - name: Build Kokkos core library
-        if: steps.cache.outputs.cache-hit != 'true'
+        if: steps.kokkos-cache.outputs.cache-hit != 'true'
         run: |
           pushd . &> /dev/null
           mkdir -p ${{ github.workspace }}/install_dir/${{ matrix.exec_model }}
@@ -58,13 +59,13 @@ jobs:
                           -DCMAKE_CXX_STANDARD=20 \
                           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
                           -G Ninja
-                          
+
           cmake --build ./Build --verbose
           cmake --install ./Build
           popd &> /dev/null
 
       - name: Build Kokkos kernels library
-        if: steps.cache.outputs.cache-hit != 'true'
+        if: steps.kokkos-cache.outputs.cache-hit != 'true'
         run: |
           pushd . &> /dev/null
           mkdir -p ${{ github.workspace }}/install_dir/${{ matrix.exec_model }}

--- a/.github/workflows/build_cached_libs.yml
+++ b/.github/workflows/build_cached_libs.yml
@@ -27,8 +27,8 @@ jobs:
         uses: actions/cache@v3
         with:
           path: |
-            $HOME/install_dir/${{ matrix.exec_model }}
-            $HOME/.ccache
+            /root/install_dir/${{ matrix.exec_model }}
+            /root/.ccache
           key: ${{ matrix.container_img }}-kokkos${{ matrix.kokkos_version }}-${{ matrix.exec_model }}
 
       - name: Install dependencies (Ubuntu)
@@ -60,9 +60,9 @@ jobs:
         if: steps.kokkos-cache.outputs.cache-hit != 'true'
         run: |
           pushd . &> /dev/null
-          mkdir -p $HOME/install_dir/${{ matrix.exec_model }}
+          mkdir -p /root/install_dir/${{ matrix.exec_model }}
           cd kokkos
-          cmake -BBuild . -DCMAKE_INSTALL_PREFIX=$HOME/install_dir/${{ matrix.exec_model }} \
+          cmake -BBuild . -DCMAKE_INSTALL_PREFIX=/root/install_dir/${{ matrix.exec_model }} \
                           -DKokkos_ENABLE_COMPLEX_ALIGN=off \
                           -DKokkos_ENABLE_${{ matrix.exec_model }}=ON \
                           -DCMAKE_CXX_COMPILER=${{ env.COMPILER }} \
@@ -78,9 +78,9 @@ jobs:
         if: steps.kokkos-cache.outputs.cache-hit != 'true'
         run: |
           pushd . &> /dev/null
-          mkdir -p $HOME/install_dir/${{ matrix.exec_model }}
+          mkdir -p /root/install_dir/${{ matrix.exec_model }}
           cd kokkos-kernels
-          cmake -BBuild . -DCMAKE_INSTALL_PREFIX=$HOME/install_dir/${{ matrix.exec_model }} \
+          cmake -BBuild . -DCMAKE_INSTALL_PREFIX=/root/install_dir/${{ matrix.exec_model }} \
                           -DKokkos_ENABLE_${{ matrix.exec_model }}=ON \
                           -DCMAKE_CXX_COMPILER=${{ env.COMPILER }} \
                           -DCMAKE_CXX_STANDARD=20 \

--- a/.github/workflows/build_cached_libs.yml
+++ b/.github/workflows/build_cached_libs.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Install dependencies (Ubuntu)
         if: ${{ matrix.container_img == 'ubuntu:20.04' }}
-        run: apt-get update && apt-get -y -q install cmake gcc-10 g++-10 ccache ninja-build git
+        run: apt-get update && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get -y -q install cmake gcc-10 g++-10 ccache ninja-build git
 
       - name: Install dependencies (CentOS)
         if: ${{ matrix.container_img == 'quay.io/pypa/manylinux2014_x86_64' }}

--- a/.github/workflows/build_cached_libs.yml
+++ b/.github/workflows/build_cached_libs.yml
@@ -24,11 +24,15 @@ jobs:
 
       - name: Install dependencies (Ubuntu)
         if: ${{ matrix.container_img == 'ubuntu:20.04' }}
-        run: apt-get update && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get -y -q install cmake gcc-10 g++-10 ccache ninja-build git
+        run: |
+          apt-get update && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get -y -q install cmake gcc-10 g++-10 ccache ninja-build git
+          echo "COMPILER=g++-10" >> $GITHUB_ENV
 
       - name: Install dependencies (CentOS)
         if: ${{ matrix.container_img == 'quay.io/pypa/manylinux2014_x86_64' }}
-        run: yum update && yum install -y cmake ccache ninja-build
+        run: |
+          yum update && yum install -y cmake ccache ninja-build
+          echo "COMPILER=g++" >> $GITHUB_ENV
 
       - name: Clone Kokkos libs
         run: |
@@ -61,7 +65,7 @@ jobs:
           cmake -BBuild . -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/install_dir/${{ matrix.exec_model }} \
                           -DKokkos_ENABLE_COMPLEX_ALIGN=off \
                           -DKokkos_ENABLE_${{ matrix.exec_model }}=ON \
-                          -DCMAKE_CXX_COMPILER=g++-10 \
+                          -DCMAKE_CXX_COMPILER=${{ env.COMPILER }} \
                           -DCMAKE_CXX_STANDARD=20 \
                           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
                           -G Ninja
@@ -78,7 +82,7 @@ jobs:
           cd kokkos-kernels
           cmake -BBuild . -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/install_dir/${{ matrix.exec_model }} \
                           -DKokkos_ENABLE_${{ matrix.exec_model }}=ON \
-                          -DCMAKE_CXX_COMPILER=g++-10 \
+                          -DCMAKE_CXX_COMPILER=${{ env.COMPILER }} \
                           -DCMAKE_CXX_STANDARD=20 \
                           -DKokkos_DIR=$PWD/../install_dir/${{ matrix.exec_model }} \
                           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \

--- a/.github/workflows/build_cached_libs.yml
+++ b/.github/workflows/build_cached_libs.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, quay.io/pypa/manylinux2014_x86_64]
+        os: ["ubuntu-20.04", "quay.io/pypa/manylinux2014_x86_64"]
         exec_model: [SERIAL, OPENMP, THREADS]
         kokkos_version: ["3.6.00"]
     steps:

--- a/.github/workflows/build_cached_libs.yml
+++ b/.github/workflows/build_cached_libs.yml
@@ -15,7 +15,7 @@ jobs:
         os: [ubuntu-20.04]
         exec_model: [SERIAL, OPENMP, THREADS]
         kokkos_version: ["3.6.00"]
-        container_img: [ubuntu:20.04, quay.io/pypa/manylinux2014_x86_64]
+        container_img: ["ubuntu:20.04", "quay.io/pypa/manylinux2014_x86_64"]
     steps:
       - name: Cancel previous runs
         uses: styfle/cancel-workflow-action@0.4.1
@@ -23,11 +23,11 @@ jobs:
           access_token: ${{ github.token }}
 
       - name: Install dependencies (Ubuntu)
-        if: ${{ matrix.container_img == "ubuntu-20.04" }}
+        if: ${{ matrix.container_img }} == "ubuntu-20.04"
         run: sudo apt-get update && sudo apt-get -y -q install cmake gcc-10 g++-10 ccache ninja-build
 
       - name: Install dependencies (CentOS)
-        if: ${{ matrix.os == "quay.io/pypa/manylinux2014_x86_64" }}
+        if: ${{ matrix.container_img}} == "quay.io/pypa/manylinux2014_x86_64"
         run: sudo yum update && sudo yum install -y cmake ccache ninja-build
 
       - name: Clone Kokkos libs
@@ -51,7 +51,7 @@ jobs:
           path: |
             ${{ github.workspace }}/install_dir/${{ matrix.exec_model }}
             $HOME/.ccache
-          key: ${{ matrix.os }}-kokkos${{ matrix.kokkos_version }}-${{ matrix.exec_model }}
+          key: ${{ matrix.container_img }}-kokkos${{ matrix.kokkos_version }}-${{ matrix.exec_model }}
 
       - name: Build Kokkos core library
         if: steps.kokkos-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/build_cached_libs.yml
+++ b/.github/workflows/build_cached_libs.yml
@@ -13,6 +13,7 @@ jobs:
       matrix:
         os: [ubuntu-20.04] #, quay.io/pypa/manylinux2014_x86_64]
         exec_model: [SERIAL] #[OPENMP, THREADS, SERIAL]
+        kokkos_version: ["3.6.00"]
     steps:
       - name: Cancel previous runs
         uses: styfle/cancel-workflow-action@0.4.1
@@ -20,33 +21,34 @@ jobs:
           access_token: ${{ github.token }}
 
       - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get -y -q install cmake gcc-10 g++-10 ccache
+        run: sudo apt-get update && sudo apt-get -y -q install cmake gcc-10 g++-10 ccache ninja
 
       - name: Clone Kokkos libs
         run: |
           pushd . &> /dev/null
           git clone https://github.com/kokkos/kokkos.git
           cd kokkos 
-          git checkout 3.6.00
+          git checkout ${{ matrix.kokkos_version }}
           popd &> /dev/null
 
           pushd . &> /dev/null
           git clone https://github.com/kokkos/kokkos-kernels.git
           cd kokkos-kernels
-          git checkout 3.6.00
+          git checkout ${{ matrix.kokkos_version }}
           popd &> /dev/null
 
       - name: Build Kokkos core library
         run: |
           pushd . &> /dev/null
-          mkdir -p $HOME/install_dir/${{ matrix.exec_model }}
+          mkdir -p ${{ github.workspace }}/install_dir/${{ matrix.exec_model }}
           cd kokkos
-          cmake -BBuild . -DCMAKE_INSTALL_PREFIX=$HOME/install_dir/${{ matrix.exec_model }} \
+          cmake -BBuild . -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/install_dir/${{ matrix.exec_model }} \
                           -DKokkos_ENABLE_COMPLEX_ALIGN=off \
                           -DKokkos_ENABLE_${{ matrix.exec_model }}=ON \
                           -DCMAKE_CXX_COMPILER=g++-10 \
                           -DCMAKE_CXX_STANDARD=20 \
                           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+                          -G Ninja
           cmake --build ./Build --verbose
           cmake --install ./Build
           popd &> /dev/null
@@ -54,16 +56,15 @@ jobs:
       - name: Build Kokkos kernels library
         run: |
           pushd . &> /dev/null
-          mkdir -p $HOME/install_dir/${{ matrix.exec_model }}
+          mkdir -p ${{ github.workspace }}/install_dir/${{ matrix.exec_model }}
           cd kokkos-kernels
-          cmake -BBuild . -DCMAKE_INSTALL_PREFIX=$HOME/install_dir/${{ matrix.exec_model }} \
-                          -DKokkos_ENABLE_COMPLEX_ALIGN=off \
+          cmake -BBuild . -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/install_dir/${{ matrix.exec_model }} \
                           -DKokkos_ENABLE_${{ matrix.exec_model }}=ON \
                           -DCMAKE_CXX_COMPILER=g++-10 \
                           -DCMAKE_CXX_STANDARD=20 \
                           -DKokkos_DIR=$PWD/../install_dir/${{ matrix.exec_model }} \
                           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
-
+                          -G Ninja
           cmake --build ./Build --verbose
           cmake --install ./Build
           popd &> /dev/null
@@ -72,6 +73,6 @@ jobs:
         uses: actions/cache@v3
         with:
           path: |
-            install_dir/${{ matrix.exec_model }}
+            ${{ github.workspace }}/install_dir/${{ matrix.exec_model }}
             $HOME/.ccache
-          key: ${{ matrix.os }}-kokkos-${{ matrix.exec_model }}
+          key: ${{ matrix.os }}-kokkos${{ matrix.kokkos_version }}-${{ matrix.exec_model }}

--- a/.github/workflows/build_cached_libs.yml
+++ b/.github/workflows/build_cached_libs.yml
@@ -58,6 +58,7 @@ jobs:
                           -DCMAKE_CXX_STANDARD=20 \
                           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
                           -G Ninja
+                          
           cmake --build ./Build --verbose
           cmake --install ./Build
           popd &> /dev/null

--- a/.github/workflows/build_cached_libs.yml
+++ b/.github/workflows/build_cached_libs.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04] #, quay.io/pypa/manylinux2014_x86_64]
-        exec_model: [OPENMP, THREADS, SERIAL]
+        exec_model: [SERIAL] #[OPENMP, THREADS, SERIAL]
     steps:
       - name: Cancel previous runs
         uses: styfle/cancel-workflow-action@0.4.1
@@ -20,7 +20,7 @@ jobs:
           access_token: ${{ github.token }}
 
       - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get -y -q install cmake gcc-10 g++-10
+        run: sudo apt-get update && sudo apt-get -y -q install cmake gcc-10 g++-10 ccache
 
       - name: Clone Kokkos libs
         run: |
@@ -39,36 +39,39 @@ jobs:
       - name: Build Kokkos core library
         run: |
           pushd . &> /dev/null
-          mkdir -p install_dir/${{ matrix.exec_model }}
+          mkdir -p $HOME/install_dir/${{ matrix.exec_model }}
           cd kokkos
-          cmake -BBuild . -DCMAKE_INSTALL_PREFIX=$PWD/../install_dir/${{ matrix.exec_model }} \
-                          -DKokkos_ENABLE_COMPLEX_ALIGN=off \
-                          -DKokkos_ENABLE_${{ matrix.exec_model }}=ON \
-                          -DCMAKE_CXX_COMPILER=g++-10 \
-                          -DCMAKE_CXX_STANDARD=20
-          cmake --build ./Build --verbose
-          cmake --install ./Build
-          popd . &> /dev/null
-
-      - name: Build Kokkos kernels library
-        run: |
-          pushd . &> /dev/null
-          mkdir -p install_dir/${{ matrix.exec_model }}
-          cd kokkos-kernels
-          cmake -BBuild . -DCMAKE_INSTALL_PREFIX=$PWD/../install_dir/${{ matrix.exec_model }} \
+          cmake -BBuild . -DCMAKE_INSTALL_PREFIX=$HOME/install_dir/${{ matrix.exec_model }} \
                           -DKokkos_ENABLE_COMPLEX_ALIGN=off \
                           -DKokkos_ENABLE_${{ matrix.exec_model }}=ON \
                           -DCMAKE_CXX_COMPILER=g++-10 \
                           -DCMAKE_CXX_STANDARD=20 \
-                          -DKokkos_DIR=$PWD/../install_dir/${{ matrix.exec_model }}
+                          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+          cmake --build ./Build --verbose
+          cmake --install ./Build
+          popd &> /dev/null
+
+      - name: Build Kokkos kernels library
+        run: |
+          pushd . &> /dev/null
+          mkdir -p $HOME/install_dir/${{ matrix.exec_model }}
+          cd kokkos-kernels
+          cmake -BBuild . -DCMAKE_INSTALL_PREFIX=$HOME/install_dir/${{ matrix.exec_model }} \
+                          -DKokkos_ENABLE_COMPLEX_ALIGN=off \
+                          -DKokkos_ENABLE_${{ matrix.exec_model }}=ON \
+                          -DCMAKE_CXX_COMPILER=g++-10 \
+                          -DCMAKE_CXX_STANDARD=20 \
+                          -DKokkos_DIR=$PWD/../install_dir/${{ matrix.exec_model }} \
+                          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
 
           cmake --build ./Build --verbose
           cmake --install ./Build
-          popd . &> /dev/null
+          popd &> /dev/null
 
       - name: Cache installation directories
         uses: actions/cache@v3
         with:
           path: |
             install_dir/${{ matrix.exec_model }}
+            $HOME/.ccache
           key: ${{ matrix.os }}-kokkos-${{ matrix.exec_model }}

--- a/.github/workflows/build_cached_libs.yml
+++ b/.github/workflows/build_cached_libs.yml
@@ -21,7 +21,7 @@ jobs:
           access_token: ${{ github.token }}
 
       - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get -y -q install cmake gcc-10 g++-10 ccache ninja
+        run: sudo apt-get update && sudo apt-get -y -q install cmake gcc-10 g++-10 ccache ninja-build
 
       - name: Clone Kokkos libs
         run: |
@@ -37,7 +37,16 @@ jobs:
           git checkout ${{ matrix.kokkos_version }}
           popd &> /dev/null
 
+      - name: Cache installation directories
+        uses: actions/cache@v3
+        with:
+          path: |
+            ${{ github.workspace }}/install_dir/${{ matrix.exec_model }}
+            $HOME/.ccache
+          key: ${{ matrix.os }}-kokkos${{ matrix.kokkos_version }}-${{ matrix.exec_model }}
+
       - name: Build Kokkos core library
+        if: steps.cache.outputs.cache-hit != 'true'
         run: |
           pushd . &> /dev/null
           mkdir -p ${{ github.workspace }}/install_dir/${{ matrix.exec_model }}
@@ -54,6 +63,7 @@ jobs:
           popd &> /dev/null
 
       - name: Build Kokkos kernels library
+        if: steps.cache.outputs.cache-hit != 'true'
         run: |
           pushd . &> /dev/null
           mkdir -p ${{ github.workspace }}/install_dir/${{ matrix.exec_model }}
@@ -69,10 +79,3 @@ jobs:
           cmake --install ./Build
           popd &> /dev/null
 
-      - name: Cache installation directories
-        uses: actions/cache@v3
-        with:
-          path: |
-            ${{ github.workspace }}/install_dir/${{ matrix.exec_model }}
-            $HOME/.ccache
-          key: ${{ matrix.os }}-kokkos${{ matrix.kokkos_version }}-${{ matrix.exec_model }}

--- a/.github/workflows/tests_linux.yml
+++ b/.github/workflows/tests_linux.yml
@@ -11,6 +11,7 @@ env:
   GCC_VERSION: 10
   COVERAGE_FLAGS: "--cov=pennylane_lightning --cov-report=term-missing --cov-report=xml:./coverage.xml --no-flaky-report -p no:warnings --tb=native"
   OMP_NUM_THREADS: "2"
+  KOKKOS_INC: /root/install_dir/OPENMP
 
 jobs:
   cpptests:
@@ -53,7 +54,7 @@ jobs:
 
       - name: Build and run unit tests for code Coverage
         run: |
-            cmake pennylane_lightning/src -BBuildCov  -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS=ON -DENABLE_COVERAGE=ON -DCMAKE_CXX_COMPILER="$(which g++-$GCC_VERSION)"
+            cmake pennylane_lightning/src -BBuildCov -DENABLE_KOKKOS=OFF -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS=ON -DENABLE_COVERAGE=ON -DCMAKE_CXX_COMPILER="$(which g++-$GCC_VERSION)"
             cmake --build ./BuildCov
             cd ./BuildCov
             ./tests/runner
@@ -106,7 +107,7 @@ jobs:
 
       - name: Build and run unit tests for code coverage
         run: |
-            cmake pennylane_lightning/src -BBuildCov  -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS=ON -DENABLE_COVERAGE=ON -DENABLE_BLAS=ON -DCMAKE_CXX_COMPILER="$(which g++-$GCC_VERSION)"
+            cmake pennylane_lightning/src -BBuildCov -DENABLE_KOKKOS=OFF -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS=ON -DENABLE_COVERAGE=ON -DENABLE_BLAS=ON -DCMAKE_CXX_COMPILER="$(which g++-$GCC_VERSION)"
             cmake --build ./BuildCov
             cd ./BuildCov
             ./tests/runner
@@ -130,6 +131,18 @@ jobs:
         uses: styfle/cancel-workflow-action@0.4.1
         with:
           access_token: ${{ github.token }}
+
+      - name: Cache installation directories
+        id: kokkos-cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            /root/install_dir/OPENMP
+            /root/.ccache
+          key: ubuntu:20.04-kokkos3.6.00-OPENMP
+          restore-keys: |
+            ubuntu:20.04-kokkos3.6.00-THREADS
+            ubuntu:20.04-kokkos3.6.00-SERIAL
 
       - uses: actions/setup-python@v2
         name: Install Python

--- a/.github/workflows/tests_linux.yml
+++ b/.github/workflows/tests_linux.yml
@@ -132,18 +132,6 @@ jobs:
         with:
           access_token: ${{ github.token }}
 
-      - name: Cache installation directories
-        id: kokkos-cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            /root/install_dir/OPENMP
-            /root/.ccache
-          key: "ubuntu:20.04-kokkos3.6.00-OPENMP"
-          restore-keys: |
-            ubuntu:20.04-kokkos3.6.00-THREADS
-            ubuntu:20.04-kokkos3.6.00-SERIAL
-
       - uses: actions/setup-python@v2
         name: Install Python
         with:

--- a/.github/workflows/tests_linux.yml
+++ b/.github/workflows/tests_linux.yml
@@ -139,7 +139,7 @@ jobs:
           path: |
             /root/install_dir/OPENMP
             /root/.ccache
-          key: ubuntu:20.04-kokkos3.6.00-OPENMP
+          key: "ubuntu:20.04-kokkos3.6.00-OPENMP"
           restore-keys: |
             ubuntu:20.04-kokkos3.6.00-THREADS
             ubuntu:20.04-kokkos3.6.00-SERIAL

--- a/.github/workflows/wheel_linux_x86_64.yml
+++ b/.github/workflows/wheel_linux_x86_64.yml
@@ -25,9 +25,8 @@ env:
     pl-device-test --device=lightning.qubit --skip-ops -x --tb=short --no-flaky-report
 
   CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
-
-  KOKKOS_INC: kokkos_install_dir/include
-  KOKKOS_LIB: kokkos_install_dir/lib
+  
+  CIBW_ENVIRONMENT: KOKKOS_INC="kokkos_install_dir/include" KOKKOS_LIB="kokkos_install_dir/lib"
 
 jobs:
   kokkos_libs:

--- a/.github/workflows/wheel_linux_x86_64.yml
+++ b/.github/workflows/wheel_linux_x86_64.yml
@@ -26,7 +26,92 @@ env:
 
   CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
 
+  KOKKOS_INC: kokkos_dir/include
+  KOKKOS_LIB: kokkos_dir/lib
+
 jobs:
+  kokkos_libs:
+    name: Kokkos core & kernels
+    runs-on: ${{ matrix.os }}
+    container: ${{ matrix.container_img }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04]
+        exec_model: [SERIAL, OPENMP, THREADS]
+        kokkos_version: ["3.6.00"]
+        container_img: ["ubuntu:20.04", "quay.io/pypa/manylinux2014_x86_64"]
+    steps:
+      - name: Cancel previous runs
+        uses: styfle/cancel-workflow-action@0.4.1
+        with:
+          access_token: ${{ github.token }}
+
+      - name: Cache installation directories
+        id: kokkos-cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            /root/install_dir/${{ matrix.exec_model }}
+            /root/.ccache
+          key: ${{ matrix.container_img }}-kokkos${{ matrix.kokkos_version }}-${{ matrix.exec_model }}
+
+      - name: Install dependencies (Ubuntu)
+        if: ${{ matrix.container_img == 'ubuntu:20.04' }}
+        run: |
+          apt-get update && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get -y -q install cmake gcc-10 g++-10 ccache ninja-build git
+          echo "COMPILER=g++-10" >> $GITHUB_ENV
+
+      - name: Install dependencies (CentOS)
+        if: ${{ matrix.container_img == 'quay.io/pypa/manylinux2014_x86_64' }}
+        run: |
+          yum update && yum install -y cmake ccache ninja-build
+          echo "COMPILER=g++" >> $GITHUB_ENV
+
+      - name: Clone Kokkos libs
+        run: |
+          git clone https://github.com/kokkos/kokkos.git
+          cd kokkos 
+          git checkout ${{ matrix.kokkos_version }}
+          cd -
+
+          pushd . &> /dev/null
+          git clone https://github.com/kokkos/kokkos-kernels.git
+          cd kokkos-kernels
+          git checkout ${{ matrix.kokkos_version }}
+          cd -
+
+      - name: Build Kokkos core library
+        if: steps.kokkos-cache.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p /root/install_dir/${{ matrix.exec_model }}
+          cd kokkos
+          cmake -BBuild . -DCMAKE_INSTALL_PREFIX=/root/install_dir/${{ matrix.exec_model }} \
+                          -DKokkos_ENABLE_COMPLEX_ALIGN=off \
+                          -DKokkos_ENABLE_${{ matrix.exec_model }}=ON \
+                          -DCMAKE_CXX_COMPILER=${{ env.COMPILER }} \
+                          -DCMAKE_CXX_STANDARD=20 \
+                          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+                          -G Ninja
+
+          cmake --build ./Build --verbose
+          cmake --install ./Build
+          cd -
+
+      - name: Build Kokkos kernels library
+        if: steps.kokkos-cache.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p /root/install_dir/${{ matrix.exec_model }}
+          cd kokkos-kernels
+          cmake -BBuild . -DCMAKE_INSTALL_PREFIX=/root/install_dir/${{ matrix.exec_model }} \
+                          -DKokkos_ENABLE_${{ matrix.exec_model }}=ON \
+                          -DCMAKE_CXX_COMPILER=${{ env.COMPILER }} \
+                          -DCMAKE_CXX_STANDARD=20 \
+                          -DKokkos_DIR=$PWD/../install_dir/${{ matrix.exec_model }} \
+                          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+                          -G Ninja
+          cmake --build ./Build --verbose
+          cmake --install ./Build
+
   linux-wheels-x86-64:
     strategy:
       fail-fast: false
@@ -42,6 +127,18 @@ jobs:
         with:
           access_token: ${{ github.token }}
 
+      - name: Cache installation directories
+        id: kokkos-cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            /root/install_dir/OPENMP
+            /root/.ccache
+          key: "quay.io/pypa/manylinux2014_x86_64-kokkos3.6.00-OPENMP"
+          restore-keys: |
+            "quay.io/pypa/manylinux2014_x86_64-kokkos3.6.00-THREADS"
+            "quay.io/pypa/manylinux2014_x86_64-kokkos3.6.00-SERIAL"
+
       - uses: actions/checkout@v2
 
       - uses: actions/setup-python@v2
@@ -50,12 +147,14 @@ jobs:
           python-version: '3.7'
 
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.3.0
+        run: |
+          cp -rf /root/install_dir/ kokkos_dir
+          python -m pip install cibuildwheel==2.3.0
 
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
-          CIBW_ARCHS_LINUX: ${{matrix.arch}}
+          CIBW_ARCHS_LINUX: ${{matrix.arch}}         
 
       - uses: actions-ecosystem/action-regex-match@v2
         id: rc_build

--- a/.github/workflows/wheel_linux_x86_64.yml
+++ b/.github/workflows/wheel_linux_x86_64.yml
@@ -39,7 +39,7 @@ jobs:
         os: [ubuntu-20.04]
         exec_model: [SERIAL, OPENMP, THREADS]
         kokkos_version: ["3.6.00"]
-        container_img: ["ubuntu:20.04", "quay.io/pypa/manylinux2014_x86_64"]
+        container_img: ["quay.io/pypa/manylinux2014_x86_64"]
     steps:
       - name: Cancel previous runs
         uses: styfle/cancel-workflow-action@0.4.1

--- a/.github/workflows/wheel_linux_x86_64.yml
+++ b/.github/workflows/wheel_linux_x86_64.yml
@@ -56,13 +56,13 @@ jobs:
           key: ${{ matrix.container_img }}-kokkos${{ matrix.kokkos_version }}-${{ matrix.exec_model }}
 
       - name: Install dependencies (Ubuntu)
-        if: ${{ matrix.container_img == 'ubuntu:20.04' }} && ${{ steps.kokkos-cache.outputs.cache-hit != 'true' }}
+        if: ${{ (matrix.container_img == 'ubuntu:20.04') && (steps.kokkos-cache.outputs.cache-hit != 'true') }}
         run: |
           apt-get update && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get -y -q install cmake gcc-10 g++-10 ccache ninja-build git
           echo "COMPILER=g++-10" >> $GITHUB_ENV
 
       - name: Install dependencies (CentOS)
-        if: ${{ matrix.container_img == 'quay.io/pypa/manylinux2014_x86_64' }} && ${{ steps.kokkos-cache.outputs.cache-hit != 'true' }}
+        if: ${{ (matrix.container_img == 'quay.io/pypa/manylinux2014_x86_64') && (steps.kokkos-cache.outputs.cache-hit != 'true') }}
         run: |
           yum update && yum install -y cmake ccache ninja-build
           echo "COMPILER=g++" >> $GITHUB_ENV

--- a/.github/workflows/wheel_linux_x86_64.yml
+++ b/.github/workflows/wheel_linux_x86_64.yml
@@ -56,18 +56,19 @@ jobs:
           key: ${{ matrix.container_img }}-kokkos${{ matrix.kokkos_version }}-${{ matrix.exec_model }}
 
       - name: Install dependencies (Ubuntu)
-        if: ${{ matrix.container_img == 'ubuntu:20.04' }}
+        if: ${{ matrix.container_img == 'ubuntu:20.04' }} && ${{ steps.kokkos-cache.outputs.cache-hit != 'true' }}
         run: |
           apt-get update && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get -y -q install cmake gcc-10 g++-10 ccache ninja-build git
           echo "COMPILER=g++-10" >> $GITHUB_ENV
 
       - name: Install dependencies (CentOS)
-        if: ${{ matrix.container_img == 'quay.io/pypa/manylinux2014_x86_64' }}
+        if: ${{ matrix.container_img == 'quay.io/pypa/manylinux2014_x86_64' }} && ${{ steps.kokkos-cache.outputs.cache-hit != 'true' }}
         run: |
           yum update && yum install -y cmake ccache ninja-build
           echo "COMPILER=g++" >> $GITHUB_ENV
 
       - name: Clone Kokkos libs
+        if: steps.kokkos-cache.outputs.cache-hit != 'true'
         run: |
           git clone https://github.com/kokkos/kokkos.git
           cd kokkos 

--- a/.github/workflows/wheel_linux_x86_64.yml
+++ b/.github/workflows/wheel_linux_x86_64.yml
@@ -113,6 +113,7 @@ jobs:
           cmake --install ./Build
 
   linux-wheels-x86-64:
+    needs: kokkos_libs
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/wheel_linux_x86_64.yml
+++ b/.github/workflows/wheel_linux_x86_64.yml
@@ -26,8 +26,8 @@ env:
 
   CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
 
-  KOKKOS_INC: kokkos_dir/include
-  KOKKOS_LIB: kokkos_dir/lib
+  KOKKOS_INC: kokkos_install_dir/include
+  KOKKOS_LIB: kokkos_install_dir/lib
 
 jobs:
   kokkos_libs:
@@ -133,12 +133,11 @@ jobs:
         uses: actions/cache@v3
         with:
           path: |
-            /root/install_dir/OPENMP
-            /root/.ccache
-          key: "quay.io/pypa/manylinux2014_x86_64-kokkos3.6.00-OPENMP"
+            ./kokkos_install_dir
+          key: quay.io/pypa/manylinux2014_x86_64-kokkos3.6.00-OPENMP
           restore-keys: |
-            "quay.io/pypa/manylinux2014_x86_64-kokkos3.6.00-THREADS"
-            "quay.io/pypa/manylinux2014_x86_64-kokkos3.6.00-SERIAL"
+            quay.io/pypa/manylinux2014_x86_64-kokkos3.6.00-THREADS
+            quay.io/pypa/manylinux2014_x86_64-kokkos3.6.00-SERIAL
 
       - uses: actions/checkout@v2
 
@@ -149,7 +148,6 @@ jobs:
 
       - name: Install cibuildwheel
         run: |
-          cp -rf /root/install_dir/ kokkos_dir
           python -m pip install cibuildwheel==2.3.0
 
       - name: Build wheels

--- a/cmake/process_options.cmake
+++ b/cmake/process_options.cmake
@@ -137,37 +137,113 @@ else()
 endif()
 
 if(ENABLE_KOKKOS)
-    # Setting the Serial device for all cases.
-    option(Kokkos_ENABLE_SERIAL  "Enable Kokkos SERIAL device" ON)
-    message(STATUS "KOKKOS SERIAL DEVICE ENABLED.")
+    find_library(KOKKOS_CORE_STATIC
+    NAMES   libkokkoscore.a
+    HINTS   /usr/lib
+            /usr/local/lib
+            /opt
+            lib
+            lib64
+            ENV KOKKOS_LIB
+            ENV LD_LIBRARY_PATH
 
-    option(Kokkos_ENABLE_COMPLEX_ALIGN "Enable complex alignment in memory" OFF)
-
-    set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-    include(FetchContent)
-
-    FetchContent_Declare(kokkos
-                         GIT_REPOSITORY https://github.com/kokkos/kokkos.git
-                         GIT_TAG        3.6.00
     )
-  
-    FetchContent_MakeAvailable(kokkos)
-
-    get_target_property(kokkos_INC_DIR kokkos INTERFACE_INCLUDE_DIRECTORIES)
-    set_target_properties(kokkos PROPERTIES INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${kokkos_INC_DIR}")
-
-    FetchContent_Declare(kokkoskernels
-                         GIT_REPOSITORY https://github.com/kokkos/kokkos-kernels.git
-                         GIT_TAG        3.6.00
+    find_library(KOKKOS_CONTAINERS_STATIC
+    NAMES   libkokkoscontainers.a
+    HINTS   /usr/lib
+            /usr/local/lib
+            /opt
+            lib
+            lib64
+            ENV KOKKOS_LIB
+            ENV LD_LIBRARY_PATH
     )
- 
-    FetchContent_MakeAvailable(kokkoskernels)
- 
-    get_target_property(kokkoskernels_INC_DIR kokkoskernels INTERFACE_INCLUDE_DIRECTORIES)
-    set_target_properties(kokkoskernels PROPERTIES INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${kokkoskernels_INC_DIR}")
+    find_library(KOKKOS_KERNELS_STATIC
+    NAMES   libkokkoskernels.a
+    HINTS   /usr/lib
+            /usr/local/lib
+            /opt
+            lib
+            lib64
+            ENV KOKKOS_LIB
+            ENV LD_LIBRARY_PATH
+    )
+    
+    find_file( KOKKOS_CORE_INC
+    NAMES   Kokkos_Core.hpp
+    HINTS   /usr/include
+            /usr/local/include
+            /opt
+            include
+            ENV KOKKOS_INC
+            ENV CPATH
+    )
+    find_file( KOKKOS_KERNELS_INC
+    NAMES   KokkosSparse.hpp
+    HINTS   /usr/include
+            /usr/local/include
+            /opt
+            include
+            ENV KOKKOS_INC
+            ENV CPATH
+    )
 
-    target_compile_options(lightning_compile_options INTERFACE "-D_ENABLE_KOKKOS=1")
-    target_link_libraries(lightning_external_libs INTERFACE Kokkos::kokkos Kokkos::kokkoskernels)
+    if(KOKKOS_CORE_STATIC AND KOKKOS_CONTAINERS_STATIC AND KOKKOS_KERNELS_STATIC AND KOKKOS_CORE_INC AND KOKKOS_KERNELS_INC)
+        message(STATUS "Found existing Kokkos build")
+        get_filename_component(kokkos_INC_DIR KOKKOS_CORE_INC DIRECTORY [CACHE])
+        get_filename_component(kokkos_LIB_DIR KOKKOS_CORE_STATIC DIRECTORY [CACHE])
+        get_filename_component(kokkos_kernels_INC_DIR KOKKOS_KERNELS_INC DIRECTORY [CACHE])
+        get_filename_component(kokkos_kernels_LIB_DIR KOKKOS_KERNELS_STATIC DIRECTORY [CACHE])
+
+        add_library(kokkoscore STATIC IMPORTED [GLOBAL])
+        add_library(kokkoscontainers STATIC IMPORTED [GLOBAL])
+        add_library(kokkoskernels STATIC IMPORTED [GLOBAL])
+
+        set_target_properties(kokkoscore PROPERTIES INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${kokkos_INC_DIR}")
+        set_target_properties(kokkoscontainers PROPERTIES INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${kokkos_INC_DIR}")
+        set_target_properties(kokkoskernels PROPERTIES INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${kokkos_kernels_INC_DIR}")
+
+        set_target_properties(kokkoscore PROPERTIES IMPORTED_LOCATION kokkos_LIB_DIR)
+        set_target_properties(kokkoscontainers PROPERTIES IMPORTED_LOCATION kokkos_LIB_DIR)
+        set_target_properties(kokkoskernels PROPERTIES IMPORTED_LOCATION kokkos_kernels_LIB_DIR)
+
+        target_compile_options(lightning_compile_options INTERFACE "-D_ENABLE_KOKKOS=1")
+        target_link_libraries(lightning_external_libs PRIVATE kokkoscore kokkoskernels)
+
+    else()
+        # Setting the Serial device for all cases.
+        option(Kokkos_ENABLE_SERIAL  "Enable Kokkos SERIAL device" ON)
+        message(STATUS "KOKKOS SERIAL DEVICE ENABLED.")
+
+        option(Kokkos_ENABLE_COMPLEX_ALIGN "Enable complex alignment in memory" OFF)
+
+        set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+        include(FetchContent)
+
+        FetchContent_Declare(kokkos
+                            GIT_REPOSITORY https://github.com/kokkos/kokkos.git
+                            GIT_TAG        3.6.00
+        )
+    
+        FetchContent_MakeAvailable(kokkos)
+
+        get_target_property(kokkos_INC_DIR kokkos INTERFACE_INCLUDE_DIRECTORIES)
+        set_target_properties(kokkos PROPERTIES INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${kokkos_INC_DIR}")
+
+        FetchContent_Declare(kokkoskernels
+                            GIT_REPOSITORY https://github.com/kokkos/kokkos-kernels.git
+                            GIT_TAG        3.6.00
+        )
+    
+        FetchContent_MakeAvailable(kokkoskernels)
+    
+        get_target_property(kokkoskernels_INC_DIR kokkoskernels INTERFACE_INCLUDE_DIRECTORIES)
+        set_target_properties(kokkoskernels PROPERTIES INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${kokkoskernels_INC_DIR}")
+
+        target_compile_options(lightning_compile_options INTERFACE "-D_ENABLE_KOKKOS=1")
+        target_link_libraries(lightning_external_libs INTERFACE Kokkos::kokkos Kokkos::kokkoskernels)
+    endif()
+
 else()
     message(STATUS "ENABLE_KOKKOS is OFF.")
 endif()

--- a/pennylane_lightning/_version.py
+++ b/pennylane_lightning/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.25.0-dev1"
+__version__ = "0.25.0-dev2"


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [ ] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [ ] Ensure that the test suite passes, by running `make test`.

- [ ] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [ ] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:** With the addition of the Kokkos libraries to certain sections of Lightning, we notice a significant increase in build-times. This makes a quick turn around on new features and fixes challenging, especially on emulator built platforms like ARM and PowerPC, where times are upwards of 5 hours. Since the Kokkos libraries can be prebuilt and reused for other parts of our build-system, we aim to do this for a fixed release of the libraries.

**Description of the Change:** Prebuilds and caches the Kokkos core and kernels libraries for reuse within Lightning.

**Benefits:** [Will] significantly reduce build times.

**Possible Drawbacks:** Additional complexity added to build system, to handle out-of-tree buildings, caching and retrieval of the libraries.

**Related GitHub Issues:**
