### PR TITLE
[RFC] Improve handling of nested control structures

### DIFF
--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.35.0-dev7"
+__version__ = "0.35.0-dev8"


### PR DESCRIPTION
Looking for feedback on the following:

After merging #599, Lightning obtained support for the `BlockEncode` operator. However, even though Lightning in principle supports arbitrary control wires on all supported operators, it didn't automatically gain support for `C(BlockEncode)`. The reason is that this is treated as a separate gate altogether, and many operators are additionally added in their controlled form to the list of supported ops, which seems redundant. To make matters worse, operations of the form `C(C(...))` are still not supported.

The following patch is just one way we could handle controlled operations in a more generic fashion. `qml.simplify` is applied to any `Controlled` instance before processing it in order to flatten any nested control structures. Additionally, the `supports_operation` method is overridden to strip any `C(` prefixes from gate names to determine support status.

Note that nested control structures can easily arise when users write functions that call other functions while adding `qml.ctrl` into the mix.

Benefits:
- no redundant `C(...)` style specifications in the list of operations
- much faster processing of certain operations:
  For instance, `C(C(SWAP))` would previously need to be decomposed into many gates in order to simulate it, when it could just be applied in a single step. See the following benchmark for how this affects simulation time:
  <img width="570" alt="Screenshot 2024-01-25 at 7 09 38 PM" src="https://github.com/PennyLaneAI/pennylane-lightning/assets/29467667/a83d4cbc-2f29-40e3-98cf-9ab216564fa6">
  -> more than 10x improvement
- supported gates that cannot be decomposed (such as `BlockEncode`) are automatically also supported in their controlled version

[sc-55549]