### PR TITLE
Refactor obs base and safer LQRaw call for  measurement shots

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Release 0.34.0-dev
 
 ### New features since last release
+* Shot-noise related methods now accommodate observable objects with arbitary eigenvalues. Add Kronecker product method for two diagonal matrices.
+[(#570)](https://github.com/PennyLaneAI/pennylane-lightning/pull/570)
 
 * Add shot-noise support for probs in the C++ layer. Probabilities are calculated from generated samples. All Lightning backends support this feature. Please note that target wires should be sorted in ascending manner.
 [(#568)](https://github.com/PennyLaneAI/pennylane-lightning/pull/568)
@@ -20,6 +22,9 @@
   [(#540)] (https://github.com/PennyLaneAI/pennylane-lightning/pull/540)
 
 ### Improvements
+
+* Refactor shot-noise related methods of MeasurementsBase class in the C++ layer and eigenvalues are not limited to `1` and `-1`. Add `getObs()` method to Observables class. Refactor `applyInPlaceShots` to allow users to get eigenvalues of Observables object. Deprecated `_preprocess_state` method in `MeasurementsBase` class to have safer LightningQubitRaw backend safer.
+[(#570)](https://github.com/PennyLaneAI/pennylane-lightning/pull/570)
 
 * Modify `setup.py` to use backend-specific build directory (`f"build_{backend}"`) to accelerate rebuilding backends in alternance.
   [(#540)] (https://github.com/PennyLaneAI/pennylane-lightning/pull/540)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Release 0.34.0-dev
 
 ### New features since last release
-* Shot-noise related methods now accommodate observable objects with arbitary eigenvalues. Add a Kronecker product method for two diagonal matrices.
+* Shot-noise related methods now accommodate observable objects with arbitrary eigenvalues. Add a Kronecker product method for two diagonal matrices.
 [(#570)](https://github.com/PennyLaneAI/pennylane-lightning/pull/570)
 
 * Add shot-noise support for probs in the C++ layer. Probabilities are calculated from generated samples. All Lightning backends support this feature. Please note that target wires should be sorted in ascending manner.

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Release 0.34.0-dev
 
 ### New features since last release
-* Shot-noise related methods now accommodate observable objects with arbitary eigenvalues. Add Kronecker product method for two diagonal matrices.
+* Shot-noise related methods now accommodate observable objects with arbitary eigenvalues. Add a Kronecker product method for two diagonal matrices.
 [(#570)](https://github.com/PennyLaneAI/pennylane-lightning/pull/570)
 
 * Add shot-noise support for probs in the C++ layer. Probabilities are calculated from generated samples. All Lightning backends support this feature. Please note that target wires should be sorted in ascending manner.

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -23,7 +23,7 @@
 
 ### Improvements
 
-* Refactor shot-noise related methods of MeasurementsBase class in the C++ layer and eigenvalues are not limited to `1` and `-1`. Add `getObs()` method to Observables class. Refactor `applyInPlaceShots` to allow users to get eigenvalues of Observables object. Deprecated `_preprocess_state` method in `MeasurementsBase` class to have safer LightningQubitRaw backend safer.
+* Refactor shot-noise related methods of MeasurementsBase class in the C++ layer and eigenvalues are not limited to `1` and `-1`. Add `getObs()` method to Observables class. Refactor `applyInPlaceShots` to allow users to get eigenvalues of Observables object. Deprecated `_preprocess_state` method in `MeasurementsBase` class for safer use of the `LightningQubitRaw` backend.
 [(#570)](https://github.com/PennyLaneAI/pennylane-lightning/pull/570)
 
 * Modify `setup.py` to use backend-specific build directory (`f"build_{backend}"`) to accelerate rebuilding backends in alternance.

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.34.0-dev12"
+__version__ = "0.34.0-dev13"

--- a/pennylane_lightning/core/src/measurements/MeasurementsBase.hpp
+++ b/pennylane_lightning/core/src/measurements/MeasurementsBase.hpp
@@ -144,15 +144,11 @@ template <class StateVectorT, class Derived> class MeasurementsBase {
                      "supported by shots");
         } else if (obs.getObsName().find("Hamiltonian") != std::string::npos) {
             auto coeffs = obs.getCoeffs();
+            auto obsTerms = obs.getObs();
             for (size_t obs_term_idx = 0; obs_term_idx < coeffs.size();
                  obs_term_idx++) {
-                auto obs_samples = measure_with_samples(
-                    obs, num_shots, shot_range, obs_term_idx);
-                PrecisionT result_per_term = std::accumulate(
-                    obs_samples.begin(), obs_samples.end(), 0.0);
-
-                result +=
-                    coeffs[obs_term_idx] * result_per_term / obs_samples.size();
+                result += coeffs[obs_term_idx] * expval(*obsTerms[obs_term_idx],
+                                                        num_shots, shot_range);
             }
         } else {
             auto obs_samples = measure_with_samples(obs, num_shots, shot_range);
@@ -170,60 +166,39 @@ template <class StateVectorT, class Derived> class MeasurementsBase {
      * @param num_shots Number of shots used to generate samples
      * @param shot_range The range of samples to use. All samples are used
      * by default.
-     * @param term_idx Index of a Hamiltonian term
      *
      * @return Expectation value with respect to the given observable.
      */
     auto measure_with_samples(const Observable<StateVectorT> &obs,
                               const size_t &num_shots,
-                              const std::vector<size_t> &shot_range,
-                              size_t term_idx = 0) {
+                              const std::vector<size_t> &shot_range) {
         const size_t num_qubits = _statevector.getTotalNumQubits();
         std::vector<size_t> obs_wires;
-        std::vector<size_t> identity_wires;
+        std::vector<std::vector<PrecisionT>> eigenValues;
 
-        auto sub_samples = _sample_state(obs, num_shots, shot_range, obs_wires,
-                                         identity_wires, term_idx);
+        auto sub_samples =
+            _sample_state(obs, num_shots, shot_range, obs_wires, eigenValues);
 
         size_t num_samples = shot_range.empty() ? num_shots : shot_range.size();
 
         std::vector<PrecisionT> obs_samples(num_samples, 0);
 
-        size_t num_identity_obs = identity_wires.size();
-        if (!identity_wires.empty()) {
-            size_t identity_obs_idx = 0;
-            for (size_t i = 0; i < obs_wires.size(); i++) {
-                if (identity_wires[identity_obs_idx] == obs_wires[i]) {
-                    std::swap(obs_wires[identity_obs_idx], obs_wires[i]);
-                    identity_obs_idx++;
-                }
-            }
+        std::vector<PrecisionT> eigenVals = eigenValues[0];
+
+        for (size_t i = 1; i < eigenValues.size(); i++) {
+            eigenVals = kronProd(eigenVals, eigenValues[i]);
         }
 
         for (size_t i = 0; i < num_samples; i++) {
-            std::vector<size_t> local_sample(obs_wires.size());
             size_t idx = 0;
+            size_t wire_idx = 0;
             for (auto &obs_wire : obs_wires) {
-                local_sample[idx] = sub_samples[i * num_qubits + obs_wire];
-                idx++;
+                idx += sub_samples[i * num_qubits + obs_wire]
+                       << (obs_wires.size() - 1 - wire_idx);
+                wire_idx++;
             }
 
-            if (num_identity_obs != obs_wires.size()) {
-                // eigen values are `1` and `-1` for PauliX, PauliY, PauliZ,
-                // Hadamard gates the eigen value for a eigen vector |00001> is
-                // -1 since sum of the value at each bit position is odd
-                size_t bitSum = static_cast<size_t>(
-                    std::accumulate(local_sample.begin() + num_identity_obs,
-                                    local_sample.end(), 0));
-                if ((bitSum & size_t{1}) == 1) {
-                    obs_samples[i] = -1;
-                } else {
-                    obs_samples[i] = 1;
-                }
-            } else {
-                // eigen value for Identity gate is `1`
-                obs_samples[i] = 1;
-            }
+            obs_samples[i] = eigenVals[idx];
         }
         return obs_samples;
     }
@@ -238,35 +213,27 @@ template <class StateVectorT, class Derived> class MeasurementsBase {
      */
     auto var(const Observable<StateVectorT> &obs, const size_t &num_shots) {
         if (obs.getObsName().find("Hamiltonian") == std::string::npos) {
-            // Branch for NamedObs and TensorProd observables
-            auto square_mean = expval(obs, num_shots, {});
-            PrecisionT result =
-                1 - square_mean *
-                        square_mean; //`1` used here is because Eigenvalues for
-                                     // Paulis, Hadamard and Identity are {-1,
-                                     // 1}. Need to change based on eigen values
-                                     // when add Hermitian support.
+            auto obs_samples = measure_with_samples(obs, num_shots, {});
+            auto square_mean =
+                std::accumulate(obs_samples.begin(), obs_samples.end(), 0.0) /
+                obs_samples.size();
+            auto mean_square =
+                std::accumulate(obs_samples.begin(), obs_samples.end(), 0.0,
+                                [](PrecisionT acc, PrecisionT element) {
+                                    return acc + element * element;
+                                }) /
+                obs_samples.size();
+            PrecisionT result = mean_square - square_mean * square_mean;
             return result;
         }
         // Branch for Hamiltonian observables
         auto coeffs = obs.getCoeffs();
+        auto obs_terms = obs.getObs();
+
         PrecisionT result{0.0};
         size_t obs_term_idx = 0;
         for (const auto &coeff : coeffs) {
-            std::vector<size_t> shot_range = {};
-            auto obs_samples =
-                measure_with_samples(obs, num_shots, shot_range, obs_term_idx);
-            PrecisionT expval_per_term =
-                std::accumulate(obs_samples.begin(), obs_samples.end(), 0.0);
-            auto term_mean = expval_per_term / obs_samples.size();
-
-            result +=
-                coeff * coeff *
-                (1 - term_mean *
-                         term_mean); //`1` used here is because Eigenvalues for
-                                     // Paulis, Hadamard and Identity are {-1,
-                                     // 1}. Need to change based on eigen values
-                                     // when add Hermitian support.
+            result += coeff * coeff * var(*obs_terms[obs_term_idx], num_shots);
             obs_term_idx++;
         }
         return result;
@@ -287,13 +254,30 @@ template <class StateVectorT, class Derived> class MeasurementsBase {
             obs.getObsName().find("Hamiltonian") != std::string::npos,
             "Hamiltonian and Sparse Hamiltonian do not support samples().");
         std::vector<size_t> obs_wires;
-        std::vector<size_t> identity_wires;
-        auto sv = _preprocess_state(obs, obs_wires, identity_wires);
-        Derived measure(sv);
-        if (num_shots != size_t{0}) {
-            return measure.probs(obs_wires, num_shots);
+        std::vector<std::vector<PrecisionT>> eigenvalues;
+        if constexpr (std::is_same_v<
+                          typename StateVectorT::MemoryStorageT,
+                          Pennylane::Util::MemoryStorageLocation::External>) {
+            std::vector<ComplexT> data_storage(
+                this->_statevector.getData(),
+                this->_statevector.getData() + this->_statevector.getLength());
+            StateVectorT sv(data_storage.data(), data_storage.size());
+            sv.updateData(data_storage.data(), data_storage.size());
+            obs.applyInPlaceShots(sv, eigenvalues, obs_wires);
+            Derived measure(sv);
+            if (num_shots > size_t{0}) {
+                return measure.probs(obs_wires, num_shots);
+            }
+            return measure.probs(obs_wires);
+        } else {
+            StateVectorT sv(_statevector);
+            obs.applyInPlaceShots(sv, eigenvalues, obs_wires);
+            Derived measure(sv);
+            if (num_shots > size_t{0}) {
+                return measure.probs(obs_wires, num_shots);
+            }
+            return measure.probs(obs_wires);
         }
-        return measure.probs(obs_wires);
     }
 
     /**
@@ -366,11 +350,9 @@ template <class StateVectorT, class Derived> class MeasurementsBase {
             obs.getObsName().find("Hamiltonian") != std::string::npos,
             "Hamiltonian and Sparse Hamiltonian do not support samples().");
         std::vector<size_t> obs_wires;
-        std::vector<size_t> identity_wires;
         std::vector<size_t> shot_range = {};
-        size_t term_idx = 0;
 
-        return measure_with_samples(obs, num_shots, shot_range, term_idx);
+        return measure_with_samples(obs, num_shots, shot_range);
     }
 
     /**
@@ -443,35 +425,6 @@ template <class StateVectorT, class Derived> class MeasurementsBase {
 
   private:
     /**
-     * @brief Return preprocess state with a observable
-     *
-     * @param obs The observable to sample
-     * @param obs_wires Observable wires.
-     * @param identity_wires Wires of Identity gates
-     * @param term_idx Index of a Hamiltonian term. For other observables, its
-     * value is 0, which is set as default.
-     *
-     * @return a StateVectorT object
-     */
-    auto _preprocess_state(const Observable<StateVectorT> &obs,
-                           std::vector<size_t> &obs_wires,
-                           std::vector<size_t> &identity_wires,
-                           const size_t &term_idx = 0) {
-        if constexpr (std::is_same_v<
-                          typename StateVectorT::MemoryStorageT,
-                          Pennylane::Util::MemoryStorageLocation::External>) {
-            StateVectorT sv(_statevector.getData(), _statevector.getLength());
-            sv.updateData(_statevector.getData(), _statevector.getLength());
-            obs.applyInPlaceShots(sv, identity_wires, obs_wires, term_idx);
-            return sv;
-        } else {
-            StateVectorT sv(_statevector);
-            obs.applyInPlaceShots(sv, identity_wires, obs_wires, term_idx);
-            return sv;
-        }
-    }
-
-    /**
      * @brief Return samples of a observable
      *
      * @param obs The observable to sample
@@ -479,9 +432,7 @@ template <class StateVectorT, class Derived> class MeasurementsBase {
      * @param shot_range The range of samples to use. All samples are used by
      * default.
      * @param obs_wires Observable wires.
-     * @param identity_wires Wires of Identity gates
-     * @param term_idx Index of a Hamiltonian term. For other observables, its
-     * value is 0, which is set as default.
+     * @param eigenValues eigenvalues of the observable.
      *
      * @return std::vector<size_t> samples in std::vector
      */
@@ -489,12 +440,25 @@ template <class StateVectorT, class Derived> class MeasurementsBase {
                        const size_t &num_shots,
                        const std::vector<size_t> &shot_range,
                        std::vector<size_t> &obs_wires,
-                       std::vector<size_t> &identity_wires,
-                       const size_t &term_idx = 0) {
+                       std::vector<std::vector<PrecisionT>> &eigenValues) {
         const size_t num_qubits = _statevector.getTotalNumQubits();
-        auto sv = _preprocess_state(obs, obs_wires, identity_wires, term_idx);
-        Derived measure(sv);
-        auto samples = measure.generate_samples(num_shots);
+        std::vector<size_t> samples;
+        if constexpr (std::is_same_v<
+                          typename StateVectorT::MemoryStorageT,
+                          Pennylane::Util::MemoryStorageLocation::External>) {
+            std::vector<ComplexT> data_storage(
+                this->_statevector.getData(),
+                this->_statevector.getData() + this->_statevector.getLength());
+            StateVectorT sv(data_storage.data(), data_storage.size());
+            obs.applyInPlaceShots(sv, eigenValues, obs_wires);
+            Derived measure(sv);
+            samples = measure.generate_samples(num_shots);
+        } else {
+            StateVectorT sv(_statevector);
+            obs.applyInPlaceShots(sv, eigenValues, obs_wires);
+            Derived measure(sv);
+            samples = measure.generate_samples(num_shots);
+        }
 
         if (!shot_range.empty()) {
             std::vector<size_t> sub_samples(shot_range.size() * num_qubits);

--- a/pennylane_lightning/core/src/measurements/MeasurementsBase.hpp
+++ b/pennylane_lightning/core/src/measurements/MeasurementsBase.hpp
@@ -24,9 +24,12 @@
 
 #include "CPUMemoryModel.hpp"
 
+#include "Util.hpp"
+
 /// @cond DEV
 namespace {
 using namespace Pennylane::Observables;
+using namespace Pennylane::Util;
 } // namespace
 /// @endcond
 

--- a/pennylane_lightning/core/src/measurements/tests/Test_MeasurementsBase.cpp
+++ b/pennylane_lightning/core/src/measurements/tests/Test_MeasurementsBase.cpp
@@ -1253,7 +1253,7 @@ template <typename TypeList> void testHamiltonianObsExpvalShot() {
                 "Hadamard", std::vector<size_t>{1});
             auto obs1 = TensorProdObs<StateVectorT>::create({Y0, H1});
 
-            auto obs = Hamiltonian<StateVectorT>::create({1, 1}, {obs0, obs1});
+            auto obs = Hamiltonian<StateVectorT>::create({0.1, 0.3}, {obs0, obs1});
 
             Measurements<StateVectorT> Measurer_analytic(sv);
             auto expected = Measurer_analytic.expval(*obs);

--- a/pennylane_lightning/core/src/measurements/tests/Test_MeasurementsBase.cpp
+++ b/pennylane_lightning/core/src/measurements/tests/Test_MeasurementsBase.cpp
@@ -217,10 +217,12 @@ template <typename TypeList> void testProbabilitiesObs() {
 
         // Defining the Statevector that will be measured.
         auto statevector_data = createNonTrivialState<StateVectorT>();
+        auto sv_data = createNonTrivialState<StateVectorT>();
+
         StateVectorT statevector(statevector_data.data(),
                                  statevector_data.size());
 
-        StateVectorT sv(statevector_data.data(), statevector_data.size());
+        StateVectorT sv(sv_data.data(), sv_data.size());
 
         DYNAMIC_SECTION("Test PauliX"
                         << StateVectorToName<StateVectorT>::name) {
@@ -370,10 +372,11 @@ template <typename TypeList> void testProbabilitiesObsShots() {
 
         // Defining the Statevector that will be measured.
         auto statevector_data = createNonTrivialState<StateVectorT>();
+        auto sv_data = createNonTrivialState<StateVectorT>();
         StateVectorT statevector(statevector_data.data(),
                                  statevector_data.size());
 
-        StateVectorT sv(statevector_data.data(), statevector_data.size());
+        StateVectorT sv(sv_data.data(), sv_data.size());
 
         DYNAMIC_SECTION("Test TensorProd XYZ"
                         << StateVectorToName<StateVectorT>::name) {
@@ -1192,8 +1195,15 @@ template <typename TypeList> void testHamiltonianObsExpvalShot() {
         std::vector<ComplexT> statevector_data{
             {0.0, 0.0}, {0.0, 0.1}, {0.1, 0.1}, {0.1, 0.2},
             {0.2, 0.2}, {0.3, 0.3}, {0.3, 0.4}, {0.4, 0.5}};
+
+        std::vector<ComplexT> sv_data{{0.0, 0.0}, {0.0, 0.1}, {0.1, 0.1},
+                                      {0.1, 0.2}, {0.2, 0.2}, {0.3, 0.3},
+                                      {0.3, 0.4}, {0.4, 0.5}};
+
         StateVectorT statevector(statevector_data.data(),
                                  statevector_data.size());
+
+        StateVectorT sv(sv_data.data(), sv_data.size());
 
         // Initializing the measures class.
         // This object attaches to the statevector allowing several measures.
@@ -1226,6 +1236,31 @@ template <typename TypeList> void testHamiltonianObsExpvalShot() {
 
             auto res = Measurer.expval(*ob, num_shots, shots_range);
             auto expected = PrecisionT(-0.086);
+            REQUIRE(expected == Approx(res).margin(5e-2));
+        }
+
+        DYNAMIC_SECTION("TensorProd with shots_range "
+                        << StateVectorToName<StateVectorT>::name) {
+            auto X0 = std::make_shared<NamedObs<StateVectorT>>(
+                "PauliX", std::vector<size_t>{0});
+            auto Z1 = std::make_shared<NamedObs<StateVectorT>>(
+                "PauliZ", std::vector<size_t>{1});
+            auto obs0 = TensorProdObs<StateVectorT>::create({X0, Z1});
+
+            auto Y0 = std::make_shared<NamedObs<StateVectorT>>(
+                "PauliY", std::vector<size_t>{0});
+            auto H1 = std::make_shared<NamedObs<StateVectorT>>(
+                "Hadamard", std::vector<size_t>{1});
+            auto obs1 = TensorProdObs<StateVectorT>::create({Y0, H1});
+
+            auto obs = Hamiltonian<StateVectorT>::create({1, 1}, {obs0, obs1});
+
+            Measurements<StateVectorT> Measurer_analytic(sv);
+            auto expected = Measurer_analytic.expval(*obs);
+
+            size_t num_shots = 2000;
+            auto res = Measurer.expval(*obs, num_shots, {});
+
             REQUIRE(expected == Approx(res).margin(5e-2));
         }
 

--- a/pennylane_lightning/core/src/measurements/tests/Test_MeasurementsBase.cpp
+++ b/pennylane_lightning/core/src/measurements/tests/Test_MeasurementsBase.cpp
@@ -1253,7 +1253,8 @@ template <typename TypeList> void testHamiltonianObsExpvalShot() {
                 "Hadamard", std::vector<size_t>{1});
             auto obs1 = TensorProdObs<StateVectorT>::create({Y0, H1});
 
-            auto obs = Hamiltonian<StateVectorT>::create({0.1, 0.3}, {obs0, obs1});
+            auto obs =
+                Hamiltonian<StateVectorT>::create({0.1, 0.3}, {obs0, obs1});
 
             Measurements<StateVectorT> Measurer_analytic(sv);
             auto expected = Measurer_analytic.expval(*obs);

--- a/pennylane_lightning/core/src/observables/Observables.hpp
+++ b/pennylane_lightning/core/src/observables/Observables.hpp
@@ -66,16 +66,14 @@ template <class StateVectorT> class Observable {
      * place.
      *
      * @param sv Reference to StateVector object.
-     * @param identity_wires Reference to a std::vector object which stores
-     * wires of Identity gates in the observable.
+     * @param eigenValues Eigenvalues of an observable.
      * @param ob_wires Reference to a std::vector object which stores wires of
      * the observable.
-     * @param term_idx Index of a Hamiltonian term.
      */
-    virtual void applyInPlaceShots(StateVectorT &sv,
-                                   std::vector<size_t> &identity_wires,
-                                   std::vector<size_t> &ob_wires,
-                                   size_t term_idx = 0) const = 0;
+    virtual void
+    applyInPlaceShots(StateVectorT &sv,
+                      std::vector<std::vector<PrecisionT>> &eigenValues,
+                      std::vector<size_t> &ob_wires) const = 0;
 
     /**
      * @brief Get the name of the observable
@@ -86,6 +84,15 @@ template <class StateVectorT> class Observable {
      * @brief Get the wires the observable applies to.
      */
     [[nodiscard]] virtual auto getWires() const -> std::vector<size_t> = 0;
+
+    /**
+     * @brief Get the observable data.
+     *
+     */
+    [[nodiscard]] virtual auto getObs() const
+        -> std::vector<std::shared_ptr<Observable<StateVectorT>>> {
+        return {};
+    };
 
     /**
      * @brief Get the coefficients of a Hamiltonian observable.
@@ -164,12 +171,11 @@ class NamedObsBase : public Observable<StateVectorT> {
         sv.applyOperation(obs_name_, wires_, false, params_);
     }
 
-    void
-    applyInPlaceShots(StateVectorT &sv, std::vector<size_t> &identity_wire,
-                      std::vector<size_t> &ob_wires,
-                      [[maybe_unused]] size_t term_idx = 0) const override {
+    void applyInPlaceShots(StateVectorT &sv,
+                           std::vector<std::vector<PrecisionT>> &eigenValues,
+                           std::vector<size_t> &ob_wires) const override {
         ob_wires.clear();
-        identity_wire.clear();
+        eigenValues.clear();
         ob_wires.push_back(wires_[0]);
 
         if (obs_name_ == "PauliX") {
@@ -182,11 +188,16 @@ class NamedObsBase : public Observable<StateVectorT> {
             sv.applyOperation("RY", wires_, false, {theta});
         } else if (obs_name_ == "PauliZ") {
         } else if (obs_name_ == "Identity") {
-            identity_wire.push_back(wires_[0]);
         } else {
             PL_ABORT("Provided NamedObs does not supported for shots "
                      "calculation. Supported NamedObs are PauliX, PauliY, "
                      "PauliZ, Identity and Hadamard.");
+        }
+
+        if (obs_name_ == "Identity") {
+            eigenValues.push_back({1, 1});
+        } else {
+            eigenValues.push_back({1, -1});
         }
     }
 };
@@ -242,11 +253,10 @@ class HermitianObsBase : public Observable<StateVectorT> {
         sv.applyMatrix(matrix_, wires_);
     }
 
-    void
-    applyInPlaceShots([[maybe_unused]] StateVectorT &sv,
-                      [[maybe_unused]] std::vector<size_t> &identity_wire,
-                      [[maybe_unused]] std::vector<size_t> &ob_wires,
-                      [[maybe_unused]] size_t term_idx = 0) const override {
+    void applyInPlaceShots(
+        [[maybe_unused]] StateVectorT &sv,
+        [[maybe_unused]] std::vector<std::vector<PrecisionT>> &eigenValues,
+        [[maybe_unused]] std::vector<size_t> &ob_wires) const override {
         PL_ABORT("Hermitian observables do not support applyInPlaceShots "
                  "method.");
     }
@@ -360,20 +370,25 @@ class TensorProdObsBase : public Observable<StateVectorT> {
         }
     }
 
-    void
-    applyInPlaceShots(StateVectorT &sv, std::vector<size_t> &identity_wires,
-                      std::vector<size_t> &ob_wires,
-                      [[maybe_unused]] size_t term_idx = 0) const override {
-        identity_wires.clear();
+    /**
+     * @brief Get the observable.
+     */
+    [[nodiscard]] auto getObs() const
+        -> std::vector<std::shared_ptr<Observable<StateVectorT>>> override {
+        return obs_;
+    };
+
+    void applyInPlaceShots(StateVectorT &sv,
+                           std::vector<std::vector<PrecisionT>> &eigenValues,
+                           std::vector<size_t> &ob_wires) const override {
+        eigenValues.clear();
         ob_wires.clear();
         for (const auto &ob : obs_) {
-            std::vector<size_t> identity_wire;
+            std::vector<std::vector<PrecisionT>> eigenVals;
             std::vector<size_t> ob_wire;
-            ob->applyInPlaceShots(sv, identity_wire, ob_wire);
-            if (!identity_wire.empty()) {
-                identity_wires.push_back(identity_wire[0]);
-            }
+            ob->applyInPlaceShots(sv, eigenVals, ob_wire);
             ob_wires.push_back(ob_wire[0]);
+            eigenValues.push_back(eigenVals[0]);
         }
     }
 
@@ -462,13 +477,12 @@ class HamiltonianBase : public Observable<StateVectorT> {
                  "defined at the backend level.");
     }
 
-    void
-    applyInPlaceShots([[maybe_unused]] StateVectorT &sv,
-                      [[maybe_unused]] std::vector<size_t> &identity_wires,
-                      [[maybe_unused]] std::vector<size_t> &ob_wires,
-                      [[maybe_unused]] size_t term_idx = 0) const override {
-        PL_ABORT("For Hamiltonian Observables, the applyInPlace method must be "
-                 "defined at the backend level.");
+    void applyInPlaceShots(
+        [[maybe_unused]] StateVectorT &sv,
+        [[maybe_unused]] std::vector<std::vector<PrecisionT>> &eigenValues,
+        [[maybe_unused]] std::vector<size_t> &ob_wires) const override {
+        PL_ABORT(
+            "Hamiltonian observables do not support the applyInPlaceShots");
     }
 
     [[nodiscard]] auto getWires() const -> std::vector<size_t> override {
@@ -497,6 +511,14 @@ class HamiltonianBase : public Observable<StateVectorT> {
         ss << "]}";
         return ss.str();
     }
+
+    /**
+     * @brief Get the observable.
+     */
+    [[nodiscard]] auto getObs() const
+        -> std::vector<std::shared_ptr<Observable<StateVectorT>>> override {
+        return obs_;
+    };
 
     /**
      * @brief Get the coefficients of the observable.
@@ -588,12 +610,12 @@ class SparseHamiltonianBase : public Observable<StateVectorT> {
                  "defined at the backend level.");
     }
 
-    void
-    applyInPlaceShots([[maybe_unused]] StateVectorT &sv,
-                      [[maybe_unused]] std::vector<size_t> &identity_wire,
-                      [[maybe_unused]] std::vector<size_t> &ob_wires,
-                      [[maybe_unused]] size_t term_idx = 0) const override {
-        PL_ABORT("SparseHamiltonian observables do not the applyInPlaceShots "
+    void applyInPlaceShots(
+        [[maybe_unused]] StateVectorT &sv,
+        [[maybe_unused]] std::vector<std::vector<PrecisionT>> &eigenValues,
+        [[maybe_unused]] std::vector<size_t> &ob_wires) const override {
+        PL_ABORT("SparseHamiltonian observables do not support the "
+                 "applyInPlaceShots "
                  "method.");
     }
 

--- a/pennylane_lightning/core/src/observables/tests/Test_Observables.cpp
+++ b/pennylane_lightning/core/src/observables/tests/Test_Observables.cpp
@@ -130,11 +130,11 @@ template <typename TypeList> void testNamedObsBase() {
             StateVectorT state_vector(init_state.data(), init_state.size());
             auto obs = NamedObsT("RY", {0}, {0.4});
 
-            std::vector<size_t> identity_wire;
+            std::vector<std::vector<PrecisionT>> eigenValues;
             std::vector<size_t> ob_wires;
 
             REQUIRE_THROWS_WITH(
-                obs.applyInPlaceShots(state_vector, identity_wire, ob_wires),
+                obs.applyInPlaceShots(state_vector, eigenValues, ob_wires),
                 Catch::Matchers::Contains(
                     "Provided NamedObs does not supported for shots"));
         }
@@ -215,11 +215,11 @@ template <typename TypeList> void testHermitianObsBase() {
             auto obs =
                 HermitianObsT{std::vector<ComplexT>{1.0, 0.0, -1.0, 0.0}, {0}};
 
-            std::vector<size_t> identity_wire;
+            std::vector<std::vector<PrecisionT>> eigenValues;
             std::vector<size_t> ob_wires;
 
             REQUIRE_THROWS_WITH(
-                obs.applyInPlaceShots(state_vector, identity_wire, ob_wires),
+                obs.applyInPlaceShots(state_vector, eigenValues, ob_wires),
                 Catch::Matchers::Contains("Hermitian observables do not "
                                           "support applyInPlaceShots method."));
         }
@@ -503,12 +503,12 @@ template <typename TypeList> void testHamiltonianBase() {
 
                 StateVectorT state_vector(st_data.data(), st_data.size());
 
-                std::vector<size_t> identity_wires;
+                std::vector<std::vector<PrecisionT>> eigenValues;
                 std::vector<size_t> ob_wires;
 
-                REQUIRE_THROWS_AS(ham->applyInPlaceShots(
-                                      state_vector, identity_wires, ob_wires),
-                                  LightningException);
+                REQUIRE_THROWS_AS(
+                    ham->applyInPlaceShots(state_vector, eigenValues, ob_wires),
+                    LightningException);
             }
         }
         testHamiltonianBase<typename TypeList::Next>();
@@ -599,14 +599,14 @@ template <typename TypeList> void testSparseHamiltonianBase() {
 
             StateVectorT state_vector(init_state.data(), init_state.size());
 
-            std::vector<size_t> identity_wire;
+            std::vector<std::vector<PrecisionT>> eigenValues;
             std::vector<size_t> ob_wires;
 
             REQUIRE_THROWS_WITH(
-                sparseH->applyInPlaceShots(state_vector, identity_wire,
-                                           ob_wires),
-                Catch::Matchers::Contains("SparseHamiltonian observables do "
-                                          "not the applyInPlaceShots method."));
+                sparseH->applyInPlaceShots(state_vector, eigenValues, ob_wires),
+                Catch::Matchers::Contains(
+                    "SparseHamiltonian observables do "
+                    "not support the applyInPlaceShots method."));
         }
 
         testSparseHamiltonianBase<typename TypeList::Next>();

--- a/pennylane_lightning/core/src/observables/tests/Test_Observables.cpp
+++ b/pennylane_lightning/core/src/observables/tests/Test_Observables.cpp
@@ -137,6 +137,9 @@ template <typename TypeList> void testNamedObsBase() {
                 obs.applyInPlaceShots(state_vector, eigenValues, ob_wires),
                 Catch::Matchers::Contains(
                     "Provided NamedObs does not supported for shots"));
+
+            auto ob = obs.getObs();
+            REQUIRE(ob.empty() == true);
         }
 
         testNamedObsBase<typename TypeList::Next>();
@@ -304,6 +307,10 @@ template <typename TypeList> void testTensorProdObsBase() {
             REQUIRE(ob1 != ob3);
             REQUIRE(ob1 != ob4);
             REQUIRE(ob1 != ob5);
+
+            auto obs = ob1.getObs();
+            REQUIRE(obs[0]->getObsName() == "PauliX[0]");
+            REQUIRE(obs[1]->getObsName() == "PauliZ[1]");
         }
 
         DYNAMIC_SECTION("Tensor product applies to a statevector correctly"

--- a/pennylane_lightning/core/src/simulators/lightning_gpu/observables/ObservablesGPU.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_gpu/observables/ObservablesGPU.hpp
@@ -207,16 +207,6 @@ class Hamiltonian final : public HamiltonianBase<StateVectorT> {
         }
         sv.updateData(std::move(buffer));
     }
-
-    // to work with
-    void applyInPlaceShots(StateVectorT &sv,
-                           std::vector<size_t> &identity_wires,
-                           std::vector<size_t> &ob_wires,
-                           size_t term_idx) const override {
-        ob_wires.clear();
-        this->obs_[term_idx]->applyInPlaceShots(sv, identity_wires, ob_wires,
-                                                term_idx);
-    }
 };
 
 /**

--- a/pennylane_lightning/core/src/simulators/lightning_gpu/observables/ObservablesGPUMPI.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_gpu/observables/ObservablesGPUMPI.hpp
@@ -214,16 +214,6 @@ class HamiltonianMPI final : public HamiltonianBase<StateVectorT> {
         PL_CUDA_IS_SUCCESS(cudaDeviceSynchronize());
         mpi_manager.Barrier();
     }
-
-    // to work with
-    void applyInPlaceShots(StateVectorT &sv,
-                           std::vector<size_t> &identity_wires,
-                           std::vector<size_t> &ob_wires,
-                           size_t term_idx) const override {
-        ob_wires.clear();
-        this->obs_[term_idx]->applyInPlaceShots(sv, identity_wires, ob_wires,
-                                                term_idx);
-    }
 };
 
 /**

--- a/pennylane_lightning/core/src/simulators/lightning_kokkos/observables/ObservablesKokkos.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_kokkos/observables/ObservablesKokkos.hpp
@@ -198,16 +198,6 @@ class Hamiltonian final : public HamiltonianBase<StateVectorT> {
         }
         sv.updateData(buffer);
     }
-
-    // to work with
-    void applyInPlaceShots(StateVectorT &sv,
-                           std::vector<size_t> &identity_wires,
-                           std::vector<size_t> &ob_wires,
-                           size_t term_idx) const override {
-        ob_wires.clear();
-        this->obs_[term_idx]->applyInPlaceShots(sv, identity_wires, ob_wires,
-                                                term_idx);
-    }
 };
 
 /**

--- a/pennylane_lightning/core/src/simulators/lightning_qubit/observables/ObservablesLQubit.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_qubit/observables/ObservablesLQubit.hpp
@@ -358,16 +358,6 @@ class Hamiltonian final : public HamiltonianBase<StateVectorT> {
             StateVectorT, Pennylane::Util::use_openmp>::run(this->coeffs_,
                                                             this->obs_, sv);
     }
-
-    // to work with
-    void applyInPlaceShots(StateVectorT &sv,
-                           std::vector<size_t> &identity_wires,
-                           std::vector<size_t> &ob_wires,
-                           size_t term_idx) const override {
-        ob_wires.clear();
-        this->obs_[term_idx]->applyInPlaceShots(sv, identity_wires, ob_wires,
-                                                term_idx);
-    }
 };
 
 /**

--- a/pennylane_lightning/core/src/utils/Util.hpp
+++ b/pennylane_lightning/core/src/utils/Util.hpp
@@ -515,18 +515,19 @@ auto transpose_state_tensor(const std::vector<T> &tensor,
  * stored.
  *
  * @tparam T Data type.
- * @param A A diagonal matrix with only diagonal elements stored.
- * @param B A diagonal matrix with only diagonal elements stored.
- * @return result Result matrix with only diagonal elements stored.
+ * @param diagA A vector containing the values of a diagonal matrix.
+ * @param diagB A vector containing the values of a diagonal matrix.
+ * @return kronAB A vector containing the diagonal values of the Kronecker
+ * product.
  */
 template <typename T>
-auto kronProd(const std::vector<T> &A, const std::vector<T> &B)
+auto kronProd(const std::vector<T> &diagA, const std::vector<T> &diagB)
     -> std::vector<T> {
-    std::vector<T> result(A.size() * B.size(), 0);
+    std::vector<T> result(diagA.size() * diagB.size(), 0);
 
-    for (size_t i = 0; i < A.size(); i++) {
-        for (size_t j = 0; j < B.size(); j++) {
-            result[i * B.size() + j] = A[i] * B[j];
+    for (size_t i = 0; i < diagA.size(); i++) {
+        for (size_t j = 0; j < diagB.size(); j++) {
+            result[i * diagB.size() + j] = diagA[i] * diagB[j];
         }
     }
 

--- a/pennylane_lightning/core/src/utils/Util.hpp
+++ b/pennylane_lightning/core/src/utils/Util.hpp
@@ -509,4 +509,27 @@ auto transpose_state_tensor(const std::vector<T> &tensor,
     }
     return transposed_tensor;
 }
+
+/**
+ * @brief Kronecker product of two diagonal matrices. Only diagonal elements are
+ * stored.
+ *
+ * @tparam T Data type.
+ * @param A A diagonal matrix with only diagonal elements stored.
+ * @param B A diagonal matrix with only diagonal elements stored.
+ * @return result Result matrix with only diagonal elements stored.
+ */
+template <typename T>
+auto kronProd(const std::vector<T> &A, const std::vector<T> &B)
+    -> std::vector<T> {
+    std::vector<T> result(A.size() * B.size(), 0);
+
+    for (size_t i = 0; i < A.size(); i++) {
+        for (size_t j = 0; j < B.size(); j++) {
+            result[i * B.size() + j] = A[i] * B[j];
+        }
+    }
+
+    return result;
+}
 } // namespace Pennylane::Util

--- a/pennylane_lightning/core/src/utils/tests/Test_Util.cpp
+++ b/pennylane_lightning/core/src/utils/tests/Test_Util.cpp
@@ -152,3 +152,23 @@ TEMPLATE_TEST_CASE("Util::squaredNorm", "[Util][LinearAlgebra]", float,
         CHECK(squaredNorm(vec) == Approx(110.0));
     }
 }
+
+TEMPLATE_TEST_CASE("Util::kronProd", "[Util][LinearAlgebra]", float, double) {
+    SECTION("For -1, 1 values") {
+        std::vector<TestType> vec0{1, -1};
+        std::vector<TestType> vec1{1, -1};
+        auto vec = kronProd(vec0, vec1);
+        std::vector<TestType> expected = {1, -1, -1, 1};
+
+        CHECK(vec == expected);
+    }
+
+    SECTION("For NON -1, 1 values") {
+        std::vector<TestType> vec0{3, -2};
+        std::vector<TestType> vec1{-4, 5};
+        auto vec = kronProd(vec0, vec1);
+        std::vector<TestType> expected = {-12, 15, 8, -10};
+
+        CHECK(vec == expected);
+    }
+}


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [ ] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [x] Ensure that the test suite passes, by running `make test`.

- [x] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [x] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**

Shot-noise related methods now accommodate observable objects with arbitrary eigenvalues. Add a Kronecker product method for two diagonal matrices. 

**Description of the Change:**

Refactor shot-noise related methods of `MeasurementsBase` class in the C++ layer and eigenvalues are not limited to `1` and `-1`. Add `getObs()` method to Observables class. Refactor `applyInPlaceShots` to allow users to get eigenvalues of Observables object. Deprecated `_preprocess_state` method in `MeasurementsBase` class for safer use of the `LightningQubitRaw` backend.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
