### PR TITLE
Fix the failed observable serialization unit tests

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -83,6 +83,9 @@
 * `lightning.qubit` correctly decomposed state preparation operations with adjoint differentiation.
   [(#661)](https://github.com/PennyLaneAI/pennylane-lightning/pull/661)
 
+* Fix the failed observable serialization unit tests.
+  [(#683)](https://github.com/PennyLaneAI/pennylane-lightning/pull/683)
+
 ### Contributors
 
 This release contains contributions from (in alphabetical order):

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.36.0-dev28"
+__version__ = "0.36.0-dev29"

--- a/tests/test_measurements.py
+++ b/tests/test_measurements.py
@@ -695,22 +695,28 @@ class TestWiresInVar:
 
 
 @flaky(max_runs=5)
-@pytest.mark.parametrize("shots", [10000, [10000, 11111]])
+@pytest.mark.parametrize("shots", [None, 10000, [10000, 11111]])
 @pytest.mark.parametrize("measure_f", [qml.counts, qml.expval, qml.probs, qml.sample, qml.var])
 @pytest.mark.parametrize(
-    "obs", [[0], [0, 1], qml.PauliZ(0), qml.PauliY(1), qml.PauliZ(0) @ qml.PauliY(1)]
+    "obs",
+    [[0], [0, 1], qml.PauliZ(0), qml.PauliY(1), qml.PauliZ(0) @ qml.PauliY(1), qml.PauliZ(1) @ qml.PauliY(2)],
 )
 @pytest.mark.parametrize("mcmc", [False, True])
 @pytest.mark.parametrize("kernel_name", ["Local", "NonZeroRandom"])
 def test_shots_single_measure_obs(shots, measure_f, obs, mcmc, kernel_name):
     """Tests that Lightning handles shots in a circuit where a single measurement of a common observable is performed at the end."""
-    n_qubits = 2
+    n_qubits = 3
 
-    if device_name in ("lightning.gpu", "lightning.kokkos") and (mcmc or kernel_name != "Local"):
+    if (shots is None or device_name in ("lightning.gpu", "lightning.kokkos")) and (
+        mcmc or kernel_name != "Local"
+    ):
         pytest.skip(f"Device {device_name} does not have an mcmc option.")
 
     if measure_f in (qml.expval, qml.var) and isinstance(obs, Sequence):
         pytest.skip("qml.expval, qml.var do not take wire arguments.")
+
+    if measure_f in (qml.counts, qml.sample) and shots is None:
+        pytest.skip("qml.counts, qml.sample do not work with shots = None.")
 
     if device_name in ("lightning.gpu", "lightning.kokkos"):
         dev = qml.device(device_name, wires=n_qubits, shots=shots)
@@ -725,6 +731,7 @@ def test_shots_single_measure_obs(shots, measure_f, obs, mcmc, kernel_name):
         qml.RX(x, 0)
         qml.RX(y, 0)
         qml.RX(y, 1)
+        qml.RX(x, 2)
         return measure_f(wires=obs) if isinstance(obs, Sequence) else measure_f(op=obs)
 
     func1 = qml.QNode(func, dev)

--- a/tests/test_measurements.py
+++ b/tests/test_measurements.py
@@ -699,7 +699,14 @@ class TestWiresInVar:
 @pytest.mark.parametrize("measure_f", [qml.counts, qml.expval, qml.probs, qml.sample, qml.var])
 @pytest.mark.parametrize(
     "obs",
-    [[0], [0, 1], qml.PauliZ(0), qml.PauliY(1), qml.PauliZ(0) @ qml.PauliY(1), qml.PauliZ(1) @ qml.PauliY(2)],
+    [
+        [0],
+        [0, 1],
+        qml.PauliZ(0),
+        qml.PauliY(1),
+        qml.PauliZ(0) @ qml.PauliY(1),
+        qml.PauliZ(1) @ qml.PauliY(2),
+    ],
 )
 @pytest.mark.parametrize("mcmc", [False, True])
 @pytest.mark.parametrize("kernel_name", ["Local", "NonZeroRandom"])

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -483,7 +483,8 @@ class TestSerializeObs:
 
         s_expected = tensor_obs(
             [
-                named_obs("PauliZ", [0]), named_obs("PauliX", [1]),
+                named_obs("PauliZ", [0]),
+                named_obs("PauliX", [1]),
                 named_obs("Hadamard", [2]),
             ]
         )

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -317,28 +317,13 @@ class TestSerializeObs:
             tape, wires_map
         )
 
-        # Expression (ham @ obs) is converted internally by Pennylane
-        # where obs is appended to each term of the ham
-        if qml.operation.active_new_opmath():
-            first_term = tensor_prod_obs(
-                [
-                    tensor_prod_obs(
-                        [
-                            hermitian_obs(np.eye(4, dtype=c_dtype).ravel(), [0, 1]),
-                            named_obs("PauliY", [2]),
-                        ]
-                    ),
-                    named_obs("PauliZ", [3]),
-                ]
-            )
-        else:
-            first_term = tensor_prod_obs(
-                [
-                    hermitian_obs(np.eye(4, dtype=c_dtype).ravel(), [0, 1]),
-                    named_obs("PauliY", [2]),
-                    named_obs("PauliZ", [3]),
-                ]
-            )
+        first_term = tensor_prod_obs(
+            [
+                hermitian_obs(np.eye(4, dtype=c_dtype).ravel(), [0, 1]),
+                named_obs("PauliY", [2]),
+                named_obs("PauliZ", [3]),
+            ]
+        )
 
         s_expected = hamiltonian_obs(
             np.array([0.3, 0.5, 0.4], dtype=r_dtype),
@@ -498,7 +483,7 @@ class TestSerializeObs:
 
         s_expected = tensor_obs(
             [
-                tensor_obs([named_obs("PauliX", [1]), named_obs("PauliZ", [0])]),
+                named_obs("PauliZ", [0]), named_obs("PauliX", [1]),
                 named_obs("Hadamard", [2]),
             ]
         )


### PR DESCRIPTION
PR https://github.com/PennyLaneAI/pennylane/pull/5475 led to LQ and LK serialization unit tests failures. This PR updates them to pass on CIs.