### PR TITLE
Bugfix Catalyst: add GlobalPhase in TOML files

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -15,6 +15,9 @@
 
 ### Improvements
 
+* Add adjoint support for `GlobalPhase` in Lightning-GPU and Lightning-Kokkos.
+  [(#615)](https://github.com/PennyLaneAI/pennylane-lightning/pull/615)
+
 * Lower the overheads of Windows CI tests.
   [(#610)](https://github.com/PennyLaneAI/pennylane-lightning/pull/610)
 
@@ -48,6 +51,9 @@
   [(#594)](https://github.com/PennyLaneAI/pennylane-lightning/pull/594)
 
 ### Bug fixes
+
+* List `GlobalPhase` gate in each device's TOML file.
+  [(#615)](https://github.com/PennyLaneAI/pennylane-lightning/pull/615)
 
 * Lightning-GPU's gate cache failed to distinguish between certain gates.
   For example, `MultiControlledX([0, 1, 2], "111")` and `MultiControlledX([0, 2], "00")` were applied as the same operation. 

--- a/Makefile
+++ b/Makefile
@@ -98,10 +98,10 @@ test-cpp:
 	cmake -BBuildTests -G Ninja -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS=ON -DENABLE_WARNINGS=ON -DPL_BACKEND=$(PL_BACKEND) $(OPTIONS)
 ifdef target
 	cmake --build ./BuildTests $(VERBOSE) --target $(target)
-	OMP_PROC_BIND=false ./BuildTests/$(target)
+	./BuildTests/$(target)
 else
 	cmake --build ./BuildTests $(VERBOSE)
-	OMP_PROC_BIND=false cmake --build ./BuildTests $(VERBOSE) --target test
+	cmake --build ./BuildTests $(VERBOSE) --target test
 endif
 
 .PHONY: format format-cpp

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.35.0-dev15"
+__version__ = "0.35.0-dev16"

--- a/pennylane_lightning/core/src/simulators/lightning_gpu/StateVectorCudaManaged.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_gpu/StateVectorCudaManaged.hpp
@@ -684,6 +684,20 @@ class StateVectorCudaManaged
 
     /* Gate generators */
     /**
+     * @brief Gradient generator function associated with the GlobalPhase gate.
+     *
+     * @param sv Statevector
+     * @param wires Wires to apply operation.
+     * @param adj Takes adjoint of operation if true. Defaults to false.
+     */
+    inline PrecisionT
+    applyGeneratorGlobalPhase([[maybe_unused]] const std::vector<size_t> &wires,
+                              [[maybe_unused]] bool adj = false) {
+        return static_cast<PrecisionT>(-1.0);
+    }
+
+    /* Gate generators */
+    /**
      * @brief Gradient generator function associated with the RX gate.
      *
      * @param sv Statevector
@@ -1149,6 +1163,12 @@ class StateVectorCudaManaged
 
     // Holds the mapping from gate labels to associated generator functions.
     const GMap generator_map_{
+        {"GlobalPhase",
+         [&](auto &&wires, auto &&adjoint) {
+             return applyGeneratorGlobalPhase(
+                 std::forward<decltype(wires)>(wires),
+                 std::forward<decltype(adjoint)>(adjoint));
+         }},
         {"RX",
          [&](auto &&wires, auto &&adjoint) {
              return applyGeneratorRX(std::forward<decltype(wires)>(wires),

--- a/pennylane_lightning/core/src/simulators/lightning_kokkos/StateVectorKokkos.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_kokkos/StateVectorKokkos.hpp
@@ -648,6 +648,8 @@ class StateVectorKokkos final
             return -static_cast<fp_t>(0.5);
         case GeneratorOperation::MultiRZ:
             return applyGeneratorMultiRZ(wires, inverse, params);
+        case GeneratorOperation::GlobalPhase:
+            return static_cast<PrecisionT>(-1.0);
         /// LCOV_EXCL_START
         default:
             PL_ABORT(std::string("Generator does not exist for ") + opName);
@@ -924,6 +926,7 @@ class StateVectorKokkos final
         generators_indices_["DoubleExcitationPlus"]  = GeneratorOperation::DoubleExcitationPlus;
         generators_indices_["PhaseShift"]            = GeneratorOperation::PhaseShift;
         generators_indices_["MultiRZ"]               = GeneratorOperation::MultiRZ;
+        generators_indices_["GlobalPhase"]           = GeneratorOperation::GlobalPhase;
     }
     // clang-format on
 };

--- a/pennylane_lightning/core/src/simulators/lightning_kokkos/gates/tests/Test_StateVectorKokkos_Generator.cpp
+++ b/pennylane_lightning/core/src/simulators/lightning_kokkos/gates/tests/Test_StateVectorKokkos_Generator.cpp
@@ -708,6 +708,7 @@ TEMPLATE_TEST_CASE("StateVectorKokkosManaged::applyGeneratorCRZ",
 TEMPLATE_TEST_CASE("StateVectorKokkosManaged::applyGeneratorMultiRZ",
                    "[StateVectorKokkosManaged_Generator]", float, double) {
     const bool inverse = GENERATE(true, false);
+    const std::string gate_name = GENERATE("GlobalPhase", "MultiRZ");
     {
         using ComplexT = StateVectorKokkos<TestType>::ComplexT;
         const size_t num_qubits = 4;
@@ -749,13 +750,13 @@ TEMPLATE_TEST_CASE("StateVectorKokkosManaged::applyGeneratorMultiRZ",
             kokkos_gate_svp.HostToDevice(ini_st.data(), ini_st.size());
             kokkos_gate_svm.HostToDevice(ini_st.data(), ini_st.size());
 
-            auto scale = kokkos_gntr_sv.applyGenerator("MultiRZ", {0}, inverse);
+            auto scale = kokkos_gntr_sv.applyGenerator(gate_name, {0}, inverse);
             if (inverse) {
-                kokkos_gate_svp.applyOperation("MultiRZ", {0}, inverse, {-ep});
-                kokkos_gate_svm.applyOperation("MultiRZ", {0}, inverse, {ep});
+                kokkos_gate_svp.applyOperation(gate_name, {0}, inverse, {-ep});
+                kokkos_gate_svm.applyOperation(gate_name, {0}, inverse, {ep});
             } else {
-                kokkos_gate_svp.applyOperation("MultiRZ", {0}, inverse, {ep});
-                kokkos_gate_svm.applyOperation("MultiRZ", {0}, inverse, {-ep});
+                kokkos_gate_svp.applyOperation(gate_name, {0}, inverse, {ep});
+                kokkos_gate_svm.applyOperation(gate_name, {0}, inverse, {-ep});
             }
 
             kokkos_gntr_sv.DeviceToHost(result_gntr_sv.data(),

--- a/pennylane_lightning/core/src/simulators/lightning_kokkos/gates/tests/Test_StateVectorKokkos_Generator.cpp
+++ b/pennylane_lightning/core/src/simulators/lightning_kokkos/gates/tests/Test_StateVectorKokkos_Generator.cpp
@@ -42,7 +42,7 @@ using std::size_t;
 } // namespace
 /// @endcond
 
-TEMPLATE_TEST_CASE("StateVectorKokkos::applyGenerator",
+TEMPLATE_TEST_CASE("StateVectorKokkos::applyGenerator - errors",
                    "[StateVectorKokkos_Generator]", float, double) {
     {
         const size_t num_qubits = 3;

--- a/pennylane_lightning/core/src/simulators/lightning_kokkos/gates/tests/Test_StateVectorKokkos_Generator.cpp
+++ b/pennylane_lightning/core/src/simulators/lightning_kokkos/gates/tests/Test_StateVectorKokkos_Generator.cpp
@@ -16,13 +16,17 @@
 #include <cstddef>
 #include <limits>
 #include <type_traits>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
 #include <catch2/catch.hpp>
 
+#include "Constant.hpp"
+#include "ConstantUtil.hpp" // lookup, array_has_elem, prepend_to_tuple, tuple_to_array
 #include "StateVectorKokkos.hpp"
 #include "TestHelpers.hpp"
+#include "TestHelpersWires.hpp"
 
 /**
  * @file
@@ -31,6 +35,7 @@
 
 /// @cond DEV
 namespace {
+using namespace Pennylane::Gates;
 using namespace Pennylane::LightningKokkos;
 using namespace Pennylane::Util;
 using std::size_t;
@@ -38,7 +43,7 @@ using std::size_t;
 /// @endcond
 
 TEMPLATE_TEST_CASE("StateVectorKokkos::applyGenerator",
-                   "[StateVectorKokkosManaged_Generator]", float, double) {
+                   "[StateVectorKokkos_Generator]", float, double) {
     {
         const size_t num_qubits = 3;
         StateVectorKokkos<TestType> state_vector{num_qubits};
@@ -48,1187 +53,79 @@ TEMPLATE_TEST_CASE("StateVectorKokkos::applyGenerator",
     }
 }
 
-TEMPLATE_TEST_CASE("StateVectorKokkosManaged::applyGeneratorPhaseShift",
-                   "[StateVectorKokkosManaged_Generator]", double) {
-    {
-        using ComplexT = StateVectorKokkos<TestType>::ComplexT;
-        const size_t num_qubits = 4;
-        const TestType ep = 1e-3;
-        const TestType EP = 1e-4;
+TEMPLATE_TEST_CASE("StateVectorKokkos::applyGenerator",
+                   "[StateVectorKokkos_Generator]", float, double) {
+    using ComplexT = StateVectorKokkos<TestType>::ComplexT;
+    const size_t num_qubits = 4;
+    const TestType ep = 1e-3;
+    const TestType EP = 1e-4;
 
-        std::vector<ComplexT> ini_st{
-            ComplexT{0.267462841882, 0.010768564798},
-            ComplexT{0.228575129706, 0.010564590956},
-            ComplexT{0.099492749900, 0.260849823392},
-            ComplexT{0.093690204310, 0.189847108173},
-            ComplexT{0.033390732374, 0.203836830144},
-            ComplexT{0.226979395737, 0.081852150975},
-            ComplexT{0.031235505729, 0.176933497281},
-            ComplexT{0.294287602843, 0.145156781198},
-            ComplexT{0.152742706049, 0.111628061129},
-            ComplexT{0.012553863703, 0.120027860480},
-            ComplexT{0.237156555364, 0.154658769755},
-            ComplexT{0.117001120872, 0.228059505033},
-            ComplexT{0.041495873225, 0.065934827444},
-            ComplexT{0.089653239407, 0.221581340372},
-            ComplexT{0.217892322429, 0.291261296999},
-            ComplexT{0.292993251871, 0.186570798697},
-        };
+    std::vector<ComplexT> ini_st{
+        ComplexT{0.267462841882, 0.010768564798},
+        ComplexT{0.228575129706, 0.010564590956},
+        ComplexT{0.099492749900, 0.260849823392},
+        ComplexT{0.093690204310, 0.189847108173},
+        ComplexT{0.033390732374, 0.203836830144},
+        ComplexT{0.226979395737, 0.081852150975},
+        ComplexT{0.031235505729, 0.176933497281},
+        ComplexT{0.294287602843, 0.145156781198},
+        ComplexT{0.152742706049, 0.111628061129},
+        ComplexT{0.012553863703, 0.120027860480},
+        ComplexT{0.237156555364, 0.154658769755},
+        ComplexT{0.117001120872, 0.228059505033},
+        ComplexT{0.041495873225, 0.065934827444},
+        ComplexT{0.089653239407, 0.221581340372},
+        ComplexT{0.217892322429, 0.291261296999},
+        ComplexT{0.292993251871, 0.186570798697},
+    };
 
-        SECTION("Apply using dispatcher") {
-            StateVectorKokkos<TestType> kokkos_gntr_sv{num_qubits};
-            StateVectorKokkos<TestType> kokkos_gate_svp{num_qubits};
-            StateVectorKokkos<TestType> kokkos_gate_svm{num_qubits};
-
-            std::vector<ComplexT> result_gntr_sv(kokkos_gntr_sv.getLength(),
-                                                 {0, 0});
-            std::vector<ComplexT> result_gate_svp(kokkos_gate_svp.getLength(),
-                                                  {0, 0});
-            std::vector<ComplexT> result_gate_svm(kokkos_gate_svm.getLength(),
-                                                  {0, 0});
-
-            kokkos_gntr_sv.HostToDevice(ini_st.data(), ini_st.size());
-            kokkos_gate_svp.HostToDevice(ini_st.data(), ini_st.size());
-            kokkos_gate_svm.HostToDevice(ini_st.data(), ini_st.size());
-
-            auto scale =
-                kokkos_gntr_sv.applyGenerator("PhaseShift", {1}, false);
-            kokkos_gate_svp.applyOperation("PhaseShift", {1}, false, {ep});
-            kokkos_gate_svm.applyOperation("PhaseShift", {1}, false, {-ep});
-
-            kokkos_gntr_sv.DeviceToHost(result_gntr_sv.data(),
-                                        result_gntr_sv.size());
-            kokkos_gate_svp.DeviceToHost(result_gate_svp.data(),
-                                         result_gate_svp.size());
-            kokkos_gate_svm.DeviceToHost(result_gate_svm.data(),
-                                         result_gate_svm.size());
-
-            for (size_t j = 0; j < exp2(num_qubits); j++) {
-                CHECK(-scale * imag(result_gntr_sv[j]) ==
-                      Approx(0.5 *
-                             (real(result_gate_svp[j]) -
-                              real(result_gate_svm[j])) /
-                             ep)
-                          .margin(EP));
-                CHECK(scale * real(result_gntr_sv[j]) ==
-                      Approx(0.5 *
-                             (imag(result_gate_svp[j]) -
-                              imag(result_gate_svm[j])) /
-                             ep)
-                          .margin(EP));
-            }
-        }
+    std::unordered_map<std::string, GateOperation> str_to_gates_{};
+    for (const auto &[gate_op, gate_name] : Constant::gate_names) {
+        str_to_gates_.emplace(gate_name, gate_op);
     }
-}
 
-TEMPLATE_TEST_CASE("StateVectorKokkosManaged::applyGeneratorIsingXX",
-                   "[StateVectorKokkosManaged_Generator]", float, double) {
-    {
-        using ComplexT = StateVectorKokkos<TestType>::ComplexT;
-        const size_t num_qubits = 4;
-        const TestType ep = 1e-3;
-        const TestType EP = 1e-4;
-
-        std::vector<ComplexT> ini_st{
-            ComplexT{0.267462841882, 0.010768564798},
-            ComplexT{0.228575129706, 0.010564590956},
-            ComplexT{0.099492749900, 0.260849823392},
-            ComplexT{0.093690204310, 0.189847108173},
-            ComplexT{0.033390732374, 0.203836830144},
-            ComplexT{0.226979395737, 0.081852150975},
-            ComplexT{0.031235505729, 0.176933497281},
-            ComplexT{0.294287602843, 0.145156781198},
-            ComplexT{0.152742706049, 0.111628061129},
-            ComplexT{0.012553863703, 0.120027860480},
-            ComplexT{0.237156555364, 0.154658769755},
-            ComplexT{0.117001120872, 0.228059505033},
-            ComplexT{0.041495873225, 0.065934827444},
-            ComplexT{0.089653239407, 0.221581340372},
-            ComplexT{0.217892322429, 0.291261296999},
-            ComplexT{0.292993251871, 0.186570798697},
-        };
-
-        SECTION("Apply using dispatcher") {
-            StateVectorKokkos<TestType> kokkos_gntr_sv{num_qubits};
-            StateVectorKokkos<TestType> kokkos_gate_svp{num_qubits};
-            StateVectorKokkos<TestType> kokkos_gate_svm{num_qubits};
-
-            std::vector<ComplexT> result_gntr_sv(kokkos_gntr_sv.getLength(),
-                                                 {0, 0});
-            std::vector<ComplexT> result_gate_svp(kokkos_gate_svp.getLength(),
-                                                  {0, 0});
-            std::vector<ComplexT> result_gate_svm(kokkos_gate_svm.getLength(),
-                                                  {0, 0});
-
-            kokkos_gntr_sv.HostToDevice(ini_st.data(), ini_st.size());
-            kokkos_gate_svp.HostToDevice(ini_st.data(), ini_st.size());
-            kokkos_gate_svm.HostToDevice(ini_st.data(), ini_st.size());
-
-            auto scale =
-                kokkos_gntr_sv.applyGenerator("IsingXX", {0, 1}, false);
-            kokkos_gate_svp.applyOperation("IsingXX", {0, 1}, false, {ep});
-            kokkos_gate_svm.applyOperation("IsingXX", {0, 1}, false, {-ep});
-
-            kokkos_gntr_sv.DeviceToHost(result_gntr_sv.data(),
-                                        result_gntr_sv.size());
-            kokkos_gate_svp.DeviceToHost(result_gate_svp.data(),
-                                         result_gate_svp.size());
-            kokkos_gate_svm.DeviceToHost(result_gate_svm.data(),
-                                         result_gate_svm.size());
-
-            for (size_t j = 0; j < exp2(num_qubits); j++) {
-                CHECK(-scale * imag(result_gntr_sv[j]) ==
-                      Approx(0.5 *
-                             (real(result_gate_svp[j]) -
-                              real(result_gate_svm[j])) /
-                             ep)
-                          .margin(EP));
-                CHECK(scale * real(result_gntr_sv[j]) ==
-                      Approx(0.5 *
-                             (imag(result_gate_svp[j]) -
-                              imag(result_gate_svm[j])) /
-                             ep)
-                          .margin(EP));
-            }
-        }
-    }
-}
-
-TEMPLATE_TEST_CASE("StateVectorKokkosManaged::applyGeneratorIsingXY",
-                   "[StateVectorKokkosManaged_Generator]", float, double) {
-    {
-        using ComplexT = StateVectorKokkos<TestType>::ComplexT;
-        const size_t num_qubits = 4;
-        const TestType ep = 1e-3;
-        const TestType EP = 1e-4;
-
-        std::vector<ComplexT> ini_st{
-            ComplexT{0.267462841882, 0.010768564798},
-            ComplexT{0.228575129706, 0.010564590956},
-            ComplexT{0.099492749900, 0.260849823392},
-            ComplexT{0.093690204310, 0.189847108173},
-            ComplexT{0.033390732374, 0.203836830144},
-            ComplexT{0.226979395737, 0.081852150975},
-            ComplexT{0.031235505729, 0.176933497281},
-            ComplexT{0.294287602843, 0.145156781198},
-            ComplexT{0.152742706049, 0.111628061129},
-            ComplexT{0.012553863703, 0.120027860480},
-            ComplexT{0.237156555364, 0.154658769755},
-            ComplexT{0.117001120872, 0.228059505033},
-            ComplexT{0.041495873225, 0.065934827444},
-            ComplexT{0.089653239407, 0.221581340372},
-            ComplexT{0.217892322429, 0.291261296999},
-            ComplexT{0.292993251871, 0.186570798697},
-        };
-
-        SECTION("Apply using dispatcher") {
-            StateVectorKokkos<TestType> kokkos_gntr_sv{num_qubits};
-            StateVectorKokkos<TestType> kokkos_gate_svp{num_qubits};
-            StateVectorKokkos<TestType> kokkos_gate_svm{num_qubits};
-
-            std::vector<ComplexT> result_gntr_sv(kokkos_gntr_sv.getLength(),
-                                                 {0, 0});
-            std::vector<ComplexT> result_gate_svp(kokkos_gate_svp.getLength(),
-                                                  {0, 0});
-            std::vector<ComplexT> result_gate_svm(kokkos_gate_svm.getLength(),
-                                                  {0, 0});
-
-            kokkos_gntr_sv.HostToDevice(ini_st.data(), ini_st.size());
-            kokkos_gate_svp.HostToDevice(ini_st.data(), ini_st.size());
-            kokkos_gate_svm.HostToDevice(ini_st.data(), ini_st.size());
-
-            auto scale =
-                kokkos_gntr_sv.applyGenerator("IsingXY", {0, 1}, false);
-            kokkos_gate_svp.applyOperation("IsingXY", {0, 1}, false, {ep});
-            kokkos_gate_svm.applyOperation("IsingXY", {0, 1}, false, {-ep});
-
-            kokkos_gntr_sv.DeviceToHost(result_gntr_sv.data(),
-                                        result_gntr_sv.size());
-            kokkos_gate_svp.DeviceToHost(result_gate_svp.data(),
-                                         result_gate_svp.size());
-            kokkos_gate_svm.DeviceToHost(result_gate_svm.data(),
-                                         result_gate_svm.size());
-
-            for (size_t j = 0; j < exp2(num_qubits); j++) {
-                CHECK(-scale * imag(result_gntr_sv[j]) ==
-                      Approx(0.5 *
-                             (real(result_gate_svp[j]) -
-                              real(result_gate_svm[j])) /
-                             ep)
-                          .margin(EP));
-                CHECK(scale * real(result_gntr_sv[j]) ==
-                      Approx(0.5 *
-                             (imag(result_gate_svp[j]) -
-                              imag(result_gate_svm[j])) /
-                             ep)
-                          .margin(EP));
-            }
-        }
-    }
-}
-
-TEMPLATE_TEST_CASE("StateVectorKokkosManaged::applyGeneratorIsingYY",
-                   "[StateVectorKokkosManaged_Generator]", float, double) {
-    {
-        using ComplexT = StateVectorKokkos<TestType>::ComplexT;
-        const size_t num_qubits = 4;
-        const TestType ep = 1e-3;
-        const TestType EP = 1e-4;
-
-        std::vector<ComplexT> ini_st{
-            ComplexT{0.267462841882, 0.010768564798},
-            ComplexT{0.228575129706, 0.010564590956},
-            ComplexT{0.099492749900, 0.260849823392},
-            ComplexT{0.093690204310, 0.189847108173},
-            ComplexT{0.033390732374, 0.203836830144},
-            ComplexT{0.226979395737, 0.081852150975},
-            ComplexT{0.031235505729, 0.176933497281},
-            ComplexT{0.294287602843, 0.145156781198},
-            ComplexT{0.152742706049, 0.111628061129},
-            ComplexT{0.012553863703, 0.120027860480},
-            ComplexT{0.237156555364, 0.154658769755},
-            ComplexT{0.117001120872, 0.228059505033},
-            ComplexT{0.041495873225, 0.065934827444},
-            ComplexT{0.089653239407, 0.221581340372},
-            ComplexT{0.217892322429, 0.291261296999},
-            ComplexT{0.292993251871, 0.186570798697},
-        };
-
-        SECTION("Apply using dispatcher") {
-            StateVectorKokkos<TestType> kokkos_gntr_sv{num_qubits};
-            StateVectorKokkos<TestType> kokkos_gate_svp{num_qubits};
-            StateVectorKokkos<TestType> kokkos_gate_svm{num_qubits};
-
-            std::vector<ComplexT> result_gntr_sv(kokkos_gntr_sv.getLength(),
-                                                 {0, 0});
-            std::vector<ComplexT> result_gate_svp(kokkos_gate_svp.getLength(),
-                                                  {0, 0});
-            std::vector<ComplexT> result_gate_svm(kokkos_gate_svm.getLength(),
-                                                  {0, 0});
-
-            kokkos_gntr_sv.HostToDevice(ini_st.data(), ini_st.size());
-            kokkos_gate_svp.HostToDevice(ini_st.data(), ini_st.size());
-            kokkos_gate_svm.HostToDevice(ini_st.data(), ini_st.size());
-
-            auto scale =
-                kokkos_gntr_sv.applyGenerator("IsingYY", {0, 1}, false);
-            kokkos_gate_svp.applyOperation("IsingYY", {0, 1}, false, {ep});
-            kokkos_gate_svm.applyOperation("IsingYY", {0, 1}, false, {-ep});
-
-            kokkos_gntr_sv.DeviceToHost(result_gntr_sv.data(),
-                                        result_gntr_sv.size());
-            kokkos_gate_svp.DeviceToHost(result_gate_svp.data(),
-                                         result_gate_svp.size());
-            kokkos_gate_svm.DeviceToHost(result_gate_svm.data(),
-                                         result_gate_svm.size());
-
-            for (size_t j = 0; j < exp2(num_qubits); j++) {
-                CHECK(-scale * imag(result_gntr_sv[j]) ==
-                      Approx(0.5 *
-                             (real(result_gate_svp[j]) -
-                              real(result_gate_svm[j])) /
-                             ep)
-                          .margin(EP));
-                CHECK(scale * real(result_gntr_sv[j]) ==
-                      Approx(0.5 *
-                             (imag(result_gate_svp[j]) -
-                              imag(result_gate_svm[j])) /
-                             ep)
-                          .margin(EP));
-            }
-        }
-    }
-}
-
-TEMPLATE_TEST_CASE("StateVectorKokkosManaged::applyGeneratorIsingZZ",
-                   "[StateVectorKokkosManaged_Generator]", float, double) {
-    {
-        using ComplexT = StateVectorKokkos<TestType>::ComplexT;
-        const size_t num_qubits = 4;
-        const TestType ep = 1e-3;
-        const TestType EP = 1e-4;
-
-        std::vector<ComplexT> ini_st{
-            ComplexT{0.267462841882, 0.010768564798},
-            ComplexT{0.228575129706, 0.010564590956},
-            ComplexT{0.099492749900, 0.260849823392},
-            ComplexT{0.093690204310, 0.189847108173},
-            ComplexT{0.033390732374, 0.203836830144},
-            ComplexT{0.226979395737, 0.081852150975},
-            ComplexT{0.031235505729, 0.176933497281},
-            ComplexT{0.294287602843, 0.145156781198},
-            ComplexT{0.152742706049, 0.111628061129},
-            ComplexT{0.012553863703, 0.120027860480},
-            ComplexT{0.237156555364, 0.154658769755},
-            ComplexT{0.117001120872, 0.228059505033},
-            ComplexT{0.041495873225, 0.065934827444},
-            ComplexT{0.089653239407, 0.221581340372},
-            ComplexT{0.217892322429, 0.291261296999},
-            ComplexT{0.292993251871, 0.186570798697},
-        };
-
-        SECTION("Apply using dispatcher") {
-            StateVectorKokkos<TestType> kokkos_gntr_sv{num_qubits};
-            StateVectorKokkos<TestType> kokkos_gate_svp{num_qubits};
-            StateVectorKokkos<TestType> kokkos_gate_svm{num_qubits};
-
-            std::vector<ComplexT> result_gntr_sv(kokkos_gntr_sv.getLength(),
-                                                 {0, 0});
-            std::vector<ComplexT> result_gate_svp(kokkos_gate_svp.getLength(),
-                                                  {0, 0});
-            std::vector<ComplexT> result_gate_svm(kokkos_gate_svm.getLength(),
-                                                  {0, 0});
-
-            kokkos_gntr_sv.HostToDevice(ini_st.data(), ini_st.size());
-            kokkos_gate_svp.HostToDevice(ini_st.data(), ini_st.size());
-            kokkos_gate_svm.HostToDevice(ini_st.data(), ini_st.size());
-
-            auto scale =
-                kokkos_gntr_sv.applyGenerator("IsingZZ", {0, 1}, false);
-            kokkos_gate_svp.applyOperation("IsingZZ", {0, 1}, false, {ep});
-            kokkos_gate_svm.applyOperation("IsingZZ", {0, 1}, false, {-ep});
-
-            kokkos_gntr_sv.DeviceToHost(result_gntr_sv.data(),
-                                        result_gntr_sv.size());
-            kokkos_gate_svp.DeviceToHost(result_gate_svp.data(),
-                                         result_gate_svp.size());
-            kokkos_gate_svm.DeviceToHost(result_gate_svm.data(),
-                                         result_gate_svm.size());
-
-            for (size_t j = 0; j < exp2(num_qubits); j++) {
-                CHECK(-scale * imag(result_gntr_sv[j]) ==
-                      Approx(0.5 *
-                             (real(result_gate_svp[j]) -
-                              real(result_gate_svm[j])) /
-                             ep)
-                          .margin(EP));
-                CHECK(scale * real(result_gntr_sv[j]) ==
-                      Approx(0.5 *
-                             (imag(result_gate_svp[j]) -
-                              imag(result_gate_svm[j])) /
-                             ep)
-                          .margin(EP));
-            }
-        }
-    }
-}
-
-TEMPLATE_TEST_CASE(
-    "StateVectorKokkosManaged::applyGeneratorControlledPhaseShift",
-    "[StateVectorKokkosManaged_Generator]", float, double) {
-    {
-        using ComplexT = StateVectorKokkos<TestType>::ComplexT;
-        const size_t num_qubits = 4;
-        const TestType ep = 1e-3;
-        const TestType EP = 1e-4;
-
-        std::vector<ComplexT> ini_st{
-            ComplexT{0.267462841882, 0.010768564798},
-            ComplexT{0.228575129706, 0.010564590956},
-            ComplexT{0.099492749900, 0.260849823392},
-            ComplexT{0.093690204310, 0.189847108173},
-            ComplexT{0.033390732374, 0.203836830144},
-            ComplexT{0.226979395737, 0.081852150975},
-            ComplexT{0.031235505729, 0.176933497281},
-            ComplexT{0.294287602843, 0.145156781198},
-            ComplexT{0.152742706049, 0.111628061129},
-            ComplexT{0.012553863703, 0.120027860480},
-            ComplexT{0.237156555364, 0.154658769755},
-            ComplexT{0.117001120872, 0.228059505033},
-            ComplexT{0.041495873225, 0.065934827444},
-            ComplexT{0.089653239407, 0.221581340372},
-            ComplexT{0.217892322429, 0.291261296999},
-            ComplexT{0.292993251871, 0.186570798697},
-        };
-
-        SECTION("Apply using dispatcher") {
-            StateVectorKokkos<TestType> kokkos_gntr_sv{num_qubits};
-            StateVectorKokkos<TestType> kokkos_gate_svp{num_qubits};
-            StateVectorKokkos<TestType> kokkos_gate_svm{num_qubits};
-
-            std::vector<ComplexT> result_gntr_sv(kokkos_gntr_sv.getLength(),
-                                                 {0, 0});
-            std::vector<ComplexT> result_gate_svp(kokkos_gate_svp.getLength(),
-                                                  {0, 0});
-            std::vector<ComplexT> result_gate_svm(kokkos_gate_svm.getLength(),
-                                                  {0, 0});
-
-            kokkos_gntr_sv.HostToDevice(ini_st.data(), ini_st.size());
-            kokkos_gate_svp.HostToDevice(ini_st.data(), ini_st.size());
-            kokkos_gate_svm.HostToDevice(ini_st.data(), ini_st.size());
-
-            auto scale = kokkos_gntr_sv.applyGenerator("ControlledPhaseShift",
-                                                       {0, 1}, false);
-            kokkos_gate_svp.applyOperation("ControlledPhaseShift", {0, 1},
-                                           false, {ep});
-            kokkos_gate_svm.applyOperation("ControlledPhaseShift", {0, 1},
-                                           false, {-ep});
-
-            kokkos_gntr_sv.DeviceToHost(result_gntr_sv.data(),
-                                        result_gntr_sv.size());
-            kokkos_gate_svp.DeviceToHost(result_gate_svp.data(),
-                                         result_gate_svp.size());
-            kokkos_gate_svm.DeviceToHost(result_gate_svm.data(),
-                                         result_gate_svm.size());
-
-            for (size_t j = 0; j < exp2(num_qubits); j++) {
-                CHECK(-scale * imag(result_gntr_sv[j]) ==
-                      Approx(0.5 *
-                             (real(result_gate_svp[j]) -
-                              real(result_gate_svm[j])) /
-                             ep)
-                          .margin(EP));
-                CHECK(scale * real(result_gntr_sv[j]) ==
-                      Approx(0.5 *
-                             (imag(result_gate_svp[j]) -
-                              imag(result_gate_svm[j])) /
-                             ep)
-                          .margin(EP));
-            }
-        }
-    }
-}
-
-TEMPLATE_TEST_CASE("StateVectorKokkosManaged::applyGeneratorCRX",
-                   "[StateVectorKokkosManaged_Generator]", float, double) {
-    {
-        using ComplexT = StateVectorKokkos<TestType>::ComplexT;
-        const size_t num_qubits = 4;
-        const TestType ep = 1e-3;
-        const TestType EP = 1e-4;
-
-        std::vector<ComplexT> ini_st{
-            ComplexT{0.267462841882, 0.010768564798},
-            ComplexT{0.228575129706, 0.010564590956},
-            ComplexT{0.099492749900, 0.260849823392},
-            ComplexT{0.093690204310, 0.189847108173},
-            ComplexT{0.033390732374, 0.203836830144},
-            ComplexT{0.226979395737, 0.081852150975},
-            ComplexT{0.031235505729, 0.176933497281},
-            ComplexT{0.294287602843, 0.145156781198},
-            ComplexT{0.152742706049, 0.111628061129},
-            ComplexT{0.012553863703, 0.120027860480},
-            ComplexT{0.237156555364, 0.154658769755},
-            ComplexT{0.117001120872, 0.228059505033},
-            ComplexT{0.041495873225, 0.065934827444},
-            ComplexT{0.089653239407, 0.221581340372},
-            ComplexT{0.217892322429, 0.291261296999},
-            ComplexT{0.292993251871, 0.186570798697},
-        };
-
-        SECTION("Apply using dispatcher") {
-            StateVectorKokkos<TestType> kokkos_gntr_sv{num_qubits};
-            StateVectorKokkos<TestType> kokkos_gate_svp{num_qubits};
-            StateVectorKokkos<TestType> kokkos_gate_svm{num_qubits};
-
-            std::vector<ComplexT> result_gntr_sv(kokkos_gntr_sv.getLength(),
-                                                 {0, 0});
-            std::vector<ComplexT> result_gate_svp(kokkos_gate_svp.getLength(),
-                                                  {0, 0});
-            std::vector<ComplexT> result_gate_svm(kokkos_gate_svm.getLength(),
-                                                  {0, 0});
-
-            kokkos_gntr_sv.HostToDevice(ini_st.data(), ini_st.size());
-            kokkos_gate_svp.HostToDevice(ini_st.data(), ini_st.size());
-            kokkos_gate_svm.HostToDevice(ini_st.data(), ini_st.size());
-
-            auto scale = kokkos_gntr_sv.applyGenerator("CRX", {0, 1}, false);
-            kokkos_gate_svp.applyOperation("CRX", {0, 1}, false, {ep});
-            kokkos_gate_svm.applyOperation("CRX", {0, 1}, false, {-ep});
-
-            kokkos_gntr_sv.DeviceToHost(result_gntr_sv.data(),
-                                        result_gntr_sv.size());
-            kokkos_gate_svp.DeviceToHost(result_gate_svp.data(),
-                                         result_gate_svp.size());
-            kokkos_gate_svm.DeviceToHost(result_gate_svm.data(),
-                                         result_gate_svm.size());
-
-            for (size_t j = 0; j < exp2(num_qubits); j++) {
-                CHECK(-scale * imag(result_gntr_sv[j]) ==
-                      Approx(0.5 *
-                             (real(result_gate_svp[j]) -
-                              real(result_gate_svm[j])) /
-                             ep)
-                          .margin(EP));
-                CHECK(scale * real(result_gntr_sv[j]) ==
-                      Approx(0.5 *
-                             (imag(result_gate_svp[j]) -
-                              imag(result_gate_svm[j])) /
-                             ep)
-                          .margin(EP));
-            }
-        }
-    }
-}
-
-TEMPLATE_TEST_CASE("StateVectorKokkosManaged::applyGeneratorCRY",
-                   "[StateVectorKokkosManaged_Generator]", float, double) {
-    {
-        using ComplexT = StateVectorKokkos<TestType>::ComplexT;
-        const size_t num_qubits = 4;
-        const TestType ep = 1e-3;
-        const TestType EP = 1e-4;
-
-        std::vector<ComplexT> ini_st{
-            ComplexT{0.267462841882, 0.010768564798},
-            ComplexT{0.228575129706, 0.010564590956},
-            ComplexT{0.099492749900, 0.260849823392},
-            ComplexT{0.093690204310, 0.189847108173},
-            ComplexT{0.033390732374, 0.203836830144},
-            ComplexT{0.226979395737, 0.081852150975},
-            ComplexT{0.031235505729, 0.176933497281},
-            ComplexT{0.294287602843, 0.145156781198},
-            ComplexT{0.152742706049, 0.111628061129},
-            ComplexT{0.012553863703, 0.120027860480},
-            ComplexT{0.237156555364, 0.154658769755},
-            ComplexT{0.117001120872, 0.228059505033},
-            ComplexT{0.041495873225, 0.065934827444},
-            ComplexT{0.089653239407, 0.221581340372},
-            ComplexT{0.217892322429, 0.291261296999},
-            ComplexT{0.292993251871, 0.186570798697},
-        };
-
-        SECTION("Apply using dispatcher") {
-            StateVectorKokkos<TestType> kokkos_gntr_sv{num_qubits};
-            StateVectorKokkos<TestType> kokkos_gate_svp{num_qubits};
-            StateVectorKokkos<TestType> kokkos_gate_svm{num_qubits};
-
-            std::vector<ComplexT> result_gntr_sv(kokkos_gntr_sv.getLength(),
-                                                 {0, 0});
-            std::vector<ComplexT> result_gate_svp(kokkos_gate_svp.getLength(),
-                                                  {0, 0});
-            std::vector<ComplexT> result_gate_svm(kokkos_gate_svm.getLength(),
-                                                  {0, 0});
-
-            kokkos_gntr_sv.HostToDevice(ini_st.data(), ini_st.size());
-            kokkos_gate_svp.HostToDevice(ini_st.data(), ini_st.size());
-            kokkos_gate_svm.HostToDevice(ini_st.data(), ini_st.size());
-
-            auto scale = kokkos_gntr_sv.applyGenerator("CRY", {0, 1}, false);
-            kokkos_gate_svp.applyOperation("CRY", {0, 1}, false, {ep});
-            kokkos_gate_svm.applyOperation("CRY", {0, 1}, false, {-ep});
-
-            kokkos_gntr_sv.DeviceToHost(result_gntr_sv.data(),
-                                        result_gntr_sv.size());
-            kokkos_gate_svp.DeviceToHost(result_gate_svp.data(),
-                                         result_gate_svp.size());
-            kokkos_gate_svm.DeviceToHost(result_gate_svm.data(),
-                                         result_gate_svm.size());
-
-            for (size_t j = 0; j < exp2(num_qubits); j++) {
-                CHECK(-scale * imag(result_gntr_sv[j]) ==
-                      Approx(0.5 *
-                             (real(result_gate_svp[j]) -
-                              real(result_gate_svm[j])) /
-                             ep)
-                          .margin(EP));
-                CHECK(scale * real(result_gntr_sv[j]) ==
-                      Approx(0.5 *
-                             (imag(result_gate_svp[j]) -
-                              imag(result_gate_svm[j])) /
-                             ep)
-                          .margin(EP));
-            }
-        }
-    }
-}
-
-TEMPLATE_TEST_CASE("StateVectorKokkosManaged::applyGeneratorCRZ",
-                   "[StateVectorKokkosManaged_Generator]", float, double) {
-    {
-        using ComplexT = StateVectorKokkos<TestType>::ComplexT;
-        const size_t num_qubits = 4;
-        const TestType ep = 1e-3;
-        const TestType EP = 1e-4;
-
-        std::vector<ComplexT> ini_st{
-            ComplexT{0.267462841882, 0.010768564798},
-            ComplexT{0.228575129706, 0.010564590956},
-            ComplexT{0.099492749900, 0.260849823392},
-            ComplexT{0.093690204310, 0.189847108173},
-            ComplexT{0.033390732374, 0.203836830144},
-            ComplexT{0.226979395737, 0.081852150975},
-            ComplexT{0.031235505729, 0.176933497281},
-            ComplexT{0.294287602843, 0.145156781198},
-            ComplexT{0.152742706049, 0.111628061129},
-            ComplexT{0.012553863703, 0.120027860480},
-            ComplexT{0.237156555364, 0.154658769755},
-            ComplexT{0.117001120872, 0.228059505033},
-            ComplexT{0.041495873225, 0.065934827444},
-            ComplexT{0.089653239407, 0.221581340372},
-            ComplexT{0.217892322429, 0.291261296999},
-            ComplexT{0.292993251871, 0.186570798697},
-        };
-
-        SECTION("Apply using dispatcher") {
-            StateVectorKokkos<TestType> kokkos_gntr_sv{num_qubits};
-            StateVectorKokkos<TestType> kokkos_gate_svp{num_qubits};
-            StateVectorKokkos<TestType> kokkos_gate_svm{num_qubits};
-
-            std::vector<ComplexT> result_gntr_sv(kokkos_gntr_sv.getLength(),
-                                                 {0, 0});
-            std::vector<ComplexT> result_gate_svp(kokkos_gate_svp.getLength(),
-                                                  {0, 0});
-            std::vector<ComplexT> result_gate_svm(kokkos_gate_svm.getLength(),
-                                                  {0, 0});
-
-            kokkos_gntr_sv.HostToDevice(ini_st.data(), ini_st.size());
-            kokkos_gate_svp.HostToDevice(ini_st.data(), ini_st.size());
-            kokkos_gate_svm.HostToDevice(ini_st.data(), ini_st.size());
-
-            auto scale = kokkos_gntr_sv.applyGenerator("CRZ", {0, 1}, false);
-            kokkos_gate_svp.applyOperation("CRZ", {0, 1}, false, {ep});
-            kokkos_gate_svm.applyOperation("CRZ", {0, 1}, false, {-ep});
-
-            kokkos_gntr_sv.DeviceToHost(result_gntr_sv.data(),
-                                        result_gntr_sv.size());
-            kokkos_gate_svp.DeviceToHost(result_gate_svp.data(),
-                                         result_gate_svp.size());
-            kokkos_gate_svm.DeviceToHost(result_gate_svm.data(),
-                                         result_gate_svm.size());
-
-            for (size_t j = 0; j < exp2(num_qubits); j++) {
-                CHECK(-scale * imag(result_gntr_sv[j]) ==
-                      Approx(0.5 *
-                             (real(result_gate_svp[j]) -
-                              real(result_gate_svm[j])) /
-                             ep)
-                          .margin(EP));
-                CHECK(scale * real(result_gntr_sv[j]) ==
-                      Approx(0.5 *
-                             (imag(result_gate_svp[j]) -
-                              imag(result_gate_svm[j])) /
-                             ep)
-                          .margin(EP));
-            }
-        }
-    }
-}
-
-TEMPLATE_TEST_CASE("StateVectorKokkosManaged::applyGeneratorMultiRZ",
-                   "[StateVectorKokkosManaged_Generator]", float, double) {
     const bool inverse = GENERATE(true, false);
-    const std::string gate_name = GENERATE("GlobalPhase", "MultiRZ");
+    const std::string gate_name = GENERATE(
+        "PhaseShift", "RX", "RY", "RZ", "ControlledPhaseShift", "CRX", "CRY",
+        "CRZ", "IsingXX", "IsingXY", "IsingYY", "IsingZZ", "SingleExcitation",
+        "SingleExcitationMinus", "SingleExcitationPlus", "DoubleExcitation",
+        "DoubleExcitationMinus", "DoubleExcitationPlus", "MultiRZ",
+        "GlobalPhase");
     {
-        using ComplexT = StateVectorKokkos<TestType>::ComplexT;
-        const size_t num_qubits = 4;
-        const TestType ep = 1e-3;
-        const TestType EP = 1e-4;
+        StateVectorKokkos<TestType> kokkos_gntr_sv{ini_st.data(),
+                                                   ini_st.size()};
+        StateVectorKokkos<TestType> kokkos_gate_svp{ini_st.data(),
+                                                    ini_st.size()};
+        StateVectorKokkos<TestType> kokkos_gate_svm{ini_st.data(),
+                                                    ini_st.size()};
 
-        std::vector<ComplexT> ini_st{
-            ComplexT{0.267462841882, 0.010768564798},
-            ComplexT{0.228575129706, 0.010564590956},
-            ComplexT{0.099492749900, 0.260849823392},
-            ComplexT{0.093690204310, 0.189847108173},
-            ComplexT{0.033390732374, 0.203836830144},
-            ComplexT{0.226979395737, 0.081852150975},
-            ComplexT{0.031235505729, 0.176933497281},
-            ComplexT{0.294287602843, 0.145156781198},
-            ComplexT{0.152742706049, 0.111628061129},
-            ComplexT{0.012553863703, 0.120027860480},
-            ComplexT{0.237156555364, 0.154658769755},
-            ComplexT{0.117001120872, 0.228059505033},
-            ComplexT{0.041495873225, 0.065934827444},
-            ComplexT{0.089653239407, 0.221581340372},
-            ComplexT{0.217892322429, 0.291261296999},
-            ComplexT{0.292993251871, 0.186570798697},
-        };
+        const auto wires = createWires(str_to_gates_.at(gate_name), num_qubits);
+        auto scale = kokkos_gntr_sv.applyGenerator(gate_name, wires, inverse);
+        auto h = static_cast<TestType>(((inverse) ? -1.0 : 1.0) * ep);
+        kokkos_gate_svp.applyOperation(gate_name, wires, inverse, {h});
+        kokkos_gate_svm.applyOperation(gate_name, wires, inverse, {-h});
 
-        SECTION("Apply using dispatcher") {
-            StateVectorKokkos<TestType> kokkos_gntr_sv{num_qubits};
-            StateVectorKokkos<TestType> kokkos_gate_svp{num_qubits};
-            StateVectorKokkos<TestType> kokkos_gate_svm{num_qubits};
+        auto result_gntr_sv = kokkos_gntr_sv.getDataVector();
+        auto result_gate_svp = kokkos_gate_svp.getDataVector();
+        auto result_gate_svm = kokkos_gate_svm.getDataVector();
 
-            std::vector<ComplexT> result_gntr_sv(kokkos_gntr_sv.getLength(),
-                                                 {0, 0});
-            std::vector<ComplexT> result_gate_svp(kokkos_gate_svp.getLength(),
-                                                  {0, 0});
-            std::vector<ComplexT> result_gate_svm(kokkos_gate_svm.getLength(),
-                                                  {0, 0});
-
-            kokkos_gntr_sv.HostToDevice(ini_st.data(), ini_st.size());
-            kokkos_gate_svp.HostToDevice(ini_st.data(), ini_st.size());
-            kokkos_gate_svm.HostToDevice(ini_st.data(), ini_st.size());
-
-            auto scale = kokkos_gntr_sv.applyGenerator(gate_name, {0}, inverse);
-            if (inverse) {
-                kokkos_gate_svp.applyOperation(gate_name, {0}, inverse, {-ep});
-                kokkos_gate_svm.applyOperation(gate_name, {0}, inverse, {ep});
-            } else {
-                kokkos_gate_svp.applyOperation(gate_name, {0}, inverse, {ep});
-                kokkos_gate_svm.applyOperation(gate_name, {0}, inverse, {-ep});
-            }
-
-            kokkos_gntr_sv.DeviceToHost(result_gntr_sv.data(),
-                                        result_gntr_sv.size());
-            kokkos_gate_svp.DeviceToHost(result_gate_svp.data(),
-                                         result_gate_svp.size());
-            kokkos_gate_svm.DeviceToHost(result_gate_svm.data(),
-                                         result_gate_svm.size());
-
-            for (size_t j = 0; j < exp2(num_qubits); j++) {
-                CHECK(-scale * imag(result_gntr_sv[j]) ==
-                      Approx(0.5 *
-                             (real(result_gate_svp[j]) -
-                              real(result_gate_svm[j])) /
-                             ep)
-                          .margin(EP));
-                CHECK(scale * real(result_gntr_sv[j]) ==
-                      Approx(0.5 *
-                             (imag(result_gate_svp[j]) -
-                              imag(result_gate_svm[j])) /
-                             ep)
-                          .margin(EP));
-            }
+        for (size_t j = 0; j < exp2(num_qubits); j++) {
+            CHECK(-scale * imag(result_gntr_sv[j]) ==
+                  Approx(0.5 *
+                         (real(result_gate_svp[j]) - real(result_gate_svm[j])) /
+                         ep)
+                      .margin(EP));
+            CHECK(scale * real(result_gntr_sv[j]) ==
+                  Approx(0.5 *
+                         (imag(result_gate_svp[j]) - imag(result_gate_svm[j])) /
+                         ep)
+                      .margin(EP));
         }
     }
 }
 
-TEMPLATE_TEST_CASE("StateVectorKokkosManaged::applyGeneratorRX",
-                   "[StateVectorKokkosManaged_Generator]", float, double) {
-    {
-        using ComplexT = StateVectorKokkos<TestType>::ComplexT;
-        const size_t num_qubits = 4;
-        const TestType ep = 1e-3;
-        const TestType EP = 1e-4;
-
-        std::vector<ComplexT> ini_st{
-            ComplexT{0.267462841882, 0.010768564798},
-            ComplexT{0.228575129706, 0.010564590956},
-            ComplexT{0.099492749900, 0.260849823392},
-            ComplexT{0.093690204310, 0.189847108173},
-            ComplexT{0.033390732374, 0.203836830144},
-            ComplexT{0.226979395737, 0.081852150975},
-            ComplexT{0.031235505729, 0.176933497281},
-            ComplexT{0.294287602843, 0.145156781198},
-            ComplexT{0.152742706049, 0.111628061129},
-            ComplexT{0.012553863703, 0.120027860480},
-            ComplexT{0.237156555364, 0.154658769755},
-            ComplexT{0.117001120872, 0.228059505033},
-            ComplexT{0.041495873225, 0.065934827444},
-            ComplexT{0.089653239407, 0.221581340372},
-            ComplexT{0.217892322429, 0.291261296999},
-            ComplexT{0.292993251871, 0.186570798697},
-        };
-
-        SECTION("Apply using dispatcher") {
-            StateVectorKokkos<TestType> kokkos_gntr_sv{num_qubits};
-            StateVectorKokkos<TestType> kokkos_gate_svp{num_qubits};
-            StateVectorKokkos<TestType> kokkos_gate_svm{num_qubits};
-
-            std::vector<ComplexT> result_gntr_sv(kokkos_gntr_sv.getLength(),
-                                                 {0, 0});
-            std::vector<ComplexT> result_gate_svp(kokkos_gate_svp.getLength(),
-                                                  {0, 0});
-            std::vector<ComplexT> result_gate_svm(kokkos_gate_svm.getLength(),
-                                                  {0, 0});
-
-            kokkos_gntr_sv.HostToDevice(ini_st.data(), ini_st.size());
-            kokkos_gate_svp.HostToDevice(ini_st.data(), ini_st.size());
-            kokkos_gate_svm.HostToDevice(ini_st.data(), ini_st.size());
-
-            auto scale = kokkos_gntr_sv.applyGenerator("RX", {1}, false);
-            kokkos_gate_svp.applyOperation("RX", {1}, false, {ep});
-            kokkos_gate_svm.applyOperation("RX", {1}, false, {-ep});
-
-            kokkos_gntr_sv.DeviceToHost(result_gntr_sv.data(),
-                                        result_gntr_sv.size());
-            kokkos_gate_svp.DeviceToHost(result_gate_svp.data(),
-                                         result_gate_svp.size());
-            kokkos_gate_svm.DeviceToHost(result_gate_svm.data(),
-                                         result_gate_svm.size());
-
-            for (size_t j = 0; j < exp2(num_qubits); j++) {
-                CHECK(-scale * imag(result_gntr_sv[j]) ==
-                      Approx(0.5 *
-                             (real(result_gate_svp[j]) -
-                              real(result_gate_svm[j])) /
-                             ep)
-                          .margin(EP));
-                CHECK(scale * real(result_gntr_sv[j]) ==
-                      Approx(0.5 *
-                             (imag(result_gate_svp[j]) -
-                              imag(result_gate_svm[j])) /
-                             ep)
-                          .margin(EP));
-            }
-        }
-    }
-}
-
-TEMPLATE_TEST_CASE("StateVectorKokkosManaged::applyGeneratorRY",
-                   "[StateVectorKokkosManaged_Generator]", float, double) {
-    {
-        using ComplexT = StateVectorKokkos<TestType>::ComplexT;
-        const size_t num_qubits = 4;
-        const TestType ep = 1e-3;
-        const TestType EP = 1e-4;
-
-        std::vector<ComplexT> ini_st{
-            ComplexT{0.267462841882, 0.010768564798},
-            ComplexT{0.228575129706, 0.010564590956},
-            ComplexT{0.099492749900, 0.260849823392},
-            ComplexT{0.093690204310, 0.189847108173},
-            ComplexT{0.033390732374, 0.203836830144},
-            ComplexT{0.226979395737, 0.081852150975},
-            ComplexT{0.031235505729, 0.176933497281},
-            ComplexT{0.294287602843, 0.145156781198},
-            ComplexT{0.152742706049, 0.111628061129},
-            ComplexT{0.012553863703, 0.120027860480},
-            ComplexT{0.237156555364, 0.154658769755},
-            ComplexT{0.117001120872, 0.228059505033},
-            ComplexT{0.041495873225, 0.065934827444},
-            ComplexT{0.089653239407, 0.221581340372},
-            ComplexT{0.217892322429, 0.291261296999},
-            ComplexT{0.292993251871, 0.186570798697},
-        };
-
-        SECTION("Apply using dispatcher") {
-            StateVectorKokkos<TestType> kokkos_gntr_sv{num_qubits};
-            StateVectorKokkos<TestType> kokkos_gate_svp{num_qubits};
-            StateVectorKokkos<TestType> kokkos_gate_svm{num_qubits};
-
-            std::vector<ComplexT> result_gntr_sv(kokkos_gntr_sv.getLength(),
-                                                 {0, 0});
-            std::vector<ComplexT> result_gate_svp(kokkos_gate_svp.getLength(),
-                                                  {0, 0});
-            std::vector<ComplexT> result_gate_svm(kokkos_gate_svm.getLength(),
-                                                  {0, 0});
-
-            kokkos_gntr_sv.HostToDevice(ini_st.data(), ini_st.size());
-            kokkos_gate_svp.HostToDevice(ini_st.data(), ini_st.size());
-            kokkos_gate_svm.HostToDevice(ini_st.data(), ini_st.size());
-
-            auto scale = kokkos_gntr_sv.applyGenerator("RY", {1}, false);
-            kokkos_gate_svp.applyOperation("RY", {1}, false, {ep});
-            kokkos_gate_svm.applyOperation("RY", {1}, false, {-ep});
-
-            kokkos_gntr_sv.DeviceToHost(result_gntr_sv.data(),
-                                        result_gntr_sv.size());
-            kokkos_gate_svp.DeviceToHost(result_gate_svp.data(),
-                                         result_gate_svp.size());
-            kokkos_gate_svm.DeviceToHost(result_gate_svm.data(),
-                                         result_gate_svm.size());
-
-            for (size_t j = 0; j < exp2(num_qubits); j++) {
-                CHECK(-scale * imag(result_gntr_sv[j]) ==
-                      Approx(0.5 *
-                             (real(result_gate_svp[j]) -
-                              real(result_gate_svm[j])) /
-                             ep)
-                          .margin(EP));
-                CHECK(scale * real(result_gntr_sv[j]) ==
-                      Approx(0.5 *
-                             (imag(result_gate_svp[j]) -
-                              imag(result_gate_svm[j])) /
-                             ep)
-                          .margin(EP));
-            }
-        }
-    }
-}
-
-TEMPLATE_TEST_CASE("StateVectorKokkosManaged::applyGeneratorRZ",
-                   "[StateVectorKokkosManaged_Generator]", float, double) {
-    {
-        using ComplexT = StateVectorKokkos<TestType>::ComplexT;
-        const size_t num_qubits = 4;
-        const TestType ep = 1e-3;
-        const TestType EP = 1e-4;
-
-        std::vector<ComplexT> ini_st{
-            ComplexT{0.267462841882, 0.010768564798},
-            ComplexT{0.228575129706, 0.010564590956},
-            ComplexT{0.099492749900, 0.260849823392},
-            ComplexT{0.093690204310, 0.189847108173},
-            ComplexT{0.033390732374, 0.203836830144},
-            ComplexT{0.226979395737, 0.081852150975},
-            ComplexT{0.031235505729, 0.176933497281},
-            ComplexT{0.294287602843, 0.145156781198},
-            ComplexT{0.152742706049, 0.111628061129},
-            ComplexT{0.012553863703, 0.120027860480},
-            ComplexT{0.237156555364, 0.154658769755},
-            ComplexT{0.117001120872, 0.228059505033},
-            ComplexT{0.041495873225, 0.065934827444},
-            ComplexT{0.089653239407, 0.221581340372},
-            ComplexT{0.217892322429, 0.291261296999},
-            ComplexT{0.292993251871, 0.186570798697},
-        };
-
-        SECTION("Apply using dispatcher") {
-            StateVectorKokkos<TestType> kokkos_gntr_sv{num_qubits};
-            StateVectorKokkos<TestType> kokkos_gate_svp{num_qubits};
-            StateVectorKokkos<TestType> kokkos_gate_svm{num_qubits};
-
-            std::vector<ComplexT> result_gntr_sv(kokkos_gntr_sv.getLength(),
-                                                 {0, 0});
-            std::vector<ComplexT> result_gate_svp(kokkos_gate_svp.getLength(),
-                                                  {0, 0});
-            std::vector<ComplexT> result_gate_svm(kokkos_gate_svm.getLength(),
-                                                  {0, 0});
-
-            kokkos_gntr_sv.HostToDevice(ini_st.data(), ini_st.size());
-            kokkos_gate_svp.HostToDevice(ini_st.data(), ini_st.size());
-            kokkos_gate_svm.HostToDevice(ini_st.data(), ini_st.size());
-
-            auto scale = kokkos_gntr_sv.applyGenerator("RZ", {1}, false);
-            kokkos_gate_svp.applyOperation("RZ", {1}, false, {ep});
-            kokkos_gate_svm.applyOperation("RZ", {1}, false, {-ep});
-
-            kokkos_gntr_sv.DeviceToHost(result_gntr_sv.data(),
-                                        result_gntr_sv.size());
-            kokkos_gate_svp.DeviceToHost(result_gate_svp.data(),
-                                         result_gate_svp.size());
-            kokkos_gate_svm.DeviceToHost(result_gate_svm.data(),
-                                         result_gate_svm.size());
-
-            for (size_t j = 0; j < exp2(num_qubits); j++) {
-                CHECK(-scale * imag(result_gntr_sv[j]) ==
-                      Approx(0.5 *
-                             (real(result_gate_svp[j]) -
-                              real(result_gate_svm[j])) /
-                             ep)
-                          .margin(EP));
-                CHECK(scale * real(result_gntr_sv[j]) ==
-                      Approx(0.5 *
-                             (imag(result_gate_svp[j]) -
-                              imag(result_gate_svm[j])) /
-                             ep)
-                          .margin(EP));
-            }
-        }
-    }
-}
-
-TEMPLATE_TEST_CASE("StateVectorKokkosManaged::applyGeneratorSingleExcitation",
-                   "[StateVectorKokkosManaged_Generator]", float, double) {
-    {
-        using ComplexT = StateVectorKokkos<TestType>::ComplexT;
-        const size_t num_qubits = 4;
-        const TestType ep = 1e-3;
-        const TestType EP = 1e-4;
-
-        std::vector<ComplexT> ini_st{
-            ComplexT{0.267462841882, 0.010768564798},
-            ComplexT{0.228575129706, 0.010564590956},
-            ComplexT{0.099492749900, 0.260849823392},
-            ComplexT{0.093690204310, 0.189847108173},
-            ComplexT{0.033390732374, 0.203836830144},
-            ComplexT{0.226979395737, 0.081852150975},
-            ComplexT{0.031235505729, 0.176933497281},
-            ComplexT{0.294287602843, 0.145156781198},
-            ComplexT{0.152742706049, 0.111628061129},
-            ComplexT{0.012553863703, 0.120027860480},
-            ComplexT{0.237156555364, 0.154658769755},
-            ComplexT{0.117001120872, 0.228059505033},
-            ComplexT{0.041495873225, 0.065934827444},
-            ComplexT{0.089653239407, 0.221581340372},
-            ComplexT{0.217892322429, 0.291261296999},
-            ComplexT{0.292993251871, 0.186570798697},
-        };
-
-        SECTION("Apply using dispatcher") {
-            StateVectorKokkos<TestType> kokkos_gntr_sv{num_qubits};
-            StateVectorKokkos<TestType> kokkos_gate_svp{num_qubits};
-            StateVectorKokkos<TestType> kokkos_gate_svm{num_qubits};
-
-            std::vector<ComplexT> result_gntr_sv(kokkos_gntr_sv.getLength(),
-                                                 {0, 0});
-            std::vector<ComplexT> result_gate_svp(kokkos_gate_svp.getLength(),
-                                                  {0, 0});
-            std::vector<ComplexT> result_gate_svm(kokkos_gate_svm.getLength(),
-                                                  {0, 0});
-
-            kokkos_gntr_sv.HostToDevice(ini_st.data(), ini_st.size());
-            kokkos_gate_svp.HostToDevice(ini_st.data(), ini_st.size());
-            kokkos_gate_svm.HostToDevice(ini_st.data(), ini_st.size());
-
-            auto scale = kokkos_gntr_sv.applyGenerator("SingleExcitation",
-                                                       {0, 1}, false);
-            kokkos_gate_svp.applyOperation("SingleExcitation", {0, 1}, false,
-                                           {ep});
-            kokkos_gate_svm.applyOperation("SingleExcitation", {0, 1}, false,
-                                           {-ep});
-
-            kokkos_gntr_sv.DeviceToHost(result_gntr_sv.data(),
-                                        result_gntr_sv.size());
-            kokkos_gate_svp.DeviceToHost(result_gate_svp.data(),
-                                         result_gate_svp.size());
-            kokkos_gate_svm.DeviceToHost(result_gate_svm.data(),
-                                         result_gate_svm.size());
-
-            for (size_t j = 0; j < exp2(num_qubits); j++) {
-                CHECK(-scale * imag(result_gntr_sv[j]) ==
-                      Approx(0.5 *
-                             (real(result_gate_svp[j]) -
-                              real(result_gate_svm[j])) /
-                             ep)
-                          .margin(EP));
-                CHECK(scale * real(result_gntr_sv[j]) ==
-                      Approx(0.5 *
-                             (imag(result_gate_svp[j]) -
-                              imag(result_gate_svm[j])) /
-                             ep)
-                          .margin(EP));
-            }
-        }
-    }
-}
-
-TEMPLATE_TEST_CASE(
-    "StateVectorKokkosManaged::applyGeneratorSingleExcitationMinus",
-    "[StateVectorKokkosManaged_Generator]", float, double) {
-    {
-        using ComplexT = StateVectorKokkos<TestType>::ComplexT;
-        const size_t num_qubits = 4;
-        const TestType ep = 1e-3;
-        const TestType EP = 1e-4;
-
-        std::vector<ComplexT> ini_st{
-            ComplexT{0.267462841882, 0.010768564798},
-            ComplexT{0.228575129706, 0.010564590956},
-            ComplexT{0.099492749900, 0.260849823392},
-            ComplexT{0.093690204310, 0.189847108173},
-            ComplexT{0.033390732374, 0.203836830144},
-            ComplexT{0.226979395737, 0.081852150975},
-            ComplexT{0.031235505729, 0.176933497281},
-            ComplexT{0.294287602843, 0.145156781198},
-            ComplexT{0.152742706049, 0.111628061129},
-            ComplexT{0.012553863703, 0.120027860480},
-            ComplexT{0.237156555364, 0.154658769755},
-            ComplexT{0.117001120872, 0.228059505033},
-            ComplexT{0.041495873225, 0.065934827444},
-            ComplexT{0.089653239407, 0.221581340372},
-            ComplexT{0.217892322429, 0.291261296999},
-            ComplexT{0.292993251871, 0.186570798697},
-        };
-
-        SECTION("Apply using dispatcher") {
-            StateVectorKokkos<TestType> kokkos_gntr_sv{num_qubits};
-            StateVectorKokkos<TestType> kokkos_gate_svp{num_qubits};
-            StateVectorKokkos<TestType> kokkos_gate_svm{num_qubits};
-
-            std::vector<ComplexT> result_gntr_sv(kokkos_gntr_sv.getLength(),
-                                                 {0, 0});
-            std::vector<ComplexT> result_gate_svp(kokkos_gate_svp.getLength(),
-                                                  {0, 0});
-            std::vector<ComplexT> result_gate_svm(kokkos_gate_svm.getLength(),
-                                                  {0, 0});
-
-            kokkos_gntr_sv.HostToDevice(ini_st.data(), ini_st.size());
-            kokkos_gate_svp.HostToDevice(ini_st.data(), ini_st.size());
-            kokkos_gate_svm.HostToDevice(ini_st.data(), ini_st.size());
-
-            auto scale = kokkos_gntr_sv.applyGenerator("SingleExcitationMinus",
-                                                       {0, 1}, false);
-            kokkos_gate_svp.applyOperation("SingleExcitationMinus", {0, 1},
-                                           false, {ep});
-            kokkos_gate_svm.applyOperation("SingleExcitationMinus", {0, 1},
-                                           false, {-ep});
-
-            kokkos_gntr_sv.DeviceToHost(result_gntr_sv.data(),
-                                        result_gntr_sv.size());
-            kokkos_gate_svp.DeviceToHost(result_gate_svp.data(),
-                                         result_gate_svp.size());
-            kokkos_gate_svm.DeviceToHost(result_gate_svm.data(),
-                                         result_gate_svm.size());
-
-            for (size_t j = 0; j < exp2(num_qubits); j++) {
-                CHECK(-scale * imag(result_gntr_sv[j]) ==
-                      Approx(0.5 *
-                             (real(result_gate_svp[j]) -
-                              real(result_gate_svm[j])) /
-                             ep)
-                          .margin(EP));
-                CHECK(scale * real(result_gntr_sv[j]) ==
-                      Approx(0.5 *
-                             (imag(result_gate_svp[j]) -
-                              imag(result_gate_svm[j])) /
-                             ep)
-                          .margin(EP));
-            }
-        }
-    }
-}
-
-TEMPLATE_TEST_CASE(
-    "StateVectorKokkosManaged::applyGeneratorSingleExcitationPlus",
-    "[StateVectorKokkosManaged_Generator]", float, double) {
-    {
-        using ComplexT = StateVectorKokkos<TestType>::ComplexT;
-        const size_t num_qubits = 4;
-        const TestType ep = 1e-3;
-        const TestType EP = 1e-4;
-
-        std::vector<ComplexT> ini_st{
-            ComplexT{0.267462841882, 0.010768564798},
-            ComplexT{0.228575129706, 0.010564590956},
-            ComplexT{0.099492749900, 0.260849823392},
-            ComplexT{0.093690204310, 0.189847108173},
-            ComplexT{0.033390732374, 0.203836830144},
-            ComplexT{0.226979395737, 0.081852150975},
-            ComplexT{0.031235505729, 0.176933497281},
-            ComplexT{0.294287602843, 0.145156781198},
-            ComplexT{0.152742706049, 0.111628061129},
-            ComplexT{0.012553863703, 0.120027860480},
-            ComplexT{0.237156555364, 0.154658769755},
-            ComplexT{0.117001120872, 0.228059505033},
-            ComplexT{0.041495873225, 0.065934827444},
-            ComplexT{0.089653239407, 0.221581340372},
-            ComplexT{0.217892322429, 0.291261296999},
-            ComplexT{0.292993251871, 0.186570798697},
-        };
-
-        SECTION("Apply using dispatcher") {
-            StateVectorKokkos<TestType> kokkos_gntr_sv{num_qubits};
-            StateVectorKokkos<TestType> kokkos_gate_svp{num_qubits};
-            StateVectorKokkos<TestType> kokkos_gate_svm{num_qubits};
-
-            std::vector<ComplexT> result_gntr_sv(kokkos_gntr_sv.getLength(),
-                                                 {0, 0});
-            std::vector<ComplexT> result_gate_svp(kokkos_gate_svp.getLength(),
-                                                  {0, 0});
-            std::vector<ComplexT> result_gate_svm(kokkos_gate_svm.getLength(),
-                                                  {0, 0});
-
-            kokkos_gntr_sv.HostToDevice(ini_st.data(), ini_st.size());
-            kokkos_gate_svp.HostToDevice(ini_st.data(), ini_st.size());
-            kokkos_gate_svm.HostToDevice(ini_st.data(), ini_st.size());
-
-            auto scale = kokkos_gntr_sv.applyGenerator("SingleExcitationPlus",
-                                                       {0, 1}, false);
-            kokkos_gate_svp.applyOperation("SingleExcitationPlus", {0, 1},
-                                           false, {ep});
-            kokkos_gate_svm.applyOperation("SingleExcitationPlus", {0, 1},
-                                           false, {-ep});
-
-            kokkos_gntr_sv.DeviceToHost(result_gntr_sv.data(),
-                                        result_gntr_sv.size());
-            kokkos_gate_svp.DeviceToHost(result_gate_svp.data(),
-                                         result_gate_svp.size());
-            kokkos_gate_svm.DeviceToHost(result_gate_svm.data(),
-                                         result_gate_svm.size());
-
-            for (size_t j = 0; j < exp2(num_qubits); j++) {
-                CHECK(-scale * imag(result_gntr_sv[j]) ==
-                      Approx(0.5 *
-                             (real(result_gate_svp[j]) -
-                              real(result_gate_svm[j])) /
-                             ep)
-                          .margin(EP));
-                CHECK(scale * real(result_gntr_sv[j]) ==
-                      Approx(0.5 *
-                             (imag(result_gate_svp[j]) -
-                              imag(result_gate_svm[j])) /
-                             ep)
-                          .margin(EP));
-            }
-        }
-    }
-}
-
-TEMPLATE_TEST_CASE("StateVectorKokkosManaged::applyGeneratorDoubleExcitation",
-                   "[StateVectorKokkosManaged_Generator]", float, double) {
+TEMPLATE_TEST_CASE("StateVectorKokkos::applyGeneratorDoubleExcitation",
+                   "[StateVectorKokkos_Generator]", float, double) {
     std::vector<std::size_t> wires = {0, 1, 2, 3};
     std::pair<std::size_t, std::size_t> control =
         GENERATE(std::pair<std::size_t, std::size_t>{0, 0},
@@ -1319,9 +216,8 @@ TEMPLATE_TEST_CASE("StateVectorKokkosManaged::applyGeneratorDoubleExcitation",
     }
 }
 
-TEMPLATE_TEST_CASE(
-    "StateVectorKokkosManaged::applyGeneratorDoubleExcitationMinus",
-    "[StateVectorKokkosManaged_Generator]", float, double) {
+TEMPLATE_TEST_CASE("StateVectorKokkos::applyGeneratorDoubleExcitationMinus",
+                   "[StateVectorKokkos_Generator]", float, double) {
     std::vector<std::size_t> wires = {0, 1, 2, 3};
     std::pair<std::size_t, std::size_t> control =
         GENERATE(std::pair<std::size_t, std::size_t>{0, 0},
@@ -1412,9 +308,8 @@ TEMPLATE_TEST_CASE(
     }
 }
 
-TEMPLATE_TEST_CASE(
-    "StateVectorKokkosManaged::applyGeneratorDoubleExcitationPlus",
-    "[StateVectorKokkosManaged_Generator]", float, double) {
+TEMPLATE_TEST_CASE("StateVectorKokkos::applyGeneratorDoubleExcitationPlus",
+                   "[StateVectorKokkos_Generator]", float, double) {
     std::vector<std::size_t> wires = {0, 1, 2, 3};
     std::pair<std::size_t, std::size_t> control =
         GENERATE(std::pair<std::size_t, std::size_t>{0, 0},

--- a/pennylane_lightning/lightning_gpu/lightning_gpu.toml
+++ b/pennylane_lightning/lightning_gpu/lightning_gpu.toml
@@ -59,6 +59,7 @@ native = [
         "DoubleExcitationMinus",
         "MultiRZ",
         "QubitUnitary",
+        "GlobalPhase",
 ]
 
 # Operators that should be decomposed according to the algorithm used

--- a/pennylane_lightning/lightning_kokkos/lightning_kokkos.toml
+++ b/pennylane_lightning/lightning_kokkos/lightning_kokkos.toml
@@ -59,6 +59,7 @@ native = [
         "DoubleExcitationMinus",
         "MultiRZ",
         "QubitUnitary",
+        "GlobalPhase",
 ]
 
 # Operators that should be decomposed according to the algorithm used

--- a/pennylane_lightning/lightning_qubit/lightning_qubit.toml
+++ b/pennylane_lightning/lightning_qubit/lightning_qubit.toml
@@ -61,6 +61,7 @@ native = [
         "DoubleExcitationMinus",
         "MultiRZ",
         "QubitUnitary",
+        "GlobalPhase",
 ]
 
 # Operators that should be decomposed according to the algorithm used
@@ -116,7 +117,7 @@ runtime_code_generation = false
 # If the device supports adjoint
 quantum_adjoint = true
 # If the device supports quantum control instructions natively
-quantum_control = false
+quantum_control = true
 # If the device supports mid circuit measurements natively
 mid_circuit_measurement = true
 

--- a/tests/test_adjoint_jacobian.py
+++ b/tests/test_adjoint_jacobian.py
@@ -717,7 +717,7 @@ class TestAdjointJacobianQNode:
     @pytest.mark.parametrize("n_qubits", range(2, 6))
     @pytest.mark.parametrize("par", [-np.pi / 7, np.pi / 5, 2 * np.pi / 3])
     def test_gate_jacobian(self, par, n_qubits, operation, tol):
-        """Test that the jacobian of the controlled gate matches the parameter-shift formula."""
+        """Test that the jacobian of the controlled gate matches the finite-diff formula."""
         par = np.array([0.1234, par, 0.5678])
         dev = qml.device(device_name, wires=n_qubits)
         np.random.seed(1337)

--- a/tests/test_adjoint_jacobian.py
+++ b/tests/test_adjoint_jacobian.py
@@ -785,7 +785,7 @@ class TestAdjointJacobianQNode:
     @pytest.mark.parametrize("n_qubits", range(2, 6))
     @pytest.mark.parametrize("par", [-np.pi / 7, np.pi / 5, 2 * np.pi / 3])
     def test_controlled_jacobian(self, par, n_qubits, control_value, operation, tol):
-        """Test that the jacobian of the controlled gate matches the finite-diff formula."""
+        """Test that the jacobian of the controlled gate matches the parameter-shift formula."""
         par = np.array([0.1234, par, 0.5678])
         dev = qml.device("lightning.qubit", wires=n_qubits)
         np.random.seed(1337)
@@ -814,7 +814,7 @@ class TestAdjointJacobianQNode:
                 return np.array([qml.expval(qml.PauliY(i)) for i in range(n_qubits)])
 
             circ_ad = qml.QNode(circuit, dev, diff_method="adjoint")
-            circ_ps = qml.QNode(circuit, dev, diff_method="finite-diff")
+            circ_ps = qml.QNode(circuit, dev, diff_method="parameter-shift")
             jac_ad = np.array(qml.jacobian(circ_ad)(par))
             jac_ps = np.array(qml.jacobian(circ_ps)(par))
 

--- a/tests/test_adjoint_jacobian.py
+++ b/tests/test_adjoint_jacobian.py
@@ -694,6 +694,64 @@ class TestAdjointJacobianQNode:
 
         assert np.allclose(grad_A, grad_F, atol=tol, rtol=0)
 
+    @pytest.mark.parametrize(
+        "operation",
+        [
+            qml.PhaseShift,
+            qml.RX,
+            qml.RY,
+            qml.RZ,
+            qml.IsingXX,
+            qml.IsingXY,
+            qml.IsingYY,
+            qml.IsingZZ,
+            qml.SingleExcitation,
+            qml.SingleExcitationMinus,
+            qml.SingleExcitationPlus,
+            qml.DoubleExcitation,
+            qml.DoubleExcitationMinus,
+            qml.DoubleExcitationPlus,
+            qml.GlobalPhase,
+        ],
+    )
+    @pytest.mark.parametrize("n_qubits", range(2, 6))
+    @pytest.mark.parametrize("par", [-np.pi / 7, np.pi / 5, 2 * np.pi / 3])
+    def test_gate_jacobian(self, par, n_qubits, operation, tol):
+        """Test that the jacobian of the controlled gate matches the parameter-shift formula."""
+        par = np.array([0.1234, par, 0.5678])
+        dev = qml.device(device_name, wires=n_qubits)
+        np.random.seed(1337)
+        init_state = np.random.rand(2**n_qubits) + 1.0j * np.random.rand(2**n_qubits)
+        init_state /= np.sqrt(np.dot(np.conj(init_state), init_state))
+        init_state = np.array(init_state, requires_grad=False)
+
+        num_wires = max(operation.num_wires, 1)
+        if num_wires > n_qubits:
+            return
+
+        for w in range(0, n_qubits - num_wires):
+
+            def circuit(p):
+                qml.StatePrep(init_state, wires=range(n_qubits))
+                qml.RX(p[0], 0)
+                if operation is qml.GlobalPhase:
+                    operation(p[1], wires=range(n_qubits))
+                else:
+                    operation(p[1], wires=range(w, w + num_wires))
+                qml.RY(p[2], 0)
+                return np.array([qml.expval(qml.PauliY(i)) for i in range(n_qubits)])
+
+            circ_ad = qml.QNode(circuit, dev, diff_method="adjoint")
+            circ_ps = qml.QNode(circuit, dev, diff_method="finite-diff")
+            jac_ad = np.array(qml.jacobian(circ_ad)(par))
+            jac_ps = np.array(qml.jacobian(circ_ps)(par))
+
+            # different methods must agree
+            assert jac_ad.size == n_qubits * 3
+            assert np.allclose(jac_ad.shape, [n_qubits, 3])
+            assert np.allclose(jac_ad.shape, jac_ps.shape)
+            assert np.allclose(jac_ad, jac_ps, atol=tol, rtol=0)
+
     @pytest.mark.skipif(
         device_name != "lightning.qubit" or not ld._CPP_BINARY_AVAILABLE,
         reason="N-controlled operations only implemented in lightning.qubit.",

--- a/tests/test_adjoint_jacobian.py
+++ b/tests/test_adjoint_jacobian.py
@@ -705,12 +705,17 @@ class TestAdjointJacobianQNode:
             qml.IsingXY,
             qml.IsingYY,
             qml.IsingZZ,
+            qml.CRX,
+            qml.CRY,
+            qml.CRZ,
+            qml.ControlledPhaseShift,
             qml.SingleExcitation,
             qml.SingleExcitationMinus,
             qml.SingleExcitationPlus,
             qml.DoubleExcitation,
             qml.DoubleExcitationMinus,
             qml.DoubleExcitationPlus,
+            qml.MultiRZ,
             qml.GlobalPhase,
         ],
     )
@@ -780,7 +785,7 @@ class TestAdjointJacobianQNode:
     @pytest.mark.parametrize("n_qubits", range(2, 6))
     @pytest.mark.parametrize("par", [-np.pi / 7, np.pi / 5, 2 * np.pi / 3])
     def test_controlled_jacobian(self, par, n_qubits, control_value, operation, tol):
-        """Test that the jacobian of the controlled gate matches the parameter-shift formula."""
+        """Test that the jacobian of the controlled gate matches the finite-diff formula."""
         par = np.array([0.1234, par, 0.5678])
         dev = qml.device("lightning.qubit", wires=n_qubits)
         np.random.seed(1337)


### PR DESCRIPTION
…os and L-GPU.

### Before submitting

Please complete the following checklist when submitting a PR:

- [x] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [x] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [x] Ensure that the test suite passes, by running `make test`.

- [x] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [x] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**
Catalyst tests [fail](https://github.com/PennyLaneAI/catalyst/actions/runs/7929212681/job/21648998841#step:21:77333) with 
```
frontend/test/pytest/test_transform.py::test_batch_params[lightning.qubit] - catalyst.utils.exceptions.CompileError: Gates in qml.device.operations and specification file do not match
```
following the introduction of `GlobalPhase` support (#579).

**Description of the Change:**
Add `GlobalPhase` in TOML files.
Add tests that validate the adjoint method for all supported gates.
Add `GlobalPhase` generators in L-GPU and L-Kokkos.
 

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
Bug fix update Catalyst TOML file [sc-56992]