### PR TITLE
Defer op-arithmetic to default qubit

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -15,6 +15,17 @@
 * Implements caching for Kokkos installation.
 [(#316)](https://github.com/PennyLaneAI/pennylane-lightning/pull/316)
 
+* Supports measurements of operator arithmetic classes such as `Sum`, `Prod`,
+  and `SProd` by deferring handling of them to `DefaultQubit`.
+  [(#349)](https://github.com/PennyLaneAI/pennylane-lightning/pull/349)
+
+```
+@qml.qnode(qml.device('lightning.qubit', wires=2))
+def circuit():
+    obs = qml.s_prod(2.1, qml.PauliZ(0)) + qml.op_sum(qml.PauliX(0), qml.PauliZ(1))
+    return qml.expval(obs)
+```
+
 ### Documentation
 
 ### Bug fixes
@@ -32,7 +43,7 @@
 
 This release contains contributions from (in alphabetical order):
 
-Amintor Dusko, Chae-Yeun Park
+Amintor Dusko, Christina Lee, Chae-Yeun Park
 
 ---
 

--- a/pennylane_lightning/_version.py
+++ b/pennylane_lightning/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.26.0-dev11"
+__version__ = "0.26.0-dev12"

--- a/pennylane_lightning/lightning_qubit.py
+++ b/pennylane_lightning/lightning_qubit.py
@@ -608,11 +608,15 @@ class LightningQubit(DefaultQubit):
         Returns:
             Expectation value of the observable
         """
-        if (observable.arithmetic_depth > 0) or isinstance(observable.name, List) or observable.name in [
-            "Identity",
-            "Projector",
-
-        ]:
+        if (
+            (observable.arithmetic_depth > 0)
+            or isinstance(observable.name, List)
+            or observable.name
+            in [
+                "Identity",
+                "Projector",
+            ]
+        ):
             return super().expval(observable, shot_range=shot_range, bin_size=bin_size)
 
         if self.shots is not None:

--- a/pennylane_lightning/lightning_qubit.py
+++ b/pennylane_lightning/lightning_qubit.py
@@ -76,14 +76,6 @@ def _remove_snapshot_from_operations(operations):
     return operations
 
 
-def _remove_op_arithmetic_from_observables(observables):
-    observables = observables.copy()
-    observables.discard("Sum")
-    observables.discard("SProd")
-    observables.discard("Prod")
-    return observables
-
-
 class LightningQubit(DefaultQubit):
     """PennyLane Lightning device.
 
@@ -111,7 +103,6 @@ class LightningQubit(DefaultQubit):
     author = "Xanadu Inc."
     _CPP_BINARY_AVAILABLE = True
     operations = _remove_snapshot_from_operations(DefaultQubit.operations)
-    observables = _remove_op_arithmetic_from_observables(DefaultQubit.observables)
 
     def __init__(self, wires, *, c_dtype=np.complex128, shots=None, batch_obs=False):
         if c_dtype is np.complex64:
@@ -617,9 +608,10 @@ class LightningQubit(DefaultQubit):
         Returns:
             Expectation value of the observable
         """
-        if isinstance(observable.name, List) or observable.name in [
+        if (observable.arithmetic_depth > 0) or isinstance(observable.name, List) or observable.name in [
             "Identity",
             "Projector",
+
         ]:
             return super().expval(observable, shot_range=shot_range, bin_size=bin_size)
 

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -39,20 +39,3 @@ def test_create_device_with_dtype(C):
 def test_create_device_with_unsupported_dtype():
     with pytest.raises(TypeError, match="Unsupported complex Type:"):
         dev = qml.device("lightning.qubit", wires=1, c_dtype=np.complex256)
-
-
-def test_no_op_arithmetic_support():
-    """Test that lightning qubit explicitly does not support SProd, Prod, and Sum."""
-
-    dev = qml.device("lightning.qubit", wires=2)
-    for name in {"Prod", "SProd", "Sum"}:
-        assert name not in dev.operations
-
-    obs = qml.prod(qml.PauliX(0), qml.PauliY(1))
-
-    @qml.qnode(dev)
-    def circuit():
-        return qml.expval(obs)
-
-    with pytest.raises(qml.DeviceError, match=r"Observable Prod not supported on device"):
-        circuit()

--- a/tests/test_expval.py
+++ b/tests/test_expval.py
@@ -189,7 +189,7 @@ class TestExpOperatorArithmetic:
         assert qml.math.allclose(res, expected)
 
         g = qml.grad(circuit)(x, y)
-        expected = (-2.3*np.sin(x)+0.5*np.cos(y)*np.cos(x), -0.5*np.sin(x)*np.sin(y))
+        expected = (-2.3 * np.sin(x) + 0.5 * np.cos(y) * np.cos(x), -0.5 * np.sin(x) * np.sin(y))
         assert qml.math.allclose(g, expected)
 
 


### PR DESCRIPTION
```
dev = qml.device('lightning.qubit', wires=2)

@qml.qnode(dev, diff_method=None)
def circuit():
    obs = qml.s_prod(2.1, qml.PauliZ(0)) + qml.op_sum(qml.PauliX(0), qml.PauliZ(1))
    return qml.expval(obs)
```

This PR adds support for operator arithmetic observables to lightning qubit by deferring handling of them to `default.qubit`.

While we should examine to natively support them in lightning, this fix at least gets support in.