### PR TITLE
Split coverage and unit tests

### DIFF
--- a/.github/workflows/tests_linux.yml
+++ b/.github/workflows/tests_linux.yml
@@ -153,13 +153,27 @@ jobs:
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get -y -q install cmake gcc-10 g++-10 libopenblas-dev ninja-build gcovr lcov
 
-      - name: Build and run unit tests with code coverage
+      - name: Build and run unit tests
         run: |
-            cmake pennylane_lightning/src -BBuildCov -DCMAKE_BUILD_TYPE=RelWithDebInfo -DENABLE_BLAS=ON -DCMAKE_PREFIX_PATH=${{ github.workspace }}/Kokkos -DBUILD_TESTS=ON -DENABLE_COVERAGE=ON -DCMAKE_CXX_COMPILER="$(which g++-$GCC_VERSION)" -G Ninja
-            cmake --build ./BuildCov
-            cd ./BuildCov
+            cmake pennylane_lightning/src -BBuild -DCMAKE_BUILD_TYPE=RelWithDebInfo -DENABLE_BLAS=ON -DCMAKE_PREFIX_PATH=${{ github.workspace }}/Kokkos -DBUILD_TESTS=ON -DCMAKE_CXX_COMPILER="$(which g++-$GCC_VERSION)" -G Ninja
+            cmake --build ./Build
+            cd ./Build
             mkdir -p ./tests/results
             ./tests/runner --order lex --reporter junit --out ./tests/results/report_cpptestswithOpenBLAS.xml
+
+      - name: Upload test results
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: ubuntu-tests-reports
+          path: BuildCov/tests/results/report_cpptestswithOpenBLAS.xml
+
+      - name: Build and run unit tests for code coverage
+        run: |
+            cmake pennylane_lightning/src -BBuildCov -DCMAKE_BUILD_TYPE=Debug -DENABLE_BLAS=ON -DCMAKE_PREFIX_PATH=${{ github.workspace }}/Kokkos -DBUILD_TESTS=ON -DENABLE_COVERAGE=ON -DCMAKE_CXX_COMPILER="$(which g++-$GCC_VERSION)" -G Ninja
+            cmake --build ./BuildCov
+            cd ./BuildCov
+            ./tests/runner
             lcov --directory . -b ../pennylane_lightning/src --capture --output-file coverage.info
             lcov --remove coverage.info '/usr/*' --output-file coverage.info
 
@@ -169,13 +183,6 @@ jobs:
           files: ./BuildCov/coverage.info
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
-
-      - name: Upload test results
-        uses: actions/upload-artifact@v3
-        if: always()
-        with:
-          name: ubuntu-tests-reports
-          path: BuildCov/tests/results/report_cpptestswithOpenBLAS.xml
 
   pythontestswithBLAS:
     strategy:
@@ -285,13 +292,27 @@ jobs:
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get -y -q install cmake gcc-10 g++-10 ninja-build gcovr lcov
 
-      - name: Build and run unit tests with code coverage
+      - name: Build and run unit tests
         run: |
-            cmake pennylane_lightning/src -BBuildCov -DCMAKE_BUILD_TYPE=RelWithDebInfo -DENABLE_KOKKOS=ON -DCMAKE_PREFIX_PATH=${{ github.workspace }}/Kokkos -DBUILD_TESTS=ON -DENABLE_COVERAGE=ON -DCMAKE_CXX_COMPILER="$(which g++-$GCC_VERSION)" -G Ninja
-            cmake --build ./BuildCov
-            cd ./BuildCov
+            cmake pennylane_lightning/src -BBuild -DCMAKE_BUILD_TYPE=RelWithDebInfo -DENABLE_KOKKOS=ON -DCMAKE_PREFIX_PATH=${{ github.workspace }}/Kokkos -DBUILD_TESTS=ON -DCMAKE_CXX_COMPILER="$(which g++-$GCC_VERSION)" -G Ninja
+            cmake --build ./Build
+            cd ./Build
             mkdir -p ./tests/results
             ./tests/runner --order lex --reporter junit --out ./tests/results/report_cpptestswithKokkos.xml
+
+      - name: Upload test results
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: ubuntu-tests-reports
+          path: BuildCov/tests/results/report_cpptestswithKokkos.xml
+
+      - name: Build and run unit tests for code coverage
+        run: |
+            cmake pennylane_lightning/src -BBuildCov -DCMAKE_BUILD_TYPE=Debug -DENABLE_KOKKOS=ON -DCMAKE_PREFIX_PATH=${{ github.workspace }}/Kokkos -DBUILD_TESTS=ON -DENABLE_COVERAGE=ON -DCMAKE_CXX_COMPILER="$(which g++-$GCC_VERSION)" -G Ninja
+            cmake --build ./BuildCov
+            cd ./BuildCov
+            ./tests/runner
             lcov --directory . -b ../pennylane_lightning/src --capture --output-file coverage.info
             lcov --remove coverage.info '/usr/*' --output-file coverage.info
 
@@ -301,13 +322,6 @@ jobs:
           files: ./BuildCov/coverage.info
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
-
-      - name: Upload test results
-        uses: actions/upload-artifact@v3
-        if: always()
-        with:
-          name: ubuntu-tests-reports
-          path: BuildCov/tests/results/report_cpptestswithKokkos.xml
 
   pythontestswithKokkos:
     needs: [build_and_cache_Kokkos]
