### PR TITLE
Fix  apply state vector when using a lightning handle

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -81,6 +81,9 @@
 * Update jax.config imports.
   [(#619)](https://github.com/PennyLaneAI/pennylane-lightning/pull/619)
 
+* Fix apply state vector when using a Lightning handle.
+  [(#622)](https://github.com/PennyLaneAI/pennylane-lightning/pull/622)
+
 ### Contributors
 
 This release contains contributions from (in alphabetical order):

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.35.0-dev20"
+__version__ = "0.35.0-dev21"

--- a/pennylane_lightning/lightning_qubit/lightning_qubit.py
+++ b/pennylane_lightning/lightning_qubit/lightning_qubit.py
@@ -326,7 +326,7 @@ if LQ_CPP_BINARY_AVAILABLE:
             """Returns a handle to the statevector."""
             return self._qubit_state
 
-        def _apply_state_vector(self, state, device_wires):
+        def _apply_state_vector(self, state, device_wires: Wires):
             """Initialize the internal state vector in a specified state.
             Args:
                 state (array[complex]): normalized input state of length ``2**len(wires)``
@@ -336,7 +336,7 @@ if LQ_CPP_BINARY_AVAILABLE:
 
             if isinstance(state, self._qubit_state.__class__):
                 state_data = allocate_aligned_array(state.size, np.dtype(self.C_DTYPE), True)
-                self._qubit_state.getState(state_data)
+                state.getState(state_data)
                 state = state_data
 
             ravelled_indices, state = self._preprocess_state_vector(state, device_wires)

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -23,7 +23,7 @@ import numpy as np
 import pennylane as qml
 from pennylane import DeviceError
 from pennylane.operation import Operation
-import functools
+from pennylane.wires import Wires
 
 
 class TestApply:
@@ -506,6 +506,15 @@ class TestApply:
         ):
             dev.reset()
             dev.apply([qml.RZ(0.5, wires=[0]), qml.BasisState(np.array([1, 1]), wires=[0, 1])])
+
+    def test_apply_state_vector_lightning_handle(self, qubit_device, tol):
+        dev = qubit_device(wires=2)
+        dev.apply([qml.BasisState(np.array([0, 1]), wires=[0, 1])])
+
+        dev_2 = qubit_device(wires=2)
+        dev_2._apply_state_vector(dev.state_vector, device_wires=Wires([0, 1]))
+
+        assert np.allclose(dev.state, dev_2.state, atol=tol, rtol=0)
 
 
 class TestExpval:

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -16,7 +16,7 @@ Unit tests for Lightning devices.
 """
 # pylint: disable=protected-access,cell-var-from-loop
 import pytest
-from conftest import THETA, PHI, VARPHI, TOL_STOCHASTIC, LightningDevice as ld, device_name
+from conftest import THETA, PHI, TOL_STOCHASTIC, LightningDevice as ld, device_name
 
 import math
 import numpy as np
@@ -507,6 +507,10 @@ class TestApply:
             dev.reset()
             dev.apply([qml.RZ(0.5, wires=[0]), qml.BasisState(np.array([1, 1]), wires=[0, 1])])
 
+    @pytest.mark.skipif(
+        device_name != "lightning.qubit",
+        reason="Only meaningful for LightningQubit.",
+    )
     def test_apply_state_vector_lightning_handle(self, qubit_device, tol):
         dev = qubit_device(wires=2)
         dev.apply([qml.BasisState(np.array([0, 1]), wires=[0, 1])])
@@ -755,7 +759,7 @@ class TestLightningDeviceIntegration:
 
         assert np.isclose(circuit(p), 1, atol=tol, rtol=0)
 
-    def test_nonzero_shots(self, tol_stochastic):
+    def test_nonzero_shots(self, TOL_STOCHASTIC):
         """Test that the default qubit plugin provides correct result for high shot number"""
 
         shots = 10**4
@@ -773,7 +777,7 @@ class TestLightningDeviceIntegration:
         for _ in range(100):
             runs.append(circuit(p))
 
-        assert np.isclose(np.mean(runs), -np.sin(p), atol=tol_stochastic, rtol=0)
+        assert np.isclose(np.mean(runs), -np.sin(p), atol=TOL_STOCHASTIC, rtol=0)
 
     # This test is ran against the state |0> with one Z expval
     @pytest.mark.parametrize(

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -759,7 +759,7 @@ class TestLightningDeviceIntegration:
 
         assert np.isclose(circuit(p), 1, atol=tol, rtol=0)
 
-    def test_nonzero_shots(self, TOL_STOCHASTIC):
+    def test_nonzero_shots(self, tol_stochastic):
         """Test that the default qubit plugin provides correct result for high shot number"""
 
         shots = 10**4
@@ -777,7 +777,7 @@ class TestLightningDeviceIntegration:
         for _ in range(100):
             runs.append(circuit(p))
 
-        assert np.isclose(np.mean(runs), -np.sin(p), atol=TOL_STOCHASTIC, rtol=0)
+        assert np.isclose(np.mean(runs), -np.sin(p), atol=tol_stochastic, rtol=0)
 
     # This test is ran against the state |0> with one Z expval
     @pytest.mark.parametrize(

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -507,6 +507,14 @@ class TestApply:
             dev.reset()
             dev.apply([qml.RZ(0.5, wires=[0]), qml.BasisState(np.array([1, 1]), wires=[0, 1])])
 
+    # @pytest.mark.skipif(
+    #     not ld._CPP_BINARY_AVAILABLE and device_name != "lightning.qubit",
+    #     reason="Only meaningful for LightningQubit.",
+    # )
+    @pytest.mark.skipif(
+        not ld._CPP_BINARY_AVAILABLE,
+        reason="Lightning binary required",
+    )
     @pytest.mark.skipif(
         device_name != "lightning.qubit",
         reason="Only meaningful for LightningQubit.",

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -507,10 +507,6 @@ class TestApply:
             dev.reset()
             dev.apply([qml.RZ(0.5, wires=[0]), qml.BasisState(np.array([1, 1]), wires=[0, 1])])
 
-    # @pytest.mark.skipif(
-    #     not ld._CPP_BINARY_AVAILABLE and device_name != "lightning.qubit",
-    #     reason="Only meaningful for LightningQubit.",
-    # )
     @pytest.mark.skipif(
         not ld._CPP_BINARY_AVAILABLE,
         reason="Lightning binary required",

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -117,7 +117,6 @@ class TestGrover:
             zip([i for i in range(len(index) - 1, -1, -1)], index),
             0,
         )
-        print(prob)
         assert np.allclose(np.sum(prob), 1.0)
         assert prob[index] > 0.95
         assert np.sum(prob) - prob[index] < 0.05


### PR DESCRIPTION
**Context:** This PR fixes a recent code error found when asking to apply a state vector with a handle to the Lightning C++ class.

**Description of the Change:** The fix was made, and unit tests were added.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
