### PR TITLE
Add OpenGraph social preview

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -52,6 +52,9 @@
 * Fixed a small typo in the documentation page for the PennyLane-Lightning GPU device.
   [(#563)](https://github.com/PennyLaneAI/pennylane-lightning/pull/563)
 
+* Add OpenGraph social preview for Lightning docs.
+[(#574)](https://github.com/PennyLaneAI/pennylane-lightning/pull/574)
+
 ### Bug fixes
 
 * Allow support for newer clang-tidy versions on non-x86_64 platforms.
@@ -73,7 +76,7 @@
 
 This release contains contributions from (in alphabetical order):
 
-Isaac De Vlugt, Vincent Michaud-Rioux, Lee James O'Riordan, Shuli Shu
+Isaac De Vlugt, Amintor Dusko, Vincent Michaud-Rioux, Lee James O'Riordan, Shuli Shu
 
 ---
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -92,9 +92,22 @@ extensions = [
     "sphinx.ext.viewcode",
     "sphinx_automodapi.automodapi",
     "sphinx_automodapi.smart_resolver",
+    "sphinxext.opengraph",
 ]
 
-intersphinx_mapping = {"https://docs.pennylane.ai/en/stable/": None}
+# Open Graph metadata
+ogp_social_cards = {
+    "image": "_static/logo.png",
+    "enable": True,
+    "site_url": "https://docs.pennylane.ai/projects/lightning/",
+    "line_color": "#03b2ff",
+}
+ogp_image = "_static/pennylane_lightning.png"
+
+# The base URL with a proper language and version.
+html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "/")
+
+intersphinx_mapping = {"https://docs.pennylane.ai/projects/lightning/en/stable/": None}
 
 autosummary_generate = True
 autosummary_imported_members = False

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -107,7 +107,7 @@ ogp_image = "_static/pennylane_lightning.png"
 # The base URL with a proper language and version.
 html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "/")
 
-intersphinx_mapping = {"https://docs.pennylane.ai/projects/lightning/en/stable/": None}
+intersphinx_mapping = {"https://docs.pennylane.ai/en/stable/": None}
 
 autosummary_generate = True
 autosummary_imported_members = False

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -8,3 +8,5 @@ sphinx-automodapi
 pennylane-sphinx-theme
 custatevec-cu11
 wheel
+sphinxext-opengraph
+matplotlib

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.34.0-dev16"
+__version__ = "0.34.0-dev17"


### PR DESCRIPTION
**Context:** When posting links to the docs on social media, there is no social media preview, as there was no [OpenGraph](https://opengraph.xyz) metadata generated by Sphinx.

**Description of the Change:**

- Adds matplotlib and [sphinxext-opengraph](https://github.com/wpilibsuite/sphinxext-opengraph) as doc requirements

- configures `conf.py` to set the OpenGraph information, in particular,

  - the default social media preview image
  - uses [pennylane_lightning.png](https://github.com/PennyLaneAI/pennylane-lightning/blob/master/doc/_static/pennylane_lightning.png) as the preview image

**Benefits:** Better social media coverage.

[Preview](https://www.opengraph.xyz/url/https%3A%2F%2Fxanaduai-pennylane--574.com.readthedocs.build%2Fprojects%2Flightning%2Fen%2F574%2F)