### PR TITLE
Fixes clang-tidy error with aarch64 builds

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -25,7 +25,8 @@
 * Fix MPI Python unit tests for the adjoint method.
   [(#538)](https://github.com/PennyLaneAI/pennylane-lightning/pull/538)
 
-* Fixes clang-tidy error with aarch64 builds []()
+* Fixes clang-tidy error with aarch64 builds 
+  [(#554)](https://github.com/PennyLaneAI/pennylane-lightning/pull/554)
 
 ### Contributors
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -25,11 +25,13 @@
 * Fix MPI Python unit tests for the adjoint method.
   [(#538)](https://github.com/PennyLaneAI/pennylane-lightning/pull/538)
 
+* Fixes clang-tidy error with aarch64 builds []()
+
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
 
-Vincent Michaud-Rioux, Shuli Shu
+David Clark (NVIDIA), Vincent Michaud-Rioux, Shuli Shu
 
 ---
 

--- a/pennylane_lightning/core/src/utils/RuntimeInfo.cpp
+++ b/pennylane_lightning/core/src/utils/RuntimeInfo.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-2023 Xanadu Quantum Technologies Inc.
+// Copyright 2018-2023 Xanadu Quantum Technologies Inc. and contributors.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -127,6 +127,6 @@ RuntimeInfo::InternalRuntimeInfo::InternalRuntimeInfo() {
     }
 }
 #else
-RuntimeInfo::InternalRuntimeInfo::InternalRuntimeInfo(){};
+RuntimeInfo::InternalRuntimeInfo::InternalRuntimeInfo() = default;
 #endif
 } // namespace Pennylane::Util


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [ ] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [ ] Ensure that the test suite passes, by running `make test`.

- [ ] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [ ] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**

This fixes a compilation error when compiling on ARM systems with clang-tidy enabled. When compiling on an ARM Neoverse-N1 system with Ubuntu 22.04.2 and gcc-12.1, I get the following error: 

```
cd /pennylane-lightning-gpu/Build/_deps/pennylane_lightning-build/pennylane_lightning/core/src/utils && /usr/local/bin/cmake -E __run_co_compile --tidy="clang-tidy;-extra-arg=-std=c++20;--extra-arg-before=--driver-mode=g++" --source=/pennylane-lightning-gpu/Build/_deps/pennylane_lightning-src/pennylane_lightning/core/src/utils/RuntimeInfo.cpp -- /usr/bin/c++   -O2 -g -DNDEBUG -std=gnu++20 -fPIC -MD -MT _deps/pennylane_lightning-build/pennylane_lightning/core/src/utils/CMakeFiles/lightning_utils.dir/RuntimeInfo.cpp.o -MF CMakeFiles/lightning_utils.dir/RuntimeInfo.cpp.o.d -o CMakeFiles/lightning_utils.dir/RuntimeInfo.cpp.o -c /pennylane-lightning-gpu/Build/_deps/pennylane_lightning-src/pennylane_lightning/core/src/utils/RuntimeInfo.cpp
/pennylane-lightning-gpu/Build/_deps/pennylane_lightning-src/pennylane_lightning/core/src/utils/RuntimeInfo.cpp:130:35: error: use '= default' to define a trivial default constructor [hicpp-use-equals-default,modernize-use-equals-default,-warnings-as-errors]
RuntimeInfo::InternalRuntimeInfo::InternalRuntimeInfo(){};
                                  ^                    ~~
                                                       = default;
```

The error is also reproduced with gcc11.3 and clang 15.0.7. 

**Description of the Change:**

This switches to using `= default` to define a trivial default constructor

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
