### PR TITLE
Update CMake paths for dependent package use

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -21,7 +21,7 @@
 
 ### Bug fixes
 
-* Update the CMake interal references to enable sub-project compilation with affecting the parent package.
+* Update the CMake internal references to enable sub-project compilation with affecting the parent package.
   [(#478)](https://github.com/PennyLaneAI/pennylane-lightning/pull/478)
 
 * `apply` no longer mutates the inputted list of operations.

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -21,6 +21,9 @@
 
 ### Bug fixes
 
+* Update the CMake interal references to enable sub-project compilation with affecting the parent package.
+  [(#478)](https://github.com/PennyLaneAI/pennylane-lightning/pull/478)
+
 * `apply` no longer mutates the inputted list of operations.
   [(#474)](https://github.com/PennyLaneAI/pennylane-lightning/pull/474)
 

--- a/cmake/support_kokkos.cmake
+++ b/cmake/support_kokkos.cmake
@@ -13,8 +13,8 @@ set(KOKKOS_VERSION 4.0.01)
 # 3. Not installed, so fall back to building from source.
 macro(FindKokkos target_name)
     find_package(Kokkos
-    HINTS   ${CMAKE_SOURCE_DIR}/kokkos
-            ${CMAKE_SOURCE_DIR}/Kokkos
+    HINTS   ${pennylane_lightning_SOURCE_DIR}/kokkos
+            ${pennylane_lightning_SOURCE_DIR}/Kokkos
             ${Kokkos_Core_DIR}
             /usr
             /usr/local
@@ -30,7 +30,7 @@ macro(FindKokkos target_name)
 
         find_library(Kokkos_core_lib
             NAME kokkoscore.a libkokkoscore.a kokkoscore.so libkokkoscore.so
-            HINTS   ${CMAKE_SOURCE_DIR}/Kokkos/lib
+            HINTS   ${pennylane_lightning_SOURCE_DIR}/Kokkos/lib
                     ${Kokkos_Core_DIR}/lib
                     ${Kokkos_Core_DIR}/lib64
                     /usr/lib

--- a/cmake/support_simulators.cmake
+++ b/cmake/support_simulators.cmake
@@ -9,7 +9,7 @@ include_guard()
 # All simulators have their own directory in "simulators"
 # This macro will extract this list of directories.
 MACRO(FIND_SIMULATORS_LIST RESULT)
-    set(SIMULATORS_DIR ${CMAKE_SOURCE_DIR}/pennylane_lightning/core/src/simulators)
+    set(SIMULATORS_DIR ${pennylane_lightning_SOURCE_DIR}/pennylane_lightning/core/src/simulators)
     FILE(GLOB FULL_LIST RELATIVE ${SIMULATORS_DIR} ${SIMULATORS_DIR}/*)
     SET(${RESULT} "")
     FOREACH(ITEM ${FULL_LIST})

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.32.0-dev8"
+__version__ = "0.32.0-dev9"

--- a/pennylane_lightning/core/src/CMakeLists.txt
+++ b/pennylane_lightning/core/src/CMakeLists.txt
@@ -19,7 +19,7 @@ endforeach()
 
 if (BUILD_TESTS)
     # Include macros supporting tests.
-    include("${CMAKE_SOURCE_DIR}/cmake/support_tests.cmake")
+    include("${pennylane_lightning_SOURCE_DIR}/cmake/support_tests.cmake")
     FetchAndIncludeCatch()
 
     include(CTest)

--- a/pennylane_lightning/core/src/algorithms/tests/CMakeLists.txt
+++ b/pennylane_lightning/core/src/algorithms/tests/CMakeLists.txt
@@ -7,7 +7,7 @@ if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Debug)
 endif()
 
-include("${CMAKE_SOURCE_DIR}/cmake/support_tests.cmake")
+include("${pennylane_lightning_SOURCE_DIR}/cmake/support_tests.cmake")
 FetchAndIncludeCatch()
 
 ################################################################################

--- a/pennylane_lightning/core/src/measurements/tests/CMakeLists.txt
+++ b/pennylane_lightning/core/src/measurements/tests/CMakeLists.txt
@@ -7,7 +7,7 @@ if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Debug)
 endif()
 
-include("${CMAKE_SOURCE_DIR}/cmake/support_tests.cmake")
+include("${pennylane_lightning_SOURCE_DIR}/cmake/support_tests.cmake")
 FetchAndIncludeCatch()
 
 ################################################################################

--- a/pennylane_lightning/core/src/observables/tests/CMakeLists.txt
+++ b/pennylane_lightning/core/src/observables/tests/CMakeLists.txt
@@ -7,7 +7,7 @@ if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Debug)
 endif()
 
-include("${CMAKE_SOURCE_DIR}/cmake/support_tests.cmake")
+include("${pennylane_lightning_SOURCE_DIR}/cmake/support_tests.cmake")
 FetchAndIncludeCatch()
 
 ################################################################################

--- a/pennylane_lightning/core/src/simulators/CMakeLists.txt
+++ b/pennylane_lightning/core/src/simulators/CMakeLists.txt
@@ -7,7 +7,7 @@ add_subdirectory(base)
 ###############################################################################
 # Determine simulator and include its directory
 ###############################################################################
-include("${CMAKE_SOURCE_DIR}/cmake/support_simulators.cmake")
+include("${pennylane_lightning_SOURCE_DIR}/cmake/support_simulators.cmake")
 FIND_AND_ADD_SIMULATOR()
 
 if (BUILD_TESTS)

--- a/pennylane_lightning/core/src/simulators/base/tests/CMakeLists.txt
+++ b/pennylane_lightning/core/src/simulators/base/tests/CMakeLists.txt
@@ -7,7 +7,7 @@ if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Debug)
 endif()
 
-include("${CMAKE_SOURCE_DIR}/cmake/support_tests.cmake")
+include("${pennylane_lightning_SOURCE_DIR}/cmake/support_tests.cmake")
 FetchAndIncludeCatch()
 
 ################################################################################

--- a/pennylane_lightning/core/src/simulators/lightning_kokkos/CMakeLists.txt
+++ b/pennylane_lightning/core/src/simulators/lightning_kokkos/CMakeLists.txt
@@ -37,7 +37,7 @@ option(PLKOKKOS_ENABLE_SANITIZER "Enable address sanitizer" OFF)
 option(PLKOKKOS_ENABLE_WARNINGS "Enable warnings" ON)
 
 # Include macro and functions supporting Kokkos libraries.
-include("${CMAKE_SOURCE_DIR}/cmake/support_kokkos.cmake")
+include("${pennylane_lightning_SOURCE_DIR}/cmake/support_kokkos.cmake")
 FindKokkos(lightning_external_libs)
 
 if(PLKOKKOS_ENABLE_SANITIZER)

--- a/pennylane_lightning/core/src/simulators/lightning_kokkos/algorithms/tests/CMakeLists.txt
+++ b/pennylane_lightning/core/src/simulators/lightning_kokkos/algorithms/tests/CMakeLists.txt
@@ -7,7 +7,7 @@ if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Debug)
 endif()
 
-include("${CMAKE_SOURCE_DIR}/cmake/support_tests.cmake")
+include("${pennylane_lightning_SOURCE_DIR}/cmake/support_tests.cmake")
 FetchAndIncludeCatch()
 
 ################################################################################

--- a/pennylane_lightning/core/src/simulators/lightning_kokkos/gates/tests/CMakeLists.txt
+++ b/pennylane_lightning/core/src/simulators/lightning_kokkos/gates/tests/CMakeLists.txt
@@ -7,7 +7,7 @@ if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Debug)
 endif()
 
-include("${CMAKE_SOURCE_DIR}/cmake/support_tests.cmake")
+include("${pennylane_lightning_SOURCE_DIR}/cmake/support_tests.cmake")
 FetchAndIncludeCatch()
 
 ################################################################################

--- a/pennylane_lightning/core/src/simulators/lightning_kokkos/measurements/tests/CMakeLists.txt
+++ b/pennylane_lightning/core/src/simulators/lightning_kokkos/measurements/tests/CMakeLists.txt
@@ -7,7 +7,7 @@ if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Debug)
 endif()
 
-include("${CMAKE_SOURCE_DIR}/cmake/support_tests.cmake")
+include("${pennylane_lightning_SOURCE_DIR}/cmake/support_tests.cmake")
 FetchAndIncludeCatch()
 
 ################################################################################

--- a/pennylane_lightning/core/src/simulators/lightning_kokkos/observables/tests/CMakeLists.txt
+++ b/pennylane_lightning/core/src/simulators/lightning_kokkos/observables/tests/CMakeLists.txt
@@ -7,7 +7,7 @@ if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Debug)
 endif()
 
-include("${CMAKE_SOURCE_DIR}/cmake/support_tests.cmake")
+include("${pennylane_lightning_SOURCE_DIR}/cmake/support_tests.cmake")
 FetchAndIncludeCatch()
 
 ################################################################################

--- a/pennylane_lightning/core/src/simulators/lightning_kokkos/tests/CMakeLists.txt
+++ b/pennylane_lightning/core/src/simulators/lightning_kokkos/tests/CMakeLists.txt
@@ -7,7 +7,7 @@ if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Debug)
 endif()
 
-include("${CMAKE_SOURCE_DIR}/cmake/support_tests.cmake")
+include("${pennylane_lightning_SOURCE_DIR}/cmake/support_tests.cmake")
 FetchAndIncludeCatch()
 
 ################################################################################

--- a/pennylane_lightning/core/src/simulators/lightning_kokkos/utils/tests/CMakeLists.txt
+++ b/pennylane_lightning/core/src/simulators/lightning_kokkos/utils/tests/CMakeLists.txt
@@ -7,7 +7,7 @@ if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Debug)
 endif()
 
-include("${CMAKE_SOURCE_DIR}/cmake/support_tests.cmake")
+include("${pennylane_lightning_SOURCE_DIR}/cmake/support_tests.cmake")
 FetchAndIncludeCatch()
 
 ################################################################################

--- a/pennylane_lightning/core/src/simulators/lightning_qubit/algorithms/tests/CMakeLists.txt
+++ b/pennylane_lightning/core/src/simulators/lightning_qubit/algorithms/tests/CMakeLists.txt
@@ -7,7 +7,7 @@ if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Debug)
 endif()
 
-include("${CMAKE_SOURCE_DIR}/cmake/support_tests.cmake")
+include("${pennylane_lightning_SOURCE_DIR}/cmake/support_tests.cmake")
 FetchAndIncludeCatch()
 
 ################################################################################

--- a/pennylane_lightning/core/src/simulators/lightning_qubit/gates/tests/CMakeLists.txt
+++ b/pennylane_lightning/core/src/simulators/lightning_qubit/gates/tests/CMakeLists.txt
@@ -7,7 +7,7 @@ if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Debug)
 endif()
 
-include("${CMAKE_SOURCE_DIR}/cmake/support_tests.cmake")
+include("${pennylane_lightning_SOURCE_DIR}/cmake/support_tests.cmake")
 FetchAndIncludeCatch()
 
 ################################################################################

--- a/pennylane_lightning/core/src/simulators/lightning_qubit/measurements/tests/CMakeLists.txt
+++ b/pennylane_lightning/core/src/simulators/lightning_qubit/measurements/tests/CMakeLists.txt
@@ -7,7 +7,7 @@ if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Debug)
 endif()
 
-include("${CMAKE_SOURCE_DIR}/cmake/support_tests.cmake")
+include("${pennylane_lightning_SOURCE_DIR}/cmake/support_tests.cmake")
 FetchAndIncludeCatch()
 
 ################################################################################

--- a/pennylane_lightning/core/src/simulators/lightning_qubit/observables/tests/CMakeLists.txt
+++ b/pennylane_lightning/core/src/simulators/lightning_qubit/observables/tests/CMakeLists.txt
@@ -7,7 +7,7 @@ if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Debug)
 endif()
 
-include("${CMAKE_SOURCE_DIR}/cmake/support_tests.cmake")
+include("${pennylane_lightning_SOURCE_DIR}/cmake/support_tests.cmake")
 FetchAndIncludeCatch()
 
 ################################################################################

--- a/pennylane_lightning/core/src/simulators/lightning_qubit/tests/CMakeLists.txt
+++ b/pennylane_lightning/core/src/simulators/lightning_qubit/tests/CMakeLists.txt
@@ -7,7 +7,7 @@ if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Debug)
 endif()
 
-include("${CMAKE_SOURCE_DIR}/cmake/support_tests.cmake")
+include("${pennylane_lightning_SOURCE_DIR}/cmake/support_tests.cmake")
 FetchAndIncludeCatch()
 
 ################################################################################

--- a/pennylane_lightning/core/src/simulators/lightning_qubit/utils/tests/CMakeLists.txt
+++ b/pennylane_lightning/core/src/simulators/lightning_qubit/utils/tests/CMakeLists.txt
@@ -7,7 +7,7 @@ if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Debug)
 endif()
 
-include("${CMAKE_SOURCE_DIR}/cmake/support_tests.cmake")
+include("${pennylane_lightning_SOURCE_DIR}/cmake/support_tests.cmake")
 FetchAndIncludeCatch()
 
 ################################################################################

--- a/pennylane_lightning/core/src/utils/tests/CMakeLists.txt
+++ b/pennylane_lightning/core/src/utils/tests/CMakeLists.txt
@@ -7,7 +7,7 @@ if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Debug)
 endif()
 
-include("${CMAKE_SOURCE_DIR}/cmake/support_tests.cmake")
+include("${pennylane_lightning_SOURCE_DIR}/cmake/support_tests.cmake")
 FetchAndIncludeCatch()
 
 ################################################################################


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [x] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [x] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [x] Ensure that the test suite passes, by running `make test`.

- [x] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [x] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:** Currently the new package design assumes that all use will be internal to the nested projects. This however prevents packages depending on Lightning, for example through the CMake FetchContent utility, as source directories are assumed to be top-level of the outer package only. This PR updates all Lightning CMake references from `CMAKE_SOURCE_DIR` to `pennylane_lightning_SOURCE_DIR`, as discussed by https://cmake.org/cmake/help/v3.27/command/project.html#command:project

**Description of the Change:** As above.

**Benefits:** Allows the repo to be used as a sub-package with CMake.

**Possible Drawbacks:**

**Related GitHub Issues:**
