### PR TITLE
Validate all wheels with twine check after building

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -56,6 +56,9 @@ array([-0.87758256, -0.47942554])
 
 ### Improvements
 
+* Lightning wheels are now checked with `twine check` post-creation for PyPI compatibility.
+  [(#430)](https://github.com/PennyLaneAI/pennylane-lightning/pull/430)
+
 * Lightning has been made compatible with the change in return types specification.
   [(#427)](https://github.com/PennyLaneAI/pennylane-lightning/pull/427)
 

--- a/.github/workflows/wheel_linux_aarch64.yml
+++ b/.github/workflows/wheel_linux_aarch64.yml
@@ -169,8 +169,8 @@ jobs:
 
       - name: Validate wheels
         run: |
-          python -m pip install twine
-          python -m twine check ./wheelhouse/*.whl
+         python3 -m pip install twine
+         python3 -m twine check ./wheelhouse/*.whl
 
       - uses: actions-ecosystem/action-regex-match@v2
         id: rc_build

--- a/.github/workflows/wheel_linux_aarch64.yml
+++ b/.github/workflows/wheel_linux_aarch64.yml
@@ -167,6 +167,11 @@ jobs:
 
         run: python3 -m cibuildwheel --output-dir wheelhouse
 
+      - name: Validate wheels
+        run: |
+          python -m pip install twine
+          python -m twine check ./wheelhouse/*.whl
+
       - uses: actions-ecosystem/action-regex-match@v2
         id: rc_build
         with:

--- a/.github/workflows/wheel_linux_ppc64le.yml
+++ b/.github/workflows/wheel_linux_ppc64le.yml
@@ -167,6 +167,11 @@ jobs:
 
         run: python3 -m cibuildwheel --output-dir wheelhouse
 
+      - name: Validate wheels
+        run: |
+          python -m pip install twine
+          python -m twine check ./wheelhouse/*.whl
+
       - uses: actions-ecosystem/action-regex-match@v2
         id: rc_build
         with:

--- a/.github/workflows/wheel_linux_ppc64le.yml
+++ b/.github/workflows/wheel_linux_ppc64le.yml
@@ -169,8 +169,8 @@ jobs:
 
       - name: Validate wheels
         run: |
-          python -m pip install twine
-          python -m twine check ./wheelhouse/*.whl
+          python3 -m pip install twine
+          python3 -m twine check ./wheelhouse/*.whl
 
       - uses: actions-ecosystem/action-regex-match@v2
         id: rc_build

--- a/.github/workflows/wheel_linux_x86_64.yml
+++ b/.github/workflows/wheel_linux_x86_64.yml
@@ -186,6 +186,11 @@ jobs:
 
         run: python3.8 -m cibuildwheel --output-dir wheelhouse
 
+      - name: Validate wheels
+        run: |
+          python -m pip install twine
+          python -m twine check ./wheelhouse/*.whl
+
       - uses: actions-ecosystem/action-regex-match@v2
         id: rc_build
         with:

--- a/.github/workflows/wheel_linux_x86_64.yml
+++ b/.github/workflows/wheel_linux_x86_64.yml
@@ -188,8 +188,8 @@ jobs:
 
       - name: Validate wheels
         run: |
-          python -m pip install twine
-          python -m twine check ./wheelhouse/*.whl
+          python3.8 -m pip install twine
+          python3.8 -m twine check ./wheelhouse/*.whl
 
       - uses: actions-ecosystem/action-regex-match@v2
         id: rc_build

--- a/.github/workflows/wheel_macos_arm64.yml
+++ b/.github/workflows/wheel_macos_arm64.yml
@@ -105,6 +105,11 @@ jobs:
         run: |
           python -m cibuildwheel --output-dir wheelhouse
 
+      - name: Validate wheels
+        run: |
+          python -m pip install twine
+          python -m twine check ./wheelhouse/*.whl
+
       - uses: actions/upload-artifact@v2
         if: ${{ github.event_name == 'release' || github.ref == 'refs/heads/master' }}
         with:

--- a/.github/workflows/wheel_macos_x86_64.yml
+++ b/.github/workflows/wheel_macos_x86_64.yml
@@ -179,6 +179,11 @@ jobs:
         run: |
           python -m cibuildwheel --output-dir wheelhouse
 
+      - name: Validate wheels
+        run: |
+          python -m pip install twine
+          python -m twine check ./wheelhouse/*.whl
+
       - uses: actions-ecosystem/action-regex-match@v2
         id: rc_build
         with:

--- a/.github/workflows/wheel_noarch.yml
+++ b/.github/workflows/wheel_noarch.yml
@@ -42,6 +42,11 @@ jobs:
         env:
           SKIP_COMPILATION: True
 
+      - name: Validate wheels
+        run: |
+          python -m pip install twine
+          python -m twine check ./wheelhouse/*.whl
+
       - uses: actions/upload-artifact@v2
         if: ${{ github.event_name == 'release' || github.ref == 'refs/heads/master' }}
         with:

--- a/.github/workflows/wheel_noarch.yml
+++ b/.github/workflows/wheel_noarch.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Validate wheels
         run: |
           python -m pip install twine
-          python -m twine check ./wheelhouse/*.whl
+          python -m twine check .main/dist/*.whl
 
       - uses: actions/upload-artifact@v2
         if: ${{ github.event_name == 'release' || github.ref == 'refs/heads/master' }}

--- a/.github/workflows/wheel_noarch.yml
+++ b/.github/workflows/wheel_noarch.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Validate wheels
         run: |
           python -m pip install twine
-          python -m twine check .main/dist/*.whl
+          python -m twine check main/dist/*.whl
 
       - uses: actions/upload-artifact@v2
         if: ${{ github.event_name == 'release' || github.ref == 'refs/heads/master' }}

--- a/.github/workflows/wheel_win_x86_64.yml
+++ b/.github/workflows/wheel_win_x86_64.yml
@@ -182,6 +182,11 @@ jobs:
           }
           cd ..
 
+      - name: Validate wheels
+        run: |
+          python -m pip install twine
+          python -m twine check ./wheelhouse/*.whl
+
       - uses: actions-ecosystem/action-regex-match@v2
         id: rc_build
         with:

--- a/pennylane_lightning/_version.py
+++ b/pennylane_lightning/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.30.0-dev2"
+__version__ = "0.30.0-dev3"


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [x] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [x] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [x] Ensure that the test suite passes, by running `make test`.

- [x] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [x] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:** To avoid creating wheels that are incompatible with PyPI, we should validate all wheels post build to ensure they can be safely uploaded when ready.

**Description of the Change:** Adds a `twine check` command to validate each wheel after the CIBuildWheel step completes.

**Benefits:** Ensures the wheels are PyPI compatible.

**Possible Drawbacks:**

**Related GitHub Issues:**
