### PR TITLE
Update MCM measurements as dynamic_one_shot handles post-selection

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Breaking changes
 
+* `dynamic_one_shot` deals with post-selection during the post-processing phase, so Lightning-Qubit does not return `None`-valued measurements for mismatching samples anymore.
+  [(#720)](https://github.com/PennyLaneAI/pennylane-lightning/pull/720)
+  
 ### Improvements
 
 * The various OpenMP configurations of Lightning-Qubit are tested in parallel on different Github Actions runners.

--- a/.github/workflows/tests_lgpu_python.yml
+++ b/.github/workflows/tests_lgpu_python.yml
@@ -15,6 +15,7 @@ on:
     paths-ignore:
       - .github
       - '!.github/workflows/tests_lgpu_python.yml'
+      - pennylane_lightning/core/_version.py
       - pennylane_lightning/core/src/simulators/lightning_kokkos/**
       - pennylane_lightning/core/src/simulators/lightning_qubit/**
       - pennylane_lightning/lightning_kokkos/**

--- a/.github/workflows/tests_lgpumpi_python.yml
+++ b/.github/workflows/tests_lgpumpi_python.yml
@@ -18,6 +18,7 @@ on:
     paths-ignore:
       - .github
       - '!.github/workflows/tests_lgpumpi_python.yml'
+      - pennylane_lightning/core/_version.py
       - pennylane_lightning/core/src/simulators/lightning_kokkos/**
       - pennylane_lightning/core/src/simulators/lightning_qubit/**
       - pennylane_lightning/lightning_kokkos/**

--- a/.github/workflows/tests_lkcpu_python.yml
+++ b/.github/workflows/tests_lkcpu_python.yml
@@ -14,9 +14,10 @@ on:
     paths-ignore:
       - .github
       - '!.github/workflows/tests_lkcpu_python.yml'
+      - pennylane_lightning/core/_version.py
       - pennylane_lightning/core/src/simulators/lightning_gpu/**
-      - pennylane_lightning/lightning_gpu/**
       - pennylane_lightning/core/src/simulators/lightning_qubit/**
+      - pennylane_lightning/lightning_gpu/**
       - pennylane_lightning/lightning_qubit/**
   push:
     branches:

--- a/.github/workflows/tests_lkcuda_python.yml
+++ b/.github/workflows/tests_lkcuda_python.yml
@@ -14,6 +14,7 @@ on:
     paths-ignore:
       - .github
       - '!.github/workflows/tests_lkcuda_python.yml'
+      - pennylane_lightning/core/_version.py
       - pennylane_lightning/core/src/simulators/lightning_gpu/**
       - pennylane_lightning/core/src/simulators/lightning_qubit/**
       - pennylane_lightning/lightning_gpu/**

--- a/.github/workflows/tests_lqcpu_python.yml
+++ b/.github/workflows/tests_lqcpu_python.yml
@@ -14,6 +14,7 @@ on:
     paths-ignore:
       - .github
       - '!.github/workflows/tests_lqcpu_python.yml'
+      - pennylane_lightning/core/_version.py
       - pennylane_lightning/core/src/simulators/lightning_gpu/**
       - pennylane_lightning/lightning_gpu/**
       - pennylane_lightning/core/src/simulators/lightning_kokkos/**

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.37.0-dev4"
+__version__ = "0.37.0-dev5"

--- a/pennylane_lightning/lightning_kokkos/lightning_kokkos.py
+++ b/pennylane_lightning/lightning_kokkos/lightning_kokkos.py
@@ -393,9 +393,6 @@ class LightningKokkos(LightningBase):
         wires = self.wires.indices(operation.wires)
         wire = list(wires)[0]
         sample = qml.math.reshape(self.generate_samples(shots=1), (-1,))[wire]
-        if operation.postselect is not None and sample != operation.postselect:
-            mid_measurements[operation] = -1
-            return
         mid_measurements[operation] = sample
         getattr(self.state_vector, "collapse")(wire, bool(sample))
         if operation.reset and bool(sample):
@@ -482,8 +479,6 @@ class LightningKokkos(LightningBase):
                 )
 
         self.apply_lightning(operations, mid_measurements=mid_measurements)
-        if mid_measurements is not None and any(v == -1 for v in mid_measurements.values()):
-            self._apply_basis_state(np.zeros(self.num_wires), wires=self.wires)
 
     # pylint: disable=protected-access
     def expval(self, observable, shot_range=None, bin_size=None):

--- a/pennylane_lightning/lightning_qubit/_measurements.py
+++ b/pennylane_lightning/lightning_qubit/_measurements.py
@@ -307,17 +307,10 @@ class LightningMeasurements:
         """
         # last N measurements are sampling MCMs in ``dynamic_one_shot`` execution mode
         mps = measurements[0 : -len(mid_measurements)] if mid_measurements else measurements
-        skip_measure = (
-            any(v == -1 for v in mid_measurements.values()) if mid_measurements else False
-        )
-
         groups, indices = _group_measurements(mps)
 
         all_res = []
         for group in groups:
-            if skip_measure:
-                all_res.extend([None] * len(group))
-                continue
             if isinstance(group[0], (ExpectationMP, VarianceMP)) and isinstance(
                 group[0].obs, SparseHamiltonian
             ):


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [x] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [x] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [ ] Ensure that the test suite passes, by running `make test`.

- [x] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [x] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**
`dynamic_one_shot` deals with post-selection during the post-processing phase.

**Description of the Change:**
Lightning-Qubit does not return `None`-valued measurements for mismatching samples anymore.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-62954]