### PR TITLE
Revert SQRT2 definition to v0.31.0

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -21,6 +21,9 @@
 
 ### Bug fixes
 
+* Do no import `sqrt2_v` from `<numbers>` in `Util.hpp` to resolve issue with Lightning-GPU builds.
+  [(#479)](https://github.com/PennyLaneAI/pennylane-lightning/pull/479)
+
 * Update the CMake internal references to enable sub-project compilation with affecting the parent package.
   [(#478)](https://github.com/PennyLaneAI/pennylane-lightning/pull/478)
 

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -5,4 +5,5 @@ graphviz
 pybind11
 sphinx
 sphinx-automodapi
+git+https://github.com/PennyLaneAI/pennylane.git@master
 pennylane-sphinx-theme

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -5,5 +5,4 @@ graphviz
 pybind11
 sphinx
 sphinx-automodapi
-git+https://github.com/PennyLaneAI/pennylane.git@master
 pennylane-sphinx-theme

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.32.0-dev9"
+__version__ = "0.32.0-dev10"

--- a/pennylane_lightning/core/src/simulators/lightning_qubit/algorithms/tests/Test_VectorJacobianProduct.cpp
+++ b/pennylane_lightning/core/src/simulators/lightning_qubit/algorithms/tests/Test_VectorJacobianProduct.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #include <algorithm>
+#include <numbers>
 #include <random>
 #include <span>
 #include <vector>

--- a/pennylane_lightning/core/src/utils/Util.hpp
+++ b/pennylane_lightning/core/src/utils/Util.hpp
@@ -20,6 +20,7 @@
 
 #include <cmath>
 #include <complex>
+#include <numbers>
 #include <numeric> // transform_reduce
 #include <set>
 #include <type_traits> // is_same_v
@@ -174,7 +175,15 @@ inline static constexpr auto IMAG() -> ComplexT<T> {
  * @return constexpr T sqrt(2)
  */
 template <class T> inline static constexpr auto SQRT2() -> T {
-    return static_cast<T>(1.414213562373095048801688724209698079L);
+#if __cpp_lib_math_constants >= 201907L
+    return std::numbers::sqrt2_v<T>;
+#else
+    if constexpr (std::is_same_v<T, float>) {
+        return 0x1.6a09e6p+0F; // NOLINT: To be replaced in C++20
+    } else {
+        return 0x1.6a09e667f3bcdp+0; // NOLINT: To be replaced in C++20
+    }
+#endif
 }
 
 /**
@@ -186,7 +195,15 @@ template <class T> inline static constexpr auto SQRT2() -> T {
  */
 template <template <class> class ComplexT, class T>
 inline static constexpr auto SQRT2() -> ComplexT<T> {
-    return static_cast<T>(1.414213562373095048801688724209698079L);
+#if __cpp_lib_math_constants >= 201907L
+    return std::numbers::sqrt2_v<T>;
+#else
+    if constexpr (std::is_same_v<T, float>) {
+        return 0x1.6a09e6p+0F; // NOLINT: To be replaced in C++20
+    } else {
+        return 0x1.6a09e667f3bcdp+0; // NOLINT: To be replaced in C++20
+    }
+#endif
 }
 
 /**
@@ -196,7 +213,7 @@ inline static constexpr auto SQRT2() -> ComplexT<T> {
  * @return constexpr T 1/sqrt(2)
  */
 template <class T> inline static constexpr auto INVSQRT2() -> T {
-    return static_cast<T>(0.707106781186547461715008466853760182L);
+    return {1 / SQRT2<T>()};
 }
 
 /**
@@ -208,7 +225,7 @@ template <class T> inline static constexpr auto INVSQRT2() -> T {
  */
 template <template <class> class ComplexT, class T>
 inline static constexpr auto INVSQRT2() -> ComplexT<T> {
-    return static_cast<T>(0.707106781186547461715008466853760182L);
+    return static_cast<ComplexT<T>>(INVSQRT2<T>());
 }
 
 /**

--- a/pennylane_lightning/core/src/utils/Util.hpp
+++ b/pennylane_lightning/core/src/utils/Util.hpp
@@ -196,7 +196,7 @@ inline static constexpr auto SQRT2() -> ComplexT<T> {
  * @return constexpr T 1/sqrt(2)
  */
 template <class T> inline static constexpr auto INVSQRT2() -> T {
-    return {1 / SQRT2<T>()};
+    return std::sqrt(static_cast<T>(0.5));
 }
 
 /**
@@ -208,7 +208,7 @@ template <class T> inline static constexpr auto INVSQRT2() -> T {
  */
 template <template <class> class ComplexT, class T>
 inline static constexpr auto INVSQRT2() -> ComplexT<T> {
-    return {1 / SQRT2<T>()};
+    return std::sqrt(static_cast<T>(0.5));
 }
 
 /**

--- a/pennylane_lightning/core/src/utils/Util.hpp
+++ b/pennylane_lightning/core/src/utils/Util.hpp
@@ -20,7 +20,6 @@
 
 #include <cmath>
 #include <complex>
-#include <numbers> // sqrt2_v
 #include <numeric> // transform_reduce
 #include <set>
 #include <type_traits> // is_same_v
@@ -175,7 +174,7 @@ inline static constexpr auto IMAG() -> ComplexT<T> {
  * @return constexpr T sqrt(2)
  */
 template <class T> inline static constexpr auto SQRT2() -> T {
-    return std::numbers::sqrt2_v<T>;
+    return std::sqrt(static_cast<T>(2.0));
 }
 
 /**
@@ -187,7 +186,7 @@ template <class T> inline static constexpr auto SQRT2() -> T {
  */
 template <template <class> class ComplexT, class T>
 inline static constexpr auto SQRT2() -> ComplexT<T> {
-    return std::numbers::sqrt2_v<T>;
+    return std::sqrt(static_cast<T>(2.0));
 }
 
 /**

--- a/pennylane_lightning/core/src/utils/Util.hpp
+++ b/pennylane_lightning/core/src/utils/Util.hpp
@@ -174,7 +174,7 @@ inline static constexpr auto IMAG() -> ComplexT<T> {
  * @return constexpr T sqrt(2)
  */
 template <class T> inline static constexpr auto SQRT2() -> T {
-    return std::sqrt(static_cast<T>(2.0));
+    return static_cast<T>(1.414213562373095048801688724209698079L);
 }
 
 /**
@@ -186,7 +186,7 @@ template <class T> inline static constexpr auto SQRT2() -> T {
  */
 template <template <class> class ComplexT, class T>
 inline static constexpr auto SQRT2() -> ComplexT<T> {
-    return std::sqrt(static_cast<T>(2.0));
+    return static_cast<T>(1.414213562373095048801688724209698079L);
 }
 
 /**
@@ -196,7 +196,7 @@ inline static constexpr auto SQRT2() -> ComplexT<T> {
  * @return constexpr T 1/sqrt(2)
  */
 template <class T> inline static constexpr auto INVSQRT2() -> T {
-    return std::sqrt(static_cast<T>(0.5));
+    return static_cast<T>(0.707106781186547461715008466853760182L);
 }
 
 /**
@@ -208,7 +208,7 @@ template <class T> inline static constexpr auto INVSQRT2() -> T {
  */
 template <template <class> class ComplexT, class T>
 inline static constexpr auto INVSQRT2() -> ComplexT<T> {
-    return std::sqrt(static_cast<T>(0.5));
+    return static_cast<T>(0.707106781186547461715008466853760182L);
 }
 
 /**


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [x] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [x] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [x] Ensure that the test suite passes, by running `make test`.

- [x] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [x] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**
Importing `sqrt2_v` from the `<numbers>` header breaks the LGPU builds.
 
**Description of the Change:**
Revert SQRT2 definition to v0.31.0.

**Benefits:**
LGPU can move forward.

**Possible Drawbacks:**

**Related GitHub Issues:**
https://github.com/PennyLaneAI/pennylane-lightning-gpu/pull/134