@@ -427,13 +441,27 @@ jobs:
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get -y -q install cmake gcc-10 g++-10 libopenblas-dev ninja-build gcovr lcov
 
-      - name: Build and run unit tests with code coverage
+      - name: Build and run unit tests
         run: |
-            cmake pennylane_lightning/src -BBuildCov -DCMAKE_BUILD_TYPE=RelWithDebInfo -DENABLE_BLAS=ON -DENABLE_KOKKOS=ON -DCMAKE_PREFIX_PATH=${{ github.workspace }}/Kokkos -DBUILD_TESTS=ON -DENABLE_COVERAGE=ON -DCMAKE_CXX_COMPILER="$(which g++-$GCC_VERSION)" -G Ninja
-            cmake --build ./BuildCov
-            cd ./BuildCov
+            cmake pennylane_lightning/src -BBuild -DCMAKE_BUILD_TYPE=RelWithDebInfo -DENABLE_BLAS=ON -DENABLE_KOKKOS=ON -DCMAKE_PREFIX_PATH=${{ github.workspace }}/Kokkos -DBUILD_TESTS=ON -DCMAKE_CXX_COMPILER="$(which g++-$GCC_VERSION)" -G Ninja
+            cmake --build ./Build
+            cd ./Build
             mkdir -p ./tests/results
             ./tests/runner --order lex --reporter junit --out ./tests/results/report_cpptestswithKokkosAndOpenBLAS.xml
+
+      - name: Upload test results
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: ubuntu-tests-reports
+          path: BuildCov/tests/results/report_cpptestswithKokkosAndOpenBLAS.xml
+
+      - name: Build and run unit tests for code coverage
+        run: |
+            cmake pennylane_lightning/src -BBuildCov -DCMAKE_BUILD_TYPE=Debug -DENABLE_BLAS=ON -DENABLE_KOKKOS=ON -DCMAKE_PREFIX_PATH=${{ github.workspace }}/Kokkos -DBUILD_TESTS=ON -DENABLE_COVERAGE=ON -DCMAKE_CXX_COMPILER="$(which g++-$GCC_VERSION)" -G Ninja
+            cmake --build ./BuildCov
+            cd ./BuildCov
+            ./tests/runner
             lcov --directory . -b ../pennylane_lightning/src --capture --output-file coverage.info
             lcov --remove coverage.info '/usr/*' --output-file coverage.info
 
@@ -443,13 +471,6 @@ jobs:
           files: ./BuildCov/coverage.info
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
-
-      - name: Upload test results
-        uses: actions/upload-artifact@v3
-        if: always()
-        with:
-          name: ubuntu-tests-reports
-          path: BuildCov/tests/results/report_cpptestswithKokkosAndOpenBLAS.xml
 
   pythontestswithKokkosAndOpenBLAS:
     needs: [build_and_cache_Kokkos]

--- a/.github/workflows/tests_linux.yml
+++ b/.github/workflows/tests_linux.yml
@@ -40,13 +40,27 @@ jobs:
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get -y -q install cmake gcc-10 g++-10 ninja-build gcovr lcov
 
-      - name: Build and run unit tests with code coverage
+      - name: Build and run unit tests
         run: |
-            cmake pennylane_lightning/src -BBuildCov -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_TESTS=ON -DENABLE_COVERAGE=ON -DCMAKE_CXX_COMPILER="$(which g++-$GCC_VERSION)" -G Ninja
-            cmake --build ./BuildCov
-            cd ./BuildCov
+            cmake pennylane_lightning/src -BBuild -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_TESTS=ON -DCMAKE_CXX_COMPILER="$(which g++-$GCC_VERSION)" -G Ninja
+            cmake --build ./Build
+            cd ./Build
             mkdir -p ./tests/results
             ./tests/runner --order lex --reporter junit --out ./tests/results/report_cpptests.xml
+
+      - name: Upload test results
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: ubuntu-tests-reports
+          path: Build/tests/results/report_cpptests.xml
+
+      - name: Build and run unit tests for code coverage
+        run: |
+            cmake pennylane_lightning/src -BBuildCov -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS=ON -DENABLE_COVERAGE=ON -DCMAKE_CXX_COMPILER="$(which g++-$GCC_VERSION)" -G Ninja
+            cmake --build ./BuildCov
+            cd ./BuildCov
+            ./tests/runner
             lcov --directory . -b ../pennylane_lightning/src --capture --output-file coverage.info
             lcov --remove coverage.info '/usr/*' --output-file coverage.info
 
@@ -56,13 +70,6 @@ jobs:
           files: ./BuildCov/coverage.info
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
-
-      - name: Upload test results
-        uses: actions/upload-artifact@v3
-        if: always()
-        with:
-          name: ubuntu-tests-reports
-          path: BuildCov/tests/results/report_cpptests.xml
 
   pythontests:
     strategy:

--- a/pennylane_lightning/_version.py
+++ b/pennylane_lightning/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.27.0-dev3"
+__version__ = "0.27.0-dev4"


### PR DESCRIPTION
**Context:** Building coverage tests in Debug mode for CodeCov.

**Description of the Change:** Split unit and coverage test to build coverage tests in debug mode.

**Benefits:** CodeCov will work properly.

**Possible Drawbacks:**

**Related GitHub Issues:**
