### PR TITLE
Restore batching memory control functionality to LightningGPU

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -40,6 +40,9 @@
 
 ### Bug fixes
 
+* Revert single-node multi-GPU batching behaviour to match https://github.com/PennyLaneAI/pennylane-lightning-gpu/pull/27.
+  [(#564)](https://github.com/PennyLaneAI/pennylane-lightning/pull/564)
+
 * Move deprecated `stateprep` `QuantumScript` argument into the operation list in `mpitests/test_adjoint_jacobian.py`.
   [(#540)] (https://github.com/PennyLaneAI/pennylane-lightning/pull/540)
 
@@ -50,7 +53,7 @@
 
 This release contains contributions from (in alphabetical order):
 
-Isaac De Vlugt, Vincent Michaud-Rioux, Shuli Shu
+Isaac De Vlugt, Vincent Michaud-Rioux, Lee James O'Riordan, Shuli Shu
 
 ---
 

--- a/pennylane_lightning/core/_serialize.py
+++ b/pennylane_lightning/core/_serialize.py
@@ -53,7 +53,7 @@ class QuantumScriptSerializer:
 
     # pylint: disable=import-outside-toplevel, too-many-instance-attributes, c-extension-no-member
     def __init__(
-        self, device_name, use_csingle: bool = False, split_obs: bool = False, use_mpi: bool = False
+        self, device_name, use_csingle: bool = False, use_mpi: bool = False, split_obs: bool = False
     ):
         self.use_csingle = use_csingle
         self.device_name = device_name
@@ -290,7 +290,6 @@ class QuantumScriptSerializer:
             else:
                 serialized_obs.append(ser_ob)
                 offset_indices.append(offset_indices[-1] + 1)
-
         return serialized_obs, offset_indices
 
     def serialize_ops(

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.34.0-dev9"
+__version__ = "0.34.0-dev10"

--- a/pennylane_lightning/core/lightning_base.py
+++ b/pennylane_lightning/core/lightning_base.py
@@ -255,14 +255,17 @@ class LightningBase(QubitDevice):
         return int(qml.math.dot(state, basis_states))
 
     # pylint: disable=too-many-function-args, assignment-from-no-return
-    def _process_jacobian_tape(self, tape, starting_state, use_device_state, use_mpi: bool = False):
+    def _process_jacobian_tape(
+        self, tape, starting_state, use_device_state, split_obs: bool = True, use_mpi: bool = False
+    ):
         state_vector = self._init_process_jacobian_tape(tape, starting_state, use_device_state)
 
-        obs_serialized = QuantumScriptSerializer(
-            self.short_name, self.use_csingle, use_mpi
+        obs_serialized, obs_idx_offsets = QuantumScriptSerializer(
+            self.short_name, self.use_csingle, split_obs, use_mpi
         ).serialize_observables(tape, self.wire_map)
+
         ops_serialized, use_sp = QuantumScriptSerializer(
-            self.short_name, self.use_csingle, use_mpi
+            self.short_name, self.use_csingle, split_obs, use_mpi
         ).serialize_ops(tape, self.wire_map)
 
         ops_serialized = self.create_ops_list(*ops_serialized)
@@ -300,6 +303,7 @@ class LightningBase(QubitDevice):
             "tp_shift": tp_shift,
             "record_tp_rows": record_tp_rows,
             "all_params": all_params,
+            "obs_idx_offsets": obs_idx_offsets,
         }
 
     # pylint: disable=unnecessary-pass

--- a/pennylane_lightning/core/lightning_base.py
+++ b/pennylane_lightning/core/lightning_base.py
@@ -256,16 +256,16 @@ class LightningBase(QubitDevice):
 
     # pylint: disable=too-many-function-args, assignment-from-no-return
     def _process_jacobian_tape(
-        self, tape, starting_state, use_device_state, split_obs: bool = True, use_mpi: bool = False
+        self, tape, starting_state, use_device_state, use_mpi: bool = False, split_obs: bool = False
     ):
         state_vector = self._init_process_jacobian_tape(tape, starting_state, use_device_state)
 
         obs_serialized, obs_idx_offsets = QuantumScriptSerializer(
-            self.short_name, self.use_csingle, split_obs, use_mpi
+            self.short_name, self.use_csingle, use_mpi, split_obs
         ).serialize_observables(tape, self.wire_map)
 
         ops_serialized, use_sp = QuantumScriptSerializer(
-            self.short_name, self.use_csingle, split_obs, use_mpi
+            self.short_name, self.use_csingle, use_mpi, split_obs
         ).serialize_ops(tape, self.wire_map)
 
         ops_serialized = self.create_ops_list(*ops_serialized)

--- a/pennylane_lightning/core/lightning_base.py
+++ b/pennylane_lightning/core/lightning_base.py
@@ -254,7 +254,7 @@ class LightningBase(QubitDevice):
         basis_states = qml.math.convert_like(basis_states, state)
         return int(qml.math.dot(state, basis_states))
 
-    # pylint: disable=too-many-function-args, assignment-from-no-return
+    # pylint: disable=too-many-function-args, assignment-from-no-return, too-many-arguments
     def _process_jacobian_tape(
         self, tape, starting_state, use_device_state, use_mpi: bool = False, split_obs: bool = False
     ):

--- a/pennylane_lightning/core/src/simulators/lightning_gpu/algorithms/AdjointJacobianGPU.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_gpu/algorithms/AdjointJacobianGPU.hpp
@@ -201,7 +201,7 @@ class AdjointJacobian final
 
             auto jac_chunk = jac_futures[i].get();
             for (std::size_t j = 0; j < jac_chunk.size(); j++) {
-                std::copy(jac_chunk.begin(), jac_chunk.end(), 
+                std::copy(jac_chunk.begin(), jac_chunk.end(),
                           jac.begin() + first * tp_size);
             }
         }

--- a/pennylane_lightning/core/src/simulators/lightning_gpu/algorithms/AdjointJacobianGPUMPI.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_gpu/algorithms/AdjointJacobianGPUMPI.hpp
@@ -21,7 +21,6 @@
 #include <future>
 #include <omp.h>
 #include <span>
-#include <thread>
 #include <variant>
 
 #include "AdjointJacobianBase.hpp"
@@ -102,8 +101,6 @@ class AdjointJacobianMPI final
 
     /**
      * @brief Batches the adjoint_jacobian method over the available GPUs.
-     * Explicitly forbids OMP_NUM_THREADS>1 to avoid issues with std::thread
-     * contention and state access issues.
      *
      * @param jac Preallocated vector for Jacobian data results.
      * @param jd JacobianData represents the QuantumTape to differentiate.

--- a/pennylane_lightning/lightning_gpu/lightning_gpu.py
+++ b/pennylane_lightning/lightning_gpu/lightning_gpu.py
@@ -673,7 +673,7 @@ if LGPU_CPP_BINARY_AVAILABLE:
             self._check_adjdiff_supported_operations(tape.operations)
 
             processed_data = self._process_jacobian_tape(
-                tape, starting_state, use_device_state, self._mpi
+                tape, starting_state, use_device_state, self._mpi, self._batch_obs
             )
 
             if not processed_data:  # training_params is empty
@@ -692,11 +692,6 @@ if LGPU_CPP_BINARY_AVAILABLE:
             adjoint_jacobian = _adj_dtype(self.use_csingle, self._mpi)()
 
             if self._batch_obs:
-                adjoint_jacobian = adjoint_jacobian.batched
-
-            if self._batch_obs:
-                adjoint_jacobian = adjoint_jacobian.batched
-
                 if not self._mpi:
                     num_obs = len(processed_data["obs_serialized"])
                     batch_size = (
@@ -716,7 +711,7 @@ if LGPU_CPP_BINARY_AVAILABLE:
                         jac.extend(jac_chunk)
                 else:
                     if self._batch_obs is True:
-                        jac = adjoint_jacobian(
+                        jac = adjoint_jacobian.batched(
                             self._gpu_state,
                             processed_data["obs_serialized"],
                             processed_data["ops_serialized"],

--- a/pennylane_lightning/lightning_gpu/lightning_gpu.py
+++ b/pennylane_lightning/lightning_gpu/lightning_gpu.py
@@ -644,6 +644,7 @@ if LGPU_CPP_BINARY_AVAILABLE:
                 self.apply(tape.operations)
             return self._gpu_state
 
+        # pylint: disable=too-many-branches
         def adjoint_jacobian(self, tape, starting_state=None, use_device_state=False):
             """Implements the adjoint method outlined in
             `Jones and Gacon <https://arxiv.org/abs/2009.02823>`__ to differentiate an input tape.

--- a/setup.py
+++ b/setup.py
@@ -177,13 +177,8 @@ packages_list = ["pennylane_lightning." + backend]
 
 if backend == "lightning_qubit":
     packages_list += ["pennylane_lightning.core"]
-else: # Allow ease of install during development
-    is_release_version = not any(s in version for s in ("rc", "dev") )
-    if is_release_version:
-        requirements += ["pennylane_lightning==" + version]
-    else:
-        version_dep = version.split("-", 2)[0]+".*"
-        requirements += ["pennylane_lightning==" + version_dep]
+else:
+    requirements += ["pennylane_lightning==" + version]
 
 suffix = backend.replace("lightning_", "")
 if suffix == "gpu":

--- a/setup.py
+++ b/setup.py
@@ -177,8 +177,14 @@ packages_list = ["pennylane_lightning." + backend]
 
 if backend == "lightning_qubit":
     packages_list += ["pennylane_lightning.core"]
-else:
-    requirements += ["pennylane_lightning==" + version]
+else: # Allow ease of install during development
+    is_release_version = not any(s in version for s in ("rc", "dev") )
+    if is_release_version:
+        requirements += ["pennylane_lightning==" + version]
+    else:
+        version_dep = version.split("-", 2)[0]+".*"
+        requirements += ["pennylane_lightning==" + version_dep]
+
 
 suffix = backend.replace("lightning_", "")
 if suffix == "gpu":

--- a/tests/test_adjoint_jacobian.py
+++ b/tests/test_adjoint_jacobian.py
@@ -357,7 +357,6 @@ class TestAdjointJacobian:
                 [-np.sin(params[0]) * np.cos(params[2]), 0, -np.cos(params[0]) * np.sin(params[2])]
             )
         )
-
         assert np.allclose(dev_jacobian, expected_jacobian, atol=tol, rtol=0)
 
     qubit_ops = [getattr(qml, name) for name in qml.ops._qubit__ops__]

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -127,7 +127,7 @@ class TestSerializeObs:
         tensor_prod_obs = TensorProdObsC64 if use_csingle else TensorProdObsC128
         named_obs = NamedObsC64 if use_csingle else NamedObsC128
 
-        s = QuantumScriptSerializer(device_name, use_csingle).serialize_observables(
+        s, _ = QuantumScriptSerializer(device_name, use_csingle).serialize_observables(
             tape, self.wires_dict
         )
 
@@ -147,7 +147,7 @@ class TestSerializeObs:
         hermitian_obs = HermitianObsC64 if use_csingle else HermitianObsC128
         c_dtype = np.complex64 if use_csingle else np.complex128
 
-        s = QuantumScriptSerializer(device_name, use_csingle).serialize_observables(
+        s, _ = QuantumScriptSerializer(device_name, use_csingle).serialize_observables(
             tape, self.wires_dict
         )
         s_expected = hermitian_obs(
@@ -168,7 +168,7 @@ class TestSerializeObs:
         c_dtype = np.complex64 if use_csingle else np.complex128
         tensor_prod_obs = TensorProdObsC64 if use_csingle else TensorProdObsC128
         hermitian_obs = HermitianObsC64 if use_csingle else HermitianObsC128
-        s = QuantumScriptSerializer(device_name, use_csingle).serialize_observables(
+        s, _ = QuantumScriptSerializer(device_name, use_csingle).serialize_observables(
             tape, self.wires_dict
         )
 
@@ -192,7 +192,7 @@ class TestSerializeObs:
         hermitian_obs = HermitianObsC64 if use_csingle else HermitianObsC128
         named_obs = NamedObsC64 if use_csingle else NamedObsC128
 
-        s = QuantumScriptSerializer(device_name, use_csingle).serialize_observables(
+        s, _ = QuantumScriptSerializer(device_name, use_csingle).serialize_observables(
             tape, self.wires_dict
         )
 
@@ -225,7 +225,7 @@ class TestSerializeObs:
         r_dtype = np.float32 if use_csingle else np.float64
         c_dtype = np.complex64 if use_csingle else np.complex128
 
-        s = QuantumScriptSerializer(device_name, use_csingle).serialize_observables(
+        s, _ = QuantumScriptSerializer(device_name, use_csingle).serialize_observables(
             tape, self.wires_dict
         )
 
@@ -267,7 +267,7 @@ class TestSerializeObs:
         r_dtype = np.float32 if use_csingle else np.float64
         c_dtype = np.complex64 if use_csingle else np.complex128
 
-        s = QuantumScriptSerializer(device_name, use_csingle).serialize_observables(
+        s, _ = QuantumScriptSerializer(device_name, use_csingle).serialize_observables(
             tape, self.wires_dict
         )
 
@@ -322,7 +322,7 @@ class TestSerializeObs:
         r_dtype = np.float32 if use_csingle else np.float64
         c_dtype = np.complex64 if use_csingle else np.complex128
 
-        s = QuantumScriptSerializer(device_name, use_csingle).serialize_observables(
+        s, _ = QuantumScriptSerializer(device_name, use_csingle).serialize_observables(
             tape, self.wires_dict
         )
 
@@ -374,7 +374,7 @@ class TestSerializeObs:
     def test_op_arithmetic_uses_hamiltonian(self, use_csingle, obs, coeffs, terms):
         """Tests that an arithmetic obs with a PauliRep serializes as a Hamiltonian."""
         tape = qml.tape.QuantumTape(measurements=[qml.expval(obs)])
-        res = QuantumScriptSerializer(device_name, use_csingle).serialize_observables(
+        res, _ = QuantumScriptSerializer(device_name, use_csingle).serialize_observables(
             tape, self.wires_dict
         )
         assert len(res) == 1
@@ -400,7 +400,7 @@ class TestSerializeObs:
     def test_multi_wire_identity(self, use_csingle):
         """Tests that multi-wire Identity does not fail serialization."""
         tape = qml.tape.QuantumTape(measurements=[qml.expval(qml.Identity(wires=[1, 2]))])
-        res = QuantumScriptSerializer(device_name, use_csingle).serialize_observables(
+        res, _ = QuantumScriptSerializer(device_name, use_csingle).serialize_observables(
             tape, self.wires_dict
         )
         assert len(res) == 1


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [x] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [x] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [x] Ensure that the test suite passes, by running `make test`.

- [x] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [x] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:** This PR fixes batching support for LightningGPU devices, and adds preliminary support to enable it for LQ and LK at a later date.

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
