### PR TITLE
Update setup requirements

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -25,11 +25,14 @@
 * Fix MPI Python unit tests for the adjoint method.
   [(#538)](https://github.com/PennyLaneAI/pennylane-lightning/pull/538)
 
+* Update Lightning requirements.
+  [(#553)](https://github.com/PennyLaneAI/pennylane-lightning/pull/553)
+
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
 
-Vincent Michaud-Rioux, Shuli Shu
+Amintor Dusko, Vincent Michaud-Rioux, Shuli Shu
 
 ---
 
@@ -111,7 +114,7 @@ Lee J. O'Riordan
 
 ### Improvements
 
-* Improve Python testing for Lightning-GPU (+MPI) by adding jobs in Actions files and adding Python tests to increase code coverage.   
+* Improve Python testing for Lightning-GPU (+MPI) by adding jobs in Actions files and adding Python tests to increase code coverage.
   [(#522)](https://github.com/PennyLaneAI/pennylane-lightning/pull/522)
 
 * Add support for `pip install pennylane-lightning[kokkos]` for the OpenMP backend.
@@ -142,7 +145,7 @@ Lee J. O'Riordan
 
 ### Bug fixes
 
-* Fix CI issues running python-cov with MPI. 
+* Fix CI issues running python-cov with MPI.
   [(#535)](https://github.com/PennyLaneAI/pennylane-lightning/pull/535)
 
 * Re-add support for `pip install pennylane-lightning[gpu]`.

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.34.0-dev4"
+__version__ = "0.34.0-dev5"

--- a/setup.py
+++ b/setup.py
@@ -169,7 +169,7 @@ with open(os.path.join("pennylane_lightning", "core", "_version.py"), encoding="
     version = f.readlines()[-1].split()[-1].strip("\"'")
 
 requirements = [
-    "pennylane>=0.32",
+    "pennylane>=0.33",
 ]
 
 packages_list = ["pennylane_lightning." + backend]


### PR DESCRIPTION
**Context:** PennyLane Lightning relies on a fundamental level in PennyLane 0.33 functionalities.

**Description of the Change:** Update minimum required version to 0.33

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
