### PR TITLE
All tags allowed for LIGHTNING_VERSION Docker build argument.

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -12,6 +12,9 @@
 * OpenMP acceleration can now be enabled at compile time for all `lightning.qubit` gate kernels using the "-DLQ_ENABLE_KERNEL_OMP=1" CMake argument.
   [(#510)](https://github.com/PennyLaneAI/pennylane-lightning/pull/510)
 
+* Enable building Docker images for any branch or tag. Set the Docker build cron job to build images for the latest release and `master`.
+  [(#598)](https://github.com/PennyLaneAI/pennylane-lightning/pull/598)
+
 * Enable choosing the PennyLane-Lightning version and disabling push to Docker Hub in the Docker build workflow. Add a cron job calling the Docker build workflow.
   [(#597)](https://github.com/PennyLaneAI/pennylane-lightning/pull/597)
 

--- a/.github/workflows/compat-docker-latest.yml
+++ b/.github/workflows/compat-docker-latest.yml
@@ -6,10 +6,17 @@ on:
   workflow_dispatch:
 
 jobs:
-  docker_linux_x86_64:
-    name: Docker build tests - Linux::x86_64
+  docker_linux_x86_64_latest:
+    name: Docker latest - Linux::x86_64
     uses: ./.github/workflows/docker_linux_x86_64.yml
     with:
       lightning-version: 0.34.0
+      push-to-dockerhub: false
+    secrets: inherit # pass all secrets
+  docker_linux_x86_64_develop:
+    name: Docker develop - Linux::x86_64
+    uses: ./.github/workflows/docker_linux_x86_64.yml
+    with:
+      lightning-version: master
       push-to-dockerhub: false
     secrets: inherit # pass all secrets

--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ endif
 ifdef version
     VERSION := $(version)
 else
-    VERSION := 0.34.0
+    VERSION := v0.34.0
 endif
 docker-build:
 	docker build -f docker/Dockerfile --tag=pennylaneai/pennylane:$(VERSION)-$(TARGET) --target wheel-$(TARGET) --build-arg='LIGHTNING_VERSION=$(VERSION)' .

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,7 +21,7 @@ ARG CUDA_ARCH=AMPERE80
 ARG CUDA_INSTALLER=https://developer.download.nvidia.com/compute/cuda/12.2.2/local_installers/cuda_12.2.2_535.104.05_linux.run
 ARG GCC_VERSION=11
 ARG KOKKOS_VERSION=4.2.00
-ARG LIGHTNING_VERSION=0.34.0
+ARG LIGHTNING_VERSION=v0.34.0
 ARG ROCM_INSTALLER=https://repo.radeon.com/amdgpu-install/5.7/ubuntu/jammy/amdgpu-install_5.7.50700-1_all.deb
 RUN apt-get update \
     && apt-get install --no-install-recommends -y \
@@ -68,8 +68,8 @@ WORKDIR /opt/pennylane-lightning
 ENV VIRTUAL_ENV=/opt/venv-build
 RUN python3 -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
-RUN wget --progress=dot:giga https://github.com/PennyLaneAI/pennylane-lightning/archive/refs/tags/v${LIGHTNING_VERSION}.tar.gz
-RUN tar -zxf v${LIGHTNING_VERSION}.tar.gz && mv pennylane-lightning-${LIGHTNING_VERSION}/* /opt/pennylane-lightning
+RUN rm -rf tmp && git clone --depth 1 --branch ${LIGHTNING_VERSION} https://github.com/PennyLaneAI/pennylane-lightning.git tmp\
+    && mv tmp/* /opt/pennylane-lightning && rm -rf tmp
 RUN pip install --no-cache-dir wheel
 RUN pip install --no-cache-dir -r requirements-dev.txt
 RUN pip install --no-cache-dir -r doc/requirements.txt
@@ -120,6 +120,7 @@ RUN PL_BACKEND=lightning_kokkos python setup.py bdist_wheel
 FROM base-runtime AS wheel-lightning-kokkos-openmp
 COPY --from=build-kokkos-openmp /opt/kokkos /opt/kokkos
 COPY --from=build-wheel-lightning-kokkos-openmp /opt/pennylane-lightning/dist/ /
+COPY --from=build-wheel-lightning-qubit /opt/pennylane-lightning/dist/ /
 RUN pip install --force-reinstall --no-cache-dir PennyLane_Lightning*.whl && rm PennyLane_Lightning*.whl
 RUN pip install --no-cache-dir -U pennylane
 
@@ -181,6 +182,7 @@ RUN python3 -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 COPY --from=build-kokkos-cuda /opt/kokkos /opt/kokkos
 COPY --from=build-wheel-lightning-kokkos-cuda /opt/pennylane-lightning/dist/ /
+COPY --from=build-wheel-lightning-qubit /opt/pennylane-lightning/dist/ /
 RUN pip install --force-reinstall --no-cache-dir PennyLane_Lightning*.whl && rm PennyLane_Lightning*.whl
 RUN pip install --no-cache-dir -U pennylane
 
@@ -209,6 +211,7 @@ ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 RUN pip install --no-cache-dir custatevec-cu12
 ENV LD_LIBRARY_PATH="$VIRTUAL_ENV/lib/python3.10/site-packages/cuquantum/lib:$LD_LIBRARY_PATH"
 COPY --from=build-wheel-lightning-gpu /opt/pennylane-lightning/dist/ /
+COPY --from=build-wheel-lightning-qubit /opt/pennylane-lightning/dist/ /
 RUN pip install --no-cache-dir --force-reinstall PennyLane_Lightning*.whl && rm PennyLane_Lightning*.whl
 RUN pip install --no-cache-dir -U pennylane
 
@@ -272,5 +275,6 @@ RUN python3 -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 COPY --from=build-kokkos-rocm /opt/kokkos /opt/kokkos
 COPY --from=build-wheel-lightning-kokkos-rocm /opt/pennylane-lightning/dist/ /
+COPY --from=build-wheel-lightning-qubit /opt/pennylane-lightning/dist/ /
 RUN pip install --force-reinstall --no-cache-dir PennyLane_Lightning*.whl && rm PennyLane_Lightning*.whl
 RUN pip install --no-cache-dir -U pennylane

--- a/docker/README.md
+++ b/docker/README.md
@@ -14,7 +14,7 @@ You can also check the Lightning-plugins documentation:
 ## Download & install
 
 Each image contains PennyLane and one of several high-performance plugins.
-Choose a version (e.g. `0.32.0`) and append a device (plugin) name among the following:
+Choose a version (e.g. `v0.34.0`) and append a device (plugin) name among the following:
 
 - `lightning-qubit`: [pennylane-lightning](https://github.com/PennyLaneAI/pennylane-lightning) provides a fast state-vector simulator written in C++.
 - `lightning-gpu`: [pennylane-lightning-gpu](https://github.com/PennyLaneAI/pennylane-lightning-gpu) is a plugin based on the NVIDIA [cuQuantum SDK](https://developer.nvidia.com/cuquantum-sdk).
@@ -25,7 +25,7 @@ Choose a version (e.g. `0.32.0`) and append a device (plugin) name among the fol
 If you have Docker installed, download and spawn a container with `pennylane-lightning` as follows
 
 ```shell
-docker run -v pwd:/io -it pennylaneai/pennylane:0.32.0-lightning-qubit bash
+docker run -v pwd:/io -it pennylaneai/pennylane:v0.34.0-lightning-qubit bash
 ```
 
 On certain systems, there may be other solutions supporting Docker containers.
@@ -33,8 +33,8 @@ For instance, NERSC computers (e.g. Perlmutter) have [Shifter](https://docs.ners
 In this case, spawning a container is simple as
 
 ```shell
-shifterimg pull pennylaneai/pennylane:0.32.0-lightning-qubit
-shifter --image=pennylaneai/pennylane:0.32.0-lightning-qubit /bin/bash
+shifterimg pull pennylaneai/pennylane:v0.34.0-lightning-qubit
+shifter --image=pennylaneai/pennylane:v0.34.0-lightning-qubit /bin/bash
 ```
 
 where the first command downloads the image and the second spawns a container.
@@ -66,6 +66,12 @@ Then the following command will build the target
 
 ```shell
 docker build -f docker/Dockerfile --tag=${TARGET} --target ${TARGET} .
+```
+
+You may also feed a git tag or version as follows
+
+```shell
+docker build -f docker/Dockerfile --tag=${TARGET} --target ${TARGET} --build-arg="LIGHTNING_VERSION=${VERSION}" .
 ```
 
 To start a container with a `bash` shell use

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.35.0-dev5"
+__version__ = "0.35.0-dev6"


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [x] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [x] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [x] Ensure that the test suite passes, by running `make test`.

- [x] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [x] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**
The way our Dockerfile is setup prevent building against anything else than official releases. It can be convenient to rebuild against some branches, tags, etc. and hence this PR introduces flexibility in the `LIGHTNING_VERSION` build argument.

**Description of the Change:**
I also added a cron job building all images for `master` to track any regression in the Docker builds.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
