### PR TITLE
Pin the CMAKE version

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -10,9 +10,14 @@
 
 ### Bug fixes
 
+- Pin CMake to 3.24.x in wheel-builder to avoid Python not found error in CMake 3.25, when building wheels for PennyLane-Lightning-GPU.
+[(#387)](https://github.com/PennyLaneAI/pennylane-lightning/pull/387)
+
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
+
+Amintor Dusko
 
 ---
 

--- a/.github/workflows/wheel_linux_aarch64.yml
+++ b/.github/workflows/wheel_linux_aarch64.yml
@@ -159,7 +159,7 @@ jobs:
           # Python build settings
           CIBW_BEFORE_BUILD: |
             cat /etc/yum.conf | sed "s/\[main\]/\[main\]\ntimeout=5/g" > /etc/yum.conf
-            pip install ninja cmake
+            pip install ninja cmake~=3.24.0
 
           CIBW_MANYLINUX_AARCH64_IMAGE: manylinux2014
 

--- a/.github/workflows/wheel_linux_ppc64le.yml
+++ b/.github/workflows/wheel_linux_ppc64le.yml
@@ -159,7 +159,7 @@ jobs:
           # Python build settings
           CIBW_BEFORE_BUILD: |
             cat /etc/yum.conf | sed "s/\[main\]/\[main\]\ntimeout=5/g" > /etc/yum.conf
-            pip install ninja cmake
+            pip install ninja cmake~=3.24.0
 
           CIBW_MANYLINUX_PPC64LE_IMAGE: manylinux2014
 

--- a/.github/workflows/wheel_linux_x86_64.yml
+++ b/.github/workflows/wheel_linux_x86_64.yml
@@ -164,7 +164,7 @@ jobs:
           # Python build settings
           CIBW_BEFORE_BUILD: |
             cat /etc/yum.conf | sed "s/\[main\]/\[main\]\ntimeout=5/g" > /etc/yum.conf
-            pip install ninja cmake
+            pip install ninja cmake~=3.24.0
             yum clean all -y
             yum install centos-release-scl-rh -y
             yum install devtoolset-11-gcc-c++ -y

--- a/.github/workflows/wheel_macos_arm64.yml
+++ b/.github/workflows/wheel_macos_arm64.yml
@@ -88,7 +88,7 @@ jobs:
 
           # Python build settings
           CIBW_BEFORE_BUILD: |
-            pip install pybind11 ninja cmake
+            pip install pybind11 ninja cmake~=3.24.0
 
           # Testing of built wheels
           CIBW_TEST_REQUIRES: numpy~=1.21 scipy pytest pytest-cov pytest-mock flaky

--- a/.github/workflows/wheel_macos_x86_64.yml
+++ b/.github/workflows/wheel_macos_x86_64.yml
@@ -160,7 +160,7 @@ jobs:
 
           # Python build settings
           CIBW_BEFORE_BUILD: |
-            pip install pybind11 ninja cmake
+            pip install pybind11 ninja cmake~=3.24.0
 
           # Testing of built wheels
           CIBW_TEST_REQUIRES: numpy~=1.21 scipy pytest pytest-cov pytest-mock flaky

--- a/.github/workflows/wheel_win_x86_64.yml
+++ b/.github/workflows/wheel_win_x86_64.yml
@@ -145,7 +145,7 @@ jobs:
 
           # Python build settings
           CIBW_BEFORE_BUILD: |
-            pip install pybind11 cmake
+            pip install pybind11 cmake~=3.24.0
 
           # Testing of built wheels
           CIBW_TEST_REQUIRES: numpy~=1.21 scipy pytest pytest-cov pytest-mock flaky

--- a/pennylane_lightning/_version.py
+++ b/pennylane_lightning/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.28.1-dev"
+__version__ = "0.28.1-dev1"

--- a/pennylane_lightning/_version.py
+++ b/pennylane_lightning/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.28.0-dev"
+__version__ = "0.28.1-dev"

--- a/pennylane_lightning/_version.py
+++ b/pennylane_lightning/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.28.1-dev1"
+__version__ = "0.28.0-dev3"


### PR DESCRIPTION
**Context:**
Pin CMake to 3.24.x in wheel-builder to avoid Python not found error in CMake 3.25, when building wheels for PennyLane-Lightning-GPU.

**Description of the Change:**
All wheels are [consistently](https://github.com/PennyLaneAI/pennylane-lightning-gpu/pull/75) pinned to the same CMAKE version.

**Benefits:**
When building Linux wheels for PennyLane-Lightning-GPU, the building process will have a consistent CMAKE version throughout the suite.

**Possible Drawbacks:**

**Related GitHub Issues:**
