### PR TITLE
Create bug-fix release 0.25.1

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ### Bug fixes
 
-* Ensure build type for cmake in all compilers, and operational systems.
-[(#340)](https://github.com/PennyLaneAI/pennylane-lightning/pull/340)
+* Ensure build type for cmake in all compilers and operational systems.
+[(#341)](https://github.com/PennyLaneAI/pennylane-lightning/pull/341)
 
 ---
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,3 +1,12 @@
+# Release 0.25.1
+
+### Bug fixes
+
+* Ensure build type for cmake in all compilers, and operational systems.
+[(#340)](https://github.com/PennyLaneAI/pennylane-lightning/pull/340)
+
+---
+
 # Release 0.25.0
 
 ### New features since last release

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -5,6 +5,10 @@
 * Ensure build type for cmake in all compilers and operational systems.
 [(#341)](https://github.com/PennyLaneAI/pennylane-lightning/pull/341)
 
+### Contributor
+
+Amintor Dusko
+
 ---
 
 # Release 0.25.0

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -34,7 +34,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install matplotlib
-          pip install git+https://github.com/PennyLaneAI/pennylane.git@master
+          pip install git+https://github.com/PennyLaneAI/pennylane.git@v0.25.1
 
       - name: Install lightning.qubit device (master)
         run: |

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -34,7 +34,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install matplotlib
-          pip install git+https://github.com/PennyLaneAI/pennylane.git@v0.25.1
+          pip install pennylane~=0.25
 
       - name: Install lightning.qubit device (master)
         run: |

--- a/.github/workflows/tests_linux.yml
+++ b/.github/workflows/tests_linux.yml
@@ -232,7 +232,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip uninstall pennylane -y
-          pip install git+https://github.com/PennyLaneAI/pennylane.git@v0.25.1
+          pip install pennylane~=0.25.0
 
       - name: Install ML libraries for interfaces
         run: |
@@ -287,7 +287,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip uninstall pennylane -y
-          pip install git+https://github.com/PennyLaneAI/pennylane.git@v0.25.1
+          pip install pennylane~=0.25.0
 
       - name: Install ML libraries for interfaces
         run: |

--- a/.github/workflows/tests_linux.yml
+++ b/.github/workflows/tests_linux.yml
@@ -232,7 +232,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip uninstall pennylane -y
-          pip install git+https://github.com/PennyLaneAI/pennylane.git
+          pip install git+https://github.com/PennyLaneAI/pennylane.git@v0.25.1
 
       - name: Install ML libraries for interfaces
         run: |
@@ -287,7 +287,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip uninstall pennylane -y
-          pip install git+https://github.com/PennyLaneAI/pennylane.git
+          pip install git+https://github.com/PennyLaneAI/pennylane.git@v0.25.1
 
       - name: Install ML libraries for interfaces
         run: |

--- a/.github/workflows/tests_without_binary.yml
+++ b/.github/workflows/tests_without_binary.yml
@@ -38,7 +38,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip uninstall pennylane -y
-          pip install git+https://github.com/PennyLaneAI/pennylane.git@v0.25.1
+          pip install pennylane~=0.25.0
 
       - name: Install lightning.qubit device
         run: |

--- a/.github/workflows/tests_without_binary.yml
+++ b/.github/workflows/tests_without_binary.yml
@@ -38,7 +38,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip uninstall pennylane -y
-          pip install git+https://github.com/PennyLaneAI/pennylane.git
+          pip install git+https://github.com/PennyLaneAI/pennylane.git@v0.25.1
 
       - name: Install lightning.qubit device
         run: |

--- a/.github/workflows/wheel_linux_aarch64.yml
+++ b/.github/workflows/wheel_linux_aarch64.yml
@@ -88,7 +88,7 @@ jobs:
           # Testing of built wheels
           CIBW_TEST_REQUIRES: numpy~=1.21 scipy pytest pytest-cov pytest-mock flaky
 
-          CIBW_BEFORE_TEST: pip install git+https://github.com/PennyLaneAI/pennylane.git@master
+          CIBW_BEFORE_TEST: pip install git+https://github.com/PennyLaneAI/pennylane.git@v0.25.1
 
           CIBW_TEST_COMMAND: |
             pl-device-test --device=lightning.qubit --skip-ops -x --tb=short --no-flaky-report

--- a/.github/workflows/wheel_linux_aarch64.yml
+++ b/.github/workflows/wheel_linux_aarch64.yml
@@ -99,7 +99,7 @@ jobs:
           CIBW_ARCHS_LINUX: ${{matrix.arch}}
 
       - uses: actions/upload-artifact@v2
-        if: ${{ github.event_name == 'release' || github.ref == 'refs/heads/master' }}
+        # if: ${{ github.event_name == 'release' || github.ref == 'refs/heads/master' }}
         with:
           name: ${{ runner.os }}-wheels-${{ matrix.arch }}.zip
           path: ./wheelhouse/*.whl

--- a/.github/workflows/wheel_linux_aarch64.yml
+++ b/.github/workflows/wheel_linux_aarch64.yml
@@ -88,7 +88,7 @@ jobs:
           # Testing of built wheels
           CIBW_TEST_REQUIRES: numpy~=1.21 scipy pytest pytest-cov pytest-mock flaky
 
-          CIBW_BEFORE_TEST: pip install git+https://github.com/PennyLaneAI/pennylane.git@v0.25.1
+          CIBW_BEFORE_TEST: pip install pennylane~=0.25.0
 
           CIBW_TEST_COMMAND: |
             pl-device-test --device=lightning.qubit --skip-ops -x --tb=short --no-flaky-report

--- a/.github/workflows/wheel_linux_ppc64le.yml
+++ b/.github/workflows/wheel_linux_ppc64le.yml
@@ -88,7 +88,7 @@ jobs:
           # Skip PPC tests due to lack of numpy/scipy wheel support
           CIBW_TEST_SKIP: "*-manylinux_{ppc64le}"
 
-          CIBW_BEFORE_TEST: pip install git+https://github.com/PennyLaneAI/pennylane.git@master
+          CIBW_BEFORE_TEST: pip install git+https://github.com/PennyLaneAI/pennylane.git@v0.25.1
 
           # Use CentOS 7 image for PPC
           CIBW_MANYLINUX_PPC64LE_IMAGE: manylinux2014

--- a/.github/workflows/wheel_linux_ppc64le.yml
+++ b/.github/workflows/wheel_linux_ppc64le.yml
@@ -88,7 +88,7 @@ jobs:
           # Skip PPC tests due to lack of numpy/scipy wheel support
           CIBW_TEST_SKIP: "*-manylinux_{ppc64le}"
 
-          CIBW_BEFORE_TEST: pip install git+https://github.com/PennyLaneAI/pennylane.git@v0.25.1
+          CIBW_BEFORE_TEST: pip install pennylane~=0.25.0
 
           # Use CentOS 7 image for PPC
           CIBW_MANYLINUX_PPC64LE_IMAGE: manylinux2014

--- a/.github/workflows/wheel_linux_ppc64le.yml
+++ b/.github/workflows/wheel_linux_ppc64le.yml
@@ -96,7 +96,7 @@ jobs:
           CIBW_ARCHS_LINUX: ${{matrix.arch}}
 
       - uses: actions/upload-artifact@v2
-        if: ${{ github.event_name == 'release' || github.ref == 'refs/heads/master' }}
+        # if: ${{ github.event_name == 'release' || github.ref == 'refs/heads/master' }}
         with:
           name: ${{ runner.os }}-wheels-${{ matrix.arch }}.zip
           path: ./wheelhouse/*.whl

--- a/.github/workflows/wheel_linux_x86_64.yml
+++ b/.github/workflows/wheel_linux_x86_64.yml
@@ -85,8 +85,7 @@ jobs:
           # Testing of built wheels
           CIBW_TEST_REQUIRES: numpy~=1.21 scipy pytest pytest-cov pytest-mock flaky
 
-          CIBW_BEFORE_TEST: |
-            pip install git+https://github.com/PennyLaneAI/pennylane.git@master
+          CIBW_BEFORE_TEST: pip install git+https://github.com/PennyLaneAI/pennylane.git@v0.25.1
 
           CIBW_TEST_COMMAND: |
             pl-device-test --device=lightning.qubit --skip-ops -x --tb=short --no-flaky-report

--- a/.github/workflows/wheel_linux_x86_64.yml
+++ b/.github/workflows/wheel_linux_x86_64.yml
@@ -85,7 +85,7 @@ jobs:
           # Testing of built wheels
           CIBW_TEST_REQUIRES: numpy~=1.21 scipy pytest pytest-cov pytest-mock flaky
 
-          CIBW_BEFORE_TEST: pip install git+https://github.com/PennyLaneAI/pennylane.git@v0.25.1
+          CIBW_BEFORE_TEST: pip install pennylane~=0.25.0
 
           CIBW_TEST_COMMAND: |
             pl-device-test --device=lightning.qubit --skip-ops -x --tb=short --no-flaky-report

--- a/.github/workflows/wheel_macos_arm64.yml
+++ b/.github/workflows/wheel_macos_arm64.yml
@@ -102,7 +102,7 @@ jobs:
           python -m cibuildwheel --output-dir wheelhouse
 
       - uses: actions/upload-artifact@v2
-        if: ${{ github.event_name == 'release' || github.ref == 'refs/heads/master' }}
+        # if: ${{ github.event_name == 'release' || github.ref == 'refs/heads/master' }}
         with:
           name: ${{ runner.os }}-wheels-${{ matrix.arch }}.zip
           path: ./wheelhouse/*.whl

--- a/.github/workflows/wheel_macos_arm64.yml
+++ b/.github/workflows/wheel_macos_arm64.yml
@@ -89,7 +89,7 @@ jobs:
           # Testing of built wheels
           CIBW_TEST_REQUIRES: numpy~=1.21 scipy pytest pytest-cov pytest-mock flaky
 
-          CIBW_BEFORE_TEST: pip install git+https://github.com/PennyLaneAI/pennylane.git@v0.25.1
+          CIBW_BEFORE_TEST: pip install pennylane~=0.25.0
 
           CIBW_TEST_COMMAND: |
             pl-device-test --device=lightning.qubit --skip-ops -x --tb=short --no-flaky-report

--- a/.github/workflows/wheel_macos_arm64.yml
+++ b/.github/workflows/wheel_macos_arm64.yml
@@ -89,7 +89,7 @@ jobs:
           # Testing of built wheels
           CIBW_TEST_REQUIRES: numpy~=1.21 scipy pytest pytest-cov pytest-mock flaky
 
-          CIBW_BEFORE_TEST: pip install git+https://github.com/PennyLaneAI/pennylane.git@master
+          CIBW_BEFORE_TEST: pip install git+https://github.com/PennyLaneAI/pennylane.git@v0.25.1
 
           CIBW_TEST_COMMAND: |
             pl-device-test --device=lightning.qubit --skip-ops -x --tb=short --no-flaky-report

--- a/.github/workflows/wheel_macos_x86_64.yml
+++ b/.github/workflows/wheel_macos_x86_64.yml
@@ -91,7 +91,7 @@ jobs:
           # Testing of built wheels
           CIBW_TEST_REQUIRES: numpy~=1.21 scipy pytest pytest-cov pytest-mock flaky
 
-          CIBW_BEFORE_TEST: pip install git+https://github.com/PennyLaneAI/pennylane.git@master
+          CIBW_BEFORE_TEST: pip install git+https://github.com/PennyLaneAI/pennylane.git@v0.25.1
 
           CIBW_TEST_COMMAND: |
             pl-device-test --device=lightning.qubit --skip-ops -x --tb=short --no-flaky-report

--- a/.github/workflows/wheel_macos_x86_64.yml
+++ b/.github/workflows/wheel_macos_x86_64.yml
@@ -112,7 +112,7 @@ jobs:
           regex: '.*[0-9]+.[0-9]+.[0-9]+[-_]?rc[0-9]+'
 
       - uses: actions/upload-artifact@v2
-        if: ${{ github.event_name == 'release' || github.ref == 'refs/heads/master' || steps.rc_build.outputs.match != ''}}
+        # if: ${{ github.event_name == 'release' || github.ref == 'refs/heads/master' || steps.rc_build.outputs.match != ''}}
         with:
           name: ${{ runner.os }}-wheels-${{ matrix.arch }}.zip
           path: ./wheelhouse/*.whl

--- a/.github/workflows/wheel_macos_x86_64.yml
+++ b/.github/workflows/wheel_macos_x86_64.yml
@@ -91,7 +91,7 @@ jobs:
           # Testing of built wheels
           CIBW_TEST_REQUIRES: numpy~=1.21 scipy pytest pytest-cov pytest-mock flaky
 
-          CIBW_BEFORE_TEST: pip install git+https://github.com/PennyLaneAI/pennylane.git@v0.25.1
+          CIBW_BEFORE_TEST: pip install pennylane~=0.25.0
 
           CIBW_TEST_COMMAND: |
             pl-device-test --device=lightning.qubit --skip-ops -x --tb=short --no-flaky-report

--- a/.github/workflows/wheel_noarch.yml
+++ b/.github/workflows/wheel_noarch.yml
@@ -43,7 +43,7 @@ jobs:
           SKIP_COMPILATION: True
 
       - uses: actions/upload-artifact@v2
-        if: ${{ github.event_name == 'release' || github.ref == 'refs/heads/master' }}
+        # if: ${{ github.event_name == 'release' || github.ref == 'refs/heads/master' }}
         with:
           name: pure-python-wheels.zip
           path: main/dist/*.whl

--- a/.github/workflows/wheel_win_x86_64.yml
+++ b/.github/workflows/wheel_win_x86_64.yml
@@ -104,7 +104,7 @@ jobs:
         run: |
           Set-Location -Path "Z:\"
           foreach ($i in Get-ChildItem -Path Z:\dist\*.whl){ python -m pip install $i }
-          python -m pip install git+https://github.com/PennyLaneAI/pennylane.git@0.25.1 && `
+          python -m pip install pennylane~=0.25.0 && `
           python -m pip install pytest pytest-cov pytest-mock flaky && `
           pl-device-test --device=lightning.qubit --skip-ops -x --tb=short --no-flaky-report
 

--- a/.github/workflows/wheel_win_x86_64.yml
+++ b/.github/workflows/wheel_win_x86_64.yml
@@ -92,9 +92,9 @@ jobs:
             python -m wheel unpack $i.Name
             $name = $i.Name
             $dirName = python -c "s = '$name'; print('-'.join(s.split('-')[0:2]))"
-            if (Test-Path -Path $dirName\pennylane_lightning\Debug) {
-              Move-Item -Path $dirName\pennylane_lightning\Debug\* -Destination $dirName\pennylane_lightning
-              Remove-Item $dirName\pennylane_lightning\Debug -Recurse
+            if (Test-Path -Path $dirName\pennylane_lightning\RelWithDebInfo) {
+              Move-Item -Path $dirName\pennylane_lightning\RelWithDebInfo\* -Destination $dirName\pennylane_lightning
+              Remove-Item $dirName\pennylane_lightning\RelWithDebInfo -Recurse
               python -m wheel pack $dirName
             }
             Remove-Item $dirName -Recurse

--- a/.github/workflows/wheel_win_x86_64.yml
+++ b/.github/workflows/wheel_win_x86_64.yml
@@ -104,7 +104,7 @@ jobs:
         run: |
           Set-Location -Path "Z:\"
           foreach ($i in Get-ChildItem -Path Z:\dist\*.whl){ python -m pip install $i }
-          python -m pip install git+https://github.com/PennyLaneAI/pennylane.git@master && `
+          python -m pip install git+https://github.com/PennyLaneAI/pennylane.git@0.25.1 && `
           python -m pip install pytest pytest-cov pytest-mock flaky && `
           pl-device-test --device=lightning.qubit --skip-ops -x --tb=short --no-flaky-report
 

--- a/.github/workflows/wheel_win_x86_64.yml
+++ b/.github/workflows/wheel_win_x86_64.yml
@@ -115,7 +115,7 @@ jobs:
           regex: '.*[0-9]+.[0-9]+.[0-9]+[-_]?rc[0-9]+'
 
       - uses: actions/upload-artifact@v2
-        if: ${{ github.event_name == 'release' || github.ref == 'refs/heads/master' || steps.rc_build.outputs.match != ''}}
+        # if: ${{ github.event_name == 'release' || github.ref == 'refs/heads/master' || steps.rc_build.outputs.match != ''}}
         with:
           name: ${{ runner.os }}-wheels.zip
           path: Z:\dist\*.whl

--- a/pennylane_lightning/_version.py
+++ b/pennylane_lightning/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.25.0"
+__version__ = "0.25.1-rc0"

--- a/pennylane_lightning/_version.py
+++ b/pennylane_lightning/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.25.1-rc0"
+__version__ = "0.25.1"

--- a/setup.py
+++ b/setup.py
@@ -69,14 +69,15 @@ class CMakeBuild(build_ext):
                 f"-DCMAKE_MAKE_PROGRAM={ninja_path}",
             ]
         
-        if debug:
-            configure_args += ["-DCMAKE_BUILD_TYPE=Debug"]
-        configure_args += self.cmake_defines
-
         build_args = []
 
-        if not debug:
+        if debug:
+            configure_args += ["-DCMAKE_BUILD_TYPE=Debug"]
+            build_args += ["--config", "Debug"]
+        else:
             build_args += ["--config", "RelWithDebInfo"]
+        
+        configure_args += self.cmake_defines
 
         # Add more platform dependent options
         if platform.system() == "Darwin":

--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,9 @@ class CMakeBuild(build_ext):
 
         build_args = []
 
+        if not debug:
+            build_args += ["--config", "RelWithDebInfo"]
+
         # Add more platform dependent options
         if platform.system() == "Darwin":
             #To support ARM64
@@ -105,7 +108,7 @@ class CMakeBuild(build_ext):
             os.makedirs(self.build_temp)
 
         subprocess.check_call(["cmake", str(ext.sourcedir)] + configure_args, cwd=self.build_temp)
-        subprocess.check_call(["cmake", "--build", "."] + build_args, cwd=self.build_temp)
+        subprocess.check_call(["cmake", "--build", ".", "--verbose"] + build_args, cwd=self.build_temp)
 
 
 with open(os.path.join("pennylane_lightning", "_version.py")) as f:


### PR DESCRIPTION

**Context:** Issues were observed on Windows where the PennyLane-Lightning compiled modules are not importable.

**Description of the Change:** MSVC sets the build type to debug by default. Now we explicitly set it to RelWithDebInfo in all building steps.

**Benefits:** No more problems with building and compiling modules on Windows

**Possible Drawbacks:**

**Related GitHub Issues:**
