### PR TITLE
Add `default.tensor` to `setup.py`

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -16,7 +16,7 @@
   [(#686)](https://github.com/PennyLaneAI/pennylane-lightning/pull/686)  
 
 * Changed the name of `lightning.tensor` to `default.tensor` with the `quimb` backend.
-  [(#)]()
+  [(#719)](https://github.com/PennyLaneAI/pennylane-lightning/pull/719)
 
 ### Documentation
 
@@ -26,7 +26,7 @@
 
 This release contains contributions from (in alphabetical order):
 
-Amintor Dusko, Pietropaolo Frisoni, Vincent Michaud-Rioux
+Amintor Dusko, Pietropaolo Frisoni, Vincent Michaud-Rioux, Mudit Pandey
 
 ---
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -15,6 +15,9 @@
 * Add support for `qml.expval` and `qml.var` in the `lightning.tensor` device for the `quimb` interface and the MPS method.
   [(#686)](https://github.com/PennyLaneAI/pennylane-lightning/pull/686)  
 
+* Changed the name of `lightning.tensor` to `default.tensor` with the `quimb` backend.
+  [(#)]()
+
 ### Documentation
 
 ### Bug fixes

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.37.0-dev3"
+__version__ = "0.37.0-dev4"

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.37.0-dev4"
+__version__ = "0.37.0-dev5"

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.37.0-dev5"
+__version__ = "0.37.0-dev6"

--- a/pennylane_lightning/lightning_tensor/backends/quimb/_mps.py
+++ b/pennylane_lightning/lightning_tensor/backends/quimb/_mps.py
@@ -116,12 +116,12 @@ _observables = frozenset(
 
 
 def stopping_condition(op: qml.operation.Operator) -> bool:
-    """A function that determines if an operation is supported by ``lightning.tensor`` for this interface."""
+    """A function that determines if an operation is supported by ``default.tensor`` for this interface."""
     return op.name in _operations  # pragma: no cover
 
 
 def accepted_observables(obs: qml.operation.Operator) -> bool:
-    """A function that determines if an observable is supported by ``lightning.tensor`` for this interface."""
+    """A function that determines if an observable is supported by ``default.tensor`` for this interface."""
     return obs.name in _observables  # pragma: no cover
 
 

--- a/pennylane_lightning/lightning_tensor/lightning_tensor.py
+++ b/pennylane_lightning/lightning_tensor/lightning_tensor.py
@@ -111,7 +111,7 @@ class LightningTensor(Device):
             raise ValueError(f"Unsupported method: {method}")
 
         if shots is not None:
-            raise ValueError("LightningTensor does not support finite shots.")
+            raise ValueError("default.tensor does not support finite shots.")
 
         super().__init__(wires=wires, shots=shots)
 
@@ -143,13 +143,13 @@ class LightningTensor(Device):
         for arg in kwargs:
             if arg not in self._device_options:
                 raise TypeError(
-                    f"Unexpected argument: {arg} during initialization of the LightningTensor device."
+                    f"Unexpected argument: {arg} during initialization of the default.tensor device."
                 )
 
     @property
     def name(self):
         """The name of the device."""
-        return "lightning.tensor"
+        return "default.tensor"
 
     @property
     def num_wires(self):
@@ -266,7 +266,7 @@ class LightningTensor(Device):
             Tuple: The Jacobian for each trainable parameter.
         """
         raise NotImplementedError(
-            "The computation of derivatives has yet to be implemented for the lightning.tensor device."
+            "The computation of derivatives has yet to be implemented for the default.tensor device."
         )
 
     def execute_and_compute_derivatives(
@@ -284,7 +284,7 @@ class LightningTensor(Device):
             tuple: A numeric result of the computation and the gradient.
         """
         raise NotImplementedError(
-            "The computation of derivatives has yet to be implemented for the lightning.tensor device."
+            "The computation of derivatives has yet to be implemented for the default.tensor device."
         )
 
     # pylint: disable=unused-argument
@@ -323,7 +323,7 @@ class LightningTensor(Device):
             tensor-like: A numeric result of computing the vector-Jacobian product.
         """
         raise NotImplementedError(
-            "The computation of vector-Jacobian product has yet to be implemented for the lightning.tensor device."
+            "The computation of vector-Jacobian product has yet to be implemented for the default.tensor device."
         )
 
     def execute_and_compute_vjp(
@@ -344,5 +344,5 @@ class LightningTensor(Device):
             Tuple, Tuple: the result of executing the scripts and the numeric result of computing the vector-Jacobian product
         """
         raise NotImplementedError(
-            "The computation of vector-Jacobian product has yet to be implemented for the lightning.tensor device."
+            "The computation of vector-Jacobian product has yet to be implemented for the default.tensor device."
         )

--- a/pennylane_lightning/lightning_tensor/lightning_tensor.py
+++ b/pennylane_lightning/lightning_tensor/lightning_tensor.py
@@ -42,12 +42,12 @@ _methods = frozenset({"mps"})
 
 
 def accepted_backends(backend: str) -> bool:
-    """A function that determines whether or not a backend is supported by ``lightning.tensor``."""
+    """A function that determines whether or not a backend is supported by ``default.tensor``."""
     return backend in _backends
 
 
 def accepted_methods(method: str) -> bool:
-    """A function that determines whether or not a method is supported by ``lightning.tensor``."""
+    """A function that determines whether or not a method is supported by ``default.tensor``."""
     return method in _methods
 
 

--- a/setup.py
+++ b/setup.py
@@ -188,9 +188,6 @@ suffix = suffix[0].upper() + suffix[1:]
 
 pennylane_plugins = [device_name + " = pennylane_lightning." + backend + ":Lightning" + suffix]
 if suffix == "Qubit":
-    print(
-        "&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&"
-    )
     pennylane_plugins.append(
         "default.tensor = pennylane_lightning.lightning_tensor:LightningTensor"
     )

--- a/setup.py
+++ b/setup.py
@@ -177,7 +177,7 @@ requirements = [
 packages_list = ["pennylane_lightning." + backend]
 
 if backend == "lightning_qubit":
-    packages_list += ["pennylane_lightning.core"]
+    packages_list += ["pennylane_lightning.core", "pennylane_lightning.lightning_tensor"]
 else:
     requirements += ["pennylane_lightning==" + version]
 
@@ -226,7 +226,11 @@ if backend == "lightning_qubit":
                 "pennylane_lightning.core": [
                     os.path.join("src", "*"),
                     os.path.join("src", "**", "*"),
-                ]
+                ],
+                "pennylane_lightning.lightning_tensor": [
+                    os.path.join("backends", "*"),
+                    os.path.join("backends", "**", "*"),
+                ],
             },
         }
     )

--- a/setup.py
+++ b/setup.py
@@ -187,6 +187,13 @@ if suffix == "gpu":
 suffix = suffix[0].upper() + suffix[1:]
 
 pennylane_plugins = [device_name + " = pennylane_lightning." + backend + ":Lightning" + suffix]
+if suffix == "Qubit":
+    print(
+        "&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&"
+    )
+    pennylane_plugins.append(
+        "default.tensor = pennylane_lightning.lightning_tensor:LightningTensor"
+    )
 
 pkg_suffix = "" if suffix == "Qubit" else "_" + suffix
 

--- a/tests/lightning_tensor/test_lightning_tensor.py
+++ b/tests/lightning_tensor/test_lightning_tensor.py
@@ -64,14 +64,14 @@ def test_invalid_keyword_arg():
     """Test an invalid keyword argument."""
     with pytest.raises(
         TypeError,
-        match=f"Unexpected argument: fake_arg during initialization of the LightningTensor device.",
+        match=f"Unexpected argument: fake_arg during initialization of the default.tensor device.",
     ):
         LightningTensor(fake_arg=None)
 
 
 def test_invalid_shots():
     """Test that an error is raised if finite number of shots are requestd."""
-    with pytest.raises(ValueError, match="LightningTensor does not support finite shots."):
+    with pytest.raises(ValueError, match="default.tensor does not support finite shots."):
         LightningTensor(shots=5)
 
 
@@ -86,7 +86,7 @@ def test_compute_derivatives():
     dev = LightningTensor()
     with pytest.raises(
         NotImplementedError,
-        match="The computation of derivatives has yet to be implemented for the lightning.tensor device.",
+        match="The computation of derivatives has yet to be implemented for the default.tensor device.",
     ):
         dev.compute_derivatives(circuits=None)
 
@@ -96,7 +96,7 @@ def test_execute_and_compute_derivatives():
     dev = LightningTensor()
     with pytest.raises(
         NotImplementedError,
-        match="The computation of derivatives has yet to be implemented for the lightning.tensor device.",
+        match="The computation of derivatives has yet to be implemented for the default.tensor device.",
     ):
         dev.execute_and_compute_derivatives(circuits=None)
 
@@ -112,7 +112,7 @@ def test_compute_vjp():
     dev = LightningTensor()
     with pytest.raises(
         NotImplementedError,
-        match="The computation of vector-Jacobian product has yet to be implemented for the lightning.tensor device.",
+        match="The computation of vector-Jacobian product has yet to be implemented for the default.tensor device.",
     ):
         dev.compute_vjp(circuits=None, cotangents=None)
 
@@ -122,6 +122,6 @@ def test_execute_and_compute_vjp():
     dev = LightningTensor()
     with pytest.raises(
         NotImplementedError,
-        match="The computation of vector-Jacobian product has yet to be implemented for the lightning.tensor device.",
+        match="The computation of vector-Jacobian product has yet to be implemented for the default.tensor device.",
     ):
         dev.execute_and_compute_vjp(circuits=None, cotangents=None)

--- a/tests/lightning_tensor/test_lightning_tensor.py
+++ b/tests/lightning_tensor/test_lightning_tensor.py
@@ -37,13 +37,19 @@ def test_device_name_and_init(num_wires, c_dtype):
     """Test the class initialization and returned properties."""
     wires = Wires(range(num_wires)) if num_wires else None
     dev = LightningTensor(wires=wires, c_dtype=c_dtype)
-    assert dev.name == "lightning.tensor"
+    assert dev.name == "default.tensor"
     assert dev.c_dtype == c_dtype
     assert dev.wires == wires
     if num_wires is None:
         assert dev.num_wires == 0
     else:
         assert dev.num_wires == num_wires
+
+
+def test_device_available_as_plugin():
+    """Test that the device can be instantiated using ``qml.device``."""
+    dev = qml.device("default.tensor", wires=2)
+    assert isinstance(dev, LightningTensor)
 
 
 @pytest.mark.parametrize("backend", ["fake_backend"])


### PR DESCRIPTION
As name says.

* `default.tensor` is the updated name of the tensor network device with the `quimb` backend. The new change installs it along with `lightning.qubit` as there are no non-python dependencies to get the device to work.
* Updated the device's `name` attribute to return `default.tensor` instead of `lightning.tensor`.
* Updated the errors raised by the device to use `default.tensor` instead of `LightningTensor` or `lightning.tensor`.
