### PR TITLE
Do not run cpp tests on schedule (compat tests).

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -46,6 +46,9 @@
 
 ### Bug fixes
 
+* Do not run C++ tests when testing for compatibility with PennyLane, hence fixing plugin-matrix failures. Fix Lightning-GPU workflow trigger.
+  [(#571)](https://github.com/PennyLaneAI/pennylane-lightning/pull/571)
+
 * Revert single-node multi-GPU batching behaviour to match https://github.com/PennyLaneAI/pennylane-lightning-gpu/pull/27.
   [(#564)](https://github.com/PennyLaneAI/pennylane-lightning/pull/564)
 

--- a/.github/workflows/tests_gpu_cu11.yml
+++ b/.github/workflows/tests_gpu_cu11.yml
@@ -52,7 +52,7 @@ jobs:
           nvidia-smi
 
   cpptestswithLGPU_cu11:
-    if: ${{ github.event_name != 'workflow_dispatch' }}
+    if: ${{ !contains(fromJSON('["schedule", "workflow_dispatch"]'), github.event_name) }}
     needs: [builddeps]
     strategy:
       matrix:

--- a/.github/workflows/tests_gpu_cu11.yml
+++ b/.github/workflows/tests_gpu_cu11.yml
@@ -1,9 +1,5 @@
 name: Testing::Linux::x86_64::LGPU
 on:
-  workflow_run:
-    workflows: ["Testing::LKokkos::CUDA"]
-    types:
-      - completed
   workflow_call:
     inputs:
       lightning-version:
@@ -14,6 +10,11 @@ on:
         type: string
         required: true
         description: The version of PennyLane to use. Valid values are either 'release' (most recent release candidate), 'stable' (most recent git-tag) or 'latest' (most recent commit from master)
+  release:
+  pull_request:
+  push:
+    branches:
+      - master
 
 env:
   CI_CUDA_ARCH: 86
@@ -51,7 +52,7 @@ jobs:
           nvidia-smi
 
   cpptestswithLGPU_cu11:
-    if: ${{ !contains(fromJSON('["workflow_call"]'), github.event_name) }}
+    if: ${{ github.event_name != 'workflow_call' }}
     needs: [builddeps]
     strategy:
       matrix:

--- a/.github/workflows/tests_gpu_cu11.yml
+++ b/.github/workflows/tests_gpu_cu11.yml
@@ -52,7 +52,7 @@ jobs:
           nvidia-smi
 
   cpptestswithLGPU_cu11:
-    if: ${{ github.event_name != 'workflow_call' }}
+    if: ${{ github.event_name != 'workflow_dispatch' }}
     needs: [builddeps]
     strategy:
       matrix:

--- a/.github/workflows/tests_linux.yml
+++ b/.github/workflows/tests_linux.yml
@@ -28,7 +28,7 @@ concurrency:
 
 jobs:
   cpptests:
-    if: ${{ github.event_name != 'workflow_dispatch' }}
+    if: ${{ !contains(fromJSON('["workflow_call"]'), github.event_name) }}
     strategy:
       matrix:
         os: [ubuntu-22.04]

--- a/.github/workflows/tests_linux.yml
+++ b/.github/workflows/tests_linux.yml
@@ -28,7 +28,7 @@ concurrency:
 
 jobs:
   cpptests:
-    if: ${{ github.event_name != 'workflow_call' }}
+    if: ${{ github.event_name != 'workflow_dispatch' }}
     strategy:
       matrix:
         os: [ubuntu-22.04]
@@ -177,7 +177,7 @@ jobs:
           if-no-files-found: error
 
   cpptestswithOpenBLAS:
-    if: ${{ github.event_name != 'workflow_call' }}
+    if: ${{ github.event_name != 'workflow_dispatch' }}
     strategy:
       matrix:
         os: [ubuntu-22.04]
@@ -333,7 +333,7 @@ jobs:
       os: ubuntu-22.04
 
   cpptestswithKokkos:
-    if: ${{ github.event_name != 'workflow_call' }}
+    if: ${{ github.event_name != 'workflow_dispatch' }}
     needs: [build_and_cache_Kokkos]
     strategy:
       matrix:
@@ -585,7 +585,7 @@ jobs:
 
   cpptestsWithMultipleBackends:
   # Device-specific tests are performed for both. Device-agnostic tests default to LightningQubit.
-    if: ${{ github.event_name != 'workflow_call' }}
+    if: ${{ github.event_name != 'workflow_dispatch' }}
     needs: [build_and_cache_Kokkos]
     strategy:
       matrix:

--- a/.github/workflows/tests_linux.yml
+++ b/.github/workflows/tests_linux.yml
@@ -28,7 +28,7 @@ concurrency:
 
 jobs:
   cpptests:
-    if: ${{ !contains(fromJSON('["workflow_call"]'), github.event_name) }}
+    if: ${{ github.event_name != 'workflow_call' }}
     strategy:
       matrix:
         os: [ubuntu-22.04]
@@ -177,7 +177,7 @@ jobs:
           if-no-files-found: error
 
   cpptestswithOpenBLAS:
-    if: ${{ !contains(fromJSON('["workflow_call"]'), github.event_name) }}
+    if: ${{ github.event_name != 'workflow_call' }}
     strategy:
       matrix:
         os: [ubuntu-22.04]
@@ -333,7 +333,7 @@ jobs:
       os: ubuntu-22.04
 
   cpptestswithKokkos:
-    if: ${{ !contains(fromJSON('["workflow_call"]'), github.event_name) }}
+    if: ${{ github.event_name != 'workflow_call' }}
     needs: [build_and_cache_Kokkos]
     strategy:
       matrix:
@@ -585,7 +585,7 @@ jobs:
 
   cpptestsWithMultipleBackends:
   # Device-specific tests are performed for both. Device-agnostic tests default to LightningQubit.
-    if: ${{ !contains(fromJSON('["workflow_call"]'), github.event_name) }}
+    if: ${{ github.event_name != 'workflow_call' }}
     needs: [build_and_cache_Kokkos]
     strategy:
       matrix:

--- a/.github/workflows/tests_linux.yml
+++ b/.github/workflows/tests_linux.yml
@@ -28,7 +28,7 @@ concurrency:
 
 jobs:
   cpptests:
-    if: ${{ !contains(fromJSON('["workflow_call"]'), github.event_name) }}
+    if: ${{ !contains(fromJSON('["workflow_dispatch"]'), github.event_name) }}
     strategy:
       matrix:
         os: [ubuntu-22.04]

--- a/.github/workflows/tests_linux.yml
+++ b/.github/workflows/tests_linux.yml
@@ -28,7 +28,7 @@ concurrency:
 
 jobs:
   cpptests:
-    if: ${{ !contains(fromJSON('["workflow_dispatch"]'), github.event_name) }}
+    if: ${{ !contains(fromJSON('["schedule", "workflow_dispatch"]'), github.event_name) }}
     strategy:
       matrix:
         os: [ubuntu-22.04]
@@ -177,7 +177,7 @@ jobs:
           if-no-files-found: error
 
   cpptestswithOpenBLAS:
-    if: ${{ github.event_name != 'workflow_dispatch' }}
+    if: ${{ !contains(fromJSON('["schedule", "workflow_dispatch"]'), github.event_name) }}
     strategy:
       matrix:
         os: [ubuntu-22.04]
@@ -333,7 +333,7 @@ jobs:
       os: ubuntu-22.04
 
   cpptestswithKokkos:
-    if: ${{ github.event_name != 'workflow_dispatch' }}
+    if: ${{ !contains(fromJSON('["schedule", "workflow_dispatch"]'), github.event_name) }}
     needs: [build_and_cache_Kokkos]
     strategy:
       matrix:
@@ -585,7 +585,7 @@ jobs:
 
   cpptestsWithMultipleBackends:
   # Device-specific tests are performed for both. Device-agnostic tests default to LightningQubit.
-    if: ${{ github.event_name != 'workflow_dispatch' }}
+    if: ${{ !contains(fromJSON('["schedule", "workflow_dispatch"]'), github.event_name) }}
     needs: [build_and_cache_Kokkos]
     strategy:
       matrix:

--- a/.github/workflows/tests_linux.yml
+++ b/.github/workflows/tests_linux.yml
@@ -47,7 +47,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get -y -q install cmake gcc-$GCC_VERSION  g++-$GCC_VERSION  ninja-build gcovr lcov
+        run: echo ${{ github.event_name }} && sudo apt-get update && sudo apt-get -y -q install cmake gcc-$GCC_VERSION  g++-$GCC_VERSION  ninja-build gcovr lcov
 
       - name: Build and run unit tests
         run: |

--- a/.github/workflows/tests_linux_x86_mpi_gpu.yml
+++ b/.github/workflows/tests_linux_x86_mpi_gpu.yml
@@ -28,7 +28,7 @@ concurrency:
 
 jobs:
   cpp_tests:
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'ci:use-multi-gpu-runner') && github.event_name != 'workflow_dispatch' }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'ci:use-multi-gpu-runner') && !contains(fromJSON('["schedule", "workflow_dispatch"]'), github.event_name) }}
     runs-on:
       - self-hosted
       - linux
