### PR TITLE
Refactor lightning_gpu_utils unit tests to remove the dependency on statevector class

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -46,6 +46,9 @@
 
 ### Improvements
 
+* Refactor lightning_gpu_utils unit tests to remove the dependency on statevector class.
+  [(#675)](https://github.com/PennyLaneAI/pennylane-lightning/pull/675)
+
 * Upgrade GitHub actions versions from v3 to v4.
   [(#669)](https://github.com/PennyLaneAI/pennylane-lightning/pull/669)
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### New features since last release
 
 * Add dynamic linking to LAPACK/OpenBlas shared objects in scipy.libs for both C++ and Python layer.
-  [(#651)](https://github.com/PennyLaneAI/pennylane-lightning/pull/651)
+  [(#653)](https://github.com/PennyLaneAI/pennylane-lightning/pull/651)
 
 * `lightning.qubit` supports mid-circuit measurements.
   [(#650)](https://github.com/PennyLaneAI/pennylane-lightning/pull/650)
@@ -36,7 +36,7 @@
 ### Breaking changes
 
 * Deprecate static LAPACK linking support.
-  [(#651)](https://github.com/PennyLaneAI/pennylane-lightning/pull/651)
+  [(#653)](https://github.com/PennyLaneAI/pennylane-lightning/pull/651)
 
 * Migrate `lightning.qubit` to the new device API.
   [(#646)](https://github.com/PennyLaneAI/pennylane-lightning/pull/646)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -46,7 +46,7 @@
 
 ### Improvements
 
-* Refactor lightning_gpu_utils unit tests to remove the dependency on statevector class.
+* Refactor `lightning_gpu_utils` unit tests to remove the dependency on statevector class.
   [(#675)](https://github.com/PennyLaneAI/pennylane-lightning/pull/675)
 
 * Upgrade GitHub actions versions from v3 to v4.

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.36.0-dev25"
+__version__ = "0.36.0-dev26"

--- a/pennylane_lightning/core/src/simulators/lightning_gpu/utils/tests/Test_LinearAlgebra.cpp
+++ b/pennylane_lightning/core/src/simulators/lightning_gpu/utils/tests/Test_LinearAlgebra.cpp
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#include <algorithm>
 #include <complex>
 #include <cstdio>
 #include <vector>

--- a/pennylane_lightning/core/src/simulators/lightning_gpu/utils/tests/Test_LinearAlgebra.cpp
+++ b/pennylane_lightning/core/src/simulators/lightning_gpu/utils/tests/Test_LinearAlgebra.cpp
@@ -17,10 +17,11 @@
 
 #include <catch2/catch.hpp>
 
+#include "DataBuffer.hpp"
 #include "LinearAlg.hpp"
-#include "StateVectorCudaManaged.hpp"
 #include "TestHelpers.hpp"
 #include "Util.hpp" // exp2
+#include "cuda_helpers.hpp"
 
 /**
  * @file
@@ -31,17 +32,20 @@
 /// @cond DEV
 namespace {
 using namespace Pennylane::LightningGPU;
+using namespace Pennylane::LightningGPU::Util;
 using namespace Pennylane::Util;
 } // namespace
 /// @endcond
 
 TEMPLATE_TEST_CASE("Linear Algebra::SparseMV", "[Linear Algebra]", float,
                    double) {
-    using StateVectorT = StateVectorCudaManaged<TestType>;
-    using ComplexT = StateVectorT::ComplexT;
-    using CFP_t = StateVectorT::CFP_t;
+    using ComplexT = std::complex<TestType>;
     using IdxT = typename std::conditional<std::is_same<TestType, float>::value,
                                            int32_t, int64_t>::type;
+
+    using CFP_t =
+        typename std::conditional<std::is_same<TestType, float>::value,
+                                  cuFloatComplex, cuDoubleComplex>::type;
 
     std::size_t num_qubits = 3;
     std::size_t data_size = exp2(num_qubits);
@@ -49,6 +53,12 @@ TEMPLATE_TEST_CASE("Linear Algebra::SparseMV", "[Linear Algebra]", float,
     std::vector<ComplexT> vectors = {{0.0, 0.0}, {0.0, 0.1}, {0.1, 0.1},
                                      {0.1, 0.2}, {0.2, 0.2}, {0.3, 0.3},
                                      {0.3, 0.4}, {0.4, 0.5}};
+
+    std::vector<CFP_t> vectors_cu;
+
+    std::transform(vectors.begin(), vectors.end(),
+                   std::back_inserter(vectors_cu),
+                   [](ComplexT x) { return complexToCu<ComplexT>(x); });
 
     const std::vector<ComplexT> result_refs = {
         {0.2, -0.1}, {-0.1, 0.2}, {0.2, 0.1}, {0.1, 0.2},
@@ -63,26 +73,26 @@ TEMPLATE_TEST_CASE("Linear Algebra::SparseMV", "[Linear Algebra]", float,
         {1.0, 0.0},  {0.0, -1.0}, {1.0, 0.0}, {0.0, 1.0},
         {0.0, -1.0}, {1.0, 0.0},  {0.0, 1.0}, {1.0, 0.0}};
 
-    StateVectorT sv_x{num_qubits};
-    StateVectorT sv_y{num_qubits};
+    DataBuffer<CFP_t> sv_x(data_size);
+    DataBuffer<CFP_t> sv_y(data_size);
 
-    sv_x.CopyHostDataToGpu(vectors.data(), vectors.size());
+    sv_x.CopyHostDataToGpu(vectors_cu.data(), vectors_cu.size());
 
     SECTION("Testing sparse matrix vector product:") {
-        std::vector<ComplexT> result(data_size);
+        std::vector<CFP_t> result(data_size);
+        auto cusparsehandle = make_shared_cusparse_handle();
 
-        cuUtil::SparseMV_cuSparse<IdxT, TestType, CFP_t>(
+        SparseMV_cuSparse<IdxT, TestType, CFP_t>(
             indptr.data(), static_cast<int64_t>(indptr.size()), indices.data(),
             values.data(), static_cast<int64_t>(values.size()), sv_x.getData(),
-            sv_y.getData(), sv_x.getDataBuffer().getDevTag().getDeviceID(),
-            sv_x.getDataBuffer().getDevTag().getStreamID(),
-            sv_x.getCusparseHandle());
+            sv_y.getData(), sv_x.getDevice(), sv_x.getStream(),
+            cusparsehandle.get());
 
         sv_y.CopyGpuDataToHost(result.data(), result.size());
 
         for (std::size_t j = 0; j < exp2(num_qubits); j++) {
-            CHECK(imag(result[j]) == Approx(imag(result_refs[j])));
-            CHECK(real(result[j]) == Approx(real(result_refs[j])));
+            CHECK(result[j].x == Approx(real(result_refs[j])));
+            CHECK(result[j].y == Approx(imag(result_refs[j])));
         }
     }
 }


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [ ] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [x] Ensure that the test suite passes, by running `make test`.

- [x] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [x] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**

Refactor lightning_gpu_utils unit tests

**Description of the Change:**

 Unit tests for `sparseMV` and `sparseMVMPI` relied on the `DataBuffer` class instead of`StateVectorCudaManaged` and  `StateVectorCudaManagedMPI`. 

**Benefits:**

It will make the lightning_gpu_utils an independent module, which can be used for both `cutensornet` and `custatevec` backends after moving it to `/src/utils/`.

**Possible Drawbacks:**

**Related GitHub Issues:**
