### PR TITLE
No longer in-place modify input to `apply`

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -21,11 +21,14 @@
 
 ### Bug fixes
 
+* `apply` no longer mutates the inputted list of operations.
+  [(#474)](https://github.com/PennyLaneAI/pennylane-lightning/pull/474)
+
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
 
-Amintor Dusko, Vincent Michaud-Rioux, Lee J. O'Riordan
+Amintor Dusko, Christina Lee, Vincent Michaud-Rioux, Lee J. O'Riordan
 
 ---
 

--- a/pennylane_lightning/lightning_kokkos/lightning_kokkos.py
+++ b/pennylane_lightning/lightning_kokkos/lightning_kokkos.py
@@ -430,10 +430,10 @@ if LK_CPP_BINARY_AVAILABLE:
                     self._apply_state_vector(
                         operations[0].parameters[0].copy(), operations[0].wires
                     )
-                    del operations[0]
+                    operations = operations[1:]
                 elif isinstance(operations[0], BasisState):
                     self._apply_basis_state(operations[0].parameters[0], operations[0].wires)
-                    del operations[0]
+                    operations = operations[1:]
 
             for operation in operations:
                 if isinstance(operation, (QubitStateVector, BasisState)):

--- a/pennylane_lightning/lightning_qubit/lightning_qubit.py
+++ b/pennylane_lightning/lightning_qubit/lightning_qubit.py
@@ -375,10 +375,10 @@ if LQ_CPP_BINARY_AVAILABLE:
                     self._apply_state_vector(
                         operations[0].parameters[0].copy(), operations[0].wires
                     )
-                    del operations[0]
+                    operations = operations[1:]
                 elif isinstance(operations[0], BasisState):
                     self._apply_basis_state(operations[0].parameters[0], operations[0].wires)
-                    del operations[0]
+                    operations = operations[1:]
 
             for operation in operations:
                 if isinstance(operation, (QubitStateVector, BasisState)):

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -204,7 +204,10 @@ class TestApply:
         par = np.array(par)
         dev = qubit_device(wires=2)
         dev.reset()
-        dev.apply([operation(par, wires=[0, 1])])
+        ops = [operation(par, wires=[0, 1])]
+
+        dev.apply(ops)
+        assert len(ops) == 1 # input not mutated
 
         assert np.allclose(dev.state, np.array(expected_output), atol=tol, rtol=0)
 

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -207,7 +207,7 @@ class TestApply:
         ops = [operation(par, wires=[0, 1])]
 
         dev.apply(ops)
-        assert len(ops) == 1 # input not mutated
+        assert len(ops) == 1  # input not mutated
 
         assert np.allclose(dev.state, np.array(expected_output), atol=tol, rtol=0)
 


### PR DESCRIPTION
In Pennylane PR [#4485](https://github.com/PennyLaneAI/pennylane/pull/4485), `tape.operations` will no longer be the sum of `tape._prep` and `tape._ops`.  

This means any modification of the `tape.operations` list will mutate the tape itself, instead of a shallow copy of its contents.

A basic example of this can be shown with the below list manipulations:

```
>>> a = [1]
>>> b = [2]
>>> c = a+b
>>> c[0] = 5
>>> c
[5, 2]
>>> a
[1]
>>> d = a
>>> d[0] = 5
>>> a
[5]
```

Long story short, we do not want to in-place modify the `operations` list anymore. So instead of using `del operations[0]`, I simply select out the contents from index one onward.