### PR TITLE
Feature/mid state prep

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### New features since last release
 
+* Add mid-circuit state preparation operation tests.
+  [(#495)](https://github.com/PennyLaneAI/pennylane-lightning/pull/495)
+
 ### Breaking changes
 
 * Enums defined in `GateOperation.hpp` start at `1` (previously `0`). `::BEGIN` is introduced in a few places where it was assumed `0` accordingly.

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.33.0-dev3"
+__version__ = "0.33.0-dev4"

--- a/pennylane_lightning/lightning_qubit/lightning_qubit.py
+++ b/pennylane_lightning/lightning_qubit/lightning_qubit.py
@@ -380,11 +380,6 @@ if LQ_CPP_BINARY_AVAILABLE:
                     self._apply_basis_state(operations[0].parameters[0], operations[0].wires)
                     operations = operations[1:]
 
-            if any(isinstance(op, (BasisState, StatePrep)) for op in operations):
-                tape = qml.tape.QuantumTape(ops=operations, measurements=[])
-                tape = qml.tape.expand_tape_state_prep(tape, skip_first=False, force_decompose=True)
-                operations = tape._ops
-
             for operation in operations:
                 if isinstance(operation, (StatePrep, BasisState)):
                     raise DeviceError(

--- a/pennylane_lightning/lightning_qubit/lightning_qubit.py
+++ b/pennylane_lightning/lightning_qubit/lightning_qubit.py
@@ -380,6 +380,11 @@ if LQ_CPP_BINARY_AVAILABLE:
                     self._apply_basis_state(operations[0].parameters[0], operations[0].wires)
                     operations = operations[1:]
 
+            if any(isinstance(op, (BasisState, StatePrep)) for op in operations):
+                tape = qml.tape.QuantumTape(ops=operations, measurements=[])
+                tape = qml.tape.expand_tape_state_prep(tape, skip_first=False, force_decompose=True)
+                operations = tape._ops
+
             for operation in operations:
                 if isinstance(operation, (StatePrep, BasisState)):
                     raise DeviceError(

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -454,39 +454,6 @@ class TestApply:
 
         assert pointer_before == pointer_after
 
-    # @pytest.mark.parametrize("stateprep", [qml.QubitStateVector, qml.StatePrep])
-    # def test_apply_errors_qubit_state_vector(self, stateprep, qubit_device):
-    #     """Test that apply fails for incorrect state preparation, and > 2 qubit gates"""
-    #     dev = qubit_device(wires=2)
-    #     with pytest.raises(ValueError, match="Sum of amplitudes-squared does not equal one."):
-    #         dev.apply([stateprep(np.array([1, -1]), wires=[0])])
-
-    #     with pytest.raises(
-    #         DeviceError,
-    #         match=f"Operation {stateprep(np.array([1, 0]), wires=[0]).name} cannot be used after other Operations have already been applied ",
-    #     ):
-    #         dev.reset()
-    #         dev.apply([qml.RZ(0.5, wires=[0]), stateprep(np.array([0, 1, 0, 0]), wires=[0, 1])])
-
-    # def test_apply_errors_basis_state(self, qubit_device):
-    #     dev = qubit_device(wires=2)
-    #     with pytest.raises(
-    #         ValueError, match="BasisState parameter must consist of 0 or 1 integers."
-    #     ):
-    #         dev.apply([qml.BasisState(np.array([-0.2, 4.2]), wires=[0, 1])])
-
-    #     with pytest.raises(
-    #         ValueError, match="BasisState parameter and wires must be of equal length."
-    #     ):
-    #         dev.apply([qml.BasisState(np.array([0, 1]), wires=[0])])
-
-    #     with pytest.raises(
-    #         DeviceError,
-    #         match="Operation BasisState cannot be used after other Operations have already been applied ",
-    #     ):
-    #         dev.reset()
-    #         dev.apply([qml.RZ(0.5, wires=[0]), qml.BasisState(np.array([1, 1]), wires=[0, 1])])
-
 
 class TestExpval:
     """Tests that expectation values are properly calculated or that the proper errors are raised."""
@@ -1491,18 +1458,6 @@ def test_circuit_with_stateprep(op, theta, phi, tol):
     U, _ = np.linalg.qr(U)
     init_state = np.random.rand(2**n_qubits) + 1j * np.random.rand(2**n_qubits)
     init_state /= np.sqrt(np.dot(np.conj(init_state), init_state))
-
-    ops = [
-        qml.StatePrep(init_state, wires=range(n_qubits)),
-        qml.RY(theta, wires=[0]),
-        qml.RY(phi, wires=[1]),
-        qml.CNOT(wires=[0, 1]),
-        op,
-        qml.QubitUnitary(U, wires=range(2, 2 + 2 * n_wires, 2)),
-    ]
-    measurements = [qml.state()]
-    tape = qml.tape.QuantumTape(ops=ops, measurements=measurements)
-    assert np.allclose(dev.execute(tape), dev_def.execute(tape), tol)
 
     def circuit():
         qml.StatePrep(init_state, wires=range(n_qubits))

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -454,38 +454,38 @@ class TestApply:
 
         assert pointer_before == pointer_after
 
-    @pytest.mark.parametrize("stateprep", [qml.QubitStateVector, qml.StatePrep])
-    def test_apply_errors_qubit_state_vector(self, stateprep, qubit_device):
-        """Test that apply fails for incorrect state preparation, and > 2 qubit gates"""
-        dev = qubit_device(wires=2)
-        with pytest.raises(ValueError, match="Sum of amplitudes-squared does not equal one."):
-            dev.apply([stateprep(np.array([1, -1]), wires=[0])])
+    # @pytest.mark.parametrize("stateprep", [qml.QubitStateVector, qml.StatePrep])
+    # def test_apply_errors_qubit_state_vector(self, stateprep, qubit_device):
+    #     """Test that apply fails for incorrect state preparation, and > 2 qubit gates"""
+    #     dev = qubit_device(wires=2)
+    #     with pytest.raises(ValueError, match="Sum of amplitudes-squared does not equal one."):
+    #         dev.apply([stateprep(np.array([1, -1]), wires=[0])])
 
-        with pytest.raises(
-            DeviceError,
-            match=f"Operation {stateprep(np.array([1, 0]), wires=[0]).name} cannot be used after other Operations have already been applied ",
-        ):
-            dev.reset()
-            dev.apply([qml.RZ(0.5, wires=[0]), stateprep(np.array([0, 1, 0, 0]), wires=[0, 1])])
+    #     with pytest.raises(
+    #         DeviceError,
+    #         match=f"Operation {stateprep(np.array([1, 0]), wires=[0]).name} cannot be used after other Operations have already been applied ",
+    #     ):
+    #         dev.reset()
+    #         dev.apply([qml.RZ(0.5, wires=[0]), stateprep(np.array([0, 1, 0, 0]), wires=[0, 1])])
 
-    def test_apply_errors_basis_state(self, qubit_device):
-        dev = qubit_device(wires=2)
-        with pytest.raises(
-            ValueError, match="BasisState parameter must consist of 0 or 1 integers."
-        ):
-            dev.apply([qml.BasisState(np.array([-0.2, 4.2]), wires=[0, 1])])
+    # def test_apply_errors_basis_state(self, qubit_device):
+    #     dev = qubit_device(wires=2)
+    #     with pytest.raises(
+    #         ValueError, match="BasisState parameter must consist of 0 or 1 integers."
+    #     ):
+    #         dev.apply([qml.BasisState(np.array([-0.2, 4.2]), wires=[0, 1])])
 
-        with pytest.raises(
-            ValueError, match="BasisState parameter and wires must be of equal length."
-        ):
-            dev.apply([qml.BasisState(np.array([0, 1]), wires=[0])])
+    #     with pytest.raises(
+    #         ValueError, match="BasisState parameter and wires must be of equal length."
+    #     ):
+    #         dev.apply([qml.BasisState(np.array([0, 1]), wires=[0])])
 
-        with pytest.raises(
-            DeviceError,
-            match="Operation BasisState cannot be used after other Operations have already been applied ",
-        ):
-            dev.reset()
-            dev.apply([qml.RZ(0.5, wires=[0]), qml.BasisState(np.array([1, 1]), wires=[0, 1])])
+    #     with pytest.raises(
+    #         DeviceError,
+    #         match="Operation BasisState cannot be used after other Operations have already been applied ",
+    #     ):
+    #         dev.reset()
+    #         dev.apply([qml.RZ(0.5, wires=[0]), qml.BasisState(np.array([1, 1]), wires=[0, 1])])
 
 
 class TestExpval:
@@ -1469,3 +1469,50 @@ def test_warning():
     """Tests if a warning is raised when lightning device binaries are not available"""
     with pytest.warns(UserWarning, match="Pre-compiled binaries for " + device_name):
         qml.device(device_name, wires=1)
+
+
+@pytest.mark.parametrize(
+    "op",
+    [
+        qml.BasisState([0, 0], wires=[0, 1]),
+        qml.QubitStateVector([0, 1, 0, 0], wires=[0, 1]),
+        qml.StatePrep([0, 1, 0, 0], wires=[0, 1]),
+    ],
+)
+@pytest.mark.parametrize("theta, phi", list(zip(THETA, PHI)))
+def test_circuit_with_stateprep(op, theta, phi, tol):
+    """Test mid-circuit StatePrep"""
+    n_qubits = 5
+    n_wires = 2
+    dev_def = qml.device("default.qubit", wires=n_qubits)
+    dev = qml.device(device_name, wires=n_qubits)
+    m = 2**n_wires
+    U = np.random.rand(m, m) + 1j * np.random.rand(m, m)
+    U, _ = np.linalg.qr(U)
+    init_state = np.random.rand(2**n_qubits) + 1j * np.random.rand(2**n_qubits)
+    init_state /= np.sqrt(np.dot(np.conj(init_state), init_state))
+
+    prep = [qml.StatePrep(init_state, wires=range(n_qubits))]
+    ops = [
+        qml.RY(theta, wires=[0]),
+        qml.RY(phi, wires=[1]),
+        qml.CNOT(wires=[0, 1]),
+        op,
+        qml.QubitUnitary(U, wires=range(2, 2 + 2 * n_wires, 2)),
+    ]
+    measurements = [qml.state()]
+    tape = qml.tape.QuantumTape(ops=ops, measurements=measurements, prep=prep)
+    assert np.allclose(dev.execute(tape), dev_def.execute(tape), tol)
+
+    def circuit():
+        qml.StatePrep(init_state, wires=range(n_qubits))
+        qml.RY(theta, wires=[0])
+        qml.RY(phi, wires=[1])
+        qml.CNOT(wires=[0, 1])
+        op
+        qml.QubitUnitary(U, wires=range(2, 2 + 2 * n_wires, 2))
+        return qml.state()
+
+    circ = qml.QNode(circuit, dev)
+    circ_def = qml.QNode(circuit, dev_def)
+    assert np.allclose(circ(), circ_def(), tol)

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -454,6 +454,39 @@ class TestApply:
 
         assert pointer_before == pointer_after
 
+    @pytest.mark.parametrize("stateprep", [qml.QubitStateVector, qml.StatePrep])
+    def test_apply_errors_qubit_state_vector(self, stateprep, qubit_device):
+        """Test that apply fails for incorrect state preparation, and > 2 qubit gates"""
+        dev = qubit_device(wires=2)
+        with pytest.raises(ValueError, match="Sum of amplitudes-squared does not equal one."):
+            dev.apply([stateprep(np.array([1, -1]), wires=[0])])
+
+        with pytest.raises(
+            DeviceError,
+            match=f"Operation {stateprep(np.array([1, 0]), wires=[0]).name} cannot be used after other Operations have already been applied ",
+        ):
+            dev.reset()
+            dev.apply([qml.RZ(0.5, wires=[0]), stateprep(np.array([0, 1, 0, 0]), wires=[0, 1])])
+
+    def test_apply_errors_basis_state(self, qubit_device):
+        dev = qubit_device(wires=2)
+        with pytest.raises(
+            ValueError, match="BasisState parameter must consist of 0 or 1 integers."
+        ):
+            dev.apply([qml.BasisState(np.array([-0.2, 4.2]), wires=[0, 1])])
+
+        with pytest.raises(
+            ValueError, match="BasisState parameter and wires must be of equal length."
+        ):
+            dev.apply([qml.BasisState(np.array([0, 1]), wires=[0])])
+
+        with pytest.raises(
+            DeviceError,
+            match="Operation BasisState cannot be used after other Operations have already been applied ",
+        ):
+            dev.reset()
+            dev.apply([qml.RZ(0.5, wires=[0]), qml.BasisState(np.array([1, 1]), wires=[0, 1])])
+
 
 class TestExpval:
     """Tests that expectation values are properly calculated or that the proper errors are raised."""

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -1492,8 +1492,8 @@ def test_circuit_with_stateprep(op, theta, phi, tol):
     init_state = np.random.rand(2**n_qubits) + 1j * np.random.rand(2**n_qubits)
     init_state /= np.sqrt(np.dot(np.conj(init_state), init_state))
 
-    prep = [qml.StatePrep(init_state, wires=range(n_qubits))]
     ops = [
+        qml.StatePrep(init_state, wires=range(n_qubits)),
         qml.RY(theta, wires=[0]),
         qml.RY(phi, wires=[1]),
         qml.CNOT(wires=[0, 1]),
@@ -1501,7 +1501,7 @@ def test_circuit_with_stateprep(op, theta, phi, tol):
         qml.QubitUnitary(U, wires=range(2, 2 + 2 * n_wires, 2)),
     ]
     measurements = [qml.state()]
-    tape = qml.tape.QuantumTape(ops=ops, measurements=measurements, prep=prep)
+    tape = qml.tape.QuantumTape(ops=ops, measurements=measurements)
     assert np.allclose(dev.execute(tape), dev_def.execute(tape), tol)
 
     def circuit():


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [x] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [x] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [x] Ensure that the test suite passes, by running `make test`.

- [x] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [x] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**
[SC-43708](https://app.shortcut.com/xanaduai/story/43708/lightning-ecosystem-devices-allow-stateprepbase-ops-to-be-used-mid-circuit) demands supporting mid-circuit state prep ops. This is dealt with by `qml.execute` already.

**Description of the Change:**
Add mid-circuit state prep ops tests.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
