### PR TITLE
Disable explicit broadcasting for lightning

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Breaking changes
 
+* We explicitly disable support for PennyLane's parameter broadcasting.
+[#317](https://github.com/PennyLaneAI/pennylane-lightning/pull/317)
+
 ### Improvements
 
 * Parallelize wheel-builds where applicable.
@@ -17,7 +20,7 @@
 
 This release contains contributions from (in alphabetical order):
 
-Amintor Dusko
+Amintor Dusko, Lee James O'Riordan
 
 ---
 

--- a/pennylane_lightning/_version.py
+++ b/pennylane_lightning/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.25.0-dev2"
+__version__ = "0.25.0-dev3"

--- a/pennylane_lightning/lightning_qubit.py
+++ b/pennylane_lightning/lightning_qubit.py
@@ -139,6 +139,7 @@ class LightningQubit(DefaultQubit):
             supports_reversible_diff=False,
             supports_inverse_operations=True,
             supports_analytic_computation=True,
+            supports_broadcasting=False,
             returns_state=True,
         )
         capabilities.pop("passthru_devices", None)


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [x] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [x] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [x] Ensure that the test suite passes, by running `make test`.

- [x] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [x] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:** This explicitly disables the broadcasting pipeline in PennyLane for `lightning.qubit` and also `lightning.gpu`

**Description of the Change:** As above.

**Benefits:** Ensures backwards compatibility of Lightning devices with PennyLane.

**Possible Drawbacks:** Updates will be required to take advantage of broadcasting supports to improve the performance with parameter-shit and finite-shots workloads.

**Related GitHub Issues:** https://github.com/PennyLaneAI/pennylane/pull/2590 https://github.com/PennyLaneAI/pennylane/pull/2627 https://github.com/PennyLaneAI/pennylane/pull/2749
