### PR TITLE
Remove unnecessary lines for resolving CodeCov issue

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -15,6 +15,9 @@
 * Update AVX2/512 kernel infrastructure for additional gate/generator operations.
 [(#404)](https://github.com/PennyLaneAI/pennylane-lightning/pull/404)
 
+* Remove unnecessary lines for resolving CodeCov issue.
+[(#415)](https://github.com/PennyLaneAI/pennylane-lightning/pull/415)
+
 ### Documentation
 
 ### Bug fixes

--- a/pennylane_lightning/_version.py
+++ b/pennylane_lightning/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.29.0-dev6"
+__version__ = "0.29.0-dev7"

--- a/pennylane_lightning/lightning_qubit.py
+++ b/pennylane_lightning/lightning_qubit.py
@@ -279,11 +279,6 @@ class LightningQubit(QubitDevice):
         state = self._asarray(state, dtype=self.C_DTYPE)
         output_shape = [2] * self.num_wires
 
-        if not qml.math.is_abstract(state):
-            norm = qml.math.linalg.norm(state, axis=-1, ord=2)
-            if not qml.math.allclose(norm, 1.0, atol=tolerance):
-                raise ValueError("Sum of amplitudes-squared does not equal one.")
-
         if len(device_wires) == self.num_wires and Wires(sorted(device_wires)) == device_wires:
             # Initialize the entire device state with the input state
             self._state = self._reshape(state, output_shape)


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [x] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [x] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [x] Ensure that the test suite passes, by running `make test`.

- [ ] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [x] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:** After https://github.com/PennyLaneAI/pennylane/pull/3685 is merged to PennyLane, checking the norm of a given state in `_apply_lightning` became unnecessary. This PR removes those lines.

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
