### PR TITLE
Pin autoray < 0.6.10

### DIFF
--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.37.0-dev8"
+__version__ = "0.37.0-dev9"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -19,4 +19,5 @@ cmake
 custatevec-cu12
 pylint
 scipy~=1.12.0
+autoray<0.6.10
 git+https://github.com/jcmgray/quimb.git

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -4,4 +4,5 @@ pytest-cov
 pytest-mock
 pytest-xdist
 flaky
+autoray<0.6.10
 git+https://github.com/PennyLaneAI/pennylane.git@master

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pytest-cov
 pytest-mock
 scipy
 pytest-xdist
+autoray<0.6.10


### PR DESCRIPTION
CIs currently are failing due to https://github.com/jcmgray/autoray/pull/23, we pin to the previous version to pass CIs.