### PR TITLE
Fix PennyLane LightningKokkos and LightningQubits tests for stable/stable

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -23,7 +23,7 @@
 
 * Lightning-Kokkos' functors are rewritten as functions wrapping around generic gate and generator functors templated over a coefficient interaction function. This reduces boilerplate while clarifying how the various kernels differ from one another.
   [(#640)](https://github.com/PennyLaneAI/pennylane-lightning/pull/640)
-  
+
 * Update C++ and Python GitHub actions names to include the matrix info.
   [(#717)](https://github.com/PennyLaneAI/pennylane-lightning/pull/717)
 
@@ -48,6 +48,9 @@
 
 * The `.github/workflows/tests_lkcpu_python.yml` workflow properly checks out the release or stable version of Lightning-Qubit during the test job.
   [(#723)](https://github.com/PennyLaneAI/pennylane-lightning/pull/723)
+
+* Fix PennyLane LightningKokkos and LightningQubit tests for stable/stable configuration;
+  [(#734)](https://github.com/PennyLaneAI/pennylane-lightning/pull/734)
 
 ### Contributors
 

--- a/.github/workflows/build_and_cache_Kokkos_linux.yml
+++ b/.github/workflows/build_and_cache_Kokkos_linux.yml
@@ -12,11 +12,15 @@ on:
       runs_on:
         description: |
           The runner that should run the jobs. If left blank, the value from inputs.os is used.
-          This is useful if you want the jobs to run in a specific runner group, while not using that group name as part 
+          This is useful if you want the jobs to run in a specific runner group, while not using that group name as part
           of the cache key.
         required: false
         type: string
         default: ''
+      kokkos_version:
+        required: false
+        type: string
+        default: 4.3.01
     outputs:
       exec_model:
         description: "The execution model for Kokkos."
@@ -37,7 +41,7 @@ jobs:
 
       - name: Kokkos version
         id: kokkos_version
-        run: echo "kokkos_version=[\"4.3.01\"]" >> $GITHUB_OUTPUT
+        run: echo "kokkos_version=[\"${{ inputs.kokkos_version }}\"]" >> $GITHUB_OUTPUT
 
     outputs:
       exec_model: ${{ steps.exec_model.outputs.exec_model }}

--- a/.github/workflows/tests_lgpu_python.yml
+++ b/.github/workflows/tests_lgpu_python.yml
@@ -101,7 +101,7 @@ jobs:
         run: |
           cd main
           git fetch --tags --force
-          git checkout $(git tag | sort -V | tail -1)
+          git checkout latest_release
 
       - uses: actions/setup-python@v5
         name: Install Python

--- a/.github/workflows/tests_lgpumpi_cpp.yml
+++ b/.github/workflows/tests_lgpumpi_cpp.yml
@@ -58,7 +58,7 @@ jobs:
         if: inputs.lightning-version == 'stable'
         run: |
           git fetch tags --force
-          git checkout $(git tag | sort -V | tail -1)
+          git checkout latest_release
       - uses: actions/setup-python@v5
         id: setup_python
         name: Install Python
@@ -191,4 +191,3 @@ jobs:
           rm -rf ${{ steps.setup_venv.outputs.venv_name }}
           rm -rf * .git .gitignore .github
           pip cache purge
-

--- a/.github/workflows/tests_lgpumpi_python.yml
+++ b/.github/workflows/tests_lgpumpi_python.yml
@@ -67,7 +67,7 @@ jobs:
         if: inputs.lightning-version == 'stable'
         run: |
           git fetch --tags --force
-          git checkout $(git tag | sort -V | tail -1)
+          git checkout latest_release
 
 
       # Since the self-hosted runner can be re-used. It is best to set up all package

--- a/.github/workflows/tests_lkcpu_python.yml
+++ b/.github/workflows/tests_lkcpu_python.yml
@@ -48,6 +48,7 @@ jobs:
     uses: ./.github/workflows/build_and_cache_Kokkos_linux.yml
     with:
       os: ubuntu-22.04
+      kokkos_version: ${{ inputs.lightning-version == 'latest' && '4.2.00' || '4.3.01' }}
 
   build_lightning_kokkos_wheels:
     needs: [determine_runner, build_and_cache_Kokkos]
@@ -168,7 +169,7 @@ jobs:
           fetch-tags: true
           path: main
 
-      - name: Switch to release build of Lightning
+      - name: Switch to release tag of Lightning
         if: inputs.lightning-version == 'release'
         run: |
           cd main
@@ -179,6 +180,16 @@ jobs:
         if: inputs.lightning-version == 'stable'
         run: |
           python -m pip install -U pennylane-lightning --no-deps
+
+      - name: Switch to stable tag of Lightning
+        if: inputs.lightning-version == 'stable'
+        run: |
+          cd main
+          git fetch --tags --force
+          git checkout $(git tag | sort -V | tail -1)
+          git log -1 --format='%H'
+          git status
+
 
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/tests_lkcpu_python.yml
+++ b/.github/workflows/tests_lkcpu_python.yml
@@ -48,7 +48,7 @@ jobs:
     uses: ./.github/workflows/build_and_cache_Kokkos_linux.yml
     with:
       os: ubuntu-22.04
-      kokkos_version: ${{ inputs.lightning-version == 'latest' && '4.2.00' || '4.3.01' }}
+      kokkos_version: ${{ inputs.lightning-version == 'stable' && '4.2.00' || '4.3.01' }}
 
   build_lightning_kokkos_wheels:
     needs: [determine_runner, build_and_cache_Kokkos]

--- a/.github/workflows/tests_lkcpu_python.yml
+++ b/.github/workflows/tests_lkcpu_python.yml
@@ -81,7 +81,7 @@ jobs:
         run: |
           cd main
           git fetch --tags --force
-          git checkout $(git tag | sort -V | tail -1)
+          git checkout latest_release
           git log -1 --format='%H'
           git status
 
@@ -186,7 +186,7 @@ jobs:
         run: |
           cd main
           git fetch --tags --force
-          git checkout $(git tag | sort -V | tail -1)
+          git checkout latest_release
           git log -1 --format='%H'
           git status
 

--- a/.github/workflows/tests_lkcpu_python.yml
+++ b/.github/workflows/tests_lkcpu_python.yml
@@ -48,7 +48,7 @@ jobs:
     uses: ./.github/workflows/build_and_cache_Kokkos_linux.yml
     with:
       os: ubuntu-22.04
-      kokkos_version: ${{ inputs.lightning-version == 'stable' && '4.2.00' || '4.3.01' }}
+      kokkos_version: ${{ inputs.lightning-version == 'stable' && '4.2.00' || '4.3.01' }} #To be updated next Release.
 
   build_lightning_kokkos_wheels:
     needs: [determine_runner, build_and_cache_Kokkos]

--- a/.github/workflows/tests_lkcuda_python.yml
+++ b/.github/workflows/tests_lkcuda_python.yml
@@ -46,7 +46,7 @@ jobs:
       matrix:
         os: [ubuntu-22.04]
         exec_model: ["CUDA"]
-        kokkos_version: ["4.3.01"]
+        kokkos_version: ["${{ inputs.lightning-version == 'stable' && '4.2.00' || '4.3.01' }}"] #To be updated next Release.
 
     steps:
       - name: Validate GPU version and installed compiler
@@ -110,7 +110,7 @@ jobs:
         os: [ubuntu-22.04]
         pl_backend: ["lightning_kokkos", "all"]
         exec_model: ["CUDA"]
-        kokkos_version: ["4.3.01"]
+        kokkos_version: ["${{ inputs.lightning-version == 'stable' && '4.2.00' || '4.3.01' }}"] #To be updated next Release.
 
     name: Python Tests (${{ matrix.pl_backend }}, kokkos-${{ matrix.kokkos_version }}, model-${{ matrix.exec_model }})
     runs-on:

--- a/.github/workflows/tests_lkcuda_python.yml
+++ b/.github/workflows/tests_lkcuda_python.yml
@@ -161,7 +161,7 @@ jobs:
         run: |
           cd main
           git fetch --tags --force
-          git checkout $(git tag | sort -V | tail -1)
+          git checkout latest_release
           git log -1 --format='%H'
           git status
 

--- a/.github/workflows/tests_lqcpu_python.yml
+++ b/.github/workflows/tests_lqcpu_python.yml
@@ -179,13 +179,22 @@ jobs:
         if: inputs.pennylane-version == 'stable'
         run: |
           cd main
-          python -m pip uninstall -y pennylane && python -m pip install -U pennylane
+          python -m pip uninstall -y pennylane && python -m pip install -U pennylane --no-deps
 
       - name: Install ML libraries for interfaces
         run: |
           python -m pip install --upgrade torch==$TORCH_VERSION -f https://download.pytorch.org/whl/cpu/torch_stable.html
           python -m pip install --upgrade "jax[cpu]"  # This also installs jaxlib
           python -m pip install --upgrade tensorflow~=$TF_VERSION keras~=$TF_VERSION
+
+      - name: Switch to stable tag of Lightning
+        if: inputs.lightning-version == 'stable'
+        run: |
+          cd main
+          git fetch --tags --force
+          git checkout latest_release
+          git log -1 --format='%H'
+          git status
 
       - name: Run PennyLane-Lightning unit tests
         run: |

--- a/.github/workflows/tests_lqcpu_python.yml
+++ b/.github/workflows/tests_lqcpu_python.yml
@@ -76,7 +76,7 @@ jobs:
         run: |
           cd main
           git fetch --tags --force
-          git checkout $(git tag | sort -V | tail -1)
+          git checkout latest_release
           git log -1 --format='%H'
           git status
 

--- a/.github/workflows/tests_lqcpu_python.yml
+++ b/.github/workflows/tests_lqcpu_python.yml
@@ -158,7 +158,7 @@ jobs:
           mv ${{ github.workspace }}/wheel_${{ matrix.pl_backend }}-${{ matrix.blas }}.whl ${{ github.workspace }}/$WHEEL_NAME
           python -m pip install -r requirements-dev.txt
           python -m pip install openfermionpyscf
-          python -m pip install ${{ github.workspace }}/$WHEEL_NAME --no-deps
+          python -m pip install ${{ github.workspace }}/$WHEEL_NAME --no-deps --force-reinstall
 
       - name: Checkout PennyLane for release build
         if: inputs.pennylane-version == 'release'

--- a/.github/workflows/tests_without_binary.yml
+++ b/.github/workflows/tests_without_binary.yml
@@ -60,7 +60,7 @@ jobs:
         run: |
           cd main
           git fetch --tags --force
-          git checkout $(git tag | sort -V | tail -1)
+          git checkout latest_release
           git log -1 --format='%H'
           git status
 

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.37.0-dev14"
+__version__ = "0.37.0-dev15"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 pip~=22.0
-git+https://github.com/PennyLaneAI/pennylane.git@master
+# git+https://github.com/PennyLaneAI/pennylane.git@master
 ninja
 flaky
 pybind11

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 pip~=22.0
-# git+https://github.com/PennyLaneAI/pennylane.git@master
+git+https://github.com/PennyLaneAI/pennylane.git@master
 ninja
 flaky
 pybind11


### PR DESCRIPTION
**Context:** PennyLane LightningKokkos and LightningQubits tests for stable/stable configuration are currently failing.
This PR looks to solve these problems.

**Description of the Change:** 

The LightningKokkos and LightningQubits stable configurations (v0.36.0) were wrongly being tested with the most recent suite of tests.

PR #725 changed the default Kokkos version used by the LKokkos device. Currently, we build all wheels from scratch in our Plugin Test Matrix workflows, the sum of these two factors led me to expand our Kokkos caching functionality to build and cache any number of Kokkos versions. This is now configurable by an input variable `kokkos_version`.

I brought the change proposed by @vincentmr to this PR so we can have everything in a single place, to see if it is possible to merge it sooner than later.

**Benefits:** Tests are now right.

[sc-63561]