### PR TITLE
Fix wheels build for aarch64

### DIFF
--- a/.github/workflows/wheel_linux_aarch64.yml
+++ b/.github/workflows/wheel_linux_aarch64.yml
@@ -6,7 +6,6 @@ name: Wheel::Linux::ARM
 # **Who does it impact**: Wheels to be uploaded to PyPI.
 
 on:
-  pull_request:
   push:
     branches:
       - master

--- a/.github/workflows/wheel_linux_aarch64.yml
+++ b/.github/workflows/wheel_linux_aarch64.yml
@@ -6,6 +6,7 @@ name: Wheel::Linux::ARM
 # **Who does it impact**: Wheels to be uploaded to PyPI.
 
 on:
+  pull_request:
   push:
     branches:
       - master
@@ -142,7 +143,9 @@ jobs:
 
           CIBW_TEST_REQUIRES: pytest pytest-cov pytest-mock flaky
 
-          CIBW_BEFORE_TEST: if ${{ matrix.pl_backend == 'lightning_kokkos'}}; then SKIP_COMPILATION=True PL_BACKEND="lightning_qubit" pip install -e . -vv; fi
+          CIBW_BEFORE_TEST: |
+            python -m pip install git+https://github.com/PennyLaneAI/pennylane.git@master
+            if ${{ matrix.pl_backend == 'lightning_kokkos'}}; then SKIP_COMPILATION=True PL_BACKEND="lightning_qubit" pip install -e . -vv; fi
 
           CIBW_TEST_COMMAND: |
             DEVICENAME=`echo ${{ matrix.pl_backend }} | sed "s/_/./g"`

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.33.0-dev9"
+__version__ = "0.33.0-dev10"


### PR DESCRIPTION
**Context:** Wheels for aarch64 were not being tested with PennyLane master.

**Description of the Change:** Install Pennylane master before testing.

**Benefits:** Tests will work properly.

**Possible Drawbacks:**

**Related GitHub Issues:**
