### PR TITLE
Add MidMeasureMP in LightningQubit (cpp only)

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ### New features since last release
 
-* `lightning.qubit` supports mid-circuit measurements.
-  [(#621)](https://github.com/PennyLaneAI/pennylane-lightning/pull/621)
+* Add `collapse` and `normalize` methods to the `StateVectorLQubit` classes, enabling "branching" of the wavefunction. Add methods to create and seed an RNG in the `Measurements` modules.
+  [(#645)](https://github.com/PennyLaneAI/pennylane-lightning/pull/645)
 
 * Add two new python classes (LightningStateVector and LightningMeasurements) to support `lightning.qubit2`.
   [(#613)](https://github.com/PennyLaneAI/pennylane-lightning/pull/613)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### New features since last release
 
+* `lightning.qubit` supports mid-circuit measurements.
+  [(#621)](https://github.com/PennyLaneAI/pennylane-lightning/pull/621)
+
 * Add two new python classes (LightningStateVector and LightningMeasurements) to support `lightning.qubit2`.
   [(#613)](https://github.com/PennyLaneAI/pennylane-lightning/pull/613)
 
@@ -32,7 +35,7 @@
 
 This release contains contributions from (in alphabetical order):
 
-Ali Asadi, Amintor Dusko, Vincent Michaud-Rioux
+Ali Asadi, Amintor Dusko, Thomas Germain, Vincent Michaud-Rioux
 
 ---
 

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.36.0-dev10"
+__version__ = "0.36.0-dev11"

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.36.0-dev9"
+__version__ = "0.36.0-dev10"

--- a/pennylane_lightning/core/src/measurements/MeasurementsBase.hpp
+++ b/pennylane_lightning/core/src/measurements/MeasurementsBase.hpp
@@ -17,6 +17,7 @@
  */
 #pragma once
 
+#include <random>
 #include <string>
 #include <vector>
 
@@ -55,6 +56,7 @@ template <class StateVectorT, class Derived> class MeasurementsBase {
 #else
     const StateVectorT &_statevector;
 #endif
+    std::mt19937 rng;
 
   public:
 #ifdef _ENABLE_PLGPU
@@ -64,6 +66,23 @@ template <class StateVectorT, class Derived> class MeasurementsBase {
     explicit MeasurementsBase(const StateVectorT &statevector)
         : _statevector{statevector} {};
 #endif
+
+    /**
+     * @brief Set the seed of the internal random generator
+     *
+     * @param seed Seed
+     */
+    void setSeed(const size_t seed) { rng.seed(seed); }
+
+    /**
+     * @brief Randomly set the seed of the internal random generator
+     *
+     * @param seed Seed
+     */
+    void setRandomSeed() {
+        std::random_device rd;
+        setSeed(rd());
+    }
 
     /**
      * @brief Calculate the expectation value for a general Observable.

--- a/pennylane_lightning/core/src/simulators/lightning_gpu/measurements/MeasurementsGPU.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_gpu/measurements/MeasurementsGPU.hpp
@@ -224,10 +224,10 @@ class Measurements final
             data_type = CUDA_C_32F;
         }
 
-        std::mt19937 gen(std::random_device{}());
+        this->setRandomSeed();
         std::uniform_real_distribution<PrecisionT> dis(0.0, 1.0);
         for (size_t n = 0; n < num_samples; n++) {
-            rand_nums[n] = dis(gen);
+            rand_nums[n] = dis(this->rng);
         }
         std::vector<size_t> samples(num_samples * num_qubits, 0);
         std::unordered_map<size_t, size_t> cache;


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [ ] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [ ] Ensure that the test suite passes, by running `make test`.

- [ ] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [ ] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**
Native-execution of circuits with mid-measurements is enabled via the dynamic-one-shot transform. To support the transform, a device must implement methods to apply MidMeasureMP.

MidMeasureMP is a special kind of operation where a sample is drawn from the state vector probability distribution and a projector is applied to the state vector accordingly. It may also support options like reset and post-selection.

The most straightforward way to deal with the requirements is to enhance the state vector class StateVectorLQubit.

This PR is only about the C++ part.

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**

**Related GitHub Pull Request:**
https://github.com/PennyLaneAI/pennylane-lightning/pull/621 - See discussions

**Related Shortcut Story:**
[sc-57704]