### PR TITLE
do not use measurementprocess.name

### DIFF
--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.35.0-dev10"
+__version__ = "0.35.0-dev11"

--- a/pennylane_lightning/lightning_qubit/lightning_qubit.py
+++ b/pennylane_lightning/lightning_qubit/lightning_qubit.py
@@ -625,7 +625,7 @@ if LQ_CPP_BINARY_AVAILABLE:
         # pylint: disable=attribute-defined-outside-init
         def sample(self, observable, shot_range=None, bin_size=None, counts=False):
             """Return samples of an observable."""
-            if isinstance(observable, qml.PauliZ):
+            if not isinstance(observable, qml.PauliZ):
                 self.apply_lightning(observable.diagonalizing_gates())
                 self._samples = self.generate_samples()
             return super().sample(

--- a/pennylane_lightning/lightning_qubit/lightning_qubit.py
+++ b/pennylane_lightning/lightning_qubit/lightning_qubit.py
@@ -625,7 +625,7 @@ if LQ_CPP_BINARY_AVAILABLE:
         # pylint: disable=attribute-defined-outside-init
         def sample(self, observable, shot_range=None, bin_size=None, counts=False):
             """Return samples of an observable."""
-            if observable.name != "PauliZ":
+            if isinstance(observable, qml.PauliZ):
                 self.apply_lightning(observable.diagonalizing_gates())
                 self._samples = self.generate_samples()
             return super().sample(


### PR DESCRIPTION
**Context:**
`MeasurementProcess.name` has been deprecated, and we should avoid using it. Unfortunately, sometimes they disguise as observables. This is one of those times, and it [makes PennyLane CI fail](https://github.com/PennyLaneAI/pennylane/actions/runs/7729318298/job/21072294868?pr=5122) when we enable deprecation-warnings-as-errors

**Description of the Change:**
Just use `isinstance` to not check the name in case it's not an observable.

**Benefits:**
- No more deprecation warnings!
- my PR is unblocked 😄 

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
PennyLaneAI/pennylane#5122, recently introduced in #601 