@@ -158,7 +158,7 @@ jobs:
 
 
   python_tests:
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'ci:use-multi-gpu-runner') || github.event_name == 'workflow_dispatch' }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'ci:use-multi-gpu-runner') || contains(fromJSON('["schedule", "workflow_dispatch"]'), github.event_name) }}
     runs-on:
       - self-hosted
       - linux

--- a/.github/workflows/tests_linux_x86_mpi_gpu.yml
+++ b/.github/workflows/tests_linux_x86_mpi_gpu.yml
@@ -28,7 +28,7 @@ concurrency:
 
 jobs:
   cpp_tests:
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'ci:use-multi-gpu-runner') && github.event_name != 'workflow_call' }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'ci:use-multi-gpu-runner') && github.event_name != 'workflow_dispatch' }}
     runs-on:
       - self-hosted
       - linux

--- a/.github/workflows/tests_linux_x86_mpi_gpu.yml
+++ b/.github/workflows/tests_linux_x86_mpi_gpu.yml
@@ -28,7 +28,7 @@ concurrency:
 
 jobs:
   cpp_tests:
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'ci:use-multi-gpu-runner') && !contains(fromJSON('["workflow_call"]'), github.event_name) }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'ci:use-multi-gpu-runner') && github.event_name != 'workflow_call' }}
     runs-on:
       - self-hosted
       - linux

