### PR TITLE
Fix stopping condition thresholds

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -40,6 +40,9 @@
 
 ### Bug fixes
 
+* Ensure the stopping condition decompositions are respected for larger templated QFT and Grover operators.
+  [(#609)](https://github.com/PennyLaneAI/pennylane-lightning/pull/609)
+
 * Move concurrency group specifications from reusable Docker build workflow to the root workflows.
   [(#604)](https://github.com/PennyLaneAI/pennylane-lightning/pull/604)
 

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.35.0-dev12"
+__version__ = "0.35.0-dev13"

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.35.0-dev11"
+__version__ = "0.35.0-dev12"

--- a/pennylane_lightning/core/lightning_base.py
+++ b/pennylane_lightning/core/lightning_base.py
@@ -93,10 +93,10 @@ class LightningBase(QubitDevice):
         and observable) and returns ``True`` if supported by the device."""
 
         def accepts_obj(obj):
-            if obj.name == "QFT" and len(obj.wires) < 10:
-                return True
-            if obj.name == "GroverOperator" and len(obj.wires) < 13:
-                return True
+            if obj.name == "QFT":
+                return len(obj.wires) < 10
+            if obj.name == "GroverOperator":
+                return len(obj.wires) < 13
             return (not isinstance(obj, qml.tape.QuantumTape)) and getattr(
                 self, "supports_operation", lambda name: False
             )(obj.name)

--- a/pennylane_lightning/core/lightning_base.py
+++ b/pennylane_lightning/core/lightning_base.py
@@ -97,9 +97,9 @@ class LightningBase(QubitDevice):
                 return len(obj.wires) < 10
             if obj.name == "GroverOperator":
                 return len(obj.wires) < 13
-            return (not isinstance(obj, qml.tape.QuantumTape)) and getattr(
-                self, "supports_operation", lambda name: False
-            )(obj.name)
+            is_not_tape = not isinstance(obj, qml.tape.QuantumTape)
+            is_supported = getattr(self, "supports_operation", lambda name: False)(obj.name)
+            return is_not_tape and is_supported
 
         return qml.BooleanFn(accepts_obj)
 

--- a/tests/test_decomposition.py
+++ b/tests/test_decomposition.py
@@ -31,12 +31,14 @@ class TestDenseMatrixDecompositionThreshold:
     input = [
         (qml.QFT, 8, True),
         (qml.QFT, 10, False),
+        (qml.QFT, 14, False),
         (qml.GroverOperator, 8, True),
         (qml.GroverOperator, 13, False),
     ]
 
     @pytest.mark.parametrize("op, n_wires, condition", input)
     def test_threshold(self, op, n_wires, condition):
-        wires = np.linspace(0, n_wires - 1, n_wires, dtype=int)
+        wires = range(n_wires)
         op = op(wires=wires)
-        assert ld.stopping_condition.__get__(op)(op) == condition
+        dev = ld(n_wires)
+        assert dev.stopping_condition(op) == condition


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [x] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [x] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [x] Ensure that the test suite passes, by running `make test`.

- [x] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [x] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:** This fixes the matrix vs decomposition split in the stopping condition for the included aggregate template operations.

**Description of the Change:** Avoids building matrices beyond the given thresholds defined in the stopping condition.

**Benefits:** Significantly reduced runtime overheads for larger systems.

**Possible Drawbacks:**

**Related GitHub Issues:**
