### PR TITLE
Enable the generation of wheels for python 3.11 and upgrade python on CI/CD workflows to 3.8

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### New features since last release
 
+* Enable Building of wheels for python 3.11 and upgrade python on CI/CD workflows to 3.8.
+[(#381)](https://github.com/PennyLaneAI/pennylane-lightning/pull/381)
+
 ### Breaking changes
 
 ### Improvements

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### New features since last release
 
-* Enable Building of wheels for python 3.11 and upgrade python on CI/CD workflows to 3.8.
+* Enable building of python 3.11 wheels and upgrade python on CI/CD workflows to 3.8.
 [(#381)](https://github.com/PennyLaneAI/pennylane-lightning/pull/381)
 
 ### Breaking changes

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/setup-python@v4
         name: Install Python
         with:
-          python-version: '3.7'
+          python-version: '3.8'
 
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get -y -q install cmake gcc-10 g++-10 ninja-build libopenblas-dev

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -6,7 +6,7 @@ on:
       - master
 
 env:
-  GCC_VERSION: 10
+  GCC_VERSION: 11
 
 jobs:
   benchmarks:
@@ -32,7 +32,7 @@ jobs:
           python-version: '3.8'
 
       - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get -y -q install cmake gcc-10 g++-10 ninja-build libopenblas-dev
+        run: sudo apt-get update && sudo apt-get -y -q install cmake gcc-$GCC_VERSION  g++-$GCC_VERSION  ninja-build libopenblas-dev
 
       - name: Build GBenchmark
         run: |

--- a/.github/workflows/build_and_cache_Kokkos_linux.yml
+++ b/.github/workflows/build_and_cache_Kokkos_linux.yml
@@ -1,7 +1,7 @@
 name: Build and Cache Kokkos and Kokkos Kernels
 
 env:
-  GCC_VERSION: 10
+  GCC_VERSION: 11
 
 on:
   workflow_call:

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: 3.8
 
       - name: Install dependencies
         run:
@@ -77,7 +77,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.7'
+          python-version: '3.8'
 
       - name: Restoring cached dependencies
         id: kokkos-cache

--- a/.github/workflows/post_release_version_bump.yml
+++ b/.github/workflows/post_release_version_bump.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.9'
 

--- a/.github/workflows/pre_release_version_bump.yml
+++ b/.github/workflows/pre_release_version_bump.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.9'
 

--- a/.github/workflows/set_wheel_build_matrix.yml
+++ b/.github/workflows/set_wheel_build_matrix.yml
@@ -2,7 +2,7 @@ name: Set wheel build matrix
 
 env:
   PYTHON3_MIN_VERSION: "7"
-  PYTHON3_MAX_VERSION: "10"
+  PYTHON3_MAX_VERSION: "11"
 
 on:
   workflow_call:

--- a/.github/workflows/tests_linux.yml
+++ b/.github/workflows/tests_linux.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/setup-python@v4
         name: Install Python
         with:
-          python-version: '3.7'
+          python-version: '3.8'
 
       - name: Checkout PennyLane-Lightning
         uses: actions/checkout@v3
@@ -89,7 +89,7 @@ jobs:
       - uses: actions/setup-python@v4
         name: Install Python
         with:
-          python-version: '3.7'
+          python-version: '3.8'
 
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get -y -q install cmake gcc-11 g++-11
@@ -143,7 +143,7 @@ jobs:
       - uses: actions/setup-python@v4
         name: Install Python
         with:
-          python-version: '3.7'
+          python-version: '3.8'
 
       - name: Checkout PennyLane-Lightning
         uses: actions/checkout@v3
@@ -207,7 +207,7 @@ jobs:
       - uses: actions/setup-python@v4
         name: Install Python
         with:
-          python-version: '3.7'
+          python-version: '3.8'
 
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get -y -q install cmake gcc-11 g++-11 libopenblas-dev
@@ -270,7 +270,7 @@ jobs:
       - uses: actions/setup-python@v4
         name: Install Python
         with:
-          python-version: '3.7'
+          python-version: '3.8'
 
       - name: Checkout PennyLane-Lightning
         uses: actions/checkout@v3
@@ -349,7 +349,7 @@ jobs:
       - uses: actions/setup-python@v4
         name: Install Python
         with:
-          python-version: '3.7'
+          python-version: '3.8'
 
       - name: Restoring cached dependencies
         id: kokkos-cache
@@ -419,7 +419,7 @@ jobs:
       - uses: actions/setup-python@v4
         name: Install Python
         with:
-          python-version: '3.7'
+          python-version: '3.8'
 
       - name: Checkout PennyLane-Lightning
         uses: actions/checkout@v3
@@ -498,7 +498,7 @@ jobs:
       - uses: actions/setup-python@v4
         name: Install Python
         with:
-          python-version: '3.7'
+          python-version: '3.8'
 
       - name: Restoring cached dependencies
         id: kokkos-cache

--- a/.github/workflows/tests_linux.yml
+++ b/.github/workflows/tests_linux.yml
@@ -38,7 +38,7 @@ jobs:
           fetch-depth: 2
 
       - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get -y -q install cmake gcc-11 g++-11 ninja-build gcovr lcov
+        run: sudo apt-get update && sudo apt-get -y -q install cmake gcc-$GCC_VERSION  g++-$GCC_VERSION  ninja-build gcovr lcov
 
       - name: Build and run unit tests
         run: |
@@ -92,7 +92,7 @@ jobs:
           python-version: '3.8'
 
       - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get -y -q install cmake gcc-11 g++-11
+        run: sudo apt-get update && sudo apt-get -y -q install cmake gcc-$GCC_VERSION  g++-$GCC_VERSION
 
       - name: Get required Python packages
         run: |
@@ -151,7 +151,7 @@ jobs:
           fetch-depth: 2
 
       - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get -y -q install cmake gcc-11 g++-11 libopenblas-dev ninja-build gcovr lcov
+        run: sudo apt-get update && sudo apt-get -y -q install cmake gcc-$GCC_VERSION  g++-$GCC_VERSION  libopenblas-dev ninja-build gcovr lcov
 
       - name: Build and run unit tests
         run: |
@@ -210,7 +210,7 @@ jobs:
           python-version: '3.8'
 
       - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get -y -q install cmake gcc-11 g++-11 libopenblas-dev
+        run: sudo apt-get update && sudo apt-get -y -q install cmake gcc-$GCC_VERSION  g++-$GCC_VERSION  libopenblas-dev
 
       - name: Get required Python packages
         run: |
@@ -290,7 +290,7 @@ jobs:
           cp -rf ${{ github.workspace}}/Kokkos_install/${{ matrix.exec_model }}/* Kokkos/
 
       - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get -y -q install cmake gcc-11 g++-11 ninja-build gcovr lcov
+        run: sudo apt-get update && sudo apt-get -y -q install cmake gcc-$GCC_VERSION  g++-$GCC_VERSION  ninja-build gcovr lcov
 
       - name: Build and run unit tests
         run: |
@@ -365,7 +365,7 @@ jobs:
           pwd
 
       - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get -y -q install cmake gcc-11 g++-11
+        run: sudo apt-get update && sudo apt-get -y -q install cmake gcc-$GCC_VERSION  g++-$GCC_VERSION
 
       - name: Get required Python packages
         run: |
@@ -439,7 +439,7 @@ jobs:
           cp -rf ${{ github.workspace}}/Kokkos_install/${{ matrix.exec_model }}/* Kokkos/
 
       - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get -y -q install cmake gcc-11 g++-11 libopenblas-dev ninja-build gcovr lcov
+        run: sudo apt-get update && sudo apt-get -y -q install cmake gcc-$GCC_VERSION  g++-$GCC_VERSION  libopenblas-dev ninja-build gcovr lcov
 
       - name: Build and run unit tests
         run: |
@@ -514,7 +514,7 @@ jobs:
           pwd
 
       - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get -y -q install cmake gcc-11 g++-11 libopenblas-dev
+        run: sudo apt-get update && sudo apt-get -y -q install cmake gcc-$GCC_VERSION  g++-$GCC_VERSION  libopenblas-dev
 
       - name: Get required Python packages
         run: |

--- a/.github/workflows/tests_without_binary.yml
+++ b/.github/workflows/tests_without_binary.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/setup-python@v2
         name: Install Python
         with:
-          python-version: '3.7'
+          python-version: '3.8'
 
       - name: Get required Python packages
         run: |

--- a/.github/workflows/tests_without_binary.yml
+++ b/.github/workflows/tests_without_binary.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           path: main
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         name: Install Python
         with:
           python-version: '3.8'

--- a/.github/workflows/update_dev_version.yml
+++ b/.github/workflows/update_dev_version.yml
@@ -14,7 +14,7 @@ jobs:
           ref: master
           path: main
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         name: Install Python
         with:
           python-version: '3.8'

--- a/.github/workflows/update_dev_version.yml
+++ b/.github/workflows/update_dev_version.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/setup-python@v2
         name: Install Python
         with:
-          python-version: '3.7'
+          python-version: '3.8'
 
       - name: Checkout PennyLane-Lightning PR
         uses: actions/checkout@v3

--- a/.github/workflows/wheel_linux_aarch64.yml
+++ b/.github/workflows/wheel_linux_aarch64.yml
@@ -6,7 +6,6 @@ name: Wheel::Linux::ARM
 # **Who does it impact**: Wheels to be uploaded to PyPI.
 
 on:
-  pull_request:
   push:
     branches:
       - master

--- a/.github/workflows/wheel_linux_aarch64.yml
+++ b/.github/workflows/wheel_linux_aarch64.yml
@@ -6,6 +6,7 @@ name: Wheel::Linux::ARM
 # **Who does it impact**: Wheels to be uploaded to PyPI.
 
 on:
+  pull_request:
   push:
     branches:
       - master

--- a/.github/workflows/wheel_linux_aarch64.yml
+++ b/.github/workflows/wheel_linux_aarch64.yml
@@ -143,7 +143,7 @@ jobs:
           cp -rf ${{ github.workspace }}/Kokkos_install/${{ matrix.exec_model }}/* Kokkos/
 
       - name: Install cibuildwheel
-        run: python3 -m pip install cibuildwheel==2.11.2
+        run: python3 -m pip install cibuildwheel~=2.11.0
 
       - uses: docker/setup-qemu-action@v2
         name: Set up QEMU

--- a/.github/workflows/wheel_linux_aarch64.yml
+++ b/.github/workflows/wheel_linux_aarch64.yml
@@ -1,7 +1,7 @@
 name: Wheel::Linux::ARM
 
 # **What it does**: Builds python wheels for Linux (ubuntu-latest) architecture ARM 64 and store it as artifacts.
-#                   Python versions: 3.7, 3.8, 3.9, 3.10.
+#                   Python versions: 3.7, 3.8, 3.9, 3.10, 3.11.
 # **Why we have it**: To build wheels for pennylane-lightning installation.
 # **Who does it impact**: Wheels to be uploaded to PyPI.
 
@@ -72,8 +72,8 @@ jobs:
             -v ${{ github.workspace }}/Kokkos_install/${{ matrix.exec_model }}:/install \
             -i ${{ matrix.container_img }} \
             bash -c "cd /io && \
-            python3.7 -m pip install ninja && \
-            ln -s /opt/python/cp37-cp37m/bin/ninja /usr/bin/ninja && \
+            python3.8 -m pip install ninja && \
+            ln -s /opt/python/cp38-cp38m/bin/ninja /usr/bin/ninja && \
             cmake -BBuild . -DCMAKE_INSTALL_PREFIX=/install \
                             -DKokkos_ENABLE_COMPLEX_ALIGN=OFF \
                             -DKokkos_ENABLE_${{ matrix.exec_model }}=ON \
@@ -94,8 +94,8 @@ jobs:
             -v ${{ github.workspace }}/Kokkos_install/${{ matrix.exec_model }}:/install \
             -i ${{ matrix.container_img }} \
             bash -c "cd /io && \
-            python3.7 -m pip install ninja && \
-            ln -s /opt/python/cp37-cp37m/bin/ninja /usr/bin/ninja && \
+            python3.8 -m pip install ninja && \
+            ln -s /opt/python/cp38-cp38m/bin/ninja /usr/bin/ninja && \
             cmake -BBuild . -DCMAKE_INSTALL_PREFIX=/install \
                             -DKokkos_ENABLE_${{ matrix.exec_model }}=ON \
                             -DKokkos_ENABLE_DEPRECATION_WARNINGS=OFF \
@@ -119,7 +119,7 @@ jobs:
         kokkos_version: ${{ fromJson(needs.set_wheel_build_matrix.outputs.kokkos_version) }}
         container_img: ["quay.io/pypa/manylinux2014_aarch64"]
 
-    name: ubuntu-latest::aarch64 (Python ${{ fromJson('{ "cp37-*":"3.7","cp38-*":"3.8","cp39-*":"3.9","cp310-*":"3.10" }')[matrix.cibw_build] }})
+    name: ubuntu-latest::aarch64 (Python ${{ fromJson('{ "cp37-*":"3.7","cp38-*":"3.8","cp39-*":"3.9","cp310-*":"3.10","cp311-*":"3.11" }')[matrix.cibw_build] }})
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/wheel_linux_aarch64.yml
+++ b/.github/workflows/wheel_linux_aarch64.yml
@@ -143,7 +143,7 @@ jobs:
           cp -rf ${{ github.workspace }}/Kokkos_install/${{ matrix.exec_model }}/* Kokkos/
 
       - name: Install cibuildwheel
-        run: python3 -m pip install cibuildwheel==2.8.1
+        run: python3 -m pip install cibuildwheel==2.11.2
 
       - uses: docker/setup-qemu-action@v2
         name: Set up QEMU

--- a/.github/workflows/wheel_linux_ppc64le.yml
+++ b/.github/workflows/wheel_linux_ppc64le.yml
@@ -6,7 +6,6 @@ name: Wheel::Linux::PowerPC
 # **Who does it impact**: Wheels to be uploaded to PyPI.
 
 on:
-  pull_request:
   push:
     branches:
       - master

--- a/.github/workflows/wheel_linux_ppc64le.yml
+++ b/.github/workflows/wheel_linux_ppc64le.yml
@@ -6,6 +6,7 @@ name: Wheel::Linux::PowerPC
 # **Who does it impact**: Wheels to be uploaded to PyPI.
 
 on:
+  pull_request:
   push:
     branches:
       - master

--- a/.github/workflows/wheel_linux_ppc64le.yml
+++ b/.github/workflows/wheel_linux_ppc64le.yml
@@ -143,7 +143,7 @@ jobs:
           cp -rf ${{ github.workspace }}/Kokkos_install/${{ matrix.exec_model }}/* Kokkos/
 
       - name: Install cibuildwheel
-        run: python3 -m pip install cibuildwheel==2.11.2
+        run: python3 -m pip install cibuildwheel~=2.11.0
 
       - uses: docker/setup-qemu-action@v2
         name: Set up QEMU

--- a/.github/workflows/wheel_linux_ppc64le.yml
+++ b/.github/workflows/wheel_linux_ppc64le.yml
@@ -1,7 +1,7 @@
 name: Wheel::Linux::PowerPC
 
 # **What it does**: Builds python wheels for Linux (ubuntu-latest) architecture PowerPC 64 and store it as artifacts.
-#                   Python versions: 3.7, 3.8, 3.9, 3.10.
+#                   Python versions: 3.7, 3.8, 3.9, 3.10, 3.11.
 # **Why we have it**: To build wheels for pennylane-lightning installation.
 # **Who does it impact**: Wheels to be uploaded to PyPI.
 
@@ -72,8 +72,8 @@ jobs:
             -v ${{ github.workspace }}/Kokkos_install/${{ matrix.exec_model }}:/install \
             -i ${{ matrix.container_img }} \
             bash -c "cd /io && \
-            python3.7 -m pip install ninja && \
-            ln -s /opt/python/cp37-cp37m/bin/ninja /usr/bin/ninja && \
+            python3.8 -m pip install ninja && \
+            ln -s /opt/python/cp38-cp38m/bin/ninja /usr/bin/ninja && \
             cmake -BBuild . -DCMAKE_INSTALL_PREFIX=/install \
                             -DKokkos_ENABLE_COMPLEX_ALIGN=OFF \
                             -DKokkos_ENABLE_${{ matrix.exec_model }}=ON \
@@ -94,8 +94,8 @@ jobs:
             -v ${{ github.workspace }}/Kokkos_install/${{ matrix.exec_model }}:/install \
             -i ${{ matrix.container_img }} \
             bash -c "cd /io && \
-            python3.7 -m pip install ninja && \
-            ln -s /opt/python/cp37-cp37m/bin/ninja /usr/bin/ninja && \
+            python3.8 -m pip install ninja && \
+            ln -s /opt/python/cp38-cp38m/bin/ninja /usr/bin/ninja && \
             cmake -BBuild . -DCMAKE_INSTALL_PREFIX=/install \
                             -DKokkos_ENABLE_${{ matrix.exec_model }}=ON \
                             -DKokkos_ENABLE_DEPRECATION_WARNINGS=OFF \
@@ -119,7 +119,7 @@ jobs:
         kokkos_version: ${{ fromJson(needs.set_wheel_build_matrix.outputs.kokkos_version) }}
         container_img: ["quay.io/pypa/manylinux2014_ppc64le"]
 
-    name: ubuntu-latest::ppc64le (Python ${{ fromJson('{ "cp37-*":"3.7","cp38-*":"3.8","cp39-*":"3.9","cp310-*":"3.10" }')[matrix.cibw_build] }})
+    name: ubuntu-latest::ppc64le (Python ${{ fromJson('{ "cp37-*":"3.7","cp38-*":"3.8","cp39-*":"3.9","cp310-*":"3.10","cp311-*":"3.11" }')[matrix.cibw_build] }})
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/wheel_linux_ppc64le.yml
+++ b/.github/workflows/wheel_linux_ppc64le.yml
@@ -143,7 +143,7 @@ jobs:
           cp -rf ${{ github.workspace }}/Kokkos_install/${{ matrix.exec_model }}/* Kokkos/
 
       - name: Install cibuildwheel
-        run: python3 -m pip install cibuildwheel==2.8.1
+        run: python3 -m pip install cibuildwheel==2.11.2
 
       - uses: docker/setup-qemu-action@v2
         name: Set up QEMU

--- a/.github/workflows/wheel_linux_x86_64.yml
+++ b/.github/workflows/wheel_linux_x86_64.yml
@@ -148,7 +148,7 @@ jobs:
           yum update -y && yum install -y docker
 
       - name: Install cibuildwheel
-        run: python3.8 -m pip install cibuildwheel==2.11.2
+        run: python3.8 -m pip install cibuildwheel~=2.11.0
 
       - name: Build wheels
         env:

--- a/.github/workflows/wheel_linux_x86_64.yml
+++ b/.github/workflows/wheel_linux_x86_64.yml
@@ -1,7 +1,7 @@
 name: Wheel::Linux::x86_64
 
 # **What it does**: Builds python wheels for Linux (ubuntu-latest) architecture x86_64 and store it as artifacts.
-#                   Python versions: 3.7, 3.8, 3.9, 3.10.
+#                   Python versions: 3.7, 3.8, 3.9, 3.10, 3.11.
 # **Why we have it**: To build wheels for pennylane-lightning installation.
 # **Who does it impact**: Wheels to be uploaded to PyPI.
 
@@ -115,7 +115,7 @@ jobs:
         kokkos_version: ${{ fromJson(needs.set_wheel_build_matrix.outputs.kokkos_version) }}
         container_img: ["quay.io/pypa/manylinux2014_x86_64"]
 
-    name: ${{ matrix.os }} (Python ${{ fromJson('{ "cp37-*":"3.7","cp38-*":"3.8","cp39-*":"3.9","cp310-*":"3.10" }')[matrix.cibw_build] }})
+    name: ${{ matrix.os }} (Python ${{ fromJson('{ "cp37-*":"3.7","cp38-*":"3.8","cp39-*":"3.9","cp310-*":"3.10","cp311-*":"3.11" }')[matrix.cibw_build] }})
     runs-on: ${{ matrix.os }}
     container: ${{ matrix.container_img }}
 
@@ -148,7 +148,7 @@ jobs:
           yum update -y && yum install -y docker
 
       - name: Install cibuildwheel
-        run: python3.7 -m pip install cibuildwheel==2.8.1
+        run: python3.8 -m pip install cibuildwheel==2.8.1
 
       - name: Build wheels
         env:
@@ -181,7 +181,7 @@ jobs:
 
           CIBW_BUILD_VERBOSITY: 3
 
-        run: python3.7 -m cibuildwheel --output-dir wheelhouse
+        run: python3.8 -m cibuildwheel --output-dir wheelhouse
 
       - uses: actions-ecosystem/action-regex-match@v2
         id: rc_build

--- a/.github/workflows/wheel_linux_x86_64.yml
+++ b/.github/workflows/wheel_linux_x86_64.yml
@@ -148,7 +148,7 @@ jobs:
           yum update -y && yum install -y docker
 
       - name: Install cibuildwheel
-        run: python3.8 -m pip install cibuildwheel==2.8.1
+        run: python3.8 -m pip install cibuildwheel==2.11.2
 
       - name: Build wheels
         env:

--- a/.github/workflows/wheel_linux_x86_64.yml
+++ b/.github/workflows/wheel_linux_x86_64.yml
@@ -5,6 +5,9 @@ name: Wheel::Linux::x86_64
 # **Why we have it**: To build wheels for pennylane-lightning installation.
 # **Who does it impact**: Wheels to be uploaded to PyPI.
 
+env:
+  GCC_VERSION: 11
+
 on:
   pull_request:
   push:
@@ -49,7 +52,7 @@ jobs:
       - name: Install dependencies (Ubuntu)
         if: ${{ (matrix.container_img == 'ubuntu-latest') && (steps.kokkos-cache.outputs.cache-hit != 'true') }}
         run: |
-          apt-get update && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get -y -q install cmake gcc-11 g++-11 ninja-build git
+          apt-get update && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get -y -q install cmake gcc-$GCC_VERSION g++-$GCC_VERSION ninja-build git
           echo "COMPILER=g++-11" >> $GITHUB_ENV
 
       - name: Install dependencies (CentOS)

--- a/.github/workflows/wheel_linux_x86_64.yml
+++ b/.github/workflows/wheel_linux_x86_64.yml
@@ -162,6 +162,7 @@ jobs:
           CIBW_BEFORE_BUILD: |
             cat /etc/yum.conf | sed "s/\[main\]/\[main\]\ntimeout=5/g" > /etc/yum.conf
             pip install ninja cmake
+            pip install setuptools --upgrade
             yum clean all -y
             yum install centos-release-scl-rh -y
             yum install devtoolset-11-gcc-c++ -y

--- a/.github/workflows/wheel_linux_x86_64.yml
+++ b/.github/workflows/wheel_linux_x86_64.yml
@@ -162,7 +162,6 @@ jobs:
           CIBW_BEFORE_BUILD: |
             cat /etc/yum.conf | sed "s/\[main\]/\[main\]\ntimeout=5/g" > /etc/yum.conf
             pip install ninja cmake
-            pip install setuptools --upgrade
             yum clean all -y
             yum install centos-release-scl-rh -y
             yum install devtoolset-11-gcc-c++ -y

--- a/.github/workflows/wheel_macos_arm64.yml
+++ b/.github/workflows/wheel_macos_arm64.yml
@@ -76,7 +76,7 @@ jobs:
           python-version: '3.8'
 
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.11.2
+        run: python -m pip install cibuildwheel~=2.11.0
 
       - name: Build wheels
         env:

--- a/.github/workflows/wheel_macos_arm64.yml
+++ b/.github/workflows/wheel_macos_arm64.yml
@@ -1,7 +1,7 @@
 name: Wheel::MacOS::ARM
 
 # **What it does**: Builds python wheels for MacOS (11) architecture ARM 64 and store it as artifacts.
-#                   Python versions: 3.8, 3.9, 3.10.
+#                   Python versions: 3.8, 3.9, 3.10, 3.11.
 # **Why we have it**: To build wheels for pennylane-lightning installation.
 # **Who does it impact**: Wheels to be uploaded to PyPI.
 
@@ -16,7 +16,7 @@ on:
 env:
   ARCHS: 'arm64'
   PYTHON3_MIN_VERSION: "8"
-  PYTHON3_MAX_VERSION: "10"
+  PYTHON3_MAX_VERSION: "11"
 
 jobs:
   mac-set-matrix-arm:
@@ -58,7 +58,7 @@ jobs:
         arch: [arm64]
         cibw_build: ${{fromJson(needs.mac-set-matrix-arm.outputs.python_version)}}
 
-    name: macos-latest::arm64 (Python ${{ fromJson('{ "cp38-*":"3.8","cp39-*":"3.9","cp310-*":"3.10" }')[matrix.cibw_build] }})
+    name: macos-latest::arm64 (Python ${{ fromJson('{ "cp38-*":"3.8","cp39-*":"3.9","cp310-*":"3.10","cp311-*":"3.10" }')[matrix.cibw_build] }})
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/wheel_macos_arm64.yml
+++ b/.github/workflows/wheel_macos_arm64.yml
@@ -76,7 +76,7 @@ jobs:
           python-version: '3.8'
 
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.8.1
+        run: python -m pip install cibuildwheel==2.11.2
 
       - name: Build wheels
         env:

--- a/.github/workflows/wheel_macos_arm64.yml
+++ b/.github/workflows/wheel_macos_arm64.yml
@@ -58,7 +58,7 @@ jobs:
         arch: [arm64]
         cibw_build: ${{fromJson(needs.mac-set-matrix-arm.outputs.python_version)}}
 
-    name: macos-latest::arm64 (Python ${{ fromJson('{ "cp38-*":"3.8","cp39-*":"3.9","cp310-*":"3.10","cp311-*":"3.10" }')[matrix.cibw_build] }})
+    name: macos-latest::arm64 (Python ${{ fromJson('{ "cp38-*":"3.8","cp39-*":"3.9","cp310-*":"3.10","cp311-*":"3.11" }')[matrix.cibw_build] }})
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/wheel_macos_arm64.yml
+++ b/.github/workflows/wheel_macos_arm64.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Checkout PennyLane-Lightning
         uses: actions/checkout@v3
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         name: Install Python
         with:
           python-version: '3.8'

--- a/.github/workflows/wheel_macos_x86_64.yml
+++ b/.github/workflows/wheel_macos_x86_64.yml
@@ -146,7 +146,7 @@ jobs:
           python-version: '3.8'
 
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.11.2
+        run: python -m pip install cibuildwheel~=2.11.0
 
       - name: Build wheels
         env:

--- a/.github/workflows/wheel_macos_x86_64.yml
+++ b/.github/workflows/wheel_macos_x86_64.yml
@@ -64,7 +64,7 @@ jobs:
           git checkout ${{ matrix.kokkos_version }}
           cd -
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         name: Install Python
         with:
           python-version: '3.8'
@@ -140,7 +140,7 @@ jobs:
           mkdir Kokkos
           cp -rf ${{ github.workspace }}/Kokkos_install/${{ matrix.exec_model }}/* Kokkos/
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         name: Install Python
         with:
           python-version: '3.8'

--- a/.github/workflows/wheel_macos_x86_64.yml
+++ b/.github/workflows/wheel_macos_x86_64.yml
@@ -146,7 +146,7 @@ jobs:
           python-version: '3.8'
 
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.8.1
+        run: python -m pip install cibuildwheel==2.11.2
 
       - name: Build wheels
         env:

--- a/.github/workflows/wheel_macos_x86_64.yml
+++ b/.github/workflows/wheel_macos_x86_64.yml
@@ -1,7 +1,7 @@
 name: Wheel::MacOS::Intel
 
 # **What it does**: Builds python wheels for MacOS (10.15) architecture x86_64 and store it as artifacts.
-#                   Python versions: 3.7, 3.8, 3.9, 3.10.
+#                   Python versions: 3.7, 3.8, 3.9, 3.10, 3.11.
 # **Why we have it**: To build wheels for pennylane-lightning installation.
 # **Who does it impact**: Wheels to be uploaded to PyPI.
 
@@ -67,7 +67,7 @@ jobs:
       - uses: actions/setup-python@v2
         name: Install Python
         with:
-          python-version: '3.7'
+          python-version: '3.8'
 
       - name: Build Kokkos core library
         if: steps.kokkos-cache.outputs.cache-hit != 'true'
@@ -117,7 +117,7 @@ jobs:
         exec_model: ${{ fromJson(needs.set_wheel_build_matrix.outputs.exec_model) }}
         kokkos_version: ${{ fromJson(needs.set_wheel_build_matrix.outputs.kokkos_version) }}
 
-    name: ${{ matrix.os }} (Python ${{ fromJson('{ "cp37-*":"3.7","cp38-*":"3.8","cp39-*":"3.9","cp310-*":"3.10" }')[matrix.cibw_build] }})
+    name: ${{ matrix.os }} (Python ${{ fromJson('{ "cp37-*":"3.7","cp38-*":"3.8","cp39-*":"3.9","cp310-*":"3.10","cp311-*":"3.11" }')[matrix.cibw_build] }})
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -143,7 +143,7 @@ jobs:
       - uses: actions/setup-python@v2
         name: Install Python
         with:
-          python-version: '3.7'
+          python-version: '3.8'
 
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel==2.8.1

--- a/.github/workflows/wheel_noarch.yml
+++ b/.github/workflows/wheel_noarch.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           path: main
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: '3.7'
 

--- a/.github/workflows/wheel_win_x86_64.yml
+++ b/.github/workflows/wheel_win_x86_64.yml
@@ -1,7 +1,7 @@
 name: Wheel::Windows::x86_64
 
 # **What it does**: Builds python wheels for Windows (windows-latest) and store it as artifacts.
-#                   Python versions: 3.7, 3.8, 3.9, 3.10.
+#                   Python versions: 3.7, 3.8, 3.9, 3.10, 3.11.
 # **Why we have it**: To build wheels for pennylane-lightning installation.
 # **Who does it impact**: Wheels to be uploaded to PyPI.
 
@@ -110,7 +110,7 @@ jobs:
         cibw_build: ${{ fromJson(needs.set_wheel_build_matrix.outputs.python_version) }}
         exec_model: ${{ fromJson(needs.set_wheel_build_matrix.outputs.exec_model) }}
         kokkos_version: ${{ fromJson(needs.set_wheel_build_matrix.outputs.kokkos_version) }}
-    name: ${{ matrix.os }} (Python ${{ fromJson('{ "cp37-*":"3.7","cp38-*":"3.8","cp39-*":"3.9","cp310-*":"3.10" }')[matrix.cibw_build] }})
+    name: ${{ matrix.os }} (Python ${{ fromJson('{ "cp37-*":"3.7","cp38-*":"3.8","cp39-*":"3.9","cp310-*":"3.10","cp311-*":"3.11" }')[matrix.cibw_build] }})
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/wheel_win_x86_64.yml
+++ b/.github/workflows/wheel_win_x86_64.yml
@@ -135,7 +135,7 @@ jobs:
                     -Destination "D:\a\pennylane-lightning\pennylane-lightning\Kokkos" -Recurse -Force
 
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.8.1
+        run: python -m pip install cibuildwheel==2.11.2
 
       - name: Build wheels
         env:

--- a/.github/workflows/wheel_win_x86_64.yml
+++ b/.github/workflows/wheel_win_x86_64.yml
@@ -135,7 +135,7 @@ jobs:
                     -Destination "D:\a\pennylane-lightning\pennylane-lightning\Kokkos" -Recurse -Force
 
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.11.2
+        run: python -m pip install cibuildwheel~=2.11.0
 
       - name: Build wheels
         env:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,7 @@ set(CMAKE_POLICY_DEFAULT_CMP0127 NEW) # To suppress pybind11 CMP0127 warning
 include(FetchContent)
 FetchContent_Declare(pybind11
                      GIT_REPOSITORY https://github.com/pybind/pybind11.git
-                     GIT_TAG        v2.6.2
+                     GIT_TAG        v2.10.1
 )
 FetchContent_MakeAvailable(pybind11)
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -29,10 +29,10 @@ RUN apt-get update \
     python3-pip \
     python3-venv \
     python3-dev \
-    gcc-10 g++-10 cpp-10 \
+    gcc-11 g++-11 cpp-11 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
-    && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 100 --slave /usr/bin/g++ g++ /usr/bin/g++-10 --slave /usr/bin/gcov gcov /usr/bin/gcov-10 \
+    && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 100 --slave /usr/bin/g++ g++ /usr/bin/g++-11 --slave /usr/bin/gcov gcov /usr/bin/gcov-10 \
     && /usr/sbin/update-ccache-symlinks \
     && mkdir /opt/ccache \
     && ccache --set-config=cache_dir=/opt/ccache \

--- a/pennylane_lightning/_version.py
+++ b/pennylane_lightning/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.27.0-dev12"
+__version__ = "0.27.0-dev13"

--- a/setup.py
+++ b/setup.py
@@ -162,6 +162,7 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Scientific/Engineering :: Physics",
 ]


### PR DESCRIPTION
**Context:** This PR enables the generation of wheels for python 3.11. 
Also, we are updating the python version of CI/CD workflows from 3.7 to 3.8.

**Description of the Change:**

**Benefits:**
- Provide wheels for python 3.11.
- Faster CI/CD workflows with python 3.8.

**Possible Drawbacks:**

**Related GitHub Issues:**
