### PR TITLE
Updated ReadTheDocs bade to new url

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ PennyLane-Lightning Plugin
     :alt: CodeFactor Grade
     :target: https://www.codefactor.io/repository/github/pennylaneai/pennylane-lightning
 
-.. image:: https://img.shields.io/readthedocs/pennylane-lightning.svg?logo=read-the-docs&style=flat-square
+.. image:: https://readthedocs.com/projects/xanaduai-pennylane-lightning/badge/?version=latest&style=flat-square
     :alt: Read the Docs
     :target: https://docs.pennylane.ai/projects/lightning
 

--- a/pennylane_lightning/_version.py
+++ b/pennylane_lightning/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.26.0-dev5"
+__version__ = "0.26.0-dev6"

--- a/pennylane_lightning/_version.py
+++ b/pennylane_lightning/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.26.0-dev8"
+__version__ = "0.26.0-dev9"


### PR DESCRIPTION
**Context:** New ReadTheDocs badge

**Description of the Change:**
The current RTD badge on the pennylane-lightning README uses https://shield.io/, which unfortunately does not support the Business tier hosting of RTD.

The new solution is to use the badge that RTD themselves generate for each project.

This PR updates the RTD docs badge with the new links.

**Benefits:**
Old badge will go stale once the current community RTD builds are disabled. This new badge reflects the updated status.

**Possible Drawbacks:**
No logo available with the new badge

**Related GitHub Issues:**
None.