### PR TITLE
Fix stateprep casting rules.

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 ### Breaking changes
 
-* Cast integral-valued arrays to the device's complex type on entry in `_preprocess_state_vector` to make ensure the state is properly represented with floating-point numbers.  
+* Cast integral-valued arrays to the device's complex type on entry in `_preprocess_state_vector` to ensure the state is correctly represented with floating-point numbers.  
   [(#501)](https://github.com/PennyLaneAI/pennylane-lightning/pull/501)
 
 * Update DefaultQubit to DefaultQubitLegacy on Lightning fallback.

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -7,14 +7,17 @@
 
 ### Breaking changes
 
+* Cast integral-valued arrays to the device's complex type on entry in `_preprocess_state_vector` to make ensure the state is properly represented with floating-point numbers.  
+  [(#501)](https://github.com/PennyLaneAI/pennylane-lightning/pull/501)
+
+* Update DefaultQubit to DefaultQubitLegacy on Lightning fallback.
+  [(#500)](https://github.com/PennyLaneAI/pennylane-lightning/pull/500)
+
 * Enums defined in `GateOperation.hpp` start at `1` (previously `0`). `::BEGIN` is introduced in a few places where it was assumed `0` accordingly.
   [(#485)](https://github.com/PennyLaneAI/pennylane-lightning/pull/485)
 
 * Enable pre-commit hooks to format all Python files and linting of all Python source files.
   [(#485)](https://github.com/PennyLaneAI/pennylane-lightning/pull/485)
-
-* Update DefaultQubit to DefaultQubitLegacy on Lightning fallback.
-  [(#500)](https://github.com/PennyLaneAI/pennylane-lightning/pull/500)
 
 ### Improvements
 

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.33.0-dev8"
+__version__ = "0.33.0-dev9"

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.33.0-dev10"
+__version__ = "0.33.0-dev11"

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.33.0-dev9"
+__version__ = "0.33.0-dev10"

--- a/pennylane_lightning/core/lightning_base.py
+++ b/pennylane_lightning/core/lightning_base.py
@@ -207,6 +207,9 @@ class LightningBase(QubitDevice):
         # translate to wire labels used by device
         device_wires = self.map_wires(device_wires)
 
+        # special case for integral types
+        if state.dtype.kind == "i":
+            state = qml.numpy.array(state, dtype=self.C_DTYPE)
         state = self._asarray(state, dtype=self.C_DTYPE)
 
         if len(device_wires) == self.num_wires and Wires(sorted(device_wires)) == device_wires:

--- a/pennylane_lightning/core/lightning_base.py
+++ b/pennylane_lightning/core/lightning_base.py
@@ -103,6 +103,7 @@ class LightningBase(QubitDevice):
 
         return qml.BooleanFn(accepts_obj)
 
+    # pylint: disable=missing-function-docstring
     @classmethod
     def capabilities(cls):
         capabilities = super().capabilities().copy()
@@ -206,6 +207,9 @@ class LightningBase(QubitDevice):
         # translate to wire labels used by device
         device_wires = self.map_wires(device_wires)
 
+        # special case for integral types
+        if state.dtype.kind == "i":
+            state = qml.numpy.array(state, dtype=self.C_DTYPE)
         state = self._asarray(state, dtype=self.C_DTYPE)
 
         if len(device_wires) == self.num_wires and Wires(sorted(device_wires)) == device_wires:

--- a/pennylane_lightning/core/lightning_base.py
+++ b/pennylane_lightning/core/lightning_base.py
@@ -207,9 +207,6 @@ class LightningBase(QubitDevice):
         # translate to wire labels used by device
         device_wires = self.map_wires(device_wires)
 
-        # special case for integral types
-        if state.dtype.kind == "i":
-            state = qml.numpy.array(state, dtype=self.C_DTYPE)
         state = self._asarray(state, dtype=self.C_DTYPE)
 
         if len(device_wires) == self.num_wires and Wires(sorted(device_wires)) == device_wires:

--- a/pennylane_lightning/lightning_qubit/lightning_qubit.py
+++ b/pennylane_lightning/lightning_qubit/lightning_qubit.py
@@ -226,7 +226,7 @@ if LQ_CPP_BINARY_AVAILABLE:
             arr = np.asarray(arr)  # arr is not copied
 
             if arr.dtype.kind not in ["f", "c"]:
-                dtype = np.complex128
+                return arr
 
             if not dtype:
                 dtype = arr.dtype

--- a/pennylane_lightning/lightning_qubit/lightning_qubit.py
+++ b/pennylane_lightning/lightning_qubit/lightning_qubit.py
@@ -225,9 +225,10 @@ if LQ_CPP_BINARY_AVAILABLE:
         def _asarray(arr, dtype=None):
             arr = np.asarray(arr)  # arr is not copied
 
-            if arr.dtype.kind == "i":
-                dtype = np.complex128
-            elif not dtype:
+            if arr.dtype.kind not in ["f", "c"]:
+                return arr
+
+            if not dtype:
                 dtype = arr.dtype
 
             # We allocate a new aligned memory and copy data to there if alignment or dtype

--- a/pennylane_lightning/lightning_qubit/lightning_qubit.py
+++ b/pennylane_lightning/lightning_qubit/lightning_qubit.py
@@ -225,10 +225,9 @@ if LQ_CPP_BINARY_AVAILABLE:
         def _asarray(arr, dtype=None):
             arr = np.asarray(arr)  # arr is not copied
 
-            if arr.dtype.kind not in ["f", "c"]:
-                return arr
-
-            if not dtype:
+            if arr.dtype.kind == "i":
+                dtype = np.complex128
+            elif not dtype:
                 dtype = arr.dtype
 
             # We allocate a new aligned memory and copy data to there if alignment or dtype

--- a/pennylane_lightning/lightning_qubit/lightning_qubit.py
+++ b/pennylane_lightning/lightning_qubit/lightning_qubit.py
@@ -205,6 +205,7 @@ if LQ_CPP_BINARY_AVAILABLE:
             self._state = self._create_basis_state(0)
             self._pre_rotated_state = self._state
 
+            self._batch_obs = batch_obs
             self._mcmc = mcmc
             if self._mcmc:
                 if kernel_name not in [
@@ -225,7 +226,7 @@ if LQ_CPP_BINARY_AVAILABLE:
             arr = np.asarray(arr)  # arr is not copied
 
             if arr.dtype.kind not in ["f", "c"]:
-                return arr
+                dtype = np.complex128
 
             if not dtype:
                 dtype = arr.dtype
@@ -281,7 +282,7 @@ if LQ_CPP_BINARY_AVAILABLE:
 
         @property
         def state(self):
-            # Flattening the state.
+            """Returns the flattened state vector."""
             shape = (1 << self.num_wires,)
             return self._reshape(self._pre_rotated_state, shape)
 
@@ -368,7 +369,9 @@ if LQ_CPP_BINARY_AVAILABLE:
 
             return np.reshape(state_vector, state.shape)
 
+        # pylint: disable=unused-argument
         def apply(self, operations, rotations=None, **kwargs):
+            """Applies operations to the state vector."""
             # State preparation is currently done in Python
             if operations:  # make sure operations[0] exists
                 if isinstance(operations[0], StatePrep):
@@ -629,6 +632,7 @@ if LQ_CPP_BINARY_AVAILABLE:
             return StateVectorC64(ket) if self.use_csingle else StateVectorC128(ket)
 
         def adjoint_jacobian(self, tape, starting_state=None, use_device_state=False):
+            """Computes and returns the Jacobian with the adjoint method."""
             if self.shots is not None:
                 warn(
                     "Requested adjoint differentiation to be computed with finite shots. "
@@ -812,7 +816,7 @@ if LQ_CPP_BINARY_AVAILABLE:
 else:
 
     class LightningQubit(LightningBaseFallBack):  # pragma: no cover
-        # pylint: disable=missing-class-docstring
+        # pylint: disable=missing-class-docstring, too-few-public-methods
         name = "Lightning qubit PennyLane plugin [No binaries found - Fallback: default.qubit]"
         short_name = "lightning.qubit"
 

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -211,6 +211,24 @@ class TestApply:
 
         assert np.allclose(dev.state, np.array(expected_output), atol=tol, rtol=0)
 
+    def test_integer_state_preparation(self, qubit_device, tol):
+        """Tests that applying an operation yields the expected output state for single wire
+        operations that have no parameters."""
+        dev = qubit_device(wires=2)
+
+        @qml.qnode(dev)
+        def circuit0():
+            qml.RX(0.2, wires=[0])
+            return qml.state()
+
+        @qml.qnode(dev)
+        def circuit1():
+            qml.StatePrep(np.array([1, 0, 0, 0]), wires=[0, 1])
+            qml.RX(0.2, wires=[0])
+            return qml.state()
+
+        assert np.allclose(circuit0(), circuit1(), atol=tol, rtol=0)
+
     """ operation,input,expected_output,par """
     test_data_single_wire_with_parameters = [
         (qml.PhaseShift, [1, 0], [1, 0], [math.pi / 2]),

--- a/tests/test_comparison.py
+++ b/tests/test_comparison.py
@@ -78,9 +78,7 @@ class TestComparison:
             basis state"""
             qml.BasisState(np.array(basis_state), wires=0)
             one_qubit_block(wires=0)
-            if callable(measurement):
-                return measurement()
-            return measurement
+            return measurement() if callable(measurement) else measurement
 
         dev_l = lightning_dev_version(wires)
         dev_d = default_qubit_dev(wires)
@@ -124,9 +122,7 @@ class TestComparison:
             one_qubit_block(wires=1)
             qml.CRZ(0.02, wires=[0, 1])
             qml.CRot(0.2, 0.3, 0.7, wires=[0, 1])
-            if callable(measurement):
-                return measurement()
-            return measurement
+            return measurement() if callable(measurement) else measurement
 
         dev_l = lightning_dev_version(wires)
         dev_d = default_qubit_dev(wires)
@@ -177,9 +173,7 @@ class TestComparison:
             qml.CRot(0.2, 0.3, 0.7, wires=[2, 1])
             qml.RZ(0.4, wires=0)
             qml.Toffoli(wires=[2, 1, 0])
-            if callable(measurement):
-                return measurement()
-            return measurement
+            return measurement() if callable(measurement) else measurement
 
         dev_l = lightning_dev_version(wires)
         dev_d = default_qubit_dev(wires)
@@ -235,9 +229,7 @@ class TestComparison:
             qml.CRot(0.2, 0.3, 0.7, wires=[2, 1])
             qml.RZ(0.4, wires=0)
             qml.Toffoli(wires=[2, 1, 0])
-            if callable(measurement):
-                return measurement()
-            return measurement
+            return measurement() if callable(measurement) else measurement
 
         dev_l = lightning_dev_version(wires)
         dev_d = default_qubit_dev(wires)
@@ -274,9 +266,7 @@ class TestComparison:
             and concludes with a simple PauliZ measurement"""
             stateprep(vec, wires=range(wires))
             qml.StronglyEntanglingLayers(w, wires=range(wires))
-            if callable(measurement):
-                return measurement()
-            return measurement
+            return measurement() if callable(measurement) else measurement
 
         dev_l = lightning_dev_version(wires)
         dev_d = default_qubit_dev(wires)

--- a/tests/test_comparison.py
+++ b/tests/test_comparison.py
@@ -73,12 +73,14 @@ class TestComparison:
 
         monkeypatch.setenv("OMP_NUM_THREADS", str(num_threads))
 
-        def circuit():
+        def circuit(measurement):
             """A combination of the one_qubit_block and a simple PauliZ measurement applied to a
             basis state"""
             qml.BasisState(np.array(basis_state), wires=0)
             one_qubit_block(wires=0)
-            return qml.expval(qml.PauliZ(0))
+            if callable(measurement):
+                return measurement()
+            return measurement
 
         dev_l = lightning_dev_version(wires)
         dev_d = default_qubit_dev(wires)
@@ -86,11 +88,10 @@ class TestComparison:
         lightning = qml.QNode(circuit, dev_l)
         default = qml.QNode(circuit, dev_d)
 
-        lightning()
+        lightning(qml.expval(qml.PauliZ(0)))
         lightning_state = dev_l.state
 
-        default()
-        default_state = dev_d.state
+        default_state = default(qml.state)
 
         assert np.allclose(lightning_state, default_state)
         assert os.getenv("OMP_NUM_THREADS") == str(num_threads)
@@ -108,7 +109,7 @@ class TestComparison:
         """Test a two-qubit circuit"""
         monkeypatch.setenv("OMP_NUM_THREADS", str(num_threads))
 
-        def circuit():
+        def circuit(measurement):
             """A combination of two qubit gates with the one_qubit_block and a simple PauliZ
             measurement applied to an input basis state"""
             qml.BasisState(np.array(basis_state), wires=[0, 1])
@@ -123,7 +124,9 @@ class TestComparison:
             one_qubit_block(wires=1)
             qml.CRZ(0.02, wires=[0, 1])
             qml.CRot(0.2, 0.3, 0.7, wires=[0, 1])
-            return qml.expval(qml.PauliZ(0))
+            if callable(measurement):
+                return measurement()
+            return measurement
 
         dev_l = lightning_dev_version(wires)
         dev_d = default_qubit_dev(wires)
@@ -131,11 +134,10 @@ class TestComparison:
         lightning = qml.QNode(circuit, dev_l)
         default = qml.QNode(circuit, dev_d)
 
-        lightning()
+        lightning(qml.expval(qml.PauliZ(0)))
         lightning_state = dev_l.state
 
-        default()
-        default_state = dev_d.state
+        default_state = default(qml.state)
 
         assert np.allclose(lightning_state, default_state)
 
@@ -152,7 +154,7 @@ class TestComparison:
         """Test a three-qubit circuit"""
         monkeypatch.setenv("OMP_NUM_THREADS", str(num_threads))
 
-        def circuit():
+        def circuit(measurement):
             """A combination of two and three qubit gates with the one_qubit_block and a simple
             PauliZ measurement applied to an input basis state"""
             qml.BasisState(np.array(basis_state), wires=[0, 1, 2])
@@ -175,7 +177,9 @@ class TestComparison:
             qml.CRot(0.2, 0.3, 0.7, wires=[2, 1])
             qml.RZ(0.4, wires=0)
             qml.Toffoli(wires=[2, 1, 0])
-            return qml.expval(qml.PauliZ(0))
+            if callable(measurement):
+                return measurement()
+            return measurement
 
         dev_l = lightning_dev_version(wires)
         dev_d = default_qubit_dev(wires)
@@ -183,11 +187,10 @@ class TestComparison:
         lightning = qml.QNode(circuit, dev_l)
         default = qml.QNode(circuit, dev_d)
 
-        lightning()
+        lightning(qml.expval(qml.PauliZ(0)))
         lightning_state = dev_l.state
 
-        default()
-        default_state = dev_d.state
+        default_state = default(qml.state)
 
         assert np.allclose(lightning_state, default_state)
 
@@ -204,7 +207,7 @@ class TestComparison:
         """Test a four-qubit circuit"""
         monkeypatch.setenv("OMP_NUM_THREADS", str(num_threads))
 
-        def circuit():
+        def circuit(measurement):
             """A combination of two and three qubit gates with the one_qubit_block and a simple
             PauliZ measurement, all acting on a four qubit input basis state"""
             qml.BasisState(np.array(basis_state), wires=[0, 1, 2, 3])
@@ -232,7 +235,9 @@ class TestComparison:
             qml.CRot(0.2, 0.3, 0.7, wires=[2, 1])
             qml.RZ(0.4, wires=0)
             qml.Toffoli(wires=[2, 1, 0])
-            return qml.expval(qml.PauliZ(0))
+            if callable(measurement):
+                return measurement()
+            return measurement
 
         dev_l = lightning_dev_version(wires)
         dev_d = default_qubit_dev(wires)
@@ -240,11 +245,10 @@ class TestComparison:
         lightning = qml.QNode(circuit, dev_l)
         default = qml.QNode(circuit, dev_d)
 
-        lightning()
+        lightning(qml.expval(qml.PauliZ(0)))
         lightning_state = dev_l.state
 
-        default()
-        default_state = dev_d.state
+        default_state = default(qml.state)
 
         assert np.allclose(lightning_state, default_state)
 
@@ -265,12 +269,14 @@ class TestComparison:
         shape = qml.StronglyEntanglingLayers.shape(2, wires)
         w = np.random.uniform(high=2 * np.pi, size=shape)
 
-        def circuit():
+        def circuit(measurement):
             """Prepares the equal superposition state and then applies StronglyEntanglingLayers
             and concludes with a simple PauliZ measurement"""
             stateprep(vec, wires=range(wires))
             qml.StronglyEntanglingLayers(w, wires=range(wires))
-            return qml.expval(qml.PauliZ(0))
+            if callable(measurement):
+                return measurement()
+            return measurement
 
         dev_l = lightning_dev_version(wires)
         dev_d = default_qubit_dev(wires)
@@ -278,10 +284,9 @@ class TestComparison:
         lightning = qml.QNode(circuit, dev_l)
         default = qml.QNode(circuit, dev_d)
 
-        lightning()
+        lightning(qml.expval(qml.PauliZ(0)))
         lightning_state = dev_l.state
 
-        default()
-        default_state = dev_d.state
+        default_state = default(qml.state)
 
         assert np.allclose(lightning_state, default_state)


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [x] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [x] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [x] Ensure that the test suite passes, by running `make test`.

- [x] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [x] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**
We currently have the following
```
@qml.qnode(qml.device("lightning.qubit", wires=2))
def circuit():
    qml.StatePrep(np.array([1, 0, 0, 0]), wires=[0, 1])
    return qml.state()

>>> [1 0 0 0]
```
why causes issues as the integer-valued state is not casted to complex.

**Description of the Change:**
Introduce ad hoc casting clause for integral types in Lightning.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
