### PR TITLE
Disable gate dispatcher on x64 MacOS

### DIFF
--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.36.0-dev37"
+__version__ = "0.36.0-dev38"

--- a/setup.py
+++ b/setup.py
@@ -130,6 +130,7 @@ class CMakeBuild(build_ext):
             configure_args += [
                 f"-DCMAKE_CXX_COMPILER={clang_path}/bin/clang++",
                 f"-DCMAKE_LINKER={clang_path}/bin/lld",
+                f"-DENABLE_GATE_DISPATCHER=OFF",
             ]
             if shutil.which("brew"):
                 libomp_path = subprocess.run(


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [ ] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [ ] Ensure that the test suite passes, by running `make test`.

- [ ] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [ ] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:** Due to intermittent failures on the CI, this PR disable the dynamic dispatcher on x64 MacOS builds of LightningQubit.

**Description of the Change:** As above.

**Benefits:** Ensures successful builds of the packages for testing and validation across ecosystem.

**Possible Drawbacks:**

**Related GitHub Issues:**