--- a/.github/workflows/tests_linux_x86_mpi_gpu.yml
+++ b/.github/workflows/tests_linux_x86_mpi_gpu.yml
@@ -158,7 +158,7 @@ jobs:
 
 
   python_tests:
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'ci:use-multi-gpu-runner') || contains(fromJSON('["workflow_call"]'), github.event_name) }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'ci:use-multi-gpu-runner') || github.event_name == 'workflow_dispatch' }}
     runs-on:
       - self-hosted
       - linux

--- a/.github/workflows/tests_windows.yml
+++ b/.github/workflows/tests_windows.yml
@@ -21,7 +21,7 @@ concurrency:
 
 jobs:
   cpptests:
-    if: ${{ github.event_name != 'workflow_dispatch' }}
+    if: ${{ !contains(fromJSON('["schedule", "workflow_dispatch"]'), github.event_name) }}
     timeout-minutes: 30
     name: C++ tests (Windows)
     runs-on: ${{ matrix.os }}
@@ -155,7 +155,7 @@ jobs:
           cmake --install ./Build --config Debug --verbose
 
   cpptestswithkokkos:
-    if: ${{ github.event_name != 'workflow_dispatch' }}
+    if: ${{ !contains(fromJSON('["schedule", "workflow_dispatch"]'), github.event_name) }}
     needs: [build_dependencies, win-set-matrix-x86]
     strategy:
       matrix:

--- a/.github/workflows/tests_windows.yml
+++ b/.github/workflows/tests_windows.yml
@@ -1,5 +1,15 @@
 name: Testing (Windows)
 on:
+  workflow_call:
+    inputs:
+      lightning-version:
+        type: string
+        required: true
+        description: The version of Lightning to use. Valid values are either 'release' (most recent release candidate), 'stable' (most recent git-tag) or 'latest' (most recent commit from master)
+      pennylane-version:
+        type: string
+        required: true
+        description: The version of PennyLane to use. Valid values are either 'release' (most recent release candidate), 'stable' (most recent git-tag) or 'latest' (most recent commit from master)
   push:
     branches:
       - master
@@ -11,6 +21,7 @@ concurrency:
 
 jobs:
   cpptests:
+    if: ${{ github.event_name != 'workflow_call' }}
     timeout-minutes: 30
     name: C++ tests (Windows)
     runs-on: ${{ matrix.os }}
@@ -144,11 +155,12 @@ jobs:
           cmake --install ./Build --config Debug --verbose
 
   cpptestswithkokkos:
+    if: ${{ github.event_name != 'workflow_call' }}
     needs: [build_dependencies, win-set-matrix-x86]
     strategy:
       matrix:
         os: [windows-latest]
-        pl_backend: ["lightning_qubit"]
+        pl_backend: ["lightning_kokkos"]
         exec_model: ${{ fromJson(needs.win-set-matrix-x86.outputs.exec_model) }}
         kokkos_version: ${{ fromJson(needs.win-set-matrix-x86.outputs.kokkos_version) }}
 

--- a/.github/workflows/tests_windows.yml
+++ b/.github/workflows/tests_windows.yml
@@ -21,7 +21,7 @@ concurrency:
 
 jobs:
   cpptests:
-    if: ${{ github.event_name != 'workflow_call' }}
+    if: ${{ github.event_name != 'workflow_dispatch' }}
     timeout-minutes: 30
     name: C++ tests (Windows)
     runs-on: ${{ matrix.os }}
@@ -155,7 +155,7 @@ jobs:
           cmake --install ./Build --config Debug --verbose
 
   cpptestswithkokkos:
-    if: ${{ github.event_name != 'workflow_call' }}
+    if: ${{ github.event_name != 'workflow_dispatch' }}
     needs: [build_dependencies, win-set-matrix-x86]
     strategy:
       matrix:

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.34.0-dev13"
+__version__ = "0.34.0-dev14"


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [x] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [x] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [x] Ensure that the test suite passes, by running `make test`.

- [x] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [x] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**
C++ tests do not depend on PennyLane and they are run in compatibility tests that are meant to test compatibility between Lightning and Pennylane. Some C++ tests triggered by compatibility workflows running on schedule fail intermittently.

**Description of the Change:**
Properly select tests based on `event_name`. Fix L-GPU trigger (`workflow_run` does not work).

**Benefits:**
Run only necessary tests. Fix plugin-matrix failures. Run L-GPU tests.

**Possible Drawbacks:**

**Related GitHub Issues:**
