### PR TITLE
Only build wheels when label build_wheels is activated.

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -23,6 +23,9 @@
 
 ### Breaking changes
 
+* Introduce `ci:build_wheel` label, which controls wheel building on `pull_request` and other triggers.
+  [(#648)](https://github.com/PennyLaneAI/pennylane-lightning/pull/648)
+
 ### Improvements
 
 * Initialize the private attributes `gates_indices_` and `generators_indices_` of `StateVectorKokkos` using the definitions of the `Pennylane::Gates::Constant` namespace.

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -23,7 +23,7 @@
 
 ### Breaking changes
 
-* Introduce `ci:build_wheel` label, which controls wheel building on `pull_request` and other triggers.
+* Introduce `ci:build_wheels` label, which controls wheel building on `pull_request` and other triggers.
   [(#648)](https://github.com/PennyLaneAI/pennylane-lightning/pull/648)
 
 ### Improvements

--- a/.github/workflows/wheel_linux_x86_64.yml
+++ b/.github/workflows/wheel_linux_x86_64.yml
@@ -22,6 +22,7 @@ concurrency:
 
 jobs:
   set_wheel_build_matrix:
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'ci:build_wheels') }}
     name: "Set wheel build matrix"
     uses: ./.github/workflows/set_wheel_build_matrix.yml
     with:

--- a/.github/workflows/wheel_linux_x86_64.yml
+++ b/.github/workflows/wheel_linux_x86_64.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   set_wheel_build_matrix:
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'ci:build_wheels') }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'ci:build_wheels') || github.ref == 'refs/heads/master' }}
     name: "Set wheel build matrix"
     uses: ./.github/workflows/set_wheel_build_matrix.yml
     with:

--- a/.github/workflows/wheel_linux_x86_64.yml
+++ b/.github/workflows/wheel_linux_x86_64.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   set_wheel_build_matrix:
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'ci:build_wheels') || github.ref == 'refs/heads/master' }}
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci:build_wheels')
     name: "Set wheel build matrix"
     uses: ./.github/workflows/set_wheel_build_matrix.yml
     with:

--- a/.github/workflows/wheel_linux_x86_64_cuda.yml
+++ b/.github/workflows/wheel_linux_x86_64_cuda.yml
@@ -22,6 +22,7 @@ concurrency:
 
 jobs:
   set_wheel_build_matrix:
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'ci:build_wheels') }}
     name: "Set wheel build matrix"
     uses: ./.github/workflows/set_wheel_build_matrix.yml
     with:

--- a/.github/workflows/wheel_linux_x86_64_cuda.yml
+++ b/.github/workflows/wheel_linux_x86_64_cuda.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   set_wheel_build_matrix:
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'ci:build_wheels') }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'ci:build_wheels') || github.ref == 'refs/heads/master' }}
     name: "Set wheel build matrix"
     uses: ./.github/workflows/set_wheel_build_matrix.yml
     with:

--- a/.github/workflows/wheel_linux_x86_64_cuda.yml
+++ b/.github/workflows/wheel_linux_x86_64_cuda.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   set_wheel_build_matrix:
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'ci:build_wheels') || github.ref == 'refs/heads/master' }}
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci:build_wheels')
     name: "Set wheel build matrix"
     uses: ./.github/workflows/set_wheel_build_matrix.yml
     with:

--- a/.github/workflows/wheel_macos_arm64.yml
+++ b/.github/workflows/wheel_macos_arm64.yml
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
   mac-set-matrix-arm:
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'ci:build_wheels') || github.ref == 'refs/heads/master' }}
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci:build_wheels')
     timeout-minutes: 30
     name: Set builder matrix
     runs-on: ubuntu-latest

--- a/.github/workflows/wheel_macos_arm64.yml
+++ b/.github/workflows/wheel_macos_arm64.yml
@@ -24,6 +24,7 @@ concurrency:
 
 jobs:
   mac-set-matrix-arm:
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'ci:build_wheels') }}
     timeout-minutes: 30
     name: Set builder matrix
     runs-on: ubuntu-latest

