### PR TITLE
Remove non-native observables from TOML files

### DIFF
--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.36.0-dev16"
+__version__ = "0.36.0-dev17"

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.36.0-dev15"
+__version__ = "0.36.0-dev16"

--- a/pennylane_lightning/lightning_gpu/lightning_gpu.toml
+++ b/pennylane_lightning/lightning_gpu/lightning_gpu.toml
@@ -6,14 +6,14 @@ name = "lightning.gpu"
 [operators]
 # Observables supported by the device
 observables = [
+        "Identity",
         "PauliX",
         "PauliY",
         "PauliZ",
         "Hadamard",
         "Hermitian",
-        "Identity",
-        "SparseHamiltonian",
         "Hamiltonian",
+        "SparseHamiltonian",
 ]
 
 # The union of all gate types listed in this section must match what

--- a/pennylane_lightning/lightning_gpu/lightning_gpu.toml
+++ b/pennylane_lightning/lightning_gpu/lightning_gpu.toml
@@ -14,10 +14,6 @@ observables = [
         "Identity",
         "SparseHamiltonian",
         "Hamiltonian",
-        "Sum",
-        "SProd",
-        "Prod",
-        "Exp",
 ]
 
 # The union of all gate types listed in this section must match what

--- a/pennylane_lightning/lightning_kokkos/lightning_kokkos.toml
+++ b/pennylane_lightning/lightning_kokkos/lightning_kokkos.toml
@@ -6,14 +6,14 @@ name = "lightning.kokkos"
 [operators]
 # Observables supported by the device
 observables = [
+        "Identity",
         "PauliX",
         "PauliY",
         "PauliZ",
         "Hadamard",
         "Hermitian",
-        "Identity",
-        "SparseHamiltonian",
         "Hamiltonian",
+        "SparseHamiltonian",
 ]
 
 # The union of all gate types listed in this section must match what

--- a/pennylane_lightning/lightning_kokkos/lightning_kokkos.toml
+++ b/pennylane_lightning/lightning_kokkos/lightning_kokkos.toml
@@ -14,10 +14,6 @@ observables = [
         "Identity",
         "SparseHamiltonian",
         "Hamiltonian",
-        "Sum",
-        "SProd",
-        "Prod",
-        "Exp",
 ]
 
 # The union of all gate types listed in this section must match what

--- a/pennylane_lightning/lightning_qubit/lightning_qubit.toml
+++ b/pennylane_lightning/lightning_qubit/lightning_qubit.toml
@@ -12,7 +12,6 @@ observables = [
         "Hadamard",
         "Hermitian",
         "Identity",
-        "Projector",
         "SparseHamiltonian",
         "Hamiltonian",
         "Sum",

--- a/pennylane_lightning/lightning_qubit/lightning_qubit.toml
+++ b/pennylane_lightning/lightning_qubit/lightning_qubit.toml
@@ -14,10 +14,6 @@ observables = [
         "Identity",
         "SparseHamiltonian",
         "Hamiltonian",
-        "Sum",
-        "SProd",
-        "Prod",
-        "Exp",
 ]
 
 # The union of all gate types listed in this section must match what

--- a/pennylane_lightning/lightning_qubit/lightning_qubit.toml
+++ b/pennylane_lightning/lightning_qubit/lightning_qubit.toml
@@ -6,14 +6,14 @@ name = "lightning.qubit"
 [operators]
 # Observables supported by the device
 observables = [
+        "Identity",
         "PauliX",
         "PauliY",
         "PauliZ",
         "Hadamard",
         "Hermitian",
-        "Identity",
-        "SparseHamiltonian",
         "Hamiltonian",
+        "SparseHamiltonian",
 ]
 
 # The union of all gate types listed in this section must match what


### PR DESCRIPTION
This PR removes non-native observables (those obs which are not supported natively by the device) from TOML files. 