### PR TITLE
Use `isinstance(op, qml.Op)` instead of operation.name string comparison in Python interfaces

### DIFF
--- a/pennylane_lightning/lightning_gpu/lightning_gpu.py
+++ b/pennylane_lightning/lightning_gpu/lightning_gpu.py
@@ -195,15 +195,15 @@ if LGPU_CPP_BINARY_AVAILABLE:
         "SProd",
     }
 
-    gate_cache_needs_hash = {
-        "QubitUnitary",
-        "ControlledQubitUnitary",
-        "MultiControlledX",
-        "DiagonalQubitUnitary",
-        "PSWAP",
-        "OrbitalRotation",
-        "BlockEncode",
-    }
+    gate_cache_needs_hash = (
+        qml.BlockEncode,
+        qml.ControlledQubitUnitary,
+        qml.DiagonalQubitUnitary,
+        qml.MultiControlledX,
+        qml.OrbitalRotation,
+        qml.PSWAP,
+        qml.QubitUnitary,
+    )
 
     class LightningGPU(LightningBase):  # pylint: disable=too-many-instance-attributes
         """PennyLane Lightning GPU device.
@@ -512,18 +512,20 @@ if LGPU_CPP_BINARY_AVAILABLE:
             # Skip over identity operations instead of performing
             # matrix multiplication with the identity.
             for ops in operations:
+                if isinstance(ops, qml.Identity):
+                    continue
                 if isinstance(ops, Adjoint):
                     name = ops.base.name
                     invert_param = True
                 else:
                     name = ops.name
                     invert_param = False
-                if name == "Identity":
-                    continue
                 method = getattr(self._gpu_state, name, None)
                 wires = self.wires.indices(ops.wires)
 
-                if ops.name == "C(GlobalPhase)":
+                if isinstance(ops, qml.ops.op_math.Controlled) and isinstance(
+                    ops.base, qml.GlobalPhase
+                ):
                     controls = ops.control_wires
                     control_values = ops.control_values
                     param = ops.base.parameters[0]
@@ -537,7 +539,7 @@ if LGPU_CPP_BINARY_AVAILABLE:
                         # To support older versions of PL
                         mat = ops.matrix
                     r_dtype = np.float32 if self.use_csingle else np.float64
-                    param = [[r_dtype(ops.hash)]] if ops.name in gate_cache_needs_hash else []
+                    param = [[r_dtype(ops.hash)]] if isinstance(ops, gate_cache_needs_hash) else []
                     if len(mat) == 0:
                         raise ValueError("Unsupported operation")
                     self._gpu_state.apply(
@@ -845,7 +847,7 @@ if LGPU_CPP_BINARY_AVAILABLE:
                 samples = self.sample(observable, shot_range=shot_range, bin_size=bin_size)
                 return np.squeeze(np.mean(samples, axis=0))
 
-            if observable.name in ["SparseHamiltonian"]:
+            if isinstance(observable, qml.SparseHamiltonian):
                 if self._mpi:
                     # Identity for CSR_SparseHamiltonian to pass to processes with rank != 0 to reduce
                     # host(cpu) memory requirements
@@ -866,7 +868,7 @@ if LGPU_CPP_BINARY_AVAILABLE:
                 )
 
             # use specialized functors to compute expval(Hermitian)
-            if observable.name == "Hermitian":
+            if isinstance(observable, qml.Hermitian):
                 observable_wires = self.map_wires(observable.wires)
                 if self._mpi and len(observable_wires) > self._num_local_wires:
                     raise RuntimeError(
@@ -876,7 +878,7 @@ if LGPU_CPP_BINARY_AVAILABLE:
                 return self.measurements.expval(matrix, observable_wires)
 
             if (
-                observable.name in ["Hermitian", "Hamiltonian"]
+                isinstance(observable, (qml.Hamiltonian, qml.Hermitian))
                 or (observable.arithmetic_depth > 0)
                 or isinstance(observable.name, List)
             ):
@@ -929,7 +931,7 @@ if LGPU_CPP_BINARY_AVAILABLE:
                 samples = self.sample(observable, shot_range=shot_range, bin_size=bin_size)
                 return np.squeeze(np.var(samples, axis=0))
 
-            if observable.name == "SparseHamiltonian":
+            if isinstance(observable, qml.SparseHamiltonian):
                 csr_hamiltonian = observable.sparse_matrix(wire_order=self.wires).tocsr(copy=False)
                 return self.measurements.var(
                     csr_hamiltonian.indptr,
@@ -938,7 +940,7 @@ if LGPU_CPP_BINARY_AVAILABLE:
                 )
 
             if (
-                observable.name in ["Hamiltonian", "Hermitian"]
+                isinstance(observable, (qml.Hamiltonian, qml.Hermitian))
                 or (observable.arithmetic_depth > 0)
                 or isinstance(observable.name, List)
             ):

--- a/pennylane_lightning/lightning_kokkos/lightning_kokkos.py
+++ b/pennylane_lightning/lightning_kokkos/lightning_kokkos.py
@@ -429,14 +429,14 @@ if LK_CPP_BINARY_AVAILABLE:
             state = self.state_vector
 
             for ops in operations:
+                if isinstance(ops, qml.Identity):
+                    continue
                 if isinstance(ops, Adjoint):
                     name = ops.base.name
                     invert_param = True
                 else:
                     name = ops.name
                     invert_param = False
-                if isinstance(ops, qml.Identity):
-                    continue
                 method = getattr(state, name, None)
                 wires = self.wires.indices(ops.wires)
 
@@ -445,7 +445,9 @@ if LK_CPP_BINARY_AVAILABLE:
                         self.apply_lightning([ops.then_op])
                 elif isinstance(ops, MidMeasureMP):
                     self._apply_lightning_midmeasure(ops, mid_measurements)
-                elif ops.name == "C(GlobalPhase)":
+                elif isinstance(ops, qml.ops.op_math.Controlled) and isinstance(
+                    ops.base, qml.GlobalPhase
+                ):
                     controls = ops.control_wires
                     control_values = ops.control_values
                     param = ops.base.parameters[0]
@@ -512,9 +514,7 @@ if LK_CPP_BINARY_AVAILABLE:
             Returns:
                 Expectation value of the observable
             """
