### PR TITLE
Downgrade auditwheel due to inability to exclude libraries for L-GPU

### DIFF
--- a/.github/workflows/wheel_linux_x86_64_cuda.yml
+++ b/.github/workflows/wheel_linux_x86_64_cuda.yml
@@ -70,7 +70,7 @@ jobs:
           # Python build settings
           CIBW_BEFORE_BUILD: |
             cat /etc/yum.conf | sed "s/\[main\]/\[main\]\ntimeout=5/g" > /etc/yum.conf
-            python -m pip install ninja cmake~=3.24.3 auditwheel custatevec-cu${{ matrix.cuda_version }}
+            python -m pip install ninja cmake~=3.24.3 auditwheel~=5.0 custatevec-cu${{ matrix.cuda_version }}
             yum clean all -y
             yum install centos-release-scl-rh -y
             yum install devtoolset-11-gcc-c++ -y

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,7 +122,7 @@ if(ENABLE_PYTHON)
     message(STATUS "ENABLE_PYTHON is ON.")
     pybind11_add_module("${PL_BACKEND}_ops" "pennylane_lightning/core/src/bindings/Bindings.cpp")
 
-    # Allow pip installation of cuQuantum & CUDA 11 libs to be accessible without setting LD_LIBRARY_PATH for lightning_gpu
+    # Allow pip installation of cuQuantum & CUDA 12 libs to be accessible without setting LD_LIBRARY_PATH for lightning_gpu
     if("${PL_BACKEND}" STREQUAL "lightning_gpu")
         set(CMAKE_BUILD_RPATH_USE_ORIGIN ON)
         set_target_properties("${PL_BACKEND}_ops" PROPERTIES BUILD_RPATH "$ORIGIN/../cuquantum/lib:$ORIGIN/../nvidia/cuda_runtime/lib:$ORIGIN/../nvidia/cublas/lib:$ORIGIN/../nvidia/cusparse/lib:$ORIGIN")

--- a/bin/auditwheel
+++ b/bin/auditwheel
@@ -5,13 +5,13 @@
 import sys
 
 from auditwheel.main import main
-from auditwheel.policy import WheelPolicies as WP
+from auditwheel.policy import _POLICIES as POLICIES
 
 # Do not include licensed dynamic libraries
 libs = [
     "libcudart.so",
-    "libcudart.so.11.0",
-    "libcudart.so.12.0",
+    "libcudart.so.11",
+    "libcudart.so.12",
     "libcublasLt.so",
     "libcublasLt.so.11",
     "libcublasLt.so.12",
@@ -22,23 +22,14 @@ libs = [
     "libcusparse.so.11",
     "libcusparse.so.12",
     "libcustatevec.so",
+    "libcustatevec.so.0",
     "libcustatevec.so.1",
 ]
 
 print(f"Excluding {libs}")
 
-for arch in [
-    "manylinux2014_x86_64",
-    "manylinux_2_28_x86_64",
-    "manylinux2014_aarch64",
-    "manylinux_2_28_aarch64",
-    "manylinux2014_ppc64le",
-    "manylinux_2_28_ppc64le",
-]:
-    wheel_policy = WP()
-    arch_pol = wheel_policy.get_policy_by_name(arch)
-    if arch_pol:
-        arch_pol["lib_whitelist"].extend(libs)
+for pol in POLICIES:
+    pol["lib_whitelist"].extend(libs)
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/cmake/support_pllgpu.cmake
+++ b/cmake/support_pllgpu.cmake
@@ -6,9 +6,8 @@
 include_guard()
 
 # Macro to aid in finding CUDA lib
-macro(findCUDA external_libs)
-    find_package(CUDA REQUIRED)
-    find_package(CUDAToolkit REQUIRED)
+macro(findCUDATK external_libs)
+    find_package(CUDAToolkit REQUIRED EXACT 12)
     if(CUDA_FOUND)
         target_link_libraries(${external_libs} INTERFACE CUDA::cudart)
     endif()

--- a/pennylane_lightning/core/src/simulators/lightning_gpu/CMakeLists.txt
+++ b/pennylane_lightning/core/src/simulators/lightning_gpu/CMakeLists.txt
@@ -13,7 +13,7 @@ project(${PL_BACKEND}
 
 # Include macro and functions supporting Nvidia and cuQuantum libraries.
 include("${pennylane_lightning_SOURCE_DIR}/cmake/support_pllgpu.cmake")
-findCUDA(lightning_external_libs)
+findCUDATK(lightning_external_libs)
 findCustatevec(lightning_external_libs)
 
 if(ENABLE_MPI)

--- a/pennylane_lightning/core/src/simulators/lightning_gpu/utils/CMakeLists.txt
+++ b/pennylane_lightning/core/src/simulators/lightning_gpu/utils/CMakeLists.txt
@@ -1,6 +1,8 @@
 project(${PL_BACKEND}_utils LANGUAGES CXX CUDA)
 set(CMAKE_CXX_STANDARD 20)
 
+findCUDATK(lightning_compile_options)
+
 add_library(${PL_BACKEND}_utils INTERFACE)
 target_include_directories(${PL_BACKEND}_utils INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
 target_link_libraries(${PL_BACKEND}_utils INTERFACE CUDA::cublas CUDA::cusparse lightning_compile_options)


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [ ] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [ ] Ensure that the test suite passes, by running `make test`.

- [ ] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [ ] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:** The wheel-build process for L-GPU requires excluding licensed libraries from the shippable wheels. A recent update to [auditwheel](https://github.com/pypa/auditwheel/releases/tag/6.0.0) changed the procedure for how to achieve this, and the exclusion functionality cannot be easily replicated with the new design. This PR downgrades auditwheel to the working version, and restores the older override file.

**Description of the Change:** As above. Also ensure versioning of the CUDA toolkit to 12 explicitly.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
