### PR TITLE
Downgrade Numpy to avoid conflicts

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -13,9 +13,12 @@
 * Fix Github shields in README.
 [(#402)](https://github.com/PennyLaneAI/pennylane-lightning/pull/402)
 
+* Limit Numpy version to avoid conflicts with Autograd.
+[(#410)](https://github.com/PennyLaneAI/pennylane-lightning/pull/410)
+
 ### Contributors
 
-Lee James O'Riordan, Chae-Yeun Park
+Amintor Dusko, Lee James O'Riordan, Chae-Yeun Park
 
 ---
 
@@ -24,7 +27,7 @@ Lee James O'Riordan, Chae-Yeun Park
 ### Bug fixes
 
 * Fix Python module versioning for Linux wheels.
-[(#407)](https://github.com/PennyLaneAI/pennylane-lightning/pull/407)
+[(#408)](https://github.com/PennyLaneAI/pennylane-lightning/pull/408)
 
 ### Contributors
 

--- a/.github/workflows/wheel_linux_x86_64.yml
+++ b/.github/workflows/wheel_linux_x86_64.yml
@@ -172,7 +172,7 @@ jobs:
 
           CIBW_ENVIRONMENT: PATH=/opt/rh/devtoolset-11/root/usr/bin:$PATH
           # Testing of built wheels
-          CIBW_TEST_REQUIRES: numpy~=1.21 scipy pytest pytest-cov pytest-mock flaky
+          CIBW_TEST_REQUIRES: numpy<1.24 scipy pytest pytest-cov pytest-mock flaky
 
           CIBW_BEFORE_TEST: |
             pip install git+https://github.com/PennyLaneAI/pennylane.git@master

--- a/.github/workflows/wheel_macos_arm64.yml
+++ b/.github/workflows/wheel_macos_arm64.yml
@@ -91,7 +91,7 @@ jobs:
             pip install pybind11 ninja cmake~=3.24.0
 
           # Testing of built wheels
-          CIBW_TEST_REQUIRES: numpy~=1.21 scipy pytest pytest-cov pytest-mock flaky
+          CIBW_TEST_REQUIRES: numpy<1.24 scipy pytest pytest-cov pytest-mock flaky
 
           CIBW_BEFORE_TEST: pip install git+https://github.com/PennyLaneAI/pennylane.git@master
 

--- a/.github/workflows/wheel_macos_x86_64.yml
+++ b/.github/workflows/wheel_macos_x86_64.yml
@@ -163,7 +163,7 @@ jobs:
             pip install pybind11 ninja cmake~=3.24.0
 
           # Testing of built wheels
-          CIBW_TEST_REQUIRES: numpy~=1.21 scipy pytest pytest-cov pytest-mock flaky
+          CIBW_TEST_REQUIRES: numpy<1.24 scipy pytest pytest-cov pytest-mock flaky
 
           CIBW_BEFORE_TEST: pip install git+https://github.com/PennyLaneAI/pennylane.git@master
 

--- a/.github/workflows/wheel_win_x86_64.yml
+++ b/.github/workflows/wheel_win_x86_64.yml
@@ -148,7 +148,7 @@ jobs:
             pip install pybind11 cmake~=3.24.0 build
 
           # Testing of built wheels
-          CIBW_TEST_REQUIRES: numpy~=1.21 scipy pytest pytest-cov pytest-mock flaky
+          CIBW_TEST_REQUIRES: numpy<1.24 scipy pytest pytest-cov pytest-mock flaky
 
           CIBW_BEFORE_TEST: |
             pip install git+https://github.com/PennyLaneAI/pennylane.git@master

--- a/.github/workflows/wheel_win_x86_64.yml
+++ b/.github/workflows/wheel_win_x86_64.yml
@@ -148,7 +148,7 @@ jobs:
             pip install pybind11 cmake~=3.24.0 build
 
           # Testing of built wheels
-          CIBW_TEST_REQUIRES: numpy<1.24 scipy pytest pytest-cov pytest-mock flaky
+          CIBW_TEST_REQUIRES: numpy~=1.23 scipy pytest pytest-cov pytest-mock flaky
 
           CIBW_BEFORE_TEST: |
             pip install git+https://github.com/PennyLaneAI/pennylane.git@master

--- a/pennylane_lightning/_version.py
+++ b/pennylane_lightning/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.29.0-dev2"
+__version__ = "0.29.0-dev3"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 ninja
 flaky
-numpy
+numpy<1.24
 git+https://github.com/PennyLaneAI/pennylane.git@master
 pybind11
 pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 ninja
 flaky
-numpy
+numpy<1.24
 pennylane~=0.26
 pybind11
 pytest

--- a/setup.py
+++ b/setup.py
@@ -115,7 +115,7 @@ with open(os.path.join("pennylane_lightning", "_version.py")) as f:
 
 requirements = [
     "ninja",
-    "numpy",
+    "numpy<1.24",
     "pennylane>=0.28",
 ]
 


### PR DESCRIPTION
**Context:** Numpy last minor version 1.24 has some conflicts with Autograd.

**Description of the Change:** For now we'll limit installation to Numpy < 1.24

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
