### PR TITLE
take the old permute_wires from pennylane

### DIFF
--- a/pennylane_lightning/_version.py
+++ b/pennylane_lightning/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.29.0-dev9"
+__version__ = "0.29.0-dev10"

--- a/pennylane_lightning/lightning_qubit.py
+++ b/pennylane_lightning/lightning_qubit.py
@@ -726,6 +726,12 @@ class LightningQubit(QubitDevice):
 
         return processing_fns
 
+    def _qubit_device_permute_wires(self, wires):
+        ordered_wires = self.order_wires(wires).tolist()
+        mapped_wires = list(self.map_wires(wires))
+        permutation = np.argsort(mapped_wires)
+        return Wires([ordered_wires[index] for index in permutation])
+
     def probability(self, wires=None, shot_range=None, bin_size=None):
         """Return the probability of each computational basis state.
 
@@ -747,8 +753,7 @@ class LightningQubit(QubitDevice):
         if self.shots is not None:
             return self.estimate_probability(wires=wires, shot_range=shot_range, bin_size=bin_size)
 
-        wires = wires or self.wires
-        wires = Wires(wires)
+        wires = self._qubit_device_permute_wires(Wires(wires)) if wires else self.wires
 
         # translate to wire labels used by device
         device_wires = self.map_wires(wires)


### PR DESCRIPTION
Original code [here](https://github.com/PennyLaneAI/pennylane/blob/da798a1c23eb359d8de697f2459705f058f8bb17/pennylane/_qubit_device.py#L192-L203).

### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [ ] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [ ] Ensure that the test suite passes, by running `make test`.

- [ ] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [ ] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
