### PR TITLE
Improve the stopping condition method

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ### Improvements
 
+* Improve the stopping condition method.
+[(#386)](https://github.com/PennyLaneAI/pennylane-lightning/pull/386)
+
 ### Documentation
 
 ### Bug fixes
@@ -13,6 +16,8 @@
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
+
+Amintor Dusko
 
 ---
 

--- a/pennylane_lightning/_version.py
+++ b/pennylane_lightning/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.28.0-dev"
+__version__ = "0.28.1-dev"

--- a/pennylane_lightning/lightning_qubit.py
+++ b/pennylane_lightning/lightning_qubit.py
@@ -197,13 +197,13 @@ class LightningQubit(QubitDevice):
         and observable) and returns ``True`` if supported by the device."""
 
         def accepts_obj(obj):
-            if obj.name == "QFT" and len(obj.wires) >= 10:
-                return False
-            if obj.name == "GroverOperator" and len(obj.wires) >= 13:
-                return False
-            if getattr(obj, "has_matrix", False):
-                return not (qml.operation.is_trainable(obj))
-            return obj.name in self.observables.union(self.operations)
+            if obj.name == "QFT" and len(obj.wires) < 10:
+                return True
+            if obj.name == "GroverOperator" and len(obj.wires) < 13:
+                return True
+            return not isinstance(obj, qml.tape.QuantumTape) and getattr(
+                self, "supports_operation", lambda name: False
+            )(obj.name)
 
         return qml.BooleanFn(accepts_obj)
 

--- a/pennylane_lightning/lightning_qubit.py
+++ b/pennylane_lightning/lightning_qubit.py
@@ -201,7 +201,7 @@ class LightningQubit(QubitDevice):
                 return True
             if obj.name == "GroverOperator" and len(obj.wires) < 13:
                 return True
-            return not isinstance(obj, qml.tape.QuantumTape) and getattr(
+            return (not isinstance(obj, qml.tape.QuantumTape)) and getattr(
                 self, "supports_operation", lambda name: False
             )(obj.name)
 

--- a/tests/test_adjoint_jacobian.py
+++ b/tests/test_adjoint_jacobian.py
@@ -866,7 +866,7 @@ def test_tape_qchem(tol):
         circuit_ansatz(params, wires=range(4))
         return qml.expval(H)
 
-    params = np.linspace(0,29,30) * 0.111
+    params = np.linspace(0, 29, 30) * 0.111
 
     dev_lq = qml.device("lightning.qubit", wires=qubits)
     dev_dq = qml.device("default.qubit", wires=qubits)

--- a/tests/test_adjoint_jacobian.py
+++ b/tests/test_adjoint_jacobian.py
@@ -855,7 +855,7 @@ def circuit_ansatz(params, wires):
 
 
 @pytest.mark.skipif(not lq._CPP_BINARY_AVAILABLE, reason="Lightning binary required")
-def test__tape_qchem(tol):
+def test_tape_qchem(tol):
     """Tests the circuit Ansatz with a QChem Hamiltonian produces correct results"""
 
     H, qubits = qml.qchem.molecular_hamiltonian(
@@ -866,10 +866,10 @@ def test__tape_qchem(tol):
         circuit_ansatz(params, wires=range(4))
         return qml.expval(H)
 
-    params = np.arange(30) * 0.111
+    params = np.linspace(0,29,30) * 0.111
 
-    dev_lq = qml.device("lightning.qubit", wires=4)
-    dev_dq = qml.device("default.qubit", wires=4)
+    dev_lq = qml.device("lightning.qubit", wires=qubits)
+    dev_dq = qml.device("default.qubit", wires=qubits)
 
     circuit_lq = qml.QNode(circuit, dev_lq, diff_method="adjoint")
     circuit_dq = qml.QNode(circuit, dev_dq, diff_method="parameter-shift")

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -1,0 +1,81 @@
+# Copyright 2022 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Integration tests for the execute method of the :mod:`pennylane_lightning.LightningQubit` device.
+"""
+import pytest
+
+import pennylane as qml
+from pennylane import numpy as np
+
+@pytest.mark.parametrize("diff_method", ("param_shift", "finite_diff"))
+class TestQChem:
+    """Test tapes returning the expectation values of a Hamiltonian, with a qchem workflow. """
+
+    def test_VQE_gradients(self, diff_method, tol):
+        """Test if the VQE procedure returns the expected gradients."""
+
+        symbols = ["H", "H"]
+
+        geometry = np.array([[-0.676411907, 0.000000000, 0.000000000],
+                            [0.676411907,  0.000000000, 0.000000000]], requires_grad = False)
+
+        mol = qml.qchem.Molecule(symbols, geometry, basis_name = 'STO-3G')
+
+        H, qubits = qml.qchem.molecular_hamiltonian(
+                symbols,
+                geometry,
+                basis='STO-3G',
+            )
+
+        singles, doubles = qml.qchem.excitations(mol.n_electrons, len(H.wires))
+
+        excitations = singles + doubles
+
+        num_params = len(singles + doubles)
+        params = np.zeros(num_params, requires_grad=True)
+
+        hf_state = qml.qchem.hf_state(mol.n_electrons, qubits)
+
+        with qml.tape.QuantumTape() as tape:
+            qml.BasisState(hf_state, wires=range(qubits))
+
+            for i, excitation in enumerate(excitations):
+                if len(excitation) == 4:
+                    qml.DoubleExcitation(params[i], wires=excitation)
+                elif len(excitation) == 2:
+                    qml.SingleExcitation(params[i], wires=excitation)
+
+            qml.expval(H)
+
+        num_params = len(excitations)
+        tape.trainable_params = np.linspace(1, num_params, num_params, dtype=int).tolist()
+
+        gradient_tapes, fn_grad = getattr(qml.gradients, diff_method)(tape)
+
+        dev_l = qml.device("lightning.qubit", wires=qubits)
+        dev_d = qml.device("default.qubit", wires=qubits)
+
+        def dev_l_execute(t):
+            dev = qml.device("lightning.qubit", wires=qubits)
+            return dev.execute(t)
+
+        grad_dev_l = fn_grad([dev_l_execute(t) for t in gradient_tapes])
+        grad_qml_l = fn_grad(qml.execute(gradient_tapes, dev_l))
+
+        grad_qml_d = fn_grad(qml.execute(gradient_tapes, dev_d))
+
+        assert np.allclose(grad_dev_l, grad_qml_l, tol)
+        assert np.allclose(grad_dev_l, grad_qml_d, tol)
+

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -12,32 +12,35 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Integration tests for the execute method of the :mod:`pennylane_lightning.LightningQubit` device.
+Integration tests for the ``execute`` method of LightningQubit.
 """
 import pytest
 
 import pennylane as qml
 from pennylane import numpy as np
 
+
 @pytest.mark.parametrize("diff_method", ("param_shift", "finite_diff"))
 class TestQChem:
-    """Test tapes returning the expectation values of a Hamiltonian, with a qchem workflow. """
+    """Test tapes returning the expectation values of a Hamiltonian, with a qchem workflow."""
 
     def test_VQE_gradients(self, diff_method, tol):
         """Test if the VQE procedure returns the expected gradients."""
 
         symbols = ["H", "H"]
 
-        geometry = np.array([[-0.676411907, 0.000000000, 0.000000000],
-                            [0.676411907,  0.000000000, 0.000000000]], requires_grad = False)
+        geometry = np.array(
+            [[-0.676411907, 0.000000000, 0.000000000], [0.676411907, 0.000000000, 0.000000000]],
+            requires_grad=False,
+        )
 
-        mol = qml.qchem.Molecule(symbols, geometry, basis_name = 'STO-3G')
+        mol = qml.qchem.Molecule(symbols, geometry, basis_name="STO-3G")
 
         H, qubits = qml.qchem.molecular_hamiltonian(
-                symbols,
-                geometry,
-                basis='STO-3G',
-            )
+            symbols,
+            geometry,
+            basis="STO-3G",
+        )
 
         singles, doubles = qml.qchem.excitations(mol.n_electrons, len(H.wires))
 
@@ -78,4 +81,3 @@ class TestQChem:
 
         assert np.allclose(grad_dev_l, grad_qml_l, tol)
         assert np.allclose(grad_dev_l, grad_qml_d, tol)
-


### PR DESCRIPTION
**Context:**
Improve the `stopping_condition` method, and expand tests to cover tape execution.

**Description of the Change:**

- Refactor `stopping_condition` to rely on the `supports_operation` method.
- Expand tests, to cover tape execution.

**Benefits:**
Operations will only be decomposed if not supported by Lightning.

**Possible Drawbacks:**

**Related GitHub Issues:**
