### PR TITLE
Fix random `coverage xml` CI issues

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -22,11 +22,14 @@
 
 ### Bug fixes
 
+* Fix random `coverage xml` CI issues.
+  [(#635)](https://github.com/PennyLaneAI/pennylane-lightning/pull/635)
+
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
 
-Vincent Michaud-Rioux
+Ali Asadi, Vincent Michaud-Rioux
 
 ---
 

--- a/.github/workflows/tests_linux.yml
+++ b/.github/workflows/tests_linux.yml
@@ -645,6 +645,7 @@ jobs:
           python -m pip install coverage
           python -m coverage combine .coverage-python*
           # Added cov xml -i to ignore "No source for code" random errors
+          # https://stackoverflow.com/questions/2386975/no-source-for-code-message-in-coverage-py
           python -m coverage xml -i -o coverage-${{ github.job }}.xml
 
       - name: Upload to Codecov

--- a/.github/workflows/tests_linux.yml
+++ b/.github/workflows/tests_linux.yml
@@ -644,7 +644,8 @@ jobs:
         run: |
           python -m pip install coverage
           python -m coverage combine .coverage-python*
-          python -m coverage xml -o coverage-${{ github.job }}.xml
+          # coverage -i is added to ignore "No source for code" unspecified errors
+          python -m coverage -i xml -o coverage-${{ github.job }}.xml
 
       - name: Upload to Codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/tests_linux.yml
+++ b/.github/workflows/tests_linux.yml
@@ -644,8 +644,8 @@ jobs:
         run: |
           python -m pip install coverage
           python -m coverage combine .coverage-python*
-          # coverage -i is added to ignore "No source for code" unspecified errors
-          python -m coverage -i xml -o coverage-${{ github.job }}.xml
+          # Added cov xml -i to ignore "No source for code" random errors
+          python -m coverage xml -i -o coverage-${{ github.job }}.xml
 
       - name: Upload to Codecov
         uses: codecov/codecov-action@v3

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.36.0-dev4"
+__version__ = "0.36.0-dev5"

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.36.0-dev5"
+__version__ = "0.36.0-dev6"


### PR DESCRIPTION
Fix random `coverage xml` CI non-deterministic failures with ignoring "No source for code  `__init__,py`". This shouldn't affect the coverage as `__init__` only includes the package version.  

[sc-58646]