### PR TITLE
Format with one and only one version of isort! 

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -11,12 +11,13 @@ concurrency:
 
 jobs:
   black:
+    name: Format (Python)
     runs-on: ubuntu-22.04
     steps:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: '3.10'
 
       - name: Install dependencies
         run:
@@ -61,7 +62,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: '3.10'
 
       - name: Install dependencies
         run: sudo apt update && sudo apt -y install cmake gcc-11 g++-11 ninja-build libomp-14-dev && python -m pip install -r requirements-dev.txt

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -20,13 +20,16 @@ jobs:
 
       - name: Install dependencies
         run:
-            python -m pip install click==8.0.4 black==23.7.0
+            python -m pip install click==8.0.4 black==23.7.0 isort==5.13.2
 
       - name: Checkout PennyLane-Lightning
         uses: actions/checkout@v3
 
+      - name: Run isort
+        run: 	isort --profile black ./pennylane_lightning/ ./mpitests ./tests --check --diff
+
       - name: Run Black
-        run: black -l 100 pennylane_lightning/ tests/ --check
+        run: black -l 100 pennylane_lightning/ tests/ --check --verbose
 
   format-cpp:
     name: Format (C++)

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.9'
 
       - name: Install dependencies
         run:
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Run isort
-        run: 	isort --profile black ./pennylane_lightning/ ./mpitests ./tests --check --diff
+        run: isort --profile black ./pennylane_lightning/ ./mpitests ./tests --check --diff
 
       - name: Run Black
         run: black -l 100 pennylane_lightning/ tests/ --check --verbose
@@ -62,7 +62,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.9'
 
       - name: Install dependencies
         run: sudo apt update && sudo apt -y install cmake gcc-11 g++-11 ninja-build libomp-14-dev && python -m pip install -r requirements-dev.txt

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.36.0-dev8"
+__version__ = "0.36.0-dev9"

--- a/pennylane_lightning/lightning_gpu/lightning_gpu.py
+++ b/pennylane_lightning/lightning_gpu/lightning_gpu.py
@@ -91,13 +91,6 @@ if LGPU_CPP_BINARY_AVAILABLE:
     from pennylane.ops.op_math import Adjoint
     from pennylane.wires import Wires
 
-    # pylint: disable=import-error, no-name-in-module, ungrouped-imports
-    from pennylane_lightning.core._serialize import (
-        QuantumScriptSerializer,
-        global_phase_diagonal,
-    )
-    from pennylane_lightning.core._version import __version__
-
     # pylint: disable=no-name-in-module, ungrouped-imports
     from pennylane_lightning.lightning_gpu_ops.algorithms import (
         AdjointJacobianC64,
@@ -105,6 +98,13 @@ if LGPU_CPP_BINARY_AVAILABLE:
         create_ops_listC64,
         create_ops_listC128,
     )
+
+    # pylint: disable=import-error, no-name-in-module, ungrouped-imports
+    from pennylane_lightning.core._serialize import (
+        QuantumScriptSerializer,
+        global_phase_diagonal,
+    )
+    from pennylane_lightning.core._version import __version__
 
     if MPI_SUPPORT:
         from pennylane_lightning.lightning_gpu_ops.algorithmsMPI import (

--- a/pennylane_lightning/lightning_kokkos/lightning_kokkos.py
+++ b/pennylane_lightning/lightning_kokkos/lightning_kokkos.py
@@ -65,19 +65,19 @@ if LK_CPP_BINARY_AVAILABLE:
     from pennylane.wires import Wires
 
     # pylint: disable=import-error, no-name-in-module, ungrouped-imports
-    from pennylane_lightning.core._serialize import (
-        QuantumScriptSerializer,
-        global_phase_diagonal,
-    )
-    from pennylane_lightning.core._version import __version__
-
-    # pylint: disable=import-error, no-name-in-module, ungrouped-imports
     from pennylane_lightning.lightning_kokkos_ops.algorithms import (
         AdjointJacobianC64,
         AdjointJacobianC128,
         create_ops_listC64,
         create_ops_listC128,
     )
+
+    # pylint: disable=import-error, no-name-in-module, ungrouped-imports
+    from pennylane_lightning.core._serialize import (
+        QuantumScriptSerializer,
+        global_phase_diagonal,
+    )
+    from pennylane_lightning.core._version import __version__
 
     def _kokkos_dtype(dtype):
         if dtype not in [np.complex128, np.complex64]:  # pragma: no cover

--- a/pennylane_lightning/lightning_qubit/lightning_qubit.py
+++ b/pennylane_lightning/lightning_qubit/lightning_qubit.py
@@ -66,6 +66,10 @@ if LQ_CPP_BINARY_AVAILABLE:
     from pennylane.ops.op_math import Adjoint
     from pennylane.wires import Wires
 
+    # pylint: disable=import-error, no-name-in-module, ungrouped-imports
+    from pennylane_lightning.core._serialize import QuantumScriptSerializer
+    from pennylane_lightning.core._version import __version__
+
     # pylint: disable=no-name-in-module, ungrouped-imports
     from pennylane_lightning.lightning_qubit_ops.algorithms import (
         AdjointJacobianC64,
@@ -75,10 +79,6 @@ if LQ_CPP_BINARY_AVAILABLE:
         create_ops_listC64,
         create_ops_listC128,
     )
-
-    # pylint: disable=import-error, no-name-in-module, ungrouped-imports
-    from pennylane_lightning.core._serialize import QuantumScriptSerializer
-    from pennylane_lightning.core._version import __version__
 
     def _state_dtype(dtype):
         if dtype not in [np.complex128, np.complex64]:  # pragma: no cover

--- a/pennylane_lightning/lightning_qubit/lightning_qubit.py
+++ b/pennylane_lightning/lightning_qubit/lightning_qubit.py
@@ -66,10 +66,6 @@ if LQ_CPP_BINARY_AVAILABLE:
     from pennylane.ops.op_math import Adjoint
     from pennylane.wires import Wires
 
-    # pylint: disable=import-error, no-name-in-module, ungrouped-imports
-    from pennylane_lightning.core._serialize import QuantumScriptSerializer
-    from pennylane_lightning.core._version import __version__
-
     # pylint: disable=no-name-in-module, ungrouped-imports
     from pennylane_lightning.lightning_qubit_ops.algorithms import (
         AdjointJacobianC64,
@@ -79,6 +75,10 @@ if LQ_CPP_BINARY_AVAILABLE:
         create_ops_listC64,
         create_ops_listC128,
     )
+
+    # pylint: disable=import-error, no-name-in-module, ungrouped-imports
+    from pennylane_lightning.core._serialize import QuantumScriptSerializer
+    from pennylane_lightning.core._version import __version__
 
     def _state_dtype(dtype):
         if dtype not in [np.complex128, np.complex64]:  # pragma: no cover

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,7 +12,7 @@ pre-commit>=2.19.0
 black==23.7.0
 clang-tidy~=16.0
 clang-format~=16.0
-isort
+isort~=5.13.2
 cmake
 custatevec-cu12
 pylint


### PR DESCRIPTION
Reviewing PRs and noticing that we are all using multiple versions of `isort` and as such headers have been changed multiple times in several PRs! 

In this PR,
- Add a constant version number for `isort` to `requirements-dev.txt` (let's stick to the latest version: v5.13.2)
- Add `isort` to the `format.yml` GH action 