### PR TITLE
Update cancel-workflow-action and bot credentials

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -22,6 +22,9 @@
 * Updates to the release tagger to fix incompatibilities with RTD.
 [(#344)](https://github.com/PennyLaneAI/pennylane-lightning/pull/344)
 
+* Update cancel-workflow-action and bot credentials.
+[(#345)](https://github.com/PennyLaneAI/pennylane-lightning/pull/345)
+
 ### Contributors
 
 This release contains contributions from (in alphabetical order):

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.4.1
+        uses: styfle/cancel-workflow-action@0.10.0
         with:
           access_token: ${{ github.token }}
 
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Cancel previous runs
-        uses: styfle/cancel-workflow-action@0.4.1
+        uses: styfle/cancel-workflow-action@0.10.0
         with:
           access_token: ${{ github.token }}
 
@@ -63,7 +63,7 @@ jobs:
 
     steps:
       - name: Cancel previous runs
-        uses: styfle/cancel-workflow-action@0.4.1
+        uses: styfle/cancel-workflow-action@0.10.0
         with:
           access_token: ${{ github.token }}
 

--- a/.github/workflows/post_release_tag.yml
+++ b/.github/workflows/post_release_tag.yml
@@ -18,7 +18,7 @@ jobs:
 
       - name: Overwrite tag
         run: |
-          git config --local user.email "chae-yeun@xanadu.ai"
+          git config --local user.email 'github-actions[bot]@users.noreply.github.com'
           git config --local user.name "Latest tag update bot"
           git tag -d $TAG_NAME || true
           if git push --delete origin $TAG_NAME; then

--- a/.github/workflows/tests_linux.yml
+++ b/.github/workflows/tests_linux.yml
@@ -21,7 +21,7 @@ jobs:
         os: [ubuntu-20.04]
     steps:
       - name: Cancel previous runs
-        uses: styfle/cancel-workflow-action@0.4.1
+        uses: styfle/cancel-workflow-action@0.10.0
         with:
           access_token: ${{ github.token }}
 
@@ -74,7 +74,7 @@ jobs:
         os: [ubuntu-20.04]
     steps:
       - name: Cancel previous runs
-        uses: styfle/cancel-workflow-action@0.4.1
+        uses: styfle/cancel-workflow-action@0.10.0
         with:
           access_token: ${{ github.token }}
 
@@ -127,7 +127,7 @@ jobs:
         os: [ubuntu-20.04]
     steps:
       - name: Cancel previous runs
-        uses: styfle/cancel-workflow-action@0.4.1
+        uses: styfle/cancel-workflow-action@0.10.0
         with:
           access_token: ${{ github.token }}
 
@@ -181,7 +181,7 @@ jobs:
         os: [ubuntu-20.04]
     steps:
       - name: Cancel previous runs
-        uses: styfle/cancel-workflow-action@0.4.1
+        uses: styfle/cancel-workflow-action@0.10.0
         with:
           access_token: ${{ github.token }}
 

--- a/.github/workflows/tests_windows.yml
+++ b/.github/workflows/tests_windows.yml
@@ -14,7 +14,7 @@ jobs:
         os: [windows-latest]
     steps:
       - name: Cancel previous runs
-        uses: styfle/cancel-workflow-action@0.4.1
+        uses: styfle/cancel-workflow-action@0.10.0
         with:
           access_token: ${{ github.token }}
       - uses: actions/checkout@v2
@@ -60,7 +60,7 @@ jobs:
         os: [windows-latest]
     steps:
       - name: Cancel previous runs
-        uses: styfle/cancel-workflow-action@0.4.1
+        uses: styfle/cancel-workflow-action@0.10.0
         with:
           access_token: ${{ github.token }}
       - uses: actions/checkout@v2

--- a/.github/workflows/tests_without_binary.yml
+++ b/.github/workflows/tests_without_binary.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Cancel previous runs
-        uses: styfle/cancel-workflow-action@0.4.1
+        uses: styfle/cancel-workflow-action@0.10.0
         with:
           access_token: ${{ github.token }}
 

--- a/.github/workflows/update_dev_version.yml
+++ b/.github/workflows/update_dev_version.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Checkout PennyLane-Lightning PR
         uses: actions/checkout@v2
         with:
-          token: ${{ secrets.DEV_TOKEN }}
+          # token: ${{ secrets.DEV_TOKEN }}
           ref: ${{ github.head_ref }}
           path: pr
 

--- a/.github/workflows/update_dev_version.yml
+++ b/.github/workflows/update_dev_version.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Checkout PennyLane-Lightning PR
         uses: actions/checkout@v2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.DEV_TOKEN }}
           ref: ${{ github.head_ref }}
           path: pr
 

--- a/.github/workflows/update_dev_version.yml
+++ b/.github/workflows/update_dev_version.yml
@@ -36,7 +36,7 @@ jobs:
         run: |
           cd ./pr
           if [[ -n $(git status -s) ]]; then
-            git config --local user.email "chae-yeun@xanadu.ai"
+            git config --local user.email 'github-actions[bot]@users.noreply.github.com'
             git config --local user.name "Dev version update bot"
             git add .
             git commit -m 'Auto update version'

--- a/.github/workflows/update_dev_version.yml
+++ b/.github/workflows/update_dev_version.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Checkout PennyLane-Lightning PR
         uses: actions/checkout@v2
         with:
-          token: ${{ secrets.DEV_TOKEN }}
+          token: ${{ github.token }}
           ref: ${{ github.head_ref }}
           path: pr
 

--- a/.github/workflows/update_dev_version.yml
+++ b/.github/workflows/update_dev_version.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Checkout PennyLane-Lightning PR
         uses: actions/checkout@v2
         with:
-          token: ${{ github.token }}
+          token: ${{ secrets.DEV_TOKEN }}
           ref: ${{ github.head_ref }}
           path: pr
 

--- a/.github/workflows/update_dev_version.yml
+++ b/.github/workflows/update_dev_version.yml
@@ -35,8 +35,8 @@ jobs:
         run: |
           cd ./pr
           if [[ -n $(git status -s) ]]; then
-            git config --local user.email 'github-actions[bot]@users.noreply.github.com'
-            git config --local user.name "Dev version update bot"
+            git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+            git config --global user.name "Dev version update bot"
             git add .
             git commit -m 'Auto update version'
             git push

--- a/.github/workflows/update_dev_version.yml
+++ b/.github/workflows/update_dev_version.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Checkout PennyLane-Lightning PR
         uses: actions/checkout@v2
         with:
-          token: ${{ secrets.DEV_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{ github.head_ref }}
           path: pr
 

--- a/.github/workflows/update_dev_version.yml
+++ b/.github/workflows/update_dev_version.yml
@@ -22,7 +22,6 @@ jobs:
       - name: Checkout PennyLane-Lightning PR
         uses: actions/checkout@v2
         with:
-          # token: ${{ secrets.DEV_TOKEN }}
           ref: ${{ github.head_ref }}
           path: pr
 

--- a/.github/workflows/update_dev_version.yml
+++ b/.github/workflows/update_dev_version.yml
@@ -22,6 +22,7 @@ jobs:
       - name: Checkout PennyLane-Lightning PR
         uses: actions/checkout@v2
         with:
+          token: ${{ secrets.DEV_TOKEN }}
           ref: ${{ github.head_ref }}
           path: pr
 

--- a/.github/workflows/wheel_linux_aarch64.yml
+++ b/.github/workflows/wheel_linux_aarch64.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.4.1
+        uses: styfle/cancel-workflow-action@0.10.0
         with:
           access_token: ${{ github.token }}
 
@@ -71,7 +71,7 @@ jobs:
 
     steps:
       - name: Cancel previous runs
-        uses: styfle/cancel-workflow-action@0.4.1
+        uses: styfle/cancel-workflow-action@0.10.0
         with:
           access_token: ${{ github.token }}
 
@@ -161,7 +161,7 @@ jobs:
 
     steps:
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.4.1
+        uses: styfle/cancel-workflow-action@0.10.0
         with:
           access_token: ${{ github.token }}
 

--- a/.github/workflows/wheel_linux_ppc64le.yml
+++ b/.github/workflows/wheel_linux_ppc64le.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.4.1
+        uses: styfle/cancel-workflow-action@0.10.0
         with:
           access_token: ${{ github.token }}
 
@@ -71,7 +71,7 @@ jobs:
 
     steps:
       - name: Cancel previous runs
-        uses: styfle/cancel-workflow-action@0.4.1
+        uses: styfle/cancel-workflow-action@0.10.0
         with:
           access_token: ${{ github.token }}
 
@@ -161,7 +161,7 @@ jobs:
 
     steps:
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.4.1
+        uses: styfle/cancel-workflow-action@0.10.0
         with:
           access_token: ${{ github.token }}
 

--- a/.github/workflows/wheel_linux_x86_64.yml
+++ b/.github/workflows/wheel_linux_x86_64.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.4.1
+        uses: styfle/cancel-workflow-action@0.10.0
         with:
           access_token: ${{ github.token }}
 
@@ -72,7 +72,7 @@ jobs:
 
     steps:
       - name: Cancel previous runs
-        uses: styfle/cancel-workflow-action@0.4.1
+        uses: styfle/cancel-workflow-action@0.10.0
         with:
           access_token: ${{ github.token }}
 
@@ -158,7 +158,7 @@ jobs:
 
     steps:
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.4.1
+        uses: styfle/cancel-workflow-action@0.10.0
         with:
           access_token: ${{ github.token }}
 

--- a/.github/workflows/wheel_macos_arm64.yml
+++ b/.github/workflows/wheel_macos_arm64.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.4.1
+        uses: styfle/cancel-workflow-action@0.10.0
         with:
           access_token: ${{ github.token }}
 
@@ -62,7 +62,7 @@ jobs:
 
     steps:
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.4.1
+        uses: styfle/cancel-workflow-action@0.10.0
         with:
           access_token: ${{ github.token }}
 

--- a/.github/workflows/wheel_macos_x86_64.yml
+++ b/.github/workflows/wheel_macos_x86_64.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.4.1
+        uses: styfle/cancel-workflow-action@0.10.0
         with:
           access_token: ${{ github.token }}
 
@@ -72,7 +72,7 @@ jobs:
 
     steps:
       - name: Cancel previous runs
-        uses: styfle/cancel-workflow-action@0.4.1
+        uses: styfle/cancel-workflow-action@0.10.0
         with:
           access_token: ${{ github.token }}
 
@@ -157,7 +157,7 @@ jobs:
 
     steps:
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.4.1
+        uses: styfle/cancel-workflow-action@0.10.0
         with:
           access_token: ${{ github.token }}
 

--- a/.github/workflows/wheel_win_x86_64.yml
+++ b/.github/workflows/wheel_win_x86_64.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.4.1
+        uses: styfle/cancel-workflow-action@0.10.0
         with:
           access_token: ${{ github.token }}
 
@@ -73,7 +73,7 @@ jobs:
 
     steps:
       - name: Cancel previous runs
-        uses: styfle/cancel-workflow-action@0.4.1
+        uses: styfle/cancel-workflow-action@0.10.0
         with:
           access_token: ${{ github.token }}
 
@@ -150,7 +150,7 @@ jobs:
 
     steps:
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.4.1
+        uses: styfle/cancel-workflow-action@0.10.0
         with:
           access_token: ${{ github.token }}
 

--- a/pennylane_lightning/_version.py
+++ b/pennylane_lightning/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.26.0-dev8"
+__version__ = "0.26.0-dev7"

--- a/pennylane_lightning/_version.py
+++ b/pennylane_lightning/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.26.0-dev7"
+__version__ = "0.26.0-dev8"


### PR DESCRIPTION
**Context:** We have been experiencing several workflow cancellations, this is probably due to the use of an outdated cancel-workflow-action.

**Description of the Change:** Updating to the latest cancel-workflow-action at the moment. Also updating the bot credentials.

**Benefits:** Not having workflows cancelled.

**Possible Drawbacks:**

**Related GitHub Issues:**
