### PR TITLE
remove prep argument

### DIFF
--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.34.0-dev2"
+__version__ = "0.34.0-dev3"

--- a/tests/test_adjoint_jacobian.py
+++ b/tests/test_adjoint_jacobian.py
@@ -186,7 +186,7 @@ class TestAdjointJacobian:
         )
 
         tape = qml.tape.QuantumScript(
-            [G(theta, 0)], [qml.expval(qml.PauliZ(0))], [stateprep(random_state, 0)]
+            [stateprep(random_state, 0), G(theta, 0)], [qml.expval(qml.PauliZ(0))]
         )
 
         tape.trainable_params = {1}


### PR DESCRIPTION
In #4756 : https://github.com/PennyLaneAI/pennylane/pull/4756

the `prep` keyword argument was removed from `QuantumScript`, completing its deprecation cycle. Now state prep should be placed at the beginning of the `ops` queue.  