### PR TITLE
Replace set-output

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -75,7 +75,7 @@ array([-0.87758256, -0.47942554])
 
 This release contains contributions from (in alphabetical order):
 
-Christina Lee
+Chae-Yeun Park, Christina Lee, Lee James O'Riordan, Vincent Michaud-Rioux
 
 ---
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -53,8 +53,10 @@ Alternatively, the quantum function itself can return a numpy array of measureme
 array([-0.87758256, -0.47942554])
 ```
 
-
 ### Improvements
+
+* Remove deprecated `set-output` commands from workflow files.
+  [(#437)](https://github.com/PennyLaneAI/pennylane-lightning/pull/437)
 
 * Lightning wheels are now checked with `twine check` post-creation for PyPI compatibility.
   [(#430)](https://github.com/PennyLaneAI/pennylane-lightning/pull/430)

--- a/.github/workflows/build_and_cache_Kokkos_linux.yml
+++ b/.github/workflows/build_and_cache_Kokkos_linux.yml
@@ -30,11 +30,11 @@ jobs:
 
       - name: Kokkos execution strategy
         id: exec_model
-        run: echo "::set-output name=exec_model::[\"SERIAL\"]" # We may also adopt [OPENMP, THREADS] in later iterations
+        run: echo "{exec_model}={[\"SERIAL\"]}" >> $GITHUB_OUTPUT # We may also adopt [OPENMP, THREADS] in later iterations
 
       - name: Kokkos version
         id: kokkos_version
-        run: echo "::set-output name=kokkos_version::[\"3.7.00\"]"
+        run: echo "{kokkos_version}={[\"3.7.00\"]}" >> $GITHUB_OUTPUT
 
     outputs:
       exec_model: ${{ steps.exec_model.outputs.exec_model }}

--- a/.github/workflows/build_and_cache_Kokkos_linux.yml
+++ b/.github/workflows/build_and_cache_Kokkos_linux.yml
@@ -30,11 +30,11 @@ jobs:
 
       - name: Kokkos execution strategy
         id: exec_model
-        run: echo "{exec_model}={[\"SERIAL\"]}" >> $GITHUB_OUTPUT # We may also adopt [OPENMP, THREADS] in later iterations
+        run: echo "exec_model=[\"SERIAL\"]" >> $GITHUB_OUTPUT # We may also adopt [OPENMP, THREADS] in later iterations
 
       - name: Kokkos version
         id: kokkos_version
-        run: echo "{kokkos_version}={[\"3.7.00\"]}" >> $GITHUB_OUTPUT
+        run: echo "kokkos_version=[\"3.7.00\"]" >> $GITHUB_OUTPUT
 
     outputs:
       exec_model: ${{ steps.exec_model.outputs.exec_model }}

--- a/.github/workflows/set_wheel_build_matrix.yml
+++ b/.github/workflows/set_wheel_build_matrix.yml
@@ -1,5 +1,9 @@
 name: Set wheel build matrix
 
+env:
+  PYTHON3_MIN_VERSION: "8"
+  PYTHON3_MAX_VERSION: "11"
+  
 on:
   workflow_call:
     inputs:
@@ -34,9 +38,13 @@ jobs:
         id: pyver
         run: |
           if [[ ${{ inputs.event_name }} == 'pull_request' ]]; then
-            echo "{python_version}={[\"cp38-*\", \"cp311-*\"]}" >> $GITHUB_OUTPUT
+            echo "{python_version}={$(python3 scripts/gen_pyver_matrix.py \
+              --min-version=3.${{ env.PYTHON3_MIN_VERSION }} \
+              --max-version=3.${{ env.PYTHON3_MAX_VERSION }})}" >> $GITHUB_OUTPUT
           else
-            echo "{python_version}={[\"cp38-*\", \"cp39-*\", \"cp310-*\", \"cp311-*\"]}" >> $GITHUB_OUTPUT
+            echo "{python_version}={$(python3 scripts/gen_pyver_matrix.py \
+              --min-version=3.${{ env.PYTHON3_MIN_VERSION }} \
+              --max-version=3.${{ env.PYTHON3_MAX_VERSION }} --range)}" >> $GITHUB_OUTPUT
           fi
 
       - name: Kokkos execution strategy

--- a/.github/workflows/set_wheel_build_matrix.yml
+++ b/.github/workflows/set_wheel_build_matrix.yml
@@ -1,9 +1,5 @@
 name: Set wheel build matrix
 
-env:
-  PYTHON3_MIN_VERSION: "8"
-  PYTHON3_MAX_VERSION: "11"
-
 on:
   workflow_call:
     inputs:
@@ -38,23 +34,18 @@ jobs:
         id: pyver
         run: |
           if [[ ${{ inputs.event_name }} == 'pull_request' ]]; then
-            echo "::set-output name=python_version::$(python3 scripts/gen_pyver_matrix.py \
-              --min-version=3.${{ env.PYTHON3_MIN_VERSION }} \
-              --max-version=3.${{ env.PYTHON3_MAX_VERSION }})"
+            echo "{python_version}={[\"cp38-*\", \"cp311-*\"]}" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=python_version::$(python3 scripts/gen_pyver_matrix.py \
-              --min-version=3.${{ env.PYTHON3_MIN_VERSION }} \
-              --max-version=3.${{ env.PYTHON3_MAX_VERSION }} \
-              --range)"
+            echo "{python_version}={[\"cp38-*\", \"cp39-*\", \"cp310-*\", \"cp311-*\"]}" >> $GITHUB_OUTPUT
           fi
 
       - name: Kokkos execution strategy
         id: exec_model
-        run: echo "::set-output name=exec_model::[\"SERIAL\"]" # We may also adopt [OPENMP, THREADS] in later iterations
+        run: echo "{exec_model}=[\"SERIAL\"]" >> $GITHUB_OUTPUT # We may also adopt [OPENMP, THREADS] in later iterations
 
       - name: Kokkos version
         id: kokkos_version
-        run: echo "::set-output name=kokkos_version::[\"3.7.00\"]"
+        run: echo "{kokkos_version}=[\"3.7.00\"]" >> $GITHUB_OUTPUT
 
     outputs:
       python_version: ${{ steps.pyver.outputs.python_version }}

--- a/.github/workflows/set_wheel_build_matrix.yml
+++ b/.github/workflows/set_wheel_build_matrix.yml
@@ -38,22 +38,22 @@ jobs:
         id: pyver
         run: |
           if [[ ${{ inputs.event_name }} == 'pull_request' ]]; then
-            echo "{python_version}={$(python3 scripts/gen_pyver_matrix.py \
+            echo "python_version=$(python3 scripts/gen_pyver_matrix.py \
               --min-version=3.${{ env.PYTHON3_MIN_VERSION }} \
-              --max-version=3.${{ env.PYTHON3_MAX_VERSION }})}" >> $GITHUB_OUTPUT
+              --max-version=3.${{ env.PYTHON3_MAX_VERSION }})" >> $GITHUB_OUTPUT
           else
-            echo "{python_version}={$(python3 scripts/gen_pyver_matrix.py \
+            echo "python_version=$(python3 scripts/gen_pyver_matrix.py \
               --min-version=3.${{ env.PYTHON3_MIN_VERSION }} \
-              --max-version=3.${{ env.PYTHON3_MAX_VERSION }} --range)}" >> $GITHUB_OUTPUT
+              --max-version=3.${{ env.PYTHON3_MAX_VERSION }} --range)" >> $GITHUB_OUTPUT
           fi
 
       - name: Kokkos execution strategy
         id: exec_model
-        run: echo "{exec_model}=[\"SERIAL\"]" >> $GITHUB_OUTPUT # We may also adopt [OPENMP, THREADS] in later iterations
+        run: echo "exec_model=[\"SERIAL\"]" >> $GITHUB_OUTPUT # We may also adopt [OPENMP, THREADS] in later iterations
 
       - name: Kokkos version
         id: kokkos_version
-        run: echo "{kokkos_version}=[\"3.7.00\"]" >> $GITHUB_OUTPUT
+        run: echo "kokkos_version=[\"3.7.00\"]" >> $GITHUB_OUTPUT
 
     outputs:
       python_version: ${{ steps.pyver.outputs.python_version }}

--- a/.github/workflows/set_wheel_build_matrix.yml
+++ b/.github/workflows/set_wheel_build_matrix.yml
@@ -3,7 +3,7 @@ name: Set wheel build matrix
 env:
   PYTHON3_MIN_VERSION: "8"
   PYTHON3_MAX_VERSION: "11"
-  
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/tests_windows.yml
+++ b/.github/workflows/tests_windows.yml
@@ -69,11 +69,11 @@ jobs:
 
       - name: Kokkos execution strategy
         id: exec_model
-        run: echo "{exec_model}={[\"SERIAL\"]}" >> $GITHUB_OUTPUT # We may also adopt [OPENMP, THREADS] in later iterations
+        run: echo "exec_model=[\"SERIAL\"]" >> $GITHUB_OUTPUT # We may also adopt [OPENMP, THREADS] in later iterations
 
       - name: Kokkos version
         id: kokkos_version
-        run: echo "{kokkos_version}={[\"3.7.00\"]}" >> $GITHUB_OUTPUT
+        run: echo "kokkos_version=[\"3.7.00\"]" >> $GITHUB_OUTPUT
 
     outputs:
       exec_model: ${{ steps.exec_model.outputs.exec_model }}

--- a/.github/workflows/tests_windows.yml
+++ b/.github/workflows/tests_windows.yml
@@ -69,11 +69,11 @@ jobs:
 
       - name: Kokkos execution strategy
         id: exec_model
-        run: echo "::set-output name=exec_model::[\"SERIAL\"]" # We may also adopt [OPENMP, THREADS] in later iterations
+        run: echo "{exec_model}={[\"SERIAL\"]}" >> $GITHUB_OUTPUT # We may also adopt [OPENMP, THREADS] in later iterations
 
       - name: Kokkos version
         id: kokkos_version
-        run: echo "::set-output name=kokkos_version::[\"3.7.00\"]"
+        run: echo "{kokkos_version}={[\"3.7.00\"]}" >> $GITHUB_OUTPUT
 
     outputs:
       exec_model: ${{ steps.exec_model.outputs.exec_model }}

--- a/.github/workflows/wheel_macos_arm64.yml
+++ b/.github/workflows/wheel_macos_arm64.yml
@@ -15,8 +15,6 @@ on:
 
 env:
   ARCHS: 'arm64'
-  PYTHON3_MIN_VERSION: "8"
-  PYTHON3_MAX_VERSION: "11"
 
 jobs:
   mac-set-matrix-arm:
@@ -35,15 +33,10 @@ jobs:
       - name: Python version
         id: pyver
         run: |
-          if [[ ${{ github.event_name }} == 'pull_request' ]]; then
-            echo "::set-output name=python_version::$(python3 scripts/gen_pyver_matrix.py \
-              --min-version=3.${{ env.PYTHON3_MIN_VERSION }} \
-              --max-version=3.${{ env.PYTHON3_MAX_VERSION }})"
+          if [[ ${{ inputs.event_name }} == 'pull_request' ]]; then
+            echo "{python_version}={[\"cp38-*\", \"cp311-*\"]}" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=python_version::$(python3 scripts/gen_pyver_matrix.py \
-              --min-version=3.${{ env.PYTHON3_MIN_VERSION }} \
-              --max-version=3.${{ env.PYTHON3_MAX_VERSION }} \
-              --range)"
+            echo "{python_version}={[\"cp38-*\", \"cp39-*\", \"cp310-*\", \"cp311-*\"]}" >> $GITHUB_OUTPUT
           fi
 
     outputs:

--- a/.github/workflows/wheel_macos_arm64.yml
+++ b/.github/workflows/wheel_macos_arm64.yml
@@ -36,13 +36,13 @@ jobs:
         id: pyver
         run: |
           if [[ ${{ github.event_name }} == 'pull_request' ]]; then
-            echo "{python_version}={$(python3 scripts/gen_pyver_matrix.py \
+            echo "python_version=$(python3 scripts/gen_pyver_matrix.py \
               --min-version=3.${{ env.PYTHON3_MIN_VERSION }} \
-              --max-version=3.${{ env.PYTHON3_MAX_VERSION }})}" >> $GITHUB_OUTPUT
+              --max-version=3.${{ env.PYTHON3_MAX_VERSION }})" >> $GITHUB_OUTPUT
           else
-            echo "{python_version}={$(python3 scripts/gen_pyver_matrix.py \
+            echo "python_version=$(python3 scripts/gen_pyver_matrix.py \
               --min-version=3.${{ env.PYTHON3_MIN_VERSION }} \
-              --max-version=3.${{ env.PYTHON3_MAX_VERSION }} --range)}" >> $GITHUB_OUTPUT
+              --max-version=3.${{ env.PYTHON3_MAX_VERSION }} --range)" >> $GITHUB_OUTPUT
           fi
 
     outputs:

--- a/.github/workflows/wheel_macos_arm64.yml
+++ b/.github/workflows/wheel_macos_arm64.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Python version
         id: pyver
         run: |
-          if [[ ${{ inputs.event_name }} == 'pull_request' ]]; then
+          if [[ ${{ github.event_name }} == 'pull_request' ]]; then
             echo "{python_version}={[\"cp38-*\", \"cp311-*\"]}" >> $GITHUB_OUTPUT
           else
             echo "{python_version}={[\"cp38-*\", \"cp39-*\", \"cp310-*\", \"cp311-*\"]}" >> $GITHUB_OUTPUT

--- a/.github/workflows/wheel_macos_arm64.yml
+++ b/.github/workflows/wheel_macos_arm64.yml
@@ -15,6 +15,8 @@ on:
 
 env:
   ARCHS: 'arm64'
+  PYTHON3_MIN_VERSION: "8"
+  PYTHON3_MAX_VERSION: "11"
 
 jobs:
   mac-set-matrix-arm:
@@ -34,9 +36,13 @@ jobs:
         id: pyver
         run: |
           if [[ ${{ github.event_name }} == 'pull_request' ]]; then
-            echo "{python_version}={[\"cp38-*\", \"cp311-*\"]}" >> $GITHUB_OUTPUT
+            echo "{python_version}={$(python3 scripts/gen_pyver_matrix.py \
+              --min-version=3.${{ env.PYTHON3_MIN_VERSION }} \
+              --max-version=3.${{ env.PYTHON3_MAX_VERSION }})}" >> $GITHUB_OUTPUT
           else
-            echo "{python_version}={[\"cp38-*\", \"cp39-*\", \"cp310-*\", \"cp311-*\"]}" >> $GITHUB_OUTPUT
+            echo "{python_version}={$(python3 scripts/gen_pyver_matrix.py \
+              --min-version=3.${{ env.PYTHON3_MIN_VERSION }} \
+              --max-version=3.${{ env.PYTHON3_MAX_VERSION }} --range)}" >> $GITHUB_OUTPUT
           fi
 
     outputs:

--- a/pennylane_lightning/_version.py
+++ b/pennylane_lightning/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.30.0-dev4"
+__version__ = "0.30.0-dev5"


### PR DESCRIPTION
**Context:**
`save-state` and `set-output` commands will be deprecated. 
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

**Description of the Change:**
Use new env files instead of `save-state` and `set-output` commands.

**Benefits:**
CI will keep running.

**Possible Drawbacks:**
None.

**Related GitHub Issues:**
None.
