### PR TITLE
Add support for `BlockEncode` gate to lightning devices

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -9,6 +9,9 @@
 
 ### Improvements
 
+* The `BlockEncode` operation from PennyLane is now supported on all Lightning devices.
+  [(#599)](https://github.com/PennyLaneAI/pennylane-lightning/pull/599)
+
 * OpenMP acceleration can now be enabled at compile time for all `lightning.qubit` gate kernels using the "-DLQ_ENABLE_KERNEL_OMP=1" CMake argument.
   [(#510)](https://github.com/PennyLaneAI/pennylane-lightning/pull/510)
 
@@ -32,7 +35,7 @@
 
 This release contains contributions from (in alphabetical order):
 
-Amintor Dusko, Vincent Michaud-Rioux, Lee J. O'Riordan, Shuli Shu
+Amintor Dusko, David Ittah, Vincent Michaud-Rioux, Lee J. O'Riordan, Shuli Shu
 
 ---
 

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.35.0-dev5"
+__version__ = "0.35.0-dev6"

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.35.0-dev6"
+__version__ = "0.35.0-dev7"

--- a/pennylane_lightning/lightning_gpu/lightning_gpu.py
+++ b/pennylane_lightning/lightning_gpu/lightning_gpu.py
@@ -185,6 +185,7 @@ if LGPU_CPP_BINARY_AVAILABLE:
         "OrbitalRotation",
         "QFT",
         "ECR",
+        "BlockEncode",
     }
 
     allowed_observables = {

--- a/pennylane_lightning/lightning_gpu/lightning_gpu.toml
+++ b/pennylane_lightning/lightning_gpu/lightning_gpu.toml
@@ -88,6 +88,7 @@ matrix = [
         "QubitCarry",
         "QubitSum",
         "DiagonalQubitUnitary",
+        "BlockEncode",
 ]
 
 [measurement_processes]
@@ -119,4 +120,4 @@ mid_circuit_measurement = false
 
 # This field is currently unchecked but it is reserved for the purpose of
 # determining if the device supports dynamic qubit allocation/deallocation.
-dynamic_qubit_management = false 
+dynamic_qubit_management = false

--- a/pennylane_lightning/lightning_kokkos/lightning_kokkos.py
+++ b/pennylane_lightning/lightning_kokkos/lightning_kokkos.py
@@ -140,6 +140,7 @@ if LK_CPP_BINARY_AVAILABLE:
         "OrbitalRotation",
         "QFT",
         "ECR",
+        "BlockEncode",
     }
 
     allowed_observables = {

--- a/pennylane_lightning/lightning_kokkos/lightning_kokkos.toml
+++ b/pennylane_lightning/lightning_kokkos/lightning_kokkos.toml
@@ -88,6 +88,7 @@ matrix = [
         "QubitCarry",
         "QubitSum",
         "DiagonalQubitUnitary",
+        "BlockEncode",
 ]
 
 [measurement_processes]
@@ -119,4 +120,4 @@ mid_circuit_measurement = true
 
 # This field is currently unchecked but it is reserved for the purpose of
 # determining if the device supports dynamic qubit allocation/deallocation.
-dynamic_qubit_management = false 
+dynamic_qubit_management = false

--- a/pennylane_lightning/lightning_qubit/lightning_qubit.py
+++ b/pennylane_lightning/lightning_qubit/lightning_qubit.py
@@ -154,6 +154,7 @@ if LQ_CPP_BINARY_AVAILABLE:
         "OrbitalRotation",
         "QFT",
         "ECR",
+        "BlockEncode",
     }
 
     allowed_observables = {

--- a/pennylane_lightning/lightning_qubit/lightning_qubit.toml
+++ b/pennylane_lightning/lightning_qubit/lightning_qubit.toml
@@ -90,6 +90,7 @@ matrix = [
         "QubitCarry",
         "QubitSum",
         "DiagonalQubitUnitary",
+        "BlockEncode",
 ]
 
 [measurement_processes]

--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -76,6 +76,7 @@ def op(op_name):
         "QubitSum": [qml.QubitSum, [], {"wires": [0, 1, 2]}],
         "QubitCarry": [qml.QubitCarry, [], {"wires": [0, 1, 2, 3]}],
         "QubitUnitary": [qml.QubitUnitary, [], {"U": np.eye(16) * 1j, "wires": [0, 1, 2, 3]}],
+        "BlockEncode": [qml.BlockEncode, [[[0.2, 0, 0.2], [-0.2, 0.2, 0]]], {"wires": [0, 1, 2]}],
     }
     return ops_list.get(op_name)
 


### PR DESCRIPTION
A simple change to add support for BlockEncode to lightning devices via matrix application.

[sc-54971]