### PR TITLE
Closes #557, in-place implementation of expval for LightningQubit

### DIFF
--- a/pennylane_lightning/core/src/measurements/tests/Test_MeasurementsBase.cpp
+++ b/pennylane_lightning/core/src/measurements/tests/Test_MeasurementsBase.cpp
@@ -162,12 +162,15 @@ template <typename TypeList> void testNamedObsExpval() {
         Measurements<StateVectorT> Measurer(statevector);
 
         std::vector<std::vector<size_t>> wires_list = {{0}, {1}, {2}};
-        std::vector<std::string> obs_name = {"PauliX", "PauliY", "PauliZ"};
+        std::vector<std::string> obs_name = {"PauliX", "PauliY", "PauliZ",
+                                             "Hadamard", "Identity"};
         // Expected results calculated with Pennylane default.qubit:
         std::vector<std::vector<PrecisionT>> exp_values_ref = {
             {0.49272486, 0.42073549, 0.28232124},
             {-0.64421768, -0.47942553, -0.29552020},
-            {0.58498357, 0.77015115, 0.91266780}};
+            {0.58498357, 0.77015115, 0.91266780},
+            {0.76205494, 0.84208402, 0.84498485},
+            {1.0, 1.0, 1.0}};
 
         for (size_t ind_obs = 0; ind_obs < obs_name.size(); ind_obs++) {
             DYNAMIC_SECTION(obs_name[ind_obs]

--- a/pennylane_lightning/core/src/simulators/lightning_qubit/measurements/ExpValFunctorsLQubit.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_qubit/measurements/ExpValFunctorsLQubit.hpp
@@ -14,22 +14,22 @@
 #pragma once
 
 #include "BitUtil.hpp"
+#include "Util.hpp"
 
 /// @cond DEV
 namespace {
 using namespace Pennylane::Util;
-using Pennylane::Util::INVSQRT2;
 } // namespace
 /// @endcond
 
 namespace Pennylane::LightningQubit::Functors {
 
 template <class PrecisionT> struct getExpectationValueIdentityFunctor {
-    std::complex<PrecisionT> *arr;
+    const std::complex<PrecisionT> *arr;
     size_t num_qubits;
 
     getExpectationValueIdentityFunctor(
-        std::complex<PrecisionT> *arr_,
+        const std::complex<PrecisionT> *arr_,
         [[maybe_unused]] std::size_t num_qubits_,
         [[maybe_unused]] const std::vector<size_t> &wires) {
         arr = arr_;
@@ -49,7 +49,7 @@ template <class PrecisionT> struct getExpectationValueIdentityFunctor {
 };
 
 template <class PrecisionT> struct getExpectationValuePauliXFunctor {
-    std::complex<PrecisionT> *arr;
+    const std::complex<PrecisionT> *arr;
     size_t num_qubits;
 
     size_t rev_wire;
@@ -57,7 +57,7 @@ template <class PrecisionT> struct getExpectationValuePauliXFunctor {
     size_t wire_parity;
     size_t wire_parity_inv;
 
-    getExpectationValuePauliXFunctor(std::complex<PrecisionT> *arr_,
+    getExpectationValuePauliXFunctor(const std::complex<PrecisionT> *arr_,
                                      std::size_t num_qubits_,
                                      const std::vector<size_t> &wires) {
         arr = arr_;
@@ -69,7 +69,9 @@ template <class PrecisionT> struct getExpectationValuePauliXFunctor {
     }
 
     inline void operator()(PrecisionT &expval) const {
-        size_t k, i0, i1;
+        size_t k;
+        size_t i0;
+        size_t i1;
 #if defined(_OPENMP)
 #pragma omp parallel for default(none)                                         \
     shared(num_qubits, wire_parity_inv, wire_parity, rev_wire_shift,           \
@@ -86,7 +88,7 @@ template <class PrecisionT> struct getExpectationValuePauliXFunctor {
 };
 
 template <class PrecisionT> struct getExpectationValuePauliYFunctor {
-    std::complex<PrecisionT> *arr;
+    const std::complex<PrecisionT> *arr;
     size_t num_qubits;
 
     size_t rev_wire;
@@ -94,7 +96,7 @@ template <class PrecisionT> struct getExpectationValuePauliYFunctor {
     size_t wire_parity;
     size_t wire_parity_inv;
 
-    getExpectationValuePauliYFunctor(std::complex<PrecisionT> *arr_,
+    getExpectationValuePauliYFunctor(const std::complex<PrecisionT> *arr_,
                                      std::size_t num_qubits_,
                                      const std::vector<size_t> &wires) {
         arr = arr_;
@@ -106,8 +108,11 @@ template <class PrecisionT> struct getExpectationValuePauliYFunctor {
     }
 
     inline void operator()(PrecisionT &expval) const {
-        size_t k, i0, i1;
-        std::complex<PrecisionT> v0, v1;
+        size_t k;
+        size_t i0;
+        size_t i1;
+        std::complex<PrecisionT> v0;
+        std::complex<PrecisionT> v1;
 #if defined(_OPENMP)
 #pragma omp parallel for default(none)                                         \
     shared(num_qubits, wire_parity_inv, wire_parity, rev_wire_shift,           \
@@ -128,7 +133,7 @@ template <class PrecisionT> struct getExpectationValuePauliYFunctor {
 };
 
 template <class PrecisionT> struct getExpectationValuePauliZFunctor {
-    std::complex<PrecisionT> *arr;
+    const std::complex<PrecisionT> *arr;
     size_t num_qubits;
 
     size_t rev_wire;
@@ -136,7 +141,7 @@ template <class PrecisionT> struct getExpectationValuePauliZFunctor {
     size_t wire_parity;
     size_t wire_parity_inv;
 
-    getExpectationValuePauliZFunctor(std::complex<PrecisionT> *arr_,
+    getExpectationValuePauliZFunctor(const std::complex<PrecisionT> *arr_,
                                      std::size_t num_qubits_,
                                      const std::vector<size_t> &wires) {
         arr = arr_;
@@ -148,7 +153,9 @@ template <class PrecisionT> struct getExpectationValuePauliZFunctor {
     }
 
     inline void operator()(PrecisionT &expval) const {
-        size_t k, i0, i1;
+        size_t k;
+        size_t i0;
+        size_t i1;
 #if defined(_OPENMP)
 #pragma omp parallel for default(none)                                         \
     shared(num_qubits, wire_parity_inv, wire_parity, rev_wire_shift,           \
@@ -166,7 +173,7 @@ template <class PrecisionT> struct getExpectationValuePauliZFunctor {
 };
 
 template <class PrecisionT> struct getExpectationValueHadamardFunctor {
-    std::complex<PrecisionT> *arr;
+    const std::complex<PrecisionT> *arr;
     size_t num_qubits;
 
     size_t rev_wire;
@@ -174,9 +181,9 @@ template <class PrecisionT> struct getExpectationValueHadamardFunctor {
     size_t wire_parity;
     size_t wire_parity_inv;
 
-    constexpr static auto isqrt2 = INVSQRT2<PrecisionT>();
+    PrecisionT isqrt2 = INVSQRT2<PrecisionT>();
 
-    getExpectationValueHadamardFunctor(std::complex<PrecisionT> *arr_,
+    getExpectationValueHadamardFunctor(const std::complex<PrecisionT> *arr_,
                                        std::size_t num_qubits_,
                                        const std::vector<size_t> &wires) {
         arr = arr_;
@@ -188,8 +195,11 @@ template <class PrecisionT> struct getExpectationValueHadamardFunctor {
     }
 
     inline void operator()(PrecisionT &expval) const {
-        size_t k, i0, i1;
-        std::complex<PrecisionT> v0, v1;
+        size_t k;
+        size_t i0;
+        size_t i1;
+        std::complex<PrecisionT> v0;
+        std::complex<PrecisionT> v1;
 #if defined(_OPENMP)
 #pragma omp parallel for default(none)                                         \
     shared(num_qubits, wire_parity_inv, wire_parity, rev_wire_shift,           \

--- a/pennylane_lightning/core/src/simulators/lightning_qubit/measurements/ExpValFunctorsLQubit.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_qubit/measurements/ExpValFunctorsLQubit.hpp
@@ -1,0 +1,210 @@
+// Copyright 2018-2023 Xanadu Quantum Technologies Inc.
+
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include "BitUtil.hpp"
+
+/// @cond DEV
+namespace {
+using namespace Pennylane::Util;
+using Pennylane::Util::INVSQRT2;
+} // namespace
+/// @endcond
+
+namespace Pennylane::LightningQubit::Functors {
+
+template <class PrecisionT> struct getExpectationValueIdentityFunctor {
+    std::complex<PrecisionT> *arr;
+    size_t num_qubits;
+
+    getExpectationValueIdentityFunctor(
+        std::complex<PrecisionT> *arr_,
+        [[maybe_unused]] std::size_t num_qubits_,
+        [[maybe_unused]] const std::vector<size_t> &wires) {
+        arr = arr_;
+        num_qubits = num_qubits_;
+    }
+
+    inline void operator()(PrecisionT &expval) const {
+        size_t k;
+#if defined(_OPENMP)
+#pragma omp parallel for default(none) shared(num_qubits, arr) private(k)      \
+    reduction(+ : expval)
+#endif
+        for (k = 0; k < exp2(num_qubits - 1); k++) {
+            expval += real(conj(arr[k] * arr[k]));
+        }
+    }
+};
+
+template <class PrecisionT> struct getExpectationValuePauliXFunctor {
+    std::complex<PrecisionT> *arr;
+    size_t num_qubits;
+
+    size_t rev_wire;
+    size_t rev_wire_shift;
+    size_t wire_parity;
+    size_t wire_parity_inv;
+
+    getExpectationValuePauliXFunctor(std::complex<PrecisionT> *arr_,
+                                     std::size_t num_qubits_,
+                                     const std::vector<size_t> &wires) {
+        arr = arr_;
+        num_qubits = num_qubits_;
+        rev_wire = num_qubits - wires[0] - 1;
+        rev_wire_shift = (static_cast<size_t>(1U) << rev_wire);
+        wire_parity = fillTrailingOnes(rev_wire);
+        wire_parity_inv = fillLeadingOnes(rev_wire + 1);
+    }
+
+    inline void operator()(PrecisionT &expval) const {
+        size_t k, i0, i1;
+#if defined(_OPENMP)
+#pragma omp parallel for default(none)                                         \
+    shared(num_qubits, wire_parity_inv, wire_parity, rev_wire_shift,           \
+               arr) private(k, i0, i1) reduction(+ : expval)
+#endif
+        for (k = 0; k < exp2(num_qubits - 1); k++) {
+            i0 = ((k << 1U) & wire_parity_inv) | (wire_parity & k);
+            i1 = i0 | rev_wire_shift;
+
+            expval +=
+                real(conj(arr[i0]) * arr[i1]) + real(conj(arr[i1]) * arr[i0]);
+        }
+    }
+};
+
+template <class PrecisionT> struct getExpectationValuePauliYFunctor {
+    std::complex<PrecisionT> *arr;
+    size_t num_qubits;
+
+    size_t rev_wire;
+    size_t rev_wire_shift;
+    size_t wire_parity;
+    size_t wire_parity_inv;
+
+    getExpectationValuePauliYFunctor(std::complex<PrecisionT> *arr_,
+                                     std::size_t num_qubits_,
+                                     const std::vector<size_t> &wires) {
+        arr = arr_;
+        num_qubits = num_qubits_;
+        rev_wire = num_qubits - wires[0] - 1;
+        rev_wire_shift = (static_cast<size_t>(1U) << rev_wire);
+        wire_parity = fillTrailingOnes(rev_wire);
+        wire_parity_inv = fillLeadingOnes(rev_wire + 1);
+    }
+
+    inline void operator()(PrecisionT &expval) const {
+        size_t k, i0, i1;
+        std::complex<PrecisionT> v0, v1;
+#if defined(_OPENMP)
+#pragma omp parallel for default(none)                                         \
+    shared(num_qubits, wire_parity_inv, wire_parity, rev_wire_shift,           \
+               arr) private(k, i0, i1, v0, v1) reduction(+ : expval)
+#endif
+        for (k = 0; k < exp2(num_qubits - 1); k++) {
+            i0 = ((k << 1U) & wire_parity_inv) | (wire_parity & k);
+            i1 = i0 | rev_wire_shift;
+            v0 = arr[i0];
+            v1 = arr[i1];
+
+            expval += real(conj(arr[i0]) *
+                           std::complex<PrecisionT>{imag(v1), -real(v1)}) +
+                      real(conj(arr[i1]) *
+                           std::complex<PrecisionT>{-imag(v0), real(v0)});
+        }
+    }
+};
+
+template <class PrecisionT> struct getExpectationValuePauliZFunctor {
+    std::complex<PrecisionT> *arr;
+    size_t num_qubits;
+
+    size_t rev_wire;
+    size_t rev_wire_shift;
+    size_t wire_parity;
+    size_t wire_parity_inv;
+
+    getExpectationValuePauliZFunctor(std::complex<PrecisionT> *arr_,
+                                     std::size_t num_qubits_,
+                                     const std::vector<size_t> &wires) {
+        arr = arr_;
+        num_qubits = num_qubits_;
+        rev_wire = num_qubits - wires[0] - 1;
+        rev_wire_shift = (static_cast<size_t>(1U) << rev_wire);
+        wire_parity = fillTrailingOnes(rev_wire);
+        wire_parity_inv = fillLeadingOnes(rev_wire + 1);
+    }
+
+    inline void operator()(PrecisionT &expval) const {
+        size_t k, i0, i1;
+#if defined(_OPENMP)
+#pragma omp parallel for default(none)                                         \
+    shared(num_qubits, wire_parity_inv, wire_parity, rev_wire_shift,           \
+               arr) private(k, i0, i1) reduction(+ : expval)
+#endif
+        for (k = 0; k < exp2(num_qubits - 1); k++) {
+
+            i0 = ((k << 1U) & wire_parity_inv) | (wire_parity & k);
+            i1 = i0 | rev_wire_shift;
+
+            expval += real(conj(arr[i1]) * (-arr[i1])) +
+                      real(conj(arr[i0]) * (arr[i0]));
+        }
+    }
+};
+
+template <class PrecisionT> struct getExpectationValueHadamardFunctor {
+    std::complex<PrecisionT> *arr;
+    size_t num_qubits;
+
+    size_t rev_wire;
+    size_t rev_wire_shift;
+    size_t wire_parity;
+    size_t wire_parity_inv;
+
+    constexpr static auto isqrt2 = INVSQRT2<PrecisionT>();
+
+    getExpectationValueHadamardFunctor(std::complex<PrecisionT> *arr_,
+                                       std::size_t num_qubits_,
+                                       const std::vector<size_t> &wires) {
+        arr = arr_;
+        num_qubits = num_qubits_;
+        rev_wire = num_qubits - wires[0] - 1;
+        rev_wire_shift = (static_cast<size_t>(1U) << rev_wire);
+        wire_parity = fillTrailingOnes(rev_wire);
+        wire_parity_inv = fillLeadingOnes(rev_wire + 1);
+    }
+
+    inline void operator()(PrecisionT &expval) const {
+        size_t k, i0, i1;
+        std::complex<PrecisionT> v0, v1;
+#if defined(_OPENMP)
+#pragma omp parallel for default(none)                                         \
+    shared(num_qubits, wire_parity_inv, wire_parity, rev_wire_shift,           \
+               arr) private(k, i0, i1, v0, v1) reduction(+ : expval)
+#endif
+
+        for (k = 0; k < exp2(num_qubits - 1); k++) {
+            i0 = ((k << 1U) & wire_parity_inv) | (wire_parity & k);
+            i1 = i0 | rev_wire_shift;
+            v0 = arr[i0];
+            v1 = arr[i1];
+
+            expval += real(isqrt2 * (conj(arr[i0]) * (v0 + v1) +
+                                     conj(arr[i1]) * (v0 - v1)));
+        }
+    }
+};
+} // namespace Pennylane::LightningQubit::Functors

--- a/pennylane_lightning/core/src/simulators/lightning_qubit/measurements/MeasurementsLQubit.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_qubit/measurements/MeasurementsLQubit.hpp
@@ -39,9 +39,6 @@
 #include "TransitionKernels.hpp"
 #include "Util.hpp" //transpose_state_tensor, sorting_indices
 
-#include "BitUtil.hpp"
-#include <iostream>
-
 /// @cond DEV
 namespace {
 using namespace Pennylane::Measures;
@@ -108,34 +105,6 @@ class Measurements final
 
         PrecisionT expval = 0.0;
         functor_t<PrecisionT>(arr_data, num_qubits, wires)(expval);
-
-        /*
-        size_t rev_wire = num_qubits - wires[0] - 1;
-        size_t rev_wire_shift = (static_cast<size_t>(1U) << rev_wire);
-        size_t wire_parity = fillTrailingOnes(rev_wire);
-        size_t wire_parity_inv = fillLeadingOnes(rev_wire + 1);
-
-        // ======
-        // PauliX
-        // ======
-        size_t k, i0, i1;
-        PrecisionT tmp_val = 0.0;
-        double t_start = omp_get_wtime();
-        #if defined(_OPENMP)
-        #pragma omp parallel for default(none) \
-        shared(num_qubits, wire_parity_inv, wire_parity, rev_wire_shift,
-        arr_data) \ private(k, i0, i1) reduction(+ : tmp_val) #endif for (k = 0;
-        k < exp2(num_qubits - 1); k++) { i0 =
-                ((k << 1U) & wire_parity_inv) | (wire_parity & k);
-            i1 = i0 | rev_wire_shift;
-
-            tmp_val += real(conj(arr_data[i0]) * arr_data[i1]) +
-                       real(conj(arr_data[i1]) * arr_data[i0]);
-        }
-        double t_stop = omp_get_wtime();
-        double t_elapsed = t_stop - t_start;
-        std::cout << "t_kernel_direct: " << t_elapsed << std::endl;
-        */
 
         return expval;
     }
@@ -242,23 +211,18 @@ class Measurements final
         case ExpValFunc::Identity:
             return applyExpValNamedFunctor<getExpectationValueIdentityFunctor,
                                            0>(wires);
-            break;
         case ExpValFunc::PauliX:
             return applyExpValNamedFunctor<getExpectationValuePauliXFunctor, 1>(
                 wires);
-            break;
         case ExpValFunc::PauliY:
             return applyExpValNamedFunctor<getExpectationValuePauliYFunctor, 1>(
                 wires);
-            break;
         case ExpValFunc::PauliZ:
             return applyExpValNamedFunctor<getExpectationValuePauliZFunctor, 1>(
                 wires);
-            break;
         case ExpValFunc::Hadamard:
             return applyExpValNamedFunctor<getExpectationValueHadamardFunctor,
                                            1>(wires);
-            break;
         default:
             PL_ABORT(
                 std::string("Expval does not exist for named observable ") +

--- a/pennylane_lightning/core/src/simulators/lightning_qubit/measurements/MeasurementsLQubit.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_qubit/measurements/MeasurementsLQubit.hpp
@@ -236,94 +236,35 @@ class Measurements final
      */
     PrecisionT expval(const std::string &operation,
                       const std::vector<size_t> &wires) {
-        // Copying the original state vector, for the application of the
-        // observable operator.
-        StateVectorLQubitManaged<PrecisionT> operator_statevector(
-            this->_statevector);
-
-        operator_statevector.applyOperation(operation, wires);
-
-        ComplexT expected_value = innerProdC(this->_statevector.getData(),
-                                             operator_statevector.getData(),
-                                             this->_statevector.getLength());
-
-        std::cout << "Inside expval" << std::endl;
-        std::cout << "operation: " << operation << std::endl;
-        std::cout << "wires.size(): " << wires.size() << std::endl;
-        size_t data_size = this->_statevector.getLength();
-        size_t num_qubits = this->_statevector.getNumQubits();
-        std::cout << "data_size: " << data_size << std::endl;
-        std::cout << "exp2(num_qubits - 1): " << exp2(num_qubits - 1)
-                  << std::endl;
-
-        // In-place evaluation
-        PrecisionT expval_inplace = 0;
-
-        double t_start = omp_get_wtime();
+        // In-place calculation of expval without creating duplicate of the
+        // statevector.
         switch (expval_funcs_[operation]) {
         case ExpValFunc::Identity:
-            // return
-            // applyExpValNamedFunctor<getExpectationValueIdentityFunctor,
-            //                                0>(wires);
-
-            expval_inplace =
-                applyExpValNamedFunctor<getExpectationValueIdentityFunctor, 0>(
-                    wires);
+            return applyExpValNamedFunctor<getExpectationValueIdentityFunctor,
+                                           0>(wires);
             break;
-
         case ExpValFunc::PauliX:
-            // return applyExpValNamedFunctor<getExpectationValuePauliXFunctor,
-            // 1>(
-            //     wires);
-            expval_inplace =
-                applyExpValNamedFunctor<getExpectationValuePauliXFunctor, 1>(
-                    wires);
+            return applyExpValNamedFunctor<getExpectationValuePauliXFunctor, 1>(
+                wires);
             break;
-
         case ExpValFunc::PauliY:
-            // return applyExpValNamedFunctor<getExpectationValuePauliYFunctor,
-            // 1>(
-            //     wires);
-            expval_inplace =
-                applyExpValNamedFunctor<getExpectationValuePauliYFunctor, 1>(
-                    wires);
+            return applyExpValNamedFunctor<getExpectationValuePauliYFunctor, 1>(
+                wires);
             break;
-
         case ExpValFunc::PauliZ:
-            // return applyExpValNamedFunctor<getExpectationValuePauliZFunctor,
-            // 1>(
-            //     wires);
-
-            expval_inplace =
-                applyExpValNamedFunctor<getExpectationValuePauliZFunctor, 1>(
-                    wires);
+            return applyExpValNamedFunctor<getExpectationValuePauliZFunctor, 1>(
+                wires);
             break;
-
         case ExpValFunc::Hadamard:
-            // return
-            // applyExpValNamedFunctor<getExpectationValueHadamardFunctor,
-            //                                1>(wires);
-
-            expval_inplace =
-                applyExpValNamedFunctor<getExpectationValueHadamardFunctor, 1>(
-                    wires);
+            return applyExpValNamedFunctor<getExpectationValueHadamardFunctor,
+                                           1>(wires);
             break;
-
         default:
             PL_ABORT(
                 std::string("Expval does not exist for named observable ") +
                 operation);
             break;
         }
-        double t_stop = omp_get_wtime();
-        double duration = t_stop - t_start;
-        std::cout << "duration: " << duration << std::endl;
-
-        PrecisionT err_expval =
-            std::abs(std::real(expected_value) - expval_inplace);
-        std::cout << "err_expval: " << err_expval << std::endl;
-
-        return std::real(expected_value);
     };
 
     /**

--- a/pennylane_lightning/core/src/simulators/lightning_qubit/measurements/MeasurementsLQubit.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_qubit/measurements/MeasurementsLQubit.hpp
@@ -103,11 +103,11 @@ class Measurements final
             PL_ASSERT(wires.size() == num_wires);
         }
 
-        const size_t num_qubits = this->_statevector.getNumQubits();
-        auto arr_data = this->_statevector.getData();
+        size_t num_qubits = this->_statevector.getNumQubits();
+        const std::complex<PrecisionT> *arr_data = this->_statevector.getData();
 
         PrecisionT expval = 0.0;
-        functor_t(arr_data, num_qubits, wires)(expval);
+        functor_t<PrecisionT>(arr_data, num_qubits, wires)(expval);
 
         /*
         size_t rev_wire = num_qubits - wires[0] - 1;


### PR DESCRIPTION
**Context:**
This PR modifies the expval method for named operations using an in-place. OpenMP parallel, implementation to avoid creating an extra intemediate statevector.

**Description of the Change:**
The implementation closely follows that of [MeasurementsKokkos.hpp)](https://github.com/PennyLaneAI/pennylane-lightning/blob/master/pennylane_lightning/core/src/simulators/lightning_kokkos/measurements/MeasurementsKokkos.hpp). It adds the corresponding functors in `ExpValFunctorsLQubit.hpp` and modifies `MeasurementsLQubit.hpp` accordingly. It uses the existing tests of `testNamedObsExpval` in `Test_MeasurementsBase.cpp` to validate the changes. 

**Benefits:**
- Avoiding creating an extra intermediate statevector
- An order of magnitude speedup in calculating the expected value of `PauliX`, `PauliY`, `PauliZ`, `Hadamard`, and `Identity` operators

**Possible Drawbacks:**

**Related GitHub Issues:**
Closes #557
