### PR TITLE
Update tagger bot for latest release

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -19,6 +19,9 @@
 * Test updates to reflect new measurement error messages.
 [(#334)](https://github.com/PennyLaneAI/pennylane-lightning/pull/334)
 
+* Updates to the release tagger to fix incompatibilities with RTD.
+[(#344)](https://github.com/PennyLaneAI/pennylane-lightning/pull/344)
+
 ### Contributors
 
 This release contains contributions from (in alphabetical order):

--- a/.github/workflows/post_release_tag.yml
+++ b/.github/workflows/post_release_tag.yml
@@ -5,7 +5,7 @@ on:
     types: [published]
 
 env:
-  TAG_NAME: latest
+  TAG_NAME: latest_release
 
 jobs:
   post_release_tag_latest:

--- a/pennylane_lightning/_version.py
+++ b/pennylane_lightning/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.26.0-dev6"
+__version__ = "0.26.0-dev7"


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [x] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [x] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [x] Ensure that the test suite passes, by running `make test`.

- [x] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [x] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:** To avoid a known issue with RTD and the tag `latest`, we update the down-stream facing tag `latest` to `latest_release`. This PR ensures that all releases are tagged appropriately with the new release tag.

**Description of the Change:** See above.

**Benefits:** No more issues with incorrect RTD references.

**Possible Drawbacks:**

**Related GitHub Issues:** https://github.com/PennyLaneAI/pennylane-lightning-gpu/pull/51
