### PR TITLE
Use wire order specified on instantiation

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -106,7 +106,7 @@
 ### Bug fixes
 
 * Lightning Qubit once again respects the wire order specified on device instantiation.
-  [(#705)](https://github.com/PennyLaneAI/pennylane-lightning/pull/705/)
+  [(#705)](https://github.com/PennyLaneAI/pennylane-lightning/pull/705)
 
 * `dynamic_one_shot` was refactored to use `SampleMP` measurements as a way to return the mid-circuit measurement samples. `LightningQubit`'s `simulate` is modified accordingly.
   [(#694)](https://github.com/PennyLaneAI/pennylane/pull/694)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -105,6 +105,8 @@
 
 ### Bug fixes
 
+* Lightning Qubit once again respects the wire order specified on device instantiation.
+
 * `dynamic_one_shot` was refactored to use `SampleMP` measurements as a way to return the mid-circuit measurement samples. `LightningQubit`'s `simulate` is modified accordingly.
   [(#694)](https://github.com/PennyLaneAI/pennylane/pull/694)
 

--- a/pennylane_lightning/lightning_qubit/lightning_qubit.py
+++ b/pennylane_lightning/lightning_qubit/lightning_qubit.py
@@ -108,7 +108,9 @@ def jacobian(circuit: QuantumTape, state: LightningStateVector, batch_obs=False,
     return LightningAdjointJacobian(final_state, batch_obs=batch_obs).calculate_jacobian(circuit)
 
 
-def simulate_and_jacobian(circuit: QuantumTape, state: LightningStateVector, batch_obs=False, wire_map=None):
+def simulate_and_jacobian(
+    circuit: QuantumTape, state: LightningStateVector, batch_obs=False, wire_map=None
+):
     """Simulate a single quantum script and compute its Jacobian.
 
     Args:
@@ -132,7 +134,11 @@ def simulate_and_jacobian(circuit: QuantumTape, state: LightningStateVector, bat
 
 
 def vjp(
-    circuit: QuantumTape, cotangents: Tuple[Number], state: LightningStateVector, batch_obs=False, wire_map=None,
+    circuit: QuantumTape,
+    cotangents: Tuple[Number],
+    state: LightningStateVector,
+    batch_obs=False,
+    wire_map=None,
 ):
     """Compute the Vector-Jacobian Product (VJP) for a single quantum script.
     Args:
@@ -160,7 +166,11 @@ def vjp(
 
 
 def simulate_and_vjp(
-    circuit: QuantumTape, cotangents: Tuple[Number], state: LightningStateVector, batch_obs=False, wire_map=None
+    circuit: QuantumTape,
+    cotangents: Tuple[Number],
+    state: LightningStateVector,
+    batch_obs=False,
+    wire_map=None,
 ):
     """Simulate a single quantum script and compute its Vector-Jacobian Product (VJP).
     Args:
@@ -460,7 +470,7 @@ class LightningQubit(Device):
         super().__init__(wires=wires, shots=shots)
 
         if isinstance(wires, int):
-            self._wire_map = None # should just use wires as is
+            self._wire_map = None  # should just use wires as is
         else:
             self._wire_map = {w: i for i, w in enumerate(self.wires)}
 
@@ -631,7 +641,8 @@ class LightningQubit(Device):
         batch_obs = execution_config.device_options.get("batch_obs", self._batch_obs)
 
         return tuple(
-            jacobian(circuit, self._statevector, batch_obs=batch_obs, wire_map=self._wire_map) for circuit in circuits
+            jacobian(circuit, self._statevector, batch_obs=batch_obs, wire_map=self._wire_map)
+            for circuit in circuits
         )
 
     def execute_and_compute_derivatives(
@@ -650,7 +661,10 @@ class LightningQubit(Device):
         """
         batch_obs = execution_config.device_options.get("batch_obs", self._batch_obs)
         results = tuple(
-            simulate_and_jacobian(c, self._statevector, batch_obs=batch_obs, wire_map=self._wire_map) for c in circuits
+            simulate_and_jacobian(
+                c, self._statevector, batch_obs=batch_obs, wire_map=self._wire_map
+            )
+            for c in circuits
         )
         return tuple(zip(*results))
 
@@ -725,7 +739,9 @@ class LightningQubit(Device):
         """
         batch_obs = execution_config.device_options.get("batch_obs", self._batch_obs)
         results = tuple(
-            simulate_and_vjp(circuit, cots, self._statevector, batch_obs=batch_obs, wire_map=self._wire_map)
+            simulate_and_vjp(
+                circuit, cots, self._statevector, batch_obs=batch_obs, wire_map=self._wire_map
+            )
             for circuit, cots in zip(circuits, cotangents)
         )
         return tuple(zip(*results))

--- a/pennylane_lightning/lightning_qubit/lightning_qubit.py
+++ b/pennylane_lightning/lightning_qubit/lightning_qubit.py
@@ -17,7 +17,6 @@ This module contains the LightningQubit class that inherits from the new device 
 from dataclasses import replace
 from numbers import Number
 from pathlib import Path
-from this import d
 from typing import Callable, Optional, Sequence, Tuple, Union
 
 import numpy as np

--- a/pennylane_lightning/lightning_qubit/lightning_qubit.py
+++ b/pennylane_lightning/lightning_qubit/lightning_qubit.py
@@ -17,6 +17,7 @@ This module contains the LightningQubit class that inherits from the new device 
 from dataclasses import replace
 from numbers import Number
 from pathlib import Path
+from this import d
 from typing import Callable, Optional, Sequence, Tuple, Union
 
 import numpy as np
@@ -87,7 +88,7 @@ def simulate(circuit: QuantumScript, state: LightningStateVector, mcmc: dict = N
     return LightningMeasurements(final_state, **mcmc).measure_final_state(circuit)
 
 
-def jacobian(circuit: QuantumTape, state: LightningStateVector, batch_obs=False):
+def jacobian(circuit: QuantumTape, state: LightningStateVector, batch_obs=False, wire_map=None):
     """Compute the Jacobian for a single quantum script.
 
     Args:
@@ -96,17 +97,19 @@ def jacobian(circuit: QuantumTape, state: LightningStateVector, batch_obs=False)
         batch_obs (bool): Determine whether we process observables in parallel when
             computing the jacobian. This value is only relevant when the lightning
             qubit is built with OpenMP. Default is False.
+        wire_map (Optional[dict]): a map from wire labels to simulation indices
 
     Returns:
         TensorLike: The Jacobian of the quantum script
     """
-    circuit = circuit.map_to_standard_wires()
+    if wire_map is not None:
+        [circuit], _ = qml.map_wires(circuit, wire_map)
     state.reset_state()
     final_state = state.get_final_state(circuit)
     return LightningAdjointJacobian(final_state, batch_obs=batch_obs).calculate_jacobian(circuit)
 
 
-def simulate_and_jacobian(circuit: QuantumTape, state: LightningStateVector, batch_obs=False):
+def simulate_and_jacobian(circuit: QuantumTape, state: LightningStateVector, batch_obs=False, wire_map=None):
     """Simulate a single quantum script and compute its Jacobian.
 
     Args:
@@ -115,20 +118,22 @@ def simulate_and_jacobian(circuit: QuantumTape, state: LightningStateVector, bat
         batch_obs (bool): Determine whether we process observables in parallel when
             computing the jacobian. This value is only relevant when the lightning
             qubit is built with OpenMP. Default is False.
+        wire_map (Optional[dict]): a map from wire labels to simulation indices
 
     Returns:
         Tuple[TensorLike]: The results of the simulation and the calculated Jacobian
 
     Note that this function can return measurements for non-commuting observables simultaneously.
     """
-    circuit = circuit.map_to_standard_wires()
+    if wire_map is not None:
+        [circuit], _ = qml.map_wires(circuit, wire_map)
     res = simulate(circuit, state)
     jac = LightningAdjointJacobian(state, batch_obs=batch_obs).calculate_jacobian(circuit)
     return res, jac
 
 
 def vjp(
-    circuit: QuantumTape, cotangents: Tuple[Number], state: LightningStateVector, batch_obs=False
+    circuit: QuantumTape, cotangents: Tuple[Number], state: LightningStateVector, batch_obs=False, wire_map=None,
 ):
     """Compute the Vector-Jacobian Product (VJP) for a single quantum script.
     Args:
@@ -141,10 +146,13 @@ def vjp(
         batch_obs (bool): Determine whether we process observables in parallel when
             computing the VJP. This value is only relevant when the lightning
             qubit is built with OpenMP.
+        wire_map (Optional[dict]): a map from wire labels to simulation indices
+
     Returns:
         TensorLike: The VJP of the quantum script
     """
-    circuit = circuit.map_to_standard_wires()
+    if wire_map is not None:
+        [circuit], _ = qml.map_wires(circuit, wire_map)
     state.reset_state()
     final_state = state.get_final_state(circuit)
     return LightningAdjointJacobian(final_state, batch_obs=batch_obs).calculate_vjp(
@@ -153,7 +161,7 @@ def vjp(
 
 
 def simulate_and_vjp(
-    circuit: QuantumTape, cotangents: Tuple[Number], state: LightningStateVector, batch_obs=False
+    circuit: QuantumTape, cotangents: Tuple[Number], state: LightningStateVector, batch_obs=False, wire_map=None
 ):
     """Simulate a single quantum script and compute its Vector-Jacobian Product (VJP).
     Args:
@@ -166,11 +174,14 @@ def simulate_and_vjp(
         batch_obs (bool): Determine whether we process observables in parallel when
             computing the jacobian. This value is only relevant when the lightning
             qubit is built with OpenMP.
+        wire_map (Optional[dict]): a map from wire labels to simulation indices
+
     Returns:
         Tuple[TensorLike]: The results of the simulation and the calculated VJP
     Note that this function can return measurements for non-commuting observables simultaneously.
     """
-    circuit = circuit.map_to_standard_wires()
+    if wire_map is not None:
+        [circuit], _ = qml.map_wires(circuit, wire_map)
     res = simulate(circuit, state)
     _vjp = LightningAdjointJacobian(state, batch_obs=batch_obs).calculate_vjp(circuit, cotangents)
     return res, _vjp
@@ -449,6 +460,11 @@ class LightningQubit(Device):
 
         super().__init__(wires=wires, shots=shots)
 
+        if isinstance(wires, int):
+            self._wire_map = None # should just use wires as is
+        else:
+            self._wire_map = {w: i for i, w in enumerate(self.wires)}
+
         self._statevector = LightningStateVector(num_wires=len(self.wires), dtype=c_dtype)
 
         # TODO: Investigate usefulness of creating numpy random generator
@@ -568,7 +584,8 @@ class LightningQubit(Device):
         }
         results = []
         for circuit in circuits:
-            circuit = circuit.map_to_standard_wires()
+            if self._wire_map is not None:
+                [circuit], _ = qml.map_wires(circuit, self._wire_map)
             results.append(simulate(circuit, self._statevector, mcmc=mcmc))
 
         return tuple(results)
@@ -613,8 +630,9 @@ class LightningQubit(Device):
             Tuple: The jacobian for each trainable parameter
         """
         batch_obs = execution_config.device_options.get("batch_obs", self._batch_obs)
+
         return tuple(
-            jacobian(circuit, self._statevector, batch_obs=batch_obs) for circuit in circuits
+            jacobian(circuit, self._statevector, batch_obs=batch_obs, wire_map=self._wire_map) for circuit in circuits
         )
 
     def execute_and_compute_derivatives(
@@ -633,7 +651,7 @@ class LightningQubit(Device):
         """
         batch_obs = execution_config.device_options.get("batch_obs", self._batch_obs)
         results = tuple(
-            simulate_and_jacobian(c, self._statevector, batch_obs=batch_obs) for c in circuits
+            simulate_and_jacobian(c, self._statevector, batch_obs=batch_obs, wire_map=self._wire_map) for c in circuits
         )
         return tuple(zip(*results))
 
@@ -686,7 +704,7 @@ class LightningQubit(Device):
         """
         batch_obs = execution_config.device_options.get("batch_obs", self._batch_obs)
         return tuple(
-            vjp(circuit, cots, self._statevector, batch_obs=batch_obs)
+            vjp(circuit, cots, self._statevector, batch_obs=batch_obs, wire_map=self._wire_map)
             for circuit, cots in zip(circuits, cotangents)
         )
 
@@ -708,7 +726,7 @@ class LightningQubit(Device):
         """
         batch_obs = execution_config.device_options.get("batch_obs", self._batch_obs)
         results = tuple(
-            simulate_and_vjp(circuit, cots, self._statevector, batch_obs=batch_obs)
+            simulate_and_vjp(circuit, cots, self._statevector, batch_obs=batch_obs, wire_map=self._wire_map)
             for circuit, cots in zip(circuits, cotangents)
         )
         return tuple(zip(*results))

--- a/tests/new_api/test_device.py
+++ b/tests/new_api/test_device.py
@@ -456,6 +456,26 @@ class TestExecution:
         assert np.allclose(result[0], np.cos(phi))
         assert np.allclose(result[1], np.cos(phi) * np.cos(theta))
 
+    @pytest.mark.parametrize("wires, wire_order", [(3, (0,1,2)), (("a", "b", "c"), ("a", "b", "c"))])
+    def test_probs_different_wire_orders(self, wires, wire_order):
+        """Test that measuring probabilities works with custom wires."""
+
+        dev = LightningDevice(wires=wires)
+
+        op = qml.Hadamard(wire_order[1])
+
+        tape = QuantumScript([op], [qml.probs(wires=(wire_order[0], wire_order[1]))])
+
+        res = dev.execute(tape)
+        assert qml.math.allclose(res, np.array([0.5, 0.5, 0.0, 0.0]))
+
+        tape2 = QuantumScript([op], [qml.probs(wires=(wire_order[1], wire_order[2]))])
+        res2 = dev.execute(tape2)
+        assert qml.math.allclose(res2, np.array([0.5, 0.0, 0.5, 0.0]))
+
+        tape3 = QuantumScript([op], [qml.probs(wires=(wire_order[1], wire_order[0]))])
+        res3 = dev.execute(tape3)
+        assert qml.math.allclose(res3, np.array([0.5, 0.0, 0.5, 0.0]))
 
 @pytest.mark.parametrize("batch_obs", [True, False])
 class TestDerivatives:

--- a/tests/new_api/test_device.py
+++ b/tests/new_api/test_device.py
@@ -456,7 +456,9 @@ class TestExecution:
         assert np.allclose(result[0], np.cos(phi))
         assert np.allclose(result[1], np.cos(phi) * np.cos(theta))
 
-    @pytest.mark.parametrize("wires, wire_order", [(3, (0,1,2)), (("a", "b", "c"), ("a", "b", "c"))])
+    @pytest.mark.parametrize(
+        "wires, wire_order", [(3, (0, 1, 2)), (("a", "b", "c"), ("a", "b", "c"))]
+    )
     def test_probs_different_wire_orders(self, wires, wire_order):
         """Test that measuring probabilities works with custom wires."""
 
@@ -476,6 +478,7 @@ class TestExecution:
         tape3 = QuantumScript([op], [qml.probs(wires=(wire_order[1], wire_order[0]))])
         res3 = dev.execute(tape3)
         assert qml.math.allclose(res3, np.array([0.5, 0.0, 0.5, 0.0]))
+
 
 @pytest.mark.parametrize("batch_obs", [True, False])
 class TestDerivatives:


### PR DESCRIPTION
**Context:**

We recently discovered an issue with wire ordering:
```
ops = [qml.RZ(0.64, 2), qml.Z(2), qml.S(2), qml.Hadamard(2)]

tape = qml.tape.QuantumScript(ops, [qml.probs(wires=[0,1,2])])

dev1 = qml.device("lightning.qubit", wires=3)
dev2 = qml.device("default.qubit", wires=3)
res1 = dev1.execute(tape)
res2 = dev2.execute(tape)
print(res1, res2)
```

Basically, we were using `QuantumScript.map_to_standard_wires`, which changed the wire order on the probability to `probs(wires=[1, 2, 0])`.  But becuase lightning cannot handle non-ascending wire orders, the wrong result came back without error.

Another PR wil fix the fact we can't handle `probs` in a non-ascending wire order, but this PR is eliminating the use of `map_to_standard_wires`. For lightning, we want to make sure to use the wire order specified on instantiation to give users more control over the simulation indices that will be used.

**Description of the Change:**

Switch use of `map_to_standard_wires` with `qml.map_wires` with a device wire map.

**Benefits:**

Better control over simulation indices.

**Possible Drawbacks:**

Unsure how to test this. The correct answer should be outputted regardless of the simulation indices used. The only real difference is how a user can control the performance of the simulation.  We may just leave this untested, as it continues to give correct results.

**Related GitHub Issues:**
