### PR TITLE
remove `supports_reversible_diff`

### DIFF
--- a/pennylane_lightning/_version.py
+++ b/pennylane_lightning/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.26.0-dev10"
+__version__ = "0.26.0-dev11"

--- a/pennylane_lightning/lightning_qubit.py
+++ b/pennylane_lightning/lightning_qubit.py
@@ -149,7 +149,6 @@ class LightningQubit(DefaultQubit):
         capabilities = super().capabilities().copy()
         capabilities.update(
             model="qubit",
-            supports_reversible_diff=False,
             supports_inverse_operations=True,
             supports_analytic_computation=True,
             supports_broadcasting=False,


### PR DESCRIPTION
**Context:**
The feature is no longer used

**Description of the Change:**
Remove the unused option as well as the test that checks its functionality.

**Benefits:**
Less junk code

**Possible Drawbacks:**
None

**Related GitHub Issues:**
PennyLaneAI/pennylane#2878
