### PR TITLE
make compatible with new return types spec

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -7,7 +7,57 @@
 
 ### Breaking changes
 
+* Lightning now works with the new return types specification that is now default in PennyLane.
+  See [the PennyLane `qml.enable_return`](https://docs.pennylane.ai/en/stable/code/api/pennylane.enable_return.html?highlight=enable_return) documentation for more information on this change.
+  [(#427)](https://github.com/PennyLaneAI/pennylane-lightning/pull/427)
+
+Instead of creating potentially ragged numpy array, devices and `QNode`'s now return an object of the same type as that
+returned by the quantum function.
+
+```
+>>> dev = qml.device('lightning.qubit', wires=1)
+>>> @qml.qnode(dev, diff_method="adjoint")
+... def circuit(x):
+...     qml.RX(x, wires=0)
+...     return qml.expval(qml.PauliY(0)), qml.expval(qml.PauliZ(0))
+>>> x = qml.numpy.array(0.5)
+>>> circuit(qml.numpy.array(0.5))
+(array(-0.47942554), array(0.87758256))
+```
+
+Interfaces like Jax or Torch handle tuple outputs without issues:
+
+```
+>>> jax.jacobian(circuit)(jax.numpy.array(0.5))
+(Array(-0.87758255, dtype=float32, weak_type=True),
+Array(-0.47942555, dtype=float32, weak_type=True))
+```
+
+Autograd cannot differentiate an output tuple, so results must be converted to an array before
+use with `qml.jacobian`:
+
+```
+>>> qml.jacobian(lambda y: qml.numpy.array(circuit(y)))(x)
+array([-0.87758256, -0.47942554])
+```
+
+Alternatively, the quantum itself can return a numpy array of measurements:
+
+```
+>>> dev = qml.device('lightning.qubit', wires=1)
+>>> @qml.qnode(dev, diff_method="adjoint")
+>>> def circuit2(x):
+...     qml.RX(x, wires=0)
+...     return np.array([qml.expval(qml.PauliY(0)), qml.expval(qml.PauliZ(0))])
+>>> qml.jacobian(circuit2)(np.array(0.5))
+array([-0.87758256, -0.47942554])
+```
+
+
 ### Improvements
+
+* Lightning has been made compatible with the change in return types specification.
+  [(#427)](https://github.com/PennyLaneAI/pennylane-lightning/pull/427)
 
 ### Documentation
 
@@ -16,6 +66,8 @@
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
+
+Christina Lee
 
 ---
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -41,7 +41,7 @@ use with `qml.jacobian`:
 array([-0.87758256, -0.47942554])
 ```
 
-Alternatively, the quantum itself can return a numpy array of measurements:
+Alternatively, the quantum function itself can return a numpy array of measurements:
 
 ```
 >>> dev = qml.device('lightning.qubit', wires=1)

--- a/.github/workflows/wheel_macos_arm64.yml
+++ b/.github/workflows/wheel_macos_arm64.yml
@@ -88,7 +88,7 @@ jobs:
 
           # Python build settings
           CIBW_BEFORE_BUILD: |
-            pip install pybind11 ninja cmake~=3.24.0
+            pip install pybind11 ninja cmake~=3.24.0 setuptools
 
           # Testing of built wheels
           CIBW_TEST_REQUIRES: pytest pytest-cov pytest-mock flaky

--- a/.github/workflows/wheel_macos_x86_64.yml
+++ b/.github/workflows/wheel_macos_x86_64.yml
@@ -27,7 +27,7 @@ jobs:
     needs: [set_wheel_build_matrix]
     strategy:
       matrix:
-        os: [macos-11]
+        os: [macos-12]
         arch: [x86_64]
         exec_model: ${{ fromJson(needs.set_wheel_build_matrix.outputs.exec_model) }}
         kokkos_version: ${{ fromJson(needs.set_wheel_build_matrix.outputs.kokkos_version) }}
@@ -49,7 +49,8 @@ jobs:
           key: ${{ matrix.os }}-kokkos${{ matrix.kokkos_version }}-${{ matrix.exec_model }}
 
       - name: Install clang
-        run: brew install llvm
+        run: |
+          brew install libomp
 
       - name: Clone Kokkos libs
         if: steps.kokkos-cache.outputs.cache-hit != 'true'
@@ -82,7 +83,7 @@ jobs:
                           -DKokkos_ENABLE_DEPRECATION_WARNINGS=OFF \
                           -DCMAKE_CXX_STANDARD=20 \
                           -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
-                          -DCMAKE_CXX_COMPILER=$(brew --prefix llvm)/bin/clang++ \
+                          -DCMAKE_CXX_COMPILER=g++ \
                           -G Ninja
           cmake --build ./Build --verbose
           cmake --install ./Build
@@ -100,7 +101,7 @@ jobs:
                           -DCMAKE_CXX_STANDARD=20 \
                           -DCMAKE_PREFIX_PATH=${{ github.workspace}}/Kokkos_install/${{ matrix.exec_model }} \
                           -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
-                          -DCMAKE_CXX_COMPILER=$(brew --prefix llvm)/bin/clang++ \
+                          -DCMAKE_CXX_COMPILER=g++ \
                           -G Ninja
           cmake --build ./Build --verbose
           cmake --install ./Build
@@ -111,7 +112,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-11]
+        os: [macos-12]
         arch: [x86_64]
         cibw_build: ${{fromJson(needs.set_wheel_build_matrix.outputs.python_version)}}
         exec_model: ${{ fromJson(needs.set_wheel_build_matrix.outputs.exec_model) }}
@@ -156,16 +157,15 @@ jobs:
           CIBW_BEFORE_ALL_MACOS: |
             brew uninstall --force oclint
             brew install libomp
-            brew install llvm
 
           # Python build settings
           CIBW_BEFORE_BUILD: |
-            pip install pybind11 ninja cmake~=3.24.0
+            python -m pip install pybind11 ninja cmake~=3.24.0 setuptools
 
           # Testing of built wheels
           CIBW_TEST_REQUIRES: pytest pytest-cov pytest-mock flaky
 
-          CIBW_BEFORE_TEST: pip install git+https://github.com/PennyLaneAI/pennylane.git@master
+          CIBW_BEFORE_TEST: python -m pip install git+https://github.com/PennyLaneAI/pennylane.git@master
 
           CIBW_TEST_COMMAND: |
             pl-device-test --device=lightning.qubit --skip-ops -x --tb=short --no-flaky-report

--- a/pennylane_lightning/_version.py
+++ b/pennylane_lightning/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.30.0-dev1"
+__version__ = "0.30.0-dev2"

--- a/pennylane_lightning/lightning_qubit.py
+++ b/pennylane_lightning/lightning_qubit.py
@@ -532,7 +532,7 @@ class LightningQubit(QubitDevice):
 
         for op_idx, tp in enumerate(trainable_params):
             # get op_idx-th operator among differentiable operators
-            op, _, _ = tape.get_operation(op_idx, return_op_index=True)  
+            op, _, _ = tape.get_operation(op_idx, return_op_index=True)
             if isinstance(op, Operation) and not isinstance(op, (BasisState, QubitStateVector)):
                 # We now just ignore non-op or state preps
                 tp_shift.append(tp)
@@ -766,7 +766,10 @@ class LightningQubit(QubitDevice):
                 vjp = f(t)
 
                 # make sure vjp is iterable if using extend reduction
-                if not isinstance(vjp, tuple) and getattr(reduction, "__name__", reduction) == "extend":
+                if (
+                    not isinstance(vjp, tuple)
+                    and getattr(reduction, "__name__", reduction) == "extend"
+                ):
                     vjp = (vjp,)
 
                 if isinstance(reduction, str):

--- a/pennylane_lightning/lightning_qubit.py
+++ b/pennylane_lightning/lightning_qubit.py
@@ -531,9 +531,8 @@ class LightningQubit(QubitDevice):
         all_params = 0
 
         for op_idx, tp in enumerate(trainable_params):
-            op, _ = tape.get_operation(
-                op_idx
-            )  # get op_idx-th operator among differentiable operators
+            # get op_idx-th operator among differentiable operators
+            op, _, _ = tape.get_operation(op_idx, return_op_index=True)  
             if isinstance(op, Operation) and not isinstance(op, (BasisState, QubitStateVector)):
                 # We now just ignore non-op or state preps
                 tp_shift.append(tp)
@@ -611,7 +610,24 @@ class LightningQubit(QubitDevice):
         jac = jac.reshape(-1, len(trainable_params))
         jac_r = np.zeros((jac.shape[0], processed_data["all_params"]))
         jac_r[:, processed_data["record_tp_rows"]] = jac
-        return jac_r
+        return self._adjoint_jacobian_processing(jac_r) if qml.active_return() else jac_r
+
+    @staticmethod
+    def _adjoint_jacobian_processing(jac):
+        """
+        Post-process the Jacobian matrix returned by ``adjoint_jacobian`` for
+        the new return type system.
+        """
+        jac = np.squeeze(jac)
+
+        if jac.ndim == 0:
+            return np.array(jac)
+
+        if jac.ndim == 1:
+            return tuple(np.array(j) for j in jac)
+
+        # must be 2-dimensional
+        return tuple(tuple(np.array(j_) for j_ in j) for j in jac)
 
     def vjp(self, measurements, dy, starting_state=None, use_device_state=False):
         """Generate the processing function required to compute the vector-Jacobian products of a tape.
@@ -680,7 +696,7 @@ class LightningQubit(QubitDevice):
                 new_tape = tape.copy()
                 new_tape._measurements = [qml.expval(ham)]
 
-                return self.adjoint_jacobian(new_tape, starting_state, use_device_state).reshape(-1)
+                return self.adjoint_jacobian(new_tape, starting_state, use_device_state)
 
             return processing_fn
 
@@ -748,6 +764,10 @@ class LightningQubit(QubitDevice):
             vjps = []
             for t, f in zip(tapes, fns):
                 vjp = f(t)
+
+                # make sure vjp is iterable if using extend reduction
+                if not isinstance(vjp, tuple) and getattr(reduction, "__name__", reduction) == "extend":
+                    vjp = (vjp,)
 
                 if isinstance(reduction, str):
                     getattr(vjps, reduction)(vjp)

--- a/tests/test_adjoint_jacobian.py
+++ b/tests/test_adjoint_jacobian.py
@@ -146,10 +146,13 @@ class TestAdjointJacobian:
     def test_pauli_rotation_gradient(self, G, theta, dev):
         """Tests that the automatic gradients of Pauli rotations are correct."""
 
-        random_state = np.array([0.43593284-0.02945156j, 0.40812291+0.80158023j], requires_grad=False)
+        random_state = np.array(
+            [0.43593284 - 0.02945156j, 0.40812291 + 0.80158023j], requires_grad=False
+        )
 
-        tape = qml.tape.QuantumScript([G(theta, 0)], [qml.expval(qml.PauliZ(0))],
-            [qml.QubitStateVector(random_state, 0)])
+        tape = qml.tape.QuantumScript(
+            [G(theta, 0)], [qml.expval(qml.PauliZ(0))], [qml.QubitStateVector(random_state, 0)]
+        )
 
         tape.trainable_params = {1}
 
@@ -425,12 +428,10 @@ class TestAdjointJacobian:
 
         x, y, z = [0.5, 0.3, -0.7]
 
-        tape = qml.tape.QuantumScript([
-            qml.RX(0.4, wires=[0]),
-            qml.Rot(x, y, z, wires=[0]),
-            qml.RY(-0.2, wires=[0])],
-            [qml.expval(qml.PauliZ(0))])
-
+        tape = qml.tape.QuantumScript(
+            [qml.RX(0.4, wires=[0]), qml.Rot(x, y, z, wires=[0]), qml.RY(-0.2, wires=[0])],
+            [qml.expval(qml.PauliZ(0))],
+        )
 
         tape.trainable_params = {1, 2, 3}
 
@@ -452,11 +453,10 @@ class TestAdjointJacobian:
         """Tests that gates with multiple free parameters yield correct gradients."""
         x, y, z = [0.5, 0.3, -0.7]
 
-        tape = qml.tape.QuantumScript([
-            qml.RX(0.4, wires=[0]),
-            qml.Rot(x, y, z, wires=[0]),
-            qml.RY(-0.2, wires=[0])],
-            [qml.expval(qml.Hermitian([[0, 1], [1, 1]], wires=0))])
+        tape = qml.tape.QuantumScript(
+            [qml.RX(0.4, wires=[0]), qml.Rot(x, y, z, wires=[0]), qml.RY(-0.2, wires=[0])],
+            [qml.expval(qml.Hermitian([[0, 1], [1, 1]], wires=0))],
+        )
 
         tape.trainable_params = {1, 2, 3}
 
@@ -483,11 +483,10 @@ class TestAdjointJacobian:
             [1.0, 0.3, 0.3], [qml.PauliX(0) @ qml.PauliX(1), qml.PauliZ(0), qml.PauliZ(1)]
         )
 
-        tape = qml.tape.QuantumScript([
-            qml.RX(0.4, wires=[0]),
-            qml.Rot(x, y, z, wires=[0]),
-            qml.RY(-0.2, wires=[0])],
-            [qml.expval(ham)])
+        tape = qml.tape.QuantumScript(
+            [qml.RX(0.4, wires=[0]), qml.Rot(x, y, z, wires=[0]), qml.RY(-0.2, wires=[0])],
+            [qml.expval(ham)],
+        )
 
         tape.trainable_params = {1, 2, 3}
 

--- a/tests/test_adjoint_jacobian.py
+++ b/tests/test_adjoint_jacobian.py
@@ -146,10 +146,10 @@ class TestAdjointJacobian:
     def test_pauli_rotation_gradient(self, G, theta, dev):
         """Tests that the automatic gradients of Pauli rotations are correct."""
 
-        with qml.tape.QuantumTape() as tape:
-            qml.QubitStateVector(np.array([1.0, -1.0]) / np.sqrt(2), wires=0)
-            G(theta, wires=[0])
-            qml.expval(qml.PauliZ(0))
+        random_state = np.array([0.43593284-0.02945156j, 0.40812291+0.80158023j], requires_grad=False)
+
+        tape = qml.tape.QuantumScript([G(theta, 0)], [qml.expval(qml.PauliZ(0))],
+            [qml.QubitStateVector(random_state, 0)])
 
         tape.trainable_params = {1}
 
@@ -161,7 +161,7 @@ class TestAdjointJacobian:
         # compare to finite differences
         tapes, fn = qml.gradients.finite_diff(tape, h=h)
         numeric_val = fn(qml.execute(tapes, dev, None))
-        assert np.allclose(calculated_val, numeric_val[0][2], atol=tol, rtol=0)
+        assert np.allclose(calculated_val, numeric_val, atol=tol, rtol=0)
 
     @pytest.mark.parametrize("theta", np.linspace(-2 * np.pi, 2 * np.pi, 7))
     def test_Rot_gradient(self, theta, dev):
@@ -171,7 +171,7 @@ class TestAdjointJacobian:
         params = np.array([theta, theta**3, np.sqrt(2) * theta])
 
         with qml.tape.QuantumTape() as tape:
-            qml.QubitStateVector(np.array([1.0, -1.0]) / np.sqrt(2), wires=0)
+            qml.QubitStateVector(np.array([1.0, -1.0], requires_grad=False) / np.sqrt(2), wires=0)
             qml.Rot(*params, wires=[0])
             qml.expval(qml.PauliZ(0))
 
@@ -185,7 +185,7 @@ class TestAdjointJacobian:
         # compare to finite differences
         tapes, fn = qml.gradients.finite_diff(tape, h=h)
         numeric_val = fn(qml.execute(tapes, dev, None))
-        assert np.allclose(calculated_val, numeric_val[0][2:], atol=tol, rtol=0)
+        assert np.allclose(calculated_val, numeric_val, atol=tol, rtol=0)
 
     @pytest.mark.parametrize("par", [1, -2, 1.623, -0.051, 0])  # integers, floats, zero
     def test_ry_gradient(self, par, tol, dev):
@@ -425,11 +425,12 @@ class TestAdjointJacobian:
 
         x, y, z = [0.5, 0.3, -0.7]
 
-        with qml.tape.QuantumTape() as tape:
-            qml.RX(0.4, wires=[0])
-            qml.Rot(x, y, z, wires=[0])
-            qml.RY(-0.2, wires=[0])
-            qml.expval(qml.PauliZ(0))
+        tape = qml.tape.QuantumScript([
+            qml.RX(0.4, wires=[0]),
+            qml.Rot(x, y, z, wires=[0]),
+            qml.RY(-0.2, wires=[0])],
+            [qml.expval(qml.PauliZ(0))])
+
 
         tape.trainable_params = {1, 2, 3}
 
@@ -441,7 +442,8 @@ class TestAdjointJacobian:
         grad_F = fn(qml.execute(tapes, dev, None))
 
         # gradient has the correct shape and every element is nonzero
-        assert grad_D.shape == (1, 3)
+        assert len(grad_D) == 3
+        assert all(isinstance(v, np.ndarray) for v in grad_D)
         assert np.count_nonzero(grad_D) == 3
         # the different methods agree
         assert np.allclose(grad_D, grad_F, atol=tol, rtol=0)
@@ -450,11 +452,11 @@ class TestAdjointJacobian:
         """Tests that gates with multiple free parameters yield correct gradients."""
         x, y, z = [0.5, 0.3, -0.7]
 
-        with qml.tape.QuantumTape() as tape:
-            qml.RX(0.4, wires=[0])
-            qml.Rot(x, y, z, wires=[0])
-            qml.RY(-0.2, wires=[0])
-            qml.expval(qml.Hermitian([[0, 1], [1, 1]], wires=0))
+        tape = qml.tape.QuantumScript([
+            qml.RX(0.4, wires=[0]),
+            qml.Rot(x, y, z, wires=[0]),
+            qml.RY(-0.2, wires=[0])],
+            [qml.expval(qml.Hermitian([[0, 1], [1, 1]], wires=0))])
 
         tape.trainable_params = {1, 2, 3}
 
@@ -466,7 +468,8 @@ class TestAdjointJacobian:
         grad_F = fn(qml.execute(tapes, dev, None))
 
         # gradient has the correct shape and every element is nonzero
-        assert grad_D.shape == (1, 3)
+        assert len(grad_D) == 3
+        assert all(isinstance(v, np.ndarray) for v in grad_D)
         assert np.count_nonzero(grad_D) == 3
         # the different methods agree
         assert np.allclose(grad_D, grad_F, atol=tol, rtol=0)
@@ -480,11 +483,11 @@ class TestAdjointJacobian:
             [1.0, 0.3, 0.3], [qml.PauliX(0) @ qml.PauliX(1), qml.PauliZ(0), qml.PauliZ(1)]
         )
 
-        with qml.tape.QuantumTape() as tape:
-            qml.RX(0.4, wires=[0])
-            qml.Rot(x, y, z, wires=[0])
-            qml.RY(-0.2, wires=[0])
-            qml.expval(ham)
+        tape = qml.tape.QuantumScript([
+            qml.RX(0.4, wires=[0]),
+            qml.Rot(x, y, z, wires=[0]),
+            qml.RY(-0.2, wires=[0])],
+            [qml.expval(ham)])
 
         tape.trainable_params = {1, 2, 3}
 
@@ -496,7 +499,8 @@ class TestAdjointJacobian:
         grad_F = fn(qml.execute(tapes, dev, None))
 
         # gradient has the correct shape and every element is nonzero
-        assert grad_D.shape == (1, 3)
+        assert len(grad_D) == 3
+        assert all(isinstance(v, np.ndarray) for v in grad_D)
         assert np.count_nonzero(grad_D) == 3
         # the different methods agree
         assert np.allclose(grad_D, grad_F, atol=tol, rtol=0)
@@ -912,8 +916,14 @@ def test_integration(returns):
     qnode_def = qml.QNode(circuit, dev_def)
     qnode_lightning = qml.QNode(circuit, dev_lightning, diff_method="adjoint")
 
-    j_def = qml.jacobian(qnode_def)(params)
-    j_lightning = qml.jacobian(qnode_lightning)(params)
+    def casted_to_array_def(params):
+        return np.array(qnode_def(params))
+
+    def casted_to_array_lightning(params):
+        return np.array(qnode_lightning(params))
+
+    j_def = qml.jacobian(casted_to_array_def)(params)
+    j_lightning = qml.jacobian(casted_to_array_lightning)(params)
 
     assert np.allclose(j_def, j_lightning)
 
@@ -936,9 +946,18 @@ def test_integration_chunk_observables():
     qnode_lightning = qml.QNode(circuit, dev_lightning, diff_method="adjoint")
     qnode_lightning_batched = qml.QNode(circuit, dev_lightning_batched, diff_method="adjoint")
 
-    j_def = qml.jacobian(qnode_def)(params)
-    j_lightning = qml.jacobian(qnode_lightning)(params)
-    j_lightning_batched = qml.jacobian(qnode_lightning_batched)(params)
+    def casted_to_array_def(params):
+        return np.array(qnode_def(params))
+
+    def casted_to_array_lightning(params):
+        return np.array(qnode_lightning(params))
+
+    def casted_to_array_batched(params):
+        return np.array(qnode_lightning_batched(params))
+
+    j_def = qml.jacobian(casted_to_array_def)(params)
+    j_lightning = qml.jacobian(casted_to_array_lightning)(params)
+    j_lightning_batched = qml.jacobian(casted_to_array_batched)(params)
 
     assert np.allclose(j_def, j_lightning)
     assert np.allclose(j_def, j_lightning_batched)
@@ -984,7 +1003,13 @@ def test_integration_custom_wires(returns):
     qnode_def = qml.QNode(circuit, dev_def)
     qnode_lightning = qml.QNode(circuit, dev_lightning, diff_method="adjoint")
 
-    j_def = qml.jacobian(qnode_def)(params)
-    j_lightning = qml.jacobian(qnode_lightning)(params)
+    def casted_to_array_def(params):
+        return np.array(qnode_def(params))
+
+    def casted_to_array_lightning(params):
+        return np.array(qnode_lightning(params))
+
+    j_def = qml.jacobian(casted_to_array_def)(params)
+    j_lightning = qml.jacobian(casted_to_array_lightning)(params)
 
     assert np.allclose(j_def, j_lightning)

--- a/tests/test_adjoint_jacobian.py
+++ b/tests/test_adjoint_jacobian.py
@@ -158,11 +158,10 @@ class TestAdjointJacobian:
 
         calculated_val = dev.adjoint_jacobian(tape)
 
-        h = 2e-3 if dev.R_DTYPE == np.float32 else 1e-7
         tol = 1e-3 if dev.R_DTYPE == np.float32 else 1e-7
 
         # compare to finite differences
-        tapes, fn = qml.gradients.finite_diff(tape, h=h)
+        tapes, fn = qml.gradients.param_shift(tape)
         numeric_val = fn(qml.execute(tapes, dev, None))
         assert np.allclose(calculated_val, numeric_val, atol=tol, rtol=0)
 
@@ -182,11 +181,10 @@ class TestAdjointJacobian:
 
         calculated_val = dev.adjoint_jacobian(tape)
 
-        h = 2e-3 if dev.R_DTYPE == np.float32 else 1e-7
         tol = 1e-3 if dev.R_DTYPE == np.float32 else 1e-7
 
         # compare to finite differences
-        tapes, fn = qml.gradients.finite_diff(tape, h=h)
+        tapes, fn = qml.gradients.param_shift(tape)
         numeric_val = fn(qml.execute(tapes, dev, None))
         assert np.allclose(calculated_val, numeric_val, atol=tol, rtol=0)
 
@@ -366,12 +364,9 @@ class TestAdjointJacobian:
 
         tape.trainable_params = set(range(1, 1 + op.num_params))
 
-        h = 2e-3 if dev.R_DTYPE == np.float32 else 1e-7
         tol = 1e-3 if dev.R_DTYPE == np.float32 else 1e-7
 
-        grad_F = (lambda t, fn: fn(qml.execute(t, dev, None)))(
-            *qml.gradients.finite_diff(tape, h=h)
-        )
+        grad_F = (lambda t, fn: fn(qml.execute(t, dev, None)))(*qml.gradients.param_shift(tape))
         grad_D = dev.adjoint_jacobian(tape)
 
         assert np.allclose(grad_D, grad_F, atol=tol, rtol=0)
@@ -413,12 +408,9 @@ class TestAdjointJacobian:
 
         tape.trainable_params = set(range(1, 1 + op.num_params))
 
-        h = 1e-3 if dev.R_DTYPE == np.float32 else 1e-7
         tol = 1e-3 if dev.R_DTYPE == np.float32 else 1e-7
 
-        grad_F = (lambda t, fn: fn(qml.execute(t, dev, None)))(
-            *qml.gradients.finite_diff(tape, h=h)
-        )
+        grad_F = (lambda t, fn: fn(qml.execute(t, dev, None)))(*qml.gradients.param_shift(tape))
         grad_D = dev.adjoint_jacobian(tape)
 
         assert np.allclose(grad_D, grad_F, atol=tol, rtol=0)
@@ -435,11 +427,10 @@ class TestAdjointJacobian:
 
         tape.trainable_params = {1, 2, 3}
 
-        h = 2e-3 if dev.R_DTYPE == np.float32 else 1e-7
         tol = 1e-3 if dev.R_DTYPE == np.float32 else 1e-7
 
         grad_D = dev.adjoint_jacobian(tape)
-        tapes, fn = qml.gradients.finite_diff(tape, h=h)
+        tapes, fn = qml.gradients.param_shift(tape)
         grad_F = fn(qml.execute(tapes, dev, None))
 
         # gradient has the correct shape and every element is nonzero
@@ -460,11 +451,10 @@ class TestAdjointJacobian:
 
         tape.trainable_params = {1, 2, 3}
 
-        h = 2e-3 if dev.R_DTYPE == np.float32 else 1e-7
         tol = 1e-3 if dev.R_DTYPE == np.float32 else 1e-7
 
         grad_D = dev.adjoint_jacobian(tape)
-        tapes, fn = qml.gradients.finite_diff(tape, h=h)
+        tapes, fn = qml.gradients.param_shift(tape)
         grad_F = fn(qml.execute(tapes, dev, None))
 
         # gradient has the correct shape and every element is nonzero
@@ -490,11 +480,10 @@ class TestAdjointJacobian:
 
         tape.trainable_params = {1, 2, 3}
 
-        h = 2e-3 if dev.R_DTYPE == np.float32 else 1e-7
         tol = 1e-3 if dev.R_DTYPE == np.float32 else 1e-7
 
         grad_D = dev.adjoint_jacobian(tape)
-        tapes, fn = qml.gradients.finite_diff(tape, h=h)
+        tapes, fn = qml.gradients.param_shift(tape)
         grad_F = fn(qml.execute(tapes, dev, None))
 
         # gradient has the correct shape and every element is nonzero


### PR DESCRIPTION
**Context:**

With Pennylane PR #3957: https://github.com/PennyLaneAI/pennylane/pull/3957 , the new return types system is enabled by default.

To make sure lightning works with pennylane master, we need to change the return shape from `adjoint_jacobian`. The return shape from `execute` in handled inside `QubitDevice`.

**Description of the Change:**

The changes to the source code are:

* Change the output of `adjoint_jacobian` to match the new nested tuples specification
* Change use of `tape.get_parameters` to eliminate deprecation warning
* Remove reshape in vjp as it is no longer necessary
* Wrap the vjp in a tuple if it is not already a tuple and `reduction="extend"` is requested.

The changes to the tests are:

* change expected shape in a couple places
* switch `finite_diff` to `param_shift`, as finite diff was causing errors with float32
* Cast output to a numpy array from a tuple when using autograd, as autograd cannot differentiate a tuple

**Benefits:**
It works with PennyLane master.

**Possible Drawbacks:**
None

**Related GitHub Issues:**
None


