### PR TITLE
Fix clobbering with multi-backend packaging

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 ### Breaking changes
 
-* Cast integral-valued arrays to the device's complex type on entry in `_preprocess_state_vector` to ensure the state is correctly represented with floating-point numbers.  
+* Cast integral-valued arrays to the device's complex type on entry in `_preprocess_state_vector` to ensure the state is correctly represented with floating-point numbers.
   [(#501)](https://github.com/PennyLaneAI/pennylane-lightning/pull/501)
 
 * Update DefaultQubit to DefaultQubitLegacy on Lightning fallback.
@@ -20,6 +20,9 @@
   [(#485)](https://github.com/PennyLaneAI/pennylane-lightning/pull/485)
 
 ### Improvements
+
+* Update setup to allows for sensible multi-package co-existence. The PennyLane_Lightning package now is the responsible for the core package and all other backend packages will depend on it.
+  [(#504)] (https://github.com/PennyLaneAI/pennylane-lightning/pull/504)
 
 * Refactor LKokkos `StateVectorKokkos` class to use Kokkos `RangePolicy` together with special functors in `applyMultiQubitOp` to apply 1- to 4-wire generic unitary gates. For more than 4 wires, the general implementation using Kokkos `TeamPolicy` is employed to yield the best all-around performance.
   [(#490)] (https://github.com/PennyLaneAI/pennylane-lightning/pull/490)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -21,7 +21,7 @@
 
 ### Improvements
 
-* Update setup to allows for sensible multi-package co-existence. The PennyLane_Lightning package now is the responsible for the core package and all other backend packages will depend on it.
+* Update setup.py to allow for multi-package co-existence. The PennyLane_Lightning package now is the responsible for the core functionality, and will be depended upon by all other extensions.
   [(#504)] (https://github.com/PennyLaneAI/pennylane-lightning/pull/504)
 
 * Refactor LKokkos `StateVectorKokkos` class to use Kokkos `RangePolicy` together with special functors in `applyMultiQubitOp` to apply 1- to 4-wire generic unitary gates. For more than 4 wires, the general implementation using Kokkos `TeamPolicy` is employed to yield the best all-around performance.

--- a/.github/workflows/tests_without_binary.yml
+++ b/.github/workflows/tests_without_binary.yml
@@ -37,7 +37,7 @@ jobs:
           cd main
           python -m pip install -r requirements-dev.txt
 
-      - name: Install the pennylane_lightning base package
+      - name: Install the pennylane_lightning package
         if: ${{ matrix.pl_backend == 'lightning_kokkos'}}
         run: |
           cd main

--- a/.github/workflows/tests_without_binary.yml
+++ b/.github/workflows/tests_without_binary.yml
@@ -37,19 +37,19 @@ jobs:
           cd main
           python -m pip install -r requirements-dev.txt
 
-      - name: Install lightning.qubit device
+      - name: Install the pennylane_lightning base package
+        if: ${{ matrix.pl_backend == 'lightning_kokkos'}}
+        run: |
+          cd main
+          SKIP_COMPILATION=True PL_BACKEND="lightning_qubit" pip install -e . -vv
+
+      - name: Install backend device
         env:
           SKIP_COMPILATION: True
           PL_BACKEND: ${{ matrix.pl_backend }}
         run: |
           cd main
           python -m pip install -e . -vv
-
-      - name: Install the new pennylane_lightning package
-        if: ${{ matrix.pl_backend == 'lightning_kokkos'}}
-        run: |
-          cd main
-          SKIP_COMPILATION=True PL_BACKEND="lightning_qubit" pip install -e . -vv
 
       - name: Run PennyLane-Lightning unit tests
         run: |

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.33.0-dev11"
+__version__ = "0.33.0-dev12"

--- a/setup.py
+++ b/setup.py
@@ -171,6 +171,13 @@ requirements = [
     "pennylane>=0.32",
 ]
 
+packages_list = ['pennylane_lightning.'+backend]
+
+if backend == "lightning_qubit":
+    packages_list += ['pennylane_lightning.core']
+else:
+    requirements += ["pennylane_lightning=="+version]
+
 suffix = backend.replace("lightning_", "")
 suffix = suffix[0].upper() + suffix[1:]
 
@@ -185,14 +192,7 @@ info = {
     "maintainer_email": "software@xanadu.ai",
     "url": "https://github.com/XanaduAI/pennylane-lightning",
     "license": "Apache License 2.0",
-    "packages": find_namespace_packages(include=['pennylane_lightning.core',
-                                                 'pennylane_lightning.'+backend]),
-    "package_data": {
-        'pennylane_lightning.core': [
-            os.path.join("src", "*"),
-            os.path.join("src", "**", "*"),
-        ]
-    },
+    "packages": find_namespace_packages(include=packages_list),
     "include_package_data": True,
     "entry_points": {"pennylane.plugins": pennylane_plugins},
     "description": "PennyLane-Lightning plugin",
@@ -205,6 +205,15 @@ info = {
     "cmdclass": {"build_ext": CMakeBuild},
     "ext_package": "pennylane_lightning",
 }
+
+if backend == "lightning_qubit":
+    info = info | {
+        "package_data": {
+            'pennylane_lightning.core': [
+                os.path.join("src", "*"),
+                os.path.join("src", "**", "*"),
+            ]
+        },}
 
 classifiers = [
     "Development Status :: 4 - Beta",


### PR DESCRIPTION
**Context:** Installing multi-backends clobbers the common ``core`` package. This PR allows for sensible install/uninstall of multiple backends.

**Description of the Change:** Here we make the PennyLane_Lightning package (``lightning.qubit``) responsible for the core package. Any other package (backends) will require PennyLane_Lightning (same version) from now on.

**Benefits:** Better and sensible packaging

**Possible Drawbacks:**

**Related GitHub Issues:**
