### PR TITLE
Update builder shield

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -10,7 +10,12 @@
 
 ### Bug fixes
 
+* Fix Github shields in README.
+[(#402)](https://github.com/PennyLaneAI/pennylane-lightning/pull/402)
+
 ### Contributors
+
+Lee James O'Riordan, Chae-Yeun Park
 
 ---
 

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,14 @@
 PennyLane-Lightning Plugin
 ##########################
 
+.. image:: https://img.shields.io/github/actions/workflow/status/PennyLaneAI/pennylane-lightning/tests_linux.yml?branch=master&label=Test%20%28Linux%29&style=flat-square
+    :alt: GitHub Workflow Status (branch)
+    :target: https://github.com/PennyLaneAI/pennylane-lightning/actions/workflows/tests_linux.yml
+
+.. image:: https://img.shields.io/github/actions/workflow/status/PennyLaneAI/pennylane-lightning/tests_windows.yml?branch=master&label=Test%20%28Windows%29&style=flat-square
+    :alt: GitHub Workflow Status (branch)
+    :target: https://github.com/PennyLaneAI/pennylane-lightning/actions/workflows/tests_windows.yml
+
 .. image:: https://img.shields.io/github/actions/workflow/status/PennyLaneAI/pennylane-lightning/.github/workflows/wheel_linux_x86_64.yml?branch=master&logo=github&style=flat-square
     :alt: Linux x86_64 wheel builds (branch)
     :target: https://github.com/PennyLaneAI/pennylane-lightning/actions/workflows/wheel_linux_x86_64.yml?query=branch%3Amaster++

--- a/README.rst
+++ b/README.rst
@@ -2,11 +2,11 @@ PennyLane-Lightning Plugin
 ##########################
 
 .. image:: https://img.shields.io/github/actions/workflow/status/PennyLaneAI/pennylane-lightning/tests_linux.yml?branch=master&label=Test%20%28Linux%29&style=flat-square
-    :alt: GitHub Workflow Status (branch)
+    :alt: Linux x86_64 tests (branch)
     :target: https://github.com/PennyLaneAI/pennylane-lightning/actions/workflows/tests_linux.yml
 
 .. image:: https://img.shields.io/github/actions/workflow/status/PennyLaneAI/pennylane-lightning/tests_windows.yml?branch=master&label=Test%20%28Windows%29&style=flat-square
-    :alt: GitHub Workflow Status (branch)
+    :alt: Windows tests (branch)
     :target: https://github.com/PennyLaneAI/pennylane-lightning/actions/workflows/tests_windows.yml
 
 .. image:: https://img.shields.io/github/actions/workflow/status/PennyLaneAI/pennylane-lightning/.github/workflows/wheel_linux_x86_64.yml?branch=master&logo=github&style=flat-square

--- a/README.rst
+++ b/README.rst
@@ -1,9 +1,9 @@
 PennyLane-Lightning Plugin
 ##########################
 
-.. image:: https://img.shields.io/github/workflow/status/PennyLaneAI/pennylane-lightning/Testing/master?logo=github&style=flat-square
-    :alt: GitHub Workflow Status (branch)
-    :target: https://github.com/PennyLaneAI/pennylane-lightning/actions?query=workflow%3ATesting
+.. image:: https://img.shields.io/github/actions/workflow/status/PennyLaneAI/pennylane-lightning/.github/workflows/wheel_linux_x86_64.yml?branch=master&logo=github&style=flat-square
+    :alt: Linux x86_64 wheel builds (branch)
+    :target: https://github.com/PennyLaneAI/pennylane-lightning/actions/workflows/wheel_linux_x86_64.yml?query=branch%3Amaster++
 
 .. image:: https://img.shields.io/codecov/c/github/PennyLaneAI/pennylane-lightning/master.svg?logo=codecov&style=flat-square
     :alt: Codecov coverage

--- a/pennylane_lightning/_version.py
+++ b/pennylane_lightning/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.29.0-dev1"
+__version__ = "0.29.0-dev2"

--- a/pennylane_lightning/_version.py
+++ b/pennylane_lightning/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.29.0-dev0"
+__version__ = "0.29.0-dev1"


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [x] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [x] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [x] Ensure that the test suite passes, by running `make test`.

- [x] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [x] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:** Due to a recent change in the builder shield structure, the shield fails to report on the build status of the wheels. This updates the paths to the new required structures, and creates a Linux build status shield to be reported.


**Description of the Change:** Updates the shield path to check builds against the x86 Linux wheels.

**Benefits:** Fixes the broken shield, and provides more up-dated information on the master branch & wheel building status.

**Possible Drawbacks:** Build for Linux and Mac/Windows may diverge in time.

**Related GitHub Issues:**
