### PR TITLE
Fix ambiguous function overload with newer compiler when using streaming AVX ops

### DIFF
--- a/pennylane_lightning/core/src/simulators/lightning_qubit/gates/cpu_kernels/avx_common/AVX2Concept.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_qubit/gates/cpu_kernels/avx_common/AVX2Concept.hpp
@@ -56,6 +56,18 @@ template <typename T> struct AVX2Concept {
     }
 
     PL_FORCE_INLINE
+    static auto load(const PrecisionT *p) -> IntrinsicType {
+        if constexpr (std::is_same_v<PrecisionT, float>) {
+            return _mm256_load_ps(p);
+        } else if (std::is_same_v<PrecisionT, double>) {
+            return _mm256_load_pd(p);
+        } else {
+            static_assert(std::is_same_v<PrecisionT, float> ||
+                          std::is_same_v<PrecisionT, double>);
+        }
+    }
+
+    PL_FORCE_INLINE
     static auto loadu(const std::complex<PrecisionT> *p) -> IntrinsicType {
         if constexpr (std::is_same_v<PrecisionT, float>) {
             return _mm256_loadu_ps(reinterpret_cast<const PrecisionT *>(p));
@@ -85,6 +97,18 @@ template <typename T> struct AVX2Concept {
             _mm256_store_ps(reinterpret_cast<PrecisionT *>(p), value);
         } else if (std::is_same_v<PrecisionT, double>) {
             _mm256_store_pd(reinterpret_cast<PrecisionT *>(p), value);
+        } else {
+            static_assert(std::is_same_v<PrecisionT, float> ||
+                          std::is_same_v<PrecisionT, double>);
+        }
+    }
+
+    PL_FORCE_INLINE
+    static void store_(PrecisionT *p, IntrinsicType value) {
+        if constexpr (std::is_same_v<PrecisionT, float>) {
+            _mm256_store_ps(p, value);
+        } else if (std::is_same_v<PrecisionT, double>) {
+            _mm256_store_pd(p, value);
         } else {
             static_assert(std::is_same_v<PrecisionT, float> ||
                           std::is_same_v<PrecisionT, double>);

--- a/pennylane_lightning/core/src/simulators/lightning_qubit/gates/cpu_kernels/avx_common/AVX512Concept.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_qubit/gates/cpu_kernels/avx_common/AVX512Concept.hpp
@@ -47,6 +47,17 @@ template <typename T> struct AVX512Concept {
     PL_FORCE_INLINE
     static auto load(std::complex<PrecisionT> *p) -> IntrinsicType {
         if constexpr (std::is_same_v<PrecisionT, float>) {
+            return _mm512_load_ps(reinterpret_cast<PrecisionT *>(p));
+        } else if (std::is_same_v<PrecisionT, double>) {
+            return _mm512_load_pd(reinterpret_cast<PrecisionT *>(p));
+        } else {
+            static_assert(std::is_same_v<PrecisionT, float> ||
+                          std::is_same_v<PrecisionT, double>);
+        }
+    }
+    PL_FORCE_INLINE
+    static auto load(PrecisionT *p) -> IntrinsicType {
+        if constexpr (std::is_same_v<PrecisionT, float>) {
             return _mm512_load_ps(p);
         } else if (std::is_same_v<PrecisionT, double>) {
             return _mm512_load_pd(p);
@@ -59,9 +70,9 @@ template <typename T> struct AVX512Concept {
     PL_FORCE_INLINE
     static auto loadu(std::complex<PrecisionT> *p) -> IntrinsicType {
         if constexpr (std::is_same_v<PrecisionT, float>) {
-            return _mm512_loadu_ps(p);
+            return _mm512_loadu_ps(reinterpret_cast<PrecisionT *>(p));
         } else if (std::is_same_v<PrecisionT, double>) {
-            return _mm512_loadu_pd(p);
+            return _mm512_loadu_pd(reinterpret_cast<PrecisionT *>(p));
         } else {
             static_assert(std::is_same_v<PrecisionT, float> ||
                           std::is_same_v<PrecisionT, double>);
@@ -83,6 +94,18 @@ template <typename T> struct AVX512Concept {
     PL_FORCE_INLINE
     static void store_(std::complex<PrecisionT> *p, IntrinsicType value) {
         if constexpr (std::is_same_v<PrecisionT, float>) {
+            _mm512_store_ps(reinterpret_cast<PrecisionT *>(p), value);
+        } else if (std::is_same_v<PrecisionT, double>) {
+            _mm512_store_pd(reinterpret_cast<PrecisionT *>(p), value);
+        } else {
+            static_assert(std::is_same_v<PrecisionT, float> ||
+                          std::is_same_v<PrecisionT, double>);
+        }
+    }
+
+    PL_FORCE_INLINE
+    static void store_(PrecisionT *p, IntrinsicType value) {
+        if constexpr (std::is_same_v<PrecisionT, float>) {
             _mm512_store_ps(p, value);
         } else if (std::is_same_v<PrecisionT, double>) {
             _mm512_store_pd(p, value);
@@ -95,9 +118,9 @@ template <typename T> struct AVX512Concept {
     PL_FORCE_INLINE
     static void stream_(std::complex<PrecisionT> *p, IntrinsicType value) {
         if constexpr (std::is_same_v<PrecisionT, float>) {
-            _mm512_stream_ps(p, value);
+            _mm512_stream_ps(reinterpret_cast<PrecisionT *>(p), value);
         } else if (std::is_same_v<PrecisionT, double>) {
-            _mm512_stream_pd(p, value);
+            _mm512_stream_pd(reinterpret_cast<PrecisionT *>(p), value);
         } else {
             static_assert(std::is_same_v<PrecisionT, float> ||
                           std::is_same_v<PrecisionT, double>);
@@ -118,7 +141,11 @@ template <typename T> struct AVX512Concept {
 
     PL_FORCE_INLINE
     static void store(std::complex<PrecisionT> *p, IntrinsicType value) {
-        store(reinterpret_cast<PrecisionT *>(p), value);
+#ifdef PL_LQ_KERNEL_AVX_STREAMING
+        store_(reinterpret_cast<PrecisionT *>(p), value);
+#else
+        stream_(reinterpret_cast<PrecisionT *>(p), value);
+#endif
     }
 
     PL_FORCE_INLINE


### PR DESCRIPTION
…ing ops

### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [ ] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [ ] Ensure that the test suite passes, by running `make test`.

- [ ] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [ ] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:** This PR fixes an issue with failed overload acceptance using newer GCC toolchains.

**Description of the Change:** Adds more overloaded load/store/stream operations for the kernel definitions.

**Benefits:** Supports newer GCC (13.2+)

**Possible Drawbacks:**

**Related GitHub Issues:**
