### PR TITLE
Update clang-format to test MPI backends

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -40,7 +40,7 @@ jobs:
         run: sudo apt update && sudo apt -y install python3 python3-pip && python -m pip install pip~=22.0 && python3 -m pip install -r requirements-dev.txt
 
       - name: Run formatter
-        run: PATH=$PATH:$(dirname $(which python3))/ ./bin/format --check ./pennylane_lightning/core/src
+        run: PATH=$PATH:/home/ubuntu/.local/bin/:$(dirname $(which python3))/ ./bin/format --check ./pennylane_lightning/core/src
 
   tidy-cpp:
     strategy:

--- a/.github/workflows/wheel_linux_x86_64_cuda.yml
+++ b/.github/workflows/wheel_linux_x86_64_cuda.yml
@@ -116,6 +116,8 @@ jobs:
       matrix:
         arch: [x86_64]
         pl_backend: ["lightning_gpu"]
+        cuda_version: ["12"]
+
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'release' || github.ref == 'refs/heads/master'}}
     steps:

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.35.0-dev13"
+__version__ = "0.35.0-dev14"

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.35.0-dev12"
+__version__ = "0.35.0-dev13"


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [x] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [x] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [x] Ensure that the test suite passes, by running `make test`.

- [x] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [x] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:** This PR makes a minor update to the clang-formatter to allow a full end-to-end test of all the supported backends with MPI.

**Description of the Change:** Adds the ubuntu CI path explicitly to the clang-format search location.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
