### PR TITLE
Fix the issue with assigning kernels to ops before registering kernels on macOS

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -82,6 +82,9 @@
 * Fix MPI Python unit tests for the adjoint method.
   [(#538)](https://github.com/PennyLaneAI/pennylane-lightning/pull/538)
 
+* Fix the issue with assigning kernels to ops before registering kernels on macOS
+  [(#582)](https://github.com/PennyLaneAI/pennylane-lightning/pull/582)
+
 ### Contributors
 
 This release contains contributions from (in alphabetical order):

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.34.0-dev20"
+__version__ = "0.34.0-dev21"

--- a/pennylane_lightning/core/src/simulators/lightning_qubit/gates/DynamicDispatcher.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_qubit/gates/DynamicDispatcher.hpp
@@ -105,11 +105,8 @@ template <typename PrecisionT> class DynamicDispatcher {
 
   private:
     std::unordered_map<std::string, GateOperation> str_to_gates_{};
-    std::unordered_map<std::string, ControlledGateOperation>
-        str_to_controlled_gates_{};
+
     std::unordered_map<std::string, GeneratorOperation> str_to_gntrs_{};
-    std::unordered_map<std::string, ControlledGeneratorOperation>
-        str_to_controlled_gntrs_{};
 
     std::unordered_map<std::pair<GateOperation, KernelType>, GateFunc, PairHash>
         gate_kernels_{};
@@ -122,6 +119,16 @@ template <typename PrecisionT> class DynamicDispatcher {
                        PairHash>
         matrix_kernels_{};
 
+    std::unordered_map<KernelType, std::string> kernel_names_{};
+
+    // Defining controlled gates before `kernel_names_` triggers
+    // `assignKernelForOp` before registering kernels at run time.
+    std::unordered_map<std::string, ControlledGateOperation>
+        str_to_controlled_gates_{};
+
+    std::unordered_map<std::string, ControlledGeneratorOperation>
+        str_to_controlled_gntrs_{};
+
     std::unordered_map<std::pair<ControlledGateOperation, KernelType>,
                        ControlledGateFunc, PairHash>
         controlled_gate_kernels_{};
@@ -133,8 +140,6 @@ template <typename PrecisionT> class DynamicDispatcher {
     std::unordered_map<std::pair<ControlledMatrixOperation, KernelType>,
                        ControlledMatrixFunc, PairHash>
         controlled_matrix_kernels_{};
-
-    std::unordered_map<KernelType, std::string> kernel_names_{};
 
     DynamicDispatcher() {
         constexpr static auto gntr_names_without_prefix =

--- a/pennylane_lightning/core/src/simulators/lightning_qubit/gates/DynamicDispatcher.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_qubit/gates/DynamicDispatcher.hpp
@@ -121,8 +121,6 @@ template <typename PrecisionT> class DynamicDispatcher {
 
     std::unordered_map<KernelType, std::string> kernel_names_{};
 
-    // Defining controlled gates before `kernel_names_` triggers
-    // `assignKernelForOp` before registering kernels at run time.
     std::unordered_map<std::string, ControlledGateOperation>
         str_to_controlled_gates_{};
 


### PR DESCRIPTION
The addition of arbitrary controlled operations in `lightning.qubit` (PR #516) breaks the use of the `lightning.qubit` C++ API in Catalyst on macOS. This PR fixes the following issue:

``` console
libc++abi: terminating due to uncaught exception of type Pennylane::Util::LightningException: [./catalyst/runtime/build/_deps/pennylane_lightning-src/pennylane_lightning/core/src/simulators/lightning_qubit/gates/KernelMap.hpp][Line:326][Method:assignKernelForOp]: Error in PennyLane Lightning: The given kernel is not registered.
Fatal Python error: Aborted
```

Fixes https://github.com/PennyLaneAI/pennylane-lightning/issues/583

[sc-52500]