### PR TITLE
Update DefaultQubit to DefaultQubitLegacy

### DIFF
--- a/pennylane_lightning/core/lightning_base.py
+++ b/pennylane_lightning/core/lightning_base.py
@@ -27,7 +27,7 @@ from pennylane import (
     QubitDevice,
     StatePrep,
 )
-from pennylane.devices import DefaultQubit
+from pennylane.devices import DefaultQubitLegacy
 from pennylane.measurements import MeasurementProcess
 from pennylane.operation import Operation
 from pennylane.wires import Wires
@@ -388,7 +388,7 @@ class LightningBase(QubitDevice):
         return processing_fns
 
 
-class LightningBaseFallBack(DefaultQubit):  # pragma: no cover
+class LightningBaseFallBack(DefaultQubitLegacy):  # pragma: no cover
     # pylint: disable=missing-class-docstring
     pennylane_requires = ">=0.30"
     version = __version__


### PR DESCRIPTION
**Context:** In anticipation of Pennylane PR [4436](https://github.com/PennyLaneAI/pennylane/pull/4436) making DefaultQubit the new device API one, we update Lightning accordingly.

**Description of the Change:** Update DefaultQubit to DefaultQubitLegacy 

**Benefits:** Lightning Fallback will point to the right device

**Possible Drawbacks:**

**Related GitHub Issues:**
