### PR TITLE
Update import from Grouping to Pauli

### DIFF
--- a/pennylane_lightning/_serialize.py
+++ b/pennylane_lightning/_serialize.py
@@ -24,7 +24,7 @@ from pennylane import (
     QubitStateVector,
     Rot,
 )
-from pennylane.grouping import is_pauli_word
+from pennylane.pauli import is_pauli_word
 from pennylane.operation import Observable, Tensor
 from pennylane.tape import QuantumTape
 from pennylane.math import unwrap


### PR DESCRIPTION
**Context:** 
Removing the grouping module on the Pennylane core side requires updating this import in lightning to pauli 

**Description of the Change:**
update `from pennylane.grouping ...` to `from pennylane.pauli ...`