### PR TITLE
remove op arithmetic observable support

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -7,6 +7,9 @@
 * We explicitly disable support for PennyLane's parameter broadcasting.
 [#317](https://github.com/PennyLaneAI/pennylane-lightning/pull/317)
 
+* We explicitly remove support for PennyLane's `Sum`, `SProd` and `Prod`
+  as observables.
+
 ### Improvements
 
 * CI builders use a reduced set of resources and redundant tests for PRs.

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 * We explicitly remove support for PennyLane's `Sum`, `SProd` and `Prod`
   as observables.
+  [(#326)](https://github.com/PennyLaneAI/pennylane-lightning/pull/326)
 
 ### Improvements
 

--- a/pennylane_lightning/_version.py
+++ b/pennylane_lightning/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.25.0-dev8"
+__version__ = "0.25.0-dev9"

--- a/pennylane_lightning/lightning_qubit.py
+++ b/pennylane_lightning/lightning_qubit.py
@@ -75,6 +75,13 @@ def _remove_snapshot_from_operations(operations):
     operations.discard("Snapshot")
     return operations
 
+def _remove_op_arithmetic_from_observables(observables):
+    observables = observables.copy()
+    observables.discard("Sum")
+    observables.discard("SProd")
+    observables.discard("Prod")
+    return observables
+
 
 class LightningQubit(DefaultQubit):
     """PennyLane Lightning device.
@@ -103,6 +110,7 @@ class LightningQubit(DefaultQubit):
     author = "Xanadu Inc."
     _CPP_BINARY_AVAILABLE = True
     operations = _remove_snapshot_from_operations(DefaultQubit.operations)
+    observables = _remove_op_arithmetic_from_observables(DefaultQubit.observables)
 
     def __init__(self, wires, *, c_dtype=np.complex128, shots=None, batch_obs=False):
         if c_dtype is np.complex64:

--- a/pennylane_lightning/lightning_qubit.py
+++ b/pennylane_lightning/lightning_qubit.py
@@ -75,6 +75,7 @@ def _remove_snapshot_from_operations(operations):
     operations.discard("Snapshot")
     return operations
 
+
 def _remove_op_arithmetic_from_observables(observables):
     observables = observables.copy()
     observables.discard("Sum")

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -39,3 +39,19 @@ def test_create_device_with_dtype(C):
 def test_create_device_with_unsupported_dtype():
     with pytest.raises(TypeError, match="Unsupported complex Type:"):
         dev = qml.device("lightning.qubit", wires=1, c_dtype=np.complex256)
+
+def test_no_op_arithmetic_support():
+    """Test that lightning qubit explicitly does not support SProd, Prod, and Sum."""
+
+    dev = qml.device('lightning.qubit', wires=2)
+    for name in {'Prod', 'SProd', 'Sum'}:
+        assert name not in dev.operations
+
+    obs = qml.prod(qml.PauliX(0), qml.PauliY(1))
+
+    @qml.qnode(dev)
+    def circuit():
+        return qml.expval(obs)
+
+    with pytest.raises(qml.DeviceError, match=r"Observable Prod not supported on device"):
+        circuit()

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -40,11 +40,12 @@ def test_create_device_with_unsupported_dtype():
     with pytest.raises(TypeError, match="Unsupported complex Type:"):
         dev = qml.device("lightning.qubit", wires=1, c_dtype=np.complex256)
 
+
 def test_no_op_arithmetic_support():
     """Test that lightning qubit explicitly does not support SProd, Prod, and Sum."""
 
-    dev = qml.device('lightning.qubit', wires=2)
-    for name in {'Prod', 'SProd', 'Sum'}:
+    dev = qml.device("lightning.qubit", wires=2)
+    for name in {"Prod", "SProd", "Sum"}:
         assert name not in dev.operations
 
     obs = qml.prod(qml.PauliX(0), qml.PauliY(1))


### PR DESCRIPTION
`DefaultQubit` supports observable measurement of the new `Sum`, `Prod`, and `SProd` classes. Lightning does not yet support these observables, so we need to remove them from the list of supported observables. 

In the longer term, we should determine what is necessary to support these general observables.