-            if observable.name in [
-                "Projector",
-            ]:
+            if isinstance(observable, qml.Projector):
                 diagonalizing_gates = observable.diagonalizing_gates()
                 if self.shots is None and diagonalizing_gates:
                     self.apply(diagonalizing_gates)
@@ -550,7 +550,7 @@ if LK_CPP_BINARY_AVAILABLE:
                 return measure.expval(matrix, observable_wires)
 
             if (
-                observable.name in ["Hamiltonian", "Hermitian"]
+                isinstance(observable, (qml.Hamiltonian, qml.Hermitian))
                 or (observable.arithmetic_depth > 0)
                 or isinstance(observable.name, List)
             ):

--- a/pennylane_lightning/lightning_qubit/_measurements.py
+++ b/pennylane_lightning/lightning_qubit/_measurements.py
@@ -129,7 +129,7 @@ class LightningMeasurements:
             Expectation value of the observable
         """
 
-        if measurementprocess.obs.name == "SparseHamiltonian":
+        if isinstance(measurementprocess.obs, qml.SparseHamiltonian):
             # ensuring CSR sparse representation.
             CSR_SparseHamiltonian = measurementprocess.obs.sparse_matrix(
                 wire_order=list(range(self._qubit_state.num_wires))
@@ -141,7 +141,7 @@ class LightningMeasurements:
             )
 
         if (
-            measurementprocess.obs.name in ["Hamiltonian", "Hermitian"]
+            isinstance(measurementprocess.obs, (qml.Hamiltonian, qml.Hermitian))
             or (measurementprocess.obs.arithmetic_depth > 0)
             or isinstance(measurementprocess.obs.name, List)
         ):
@@ -183,7 +183,7 @@ class LightningMeasurements:
             Variance of the observable
         """
 
-        if measurementprocess.obs.name == "SparseHamiltonian":
+        if isinstance(measurementprocess.obs, qml.SparseHamiltonian):
             # ensuring CSR sparse representation.
             CSR_SparseHamiltonian = measurementprocess.obs.sparse_matrix(
                 wire_order=list(range(self._qubit_state.num_wires))
@@ -195,7 +195,7 @@ class LightningMeasurements:
             )
 
         if (
-            measurementprocess.obs.name in ["Hamiltonian", "Hermitian"]
+            isinstance(measurementprocess.obs, (qml.Hamiltonian, qml.Hermitian))
             or (measurementprocess.obs.arithmetic_depth > 0)
             or isinstance(measurementprocess.obs.name, List)
         ):
@@ -221,10 +221,7 @@ class LightningMeasurements:
         """
         if isinstance(measurementprocess, StateMeasurement):
             if isinstance(measurementprocess, ExpectationMP):
-                if measurementprocess.obs.name in [
-                    "Identity",
-                    "Projector",
-                ]:
+                if isinstance(measurementprocess.obs, (qml.Identity, qml.Projector)):
                     return self.state_diagonalizing_gates
                 return self.expval
 
@@ -232,10 +229,7 @@ class LightningMeasurements:
                 return self.probs
 
             if isinstance(measurementprocess, VarianceMP):
-                if measurementprocess.obs.name in [
-                    "Identity",
-                    "Projector",
-                ]:
+                if isinstance(measurementprocess.obs, (qml.Identity, qml.Projector)):
                     return self.state_diagonalizing_gates
                 return self.var
             if measurementprocess.obs is None or measurementprocess.obs.has_diagonalizing_gates:


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [ ] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [ ] Ensure that the test suite passes, by running `make test`.

- [ ] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [ ] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**
There are several places in Python interfaces that we use string comparison for comparing PL operations and observables.
String comparison is usually considered a bad practice in compare with using `isinstance(object, class_type)` in Python.

**Description of the Change:**
Use `isinstance` where possible.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