--- a/.github/workflows/wheel_macos_arm64.yml
+++ b/.github/workflows/wheel_macos_arm64.yml
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
   mac-set-matrix-arm:
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'ci:build_wheels') }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'ci:build_wheels') || github.ref == 'refs/heads/master' }}
     timeout-minutes: 30
     name: Set builder matrix
     runs-on: ubuntu-latest

--- a/.github/workflows/wheel_macos_x86_64.yml
+++ b/.github/workflows/wheel_macos_x86_64.yml
@@ -22,6 +22,7 @@ concurrency:
 
 jobs:
   set_wheel_build_matrix:
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'ci:build_wheels') }}
     name: "Set wheel build matrix"
     uses: ./.github/workflows/set_wheel_build_matrix.yml
     with:

--- a/.github/workflows/wheel_macos_x86_64.yml
+++ b/.github/workflows/wheel_macos_x86_64.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   set_wheel_build_matrix:
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'ci:build_wheels') }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'ci:build_wheels') || github.ref == 'refs/heads/master' }}
     name: "Set wheel build matrix"
     uses: ./.github/workflows/set_wheel_build_matrix.yml
     with:

--- a/.github/workflows/wheel_macos_x86_64.yml
+++ b/.github/workflows/wheel_macos_x86_64.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   set_wheel_build_matrix:
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'ci:build_wheels') || github.ref == 'refs/heads/master' }}
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci:build_wheels')
     name: "Set wheel build matrix"
     uses: ./.github/workflows/set_wheel_build_matrix.yml
     with:

--- a/.github/workflows/wheel_noarch.yml
+++ b/.github/workflows/wheel_noarch.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   build-pure-python-wheel:
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'ci:build_wheels') }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'ci:build_wheels') || github.ref == 'refs/heads/master' }}
     strategy:
       matrix:
         os: [ubuntu-latest]

--- a/.github/workflows/wheel_noarch.yml
+++ b/.github/workflows/wheel_noarch.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   build-pure-python-wheel:
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'ci:build_wheels') || github.ref == 'refs/heads/master' }}
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci:build_wheels')
     strategy:
       matrix:
         os: [ubuntu-latest]

--- a/.github/workflows/wheel_noarch.yml
+++ b/.github/workflows/wheel_noarch.yml
@@ -19,6 +19,7 @@ concurrency:
 
 jobs:
   build-pure-python-wheel:
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'ci:build_wheels') }}
     strategy:
       matrix:
         os: [ubuntu-latest]

--- a/.github/workflows/wheel_win_x86_64.yml
+++ b/.github/workflows/wheel_win_x86_64.yml
@@ -23,7 +23,7 @@ concurrency:
 
 jobs:
   set_wheel_build_matrix:
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'ci:build_wheels') }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'ci:build_wheels') || github.ref == 'refs/heads/master' }}
     name: "Set wheel build matrix"
     uses: ./.github/workflows/set_wheel_build_matrix.yml
     with:

--- a/.github/workflows/wheel_win_x86_64.yml
+++ b/.github/workflows/wheel_win_x86_64.yml
@@ -23,6 +23,7 @@ concurrency:
 
 jobs:
   set_wheel_build_matrix:
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'ci:build_wheels') }}
     name: "Set wheel build matrix"
     uses: ./.github/workflows/set_wheel_build_matrix.yml
     with:

--- a/.github/workflows/wheel_win_x86_64.yml
+++ b/.github/workflows/wheel_win_x86_64.yml
@@ -23,7 +23,7 @@ concurrency:
 
 jobs:
   set_wheel_build_matrix:
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'ci:build_wheels') || github.ref == 'refs/heads/master' }}
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci:build_wheels')
     name: "Set wheel build matrix"
     uses: ./.github/workflows/set_wheel_build_matrix.yml
     with:

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.36.0-dev12"
+__version__ = "0.36.0-dev13"


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [x] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [x] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [x] Ensure that the test suite passes, by running `make test`.

- [x] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [x] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**
The CI is quite heavy and we are looking for ways to alleviate it and speed up the iteration process. The wheels need not be built on each commit. Kudos to @maliasadi for pointing this out.

**Description of the Change:**
Only build the wheels before merging by labelling the PR `ci:build_wheels`.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
