### PR TITLE
QubitStateVector => StatePrep + parametrize tests.

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -16,6 +16,9 @@
 
 ### Breaking changes
 
+* Rename `QubitStateVector` to `StatePrep` in the `LightningQubit` and `LightningKokkos` classes.
+  [(#486)](https://github.com/PennyLaneAI/pennylane-lightning/pull/486)
+
 * Modify `adjointJacobian` methods to accept a (maybe unused) reference `StateVectorT`, allowing device-backed simulators to directly access state vector data for adjoint differentiation instead of copying it back-and-forth into `JacobianData` (host memory).
   [(#477)](https://github.com/PennyLaneAI/pennylane-lightning/pull/477)
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,7 +7,7 @@ python:
   install:
     - requirements: ci_build_requirements.txt
     - requirements: doc/requirements.txt
-    - requirements: requirements.txt
+    - requirements: requirements-dev.txt
     - method: pip
       path: .
   system_packages: true

--- a/pennylane_lightning/core/_serialize.py
+++ b/pennylane_lightning/core/_serialize.py
@@ -23,7 +23,7 @@ from pennylane import (
     PauliY,
     PauliZ,
     Identity,
-    QubitStateVector,
+    StatePrep,
     Rot,
 )
 from pennylane.operation import Tensor
@@ -206,7 +206,7 @@ class QuantumScriptSerializer:
         uses_stateprep = False
 
         for operation in tape.operations:
-            if isinstance(operation, (BasisState, QubitStateVector)):
+            if isinstance(operation, (BasisState, StatePrep)):
                 uses_stateprep = True
                 continue
             if isinstance(operation, Rot):

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.32.0-dev13"
+__version__ = "0.32.0-dev14"

--- a/pennylane_lightning/core/lightning_base.py
+++ b/pennylane_lightning/core/lightning_base.py
@@ -25,7 +25,7 @@ import pennylane as qml
 from pennylane import (
     BasisState,
     QubitDevice,
-    QubitStateVector,
+    StatePrep,
 )
 from pennylane.devices import DefaultQubit
 from pennylane.measurements import MeasurementProcess
@@ -277,7 +277,7 @@ class LightningBase(QubitDevice):
             # get op_idx-th operator among differentiable operators
             operation, _, _ = tape.get_operation(op_idx)
             if isinstance(operation, Operation) and not isinstance(
-                operation, (BasisState, QubitStateVector)
+                operation, (BasisState, StatePrep)
             ):
                 # We now just ignore non-op or state preps
                 tp_shift.append(trainable_param)

--- a/pennylane_lightning/core/src/algorithms/JacobianData.hpp
+++ b/pennylane_lightning/core/src/algorithms/JacobianData.hpp
@@ -246,7 +246,7 @@ template <class StateVectorT> class JacobianData {
      * we want to take a derivative respect to the :math:`i`-th operation.
      *
      * Further note that ``ops`` does not contain state preparation operations
-     * (e.g. QubitStateVector) or Hamiltonian coefficients.
+     * (e.g. StatePrep) or Hamiltonian coefficients.
      * @endrst
      */
     JacobianData(size_t num_params, size_t num_elem, const ComplexT *sv_ptr,

--- a/pennylane_lightning/core/src/simulators/lightning_kokkos/algorithms/AdjointJacobianKokkos.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_kokkos/algorithms/AdjointJacobianKokkos.hpp
@@ -134,6 +134,7 @@ class AdjointJacobian final
                         "The operation is not supported using the adjoint "
                         "differentiation method");
             if ((ops_name[op_idx] == "QubitStateVector") ||
+                (ops_name[op_idx] == "StatePrep") ||
                 (ops_name[op_idx] == "BasisState")) {
                 continue;
             }

--- a/pennylane_lightning/core/src/simulators/lightning_qubit/algorithms/AdjointJacobianLQubit.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_qubit/algorithms/AdjointJacobianLQubit.hpp
@@ -285,6 +285,7 @@ class AdjointJacobian final
                         "The operation is not supported using the adjoint "
                         "differentiation method");
             if ((ops_name[op_idx] == "QubitStateVector") ||
+                (ops_name[op_idx] == "StatePrep") ||
                 (ops_name[op_idx] == "BasisState")) {
                 continue; // Ignore them
             }

--- a/pennylane_lightning/core/src/simulators/lightning_qubit/algorithms/VectorJacobianProduct.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_qubit/algorithms/VectorJacobianProduct.hpp
@@ -121,6 +121,7 @@ class VectorJacobianProduct final
                         "The operation is not supported using the adjoint "
                         "differentiation method");
             if ((ops_name[op_idx] == "QubitStateVector") ||
+                (ops_name[op_idx] == "StatePrep") ||
                 (ops_name[op_idx] == "BasisState")) {
                 continue; // ignore them
             }

--- a/pennylane_lightning/lightning_kokkos/lightning_kokkos.py
+++ b/pennylane_lightning/lightning_kokkos/lightning_kokkos.py
@@ -52,7 +52,7 @@ if LK_CPP_BINARY_AVAILABLE:
     from pennylane import (
         math,
         BasisState,
-        QubitStateVector,
+        StatePrep,
         Projector,
         Rot,
         DeviceError,
@@ -89,6 +89,7 @@ if LK_CPP_BINARY_AVAILABLE:
         "Identity",
         "BasisState",
         "QubitStateVector",
+        "StatePrep",
         "QubitUnitary",
         "ControlledQubitUnitary",
         "MultiControlledX",
@@ -429,7 +430,7 @@ if LK_CPP_BINARY_AVAILABLE:
         def apply(self, operations, rotations=None, **kwargs):
             # State preparation is currently done in Python
             if operations:  # make sure operations[0] exists
-                if isinstance(operations[0], QubitStateVector):
+                if isinstance(operations[0], StatePrep):
                     self._apply_state_vector(
                         operations[0].parameters[0].copy(), operations[0].wires
                     )
@@ -439,7 +440,7 @@ if LK_CPP_BINARY_AVAILABLE:
                     operations = operations[1:]
 
             for operation in operations:
-                if isinstance(operation, (QubitStateVector, BasisState)):
+                if isinstance(operation, (StatePrep, BasisState)):
                     raise DeviceError(
                         f"Operation {operation.name} cannot be used after other "
                         + f"Operations have already been applied on a {self.short_name} device."

--- a/pennylane_lightning/lightning_qubit/lightning_qubit.py
+++ b/pennylane_lightning/lightning_qubit/lightning_qubit.py
@@ -50,7 +50,7 @@ if LQ_CPP_BINARY_AVAILABLE:
     from pennylane import (
         math,
         BasisState,
-        QubitStateVector,
+        StatePrep,
         Projector,
         Rot,
         DeviceError,
@@ -80,6 +80,7 @@ if LQ_CPP_BINARY_AVAILABLE:
         "Identity",
         "BasisState",
         "QubitStateVector",
+        "StatePrep",
         "QubitUnitary",
         "ControlledQubitUnitary",
         "MultiControlledX",
@@ -372,7 +373,7 @@ if LQ_CPP_BINARY_AVAILABLE:
         def apply(self, operations, rotations=None, **kwargs):
             # State preparation is currently done in Python
             if operations:  # make sure operations[0] exists
-                if isinstance(operations[0], QubitStateVector):
+                if isinstance(operations[0], StatePrep):
                     self._apply_state_vector(
                         operations[0].parameters[0].copy(), operations[0].wires
                     )
@@ -382,7 +383,7 @@ if LQ_CPP_BINARY_AVAILABLE:
                     operations = operations[1:]
 
             for operation in operations:
-                if isinstance(operation, (QubitStateVector, BasisState)):
+                if isinstance(operation, (StatePrep, BasisState)):
                     raise DeviceError(
                         f"Operation {operation.name} cannot be used after other "
                         f"Operations have already been applied on a {self.short_name} device."

--- a/tests/test_adjoint_jacobian.py
+++ b/tests/test_adjoint_jacobian.py
@@ -143,7 +143,8 @@ class TestAdjointJacobian:
 
     @pytest.mark.parametrize("theta", np.linspace(-2 * np.pi, 2 * np.pi, 7))
     @pytest.mark.parametrize("G", [qml.RX, qml.RY, qml.RZ])
-    def test_pauli_rotation_gradient(self, G, theta, dev):
+    @pytest.mark.parametrize("stateprep", [qml.QubitStateVector, qml.StatePrep])
+    def test_pauli_rotation_gradient(self, stateprep, G, theta, dev):
         """Tests that the automatic gradients of Pauli rotations are correct."""
 
         random_state = np.array(
@@ -151,7 +152,7 @@ class TestAdjointJacobian:
         )
 
         tape = qml.tape.QuantumScript(
-            [G(theta, 0)], [qml.expval(qml.PauliZ(0))], [qml.QubitStateVector(random_state, 0)]
+            [G(theta, 0)], [qml.expval(qml.PauliZ(0))], [stateprep(random_state, 0)]
         )
 
         tape.trainable_params = {1}
@@ -166,14 +167,15 @@ class TestAdjointJacobian:
         assert np.allclose(calculated_val, numeric_val, atol=tol, rtol=0)
 
     @pytest.mark.parametrize("theta", np.linspace(-2 * np.pi, 2 * np.pi, 7))
-    def test_Rot_gradient(self, theta, dev):
+    @pytest.mark.parametrize("stateprep", [qml.QubitStateVector, qml.StatePrep])
+    def test_Rot_gradient(self, stateprep, theta, dev):
         """Tests that the device gradient of an arbitrary Euler-angle-parameterized gate is
         correct."""
 
         params = np.array([theta, theta**3, np.sqrt(2) * theta])
 
         with qml.tape.QuantumTape() as tape:
-            qml.QubitStateVector(np.array([1.0, -1.0], requires_grad=False) / np.sqrt(2), wires=0)
+            stateprep(np.array([1.0, -1.0], requires_grad=False) / np.sqrt(2), wires=0)
             qml.Rot(*params, wires=[0])
             qml.expval(qml.PauliZ(0))
 

--- a/tests/test_comparison.py
+++ b/tests/test_comparison.py
@@ -254,7 +254,10 @@ class TestComparison:
     @pytest.mark.parametrize("wires", range(1, 17))
     @pytest.mark.parametrize("num_threads", [1, 2])
     @pytest.mark.skipif(not ld._CPP_BINARY_AVAILABLE, reason="Lightning binary required")
-    def test_n_qubit_circuit(self, monkeypatch, wires, lightning_dev_version, num_threads):
+    @pytest.mark.parametrize("stateprep", [qml.QubitStateVector, qml.StatePrep])
+    def test_n_qubit_circuit(
+        self, monkeypatch, stateprep, wires, lightning_dev_version, num_threads
+    ):
         """Test an n-qubit circuit"""
         monkeypatch.setenv("OMP_NUM_THREADS", str(num_threads))
 
@@ -265,7 +268,7 @@ class TestComparison:
         def circuit():
             """Prepares the equal superposition state and then applies StronglyEntanglingLayers
             and concludes with a simple PauliZ measurement"""
-            qml.QubitStateVector(vec, wires=range(wires))
+            stateprep(vec, wires=range(wires))
             qml.StronglyEntanglingLayers(w, wires=range(wires))
             return qml.expval(qml.PauliZ(0))
 

--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -84,7 +84,7 @@ def test_gate_unitary_correct(op, op_name):
     """Test if lightning device correctly applies gates by reconstructing the unitary matrix and
     comparing to the expected version"""
 
-    if op_name in ("BasisState", "QubitStateVector"):
+    if op_name in ("BasisState", "QubitStateVector", "StatePrep"):
         pytest.skip("Skipping operation because it is a state preparation")
     if op == None:
         pytest.skip("Skipping operation.")
@@ -115,7 +115,7 @@ def test_inverse_unitary_correct(op, op_name):
     """Test if lightning device correctly applies inverse gates by reconstructing the unitary matrix
     and comparing to the expected version"""
 
-    if op_name in ("BasisState", "QubitStateVector"):
+    if op_name in ("BasisState", "QubitStateVector", "StatePrep"):
         pytest.skip("Skipping operation because it is a state preparation")
     if op == None:
         pytest.skip("Skipping operation.")

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -413,11 +413,12 @@ class TestSerializeOps:
         )
         assert s == s_expected
 
-    def test_skips_prep_circuit(self):
+    @pytest.mark.parametrize("stateprep", [qml.QubitStateVector, qml.StatePrep])
+    def test_skips_prep_circuit(self, stateprep):
         """Test expected serialization for a simple circuit with state preparation, such that
         the state preparation is skipped"""
         with qml.tape.QuantumTape() as tape:
-            qml.QubitStateVector([1, 0], wires=0)
+            stateprep([1, 0], wires=0)
             qml.BasisState([1], wires=1)
             qml.RX(0.4, wires=0)
             qml.RY(0.6, wires=1)

--- a/tests/test_vjp.py
+++ b/tests/test_vjp.py
@@ -291,7 +291,8 @@ class TestVectorJacobianProduct:
         device_name == device_name,
         reason="Adjoint differentiation does not support State measurements.",
     )
-    def test_statevector_complex_circuit(self, dev, tol):
+    @pytest.mark.parametrize("stateprep", [qml.QubitStateVector, qml.StatePrep])
+    def test_statevector_complex_circuit(self, stateprep, dev, tol):
         dy = np.array(
             [
                 [1.0, 0.0, 0.0, 0.0],
@@ -308,7 +309,7 @@ class TestVectorJacobianProduct:
         params = [math.pi / 7, 6 * math.pi / 7]
 
         with qml.tape.QuantumTape() as tape:
-            qml.QubitStateVector(np.array([1.0] * 4) / 2, wires=range(2))
+            stateprep(np.array([1.0] * 4) / 2, wires=range(2))
             qml.RY(params[0], wires=0)
             qml.RZ(params[1], wires=1)
             qml.CZ(wires=[0, 1])


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [x] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [x] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [x] Ensure that the test suite passes, by running `make test`.

- [x] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [x] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**
Rename `QubitStateVector` as `StatePrep` in `Lightning` following recent changes in PennyLane [PR#4450](https://github.com/PennyLaneAI/pennylane/pull/4450).

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
