### PR TITLE
Fix the CodeCov issue with compat-check actions

### DIFF
--- a/.github/workflows/tests_gpu_cuda.yml
+++ b/.github/workflows/tests_gpu_cuda.yml
@@ -1,6 +1,10 @@
 name: Testing::Linux::x86_64::LGPU
 on:
   workflow_call:
+    secrets:
+      codecov_token:
+        description: The codecov token to use when uploading coverage files
+        required: true
     inputs:
       lightning-version:
         type: string
@@ -340,10 +344,10 @@ jobs:
           name: ubuntu-codecov-results-python
 
       - name: Upload to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           fail_ci_if_error: true
-          token: ${{ secrets.CODECOV_TOKEN }}
+          token: ${{ secrets.codecov_token }}
 
   upload-to-codecov-linux-cpp:
     needs: [cpptestswithLGPU]
@@ -359,10 +363,10 @@ jobs:
           name: ubuntu-codecov-results-cpp
 
       - name: Upload to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           fail_ci_if_error: true
-          token: ${{ secrets.CODECOV_TOKEN }}
+          token: ${{ secrets.codecov_token }}
       
       - name: Cleanup
         if: always()

--- a/.github/workflows/tests_linux.yml
+++ b/.github/workflows/tests_linux.yml
@@ -1,6 +1,10 @@
 name: Testing (Linux)
 on:
   workflow_call:
+    secrets:
+      codecov_token:
+        description: The codecov token to use when uploading coverage files
+        required: true
     inputs:
       lightning-version:
         type: string
@@ -622,10 +626,10 @@ jobs:
           python -m coverage xml -i -o coverage-${{ github.job }}.xml
 
       - name: Upload to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           fail_ci_if_error: true
-          token: ${{ secrets.CODECOV_TOKEN }}
+          token: ${{ secrets.codecov_token }}
 
   upload-to-codecov-linux-cpp:
     needs: [cpptests, cpptestswithOpenBLAS, cpptestswithKokkos]
@@ -641,10 +645,10 @@ jobs:
           name: ubuntu-codecov-results-cpp
 
       - name: Upload to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           fail_ci_if_error: true
-          token: ${{ secrets.CODECOV_TOKEN }}
+          token: ${{ secrets.codecov_token }}
 
   cpptestsWithMultipleBackends:
   # Device-specific tests are performed for both. Device-agnostic tests default to LightningQubit.

--- a/.github/workflows/tests_linux_x86_mpi_gpu.yml
+++ b/.github/workflows/tests_linux_x86_mpi_gpu.yml
@@ -1,6 +1,10 @@
 name: Tests::Linux::x86_64::LGPU::MPI
 on:
   workflow_call:
+    secrets:
+      codecov_token:
+        description: The codecov token to use when uploading coverage files
+        required: true
     inputs:
       lightning-version:
         type: string
@@ -297,11 +301,11 @@ jobs:
           name: ubuntu-codecov-results-cpp
 
       - name: Upload to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           fail_ci_if_error: true
           verbose: true
-          token: ${{ secrets.CODECOV_TOKEN }}
+          token: ${{ secrets.codecov_token }}
       
       - name: Cleanup
         if: always()
@@ -324,11 +328,11 @@ jobs:
           name: ubuntu-codecov-results-python
 
       - name: Upload to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           fail_ci_if_error: true
           verbose: true
-          token: ${{ secrets.CODECOV_TOKEN }}
+          token: ${{ secrets.codecov_token }}
 
       - name: Cleanup
         if: always()

--- a/.github/workflows/tests_windows.yml
+++ b/.github/workflows/tests_windows.yml
@@ -1,6 +1,10 @@
 name: Testing (Windows)
 on:
   workflow_call:
+    secrets:
+      codecov_token:
+        description: The codecov token to use when uploading coverage files
+        required: true
     inputs:
       lightning-version:
         type: string
@@ -262,7 +266,7 @@ jobs:
           name: windows-coverage-report
 
       - name: Upload to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           fail_ci_if_error: true
-          token: ${{ secrets.CODECOV_TOKEN }}
+          token: ${{ secrets.codecov_token }}

--- a/.github/workflows/tests_without_binary.yml
+++ b/.github/workflows/tests_without_binary.yml
@@ -1,6 +1,10 @@
 name: Testing without binary
 on:
   workflow_call:
+    secrets:
+      codecov_token:
+        description: The codecov token to use when uploading coverage files
+        required: true
     inputs:
       lightning-version:
         type: string
@@ -109,8 +113,8 @@ jobs:
           PL_DEVICE=${DEVICENAME} python -m pytest tests/ $COVERAGE_FLAGS
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           files: ./main/coverage.xml
           fail_ci_if_error: true
-          token: ${{ secrets.CODECOV_TOKEN }}
+          token: ${{ secrets.codecov_token }}


### PR DESCRIPTION
This PR fixes the CodeCov job failures in compat-check actions by
- Updating the version of codecov-action from v3 to v4
- Add the codecov token to be used when uploading coverage files