### PR TITLE
ISWAP Method Added

### DIFF
--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.37.0-dev16"
+__version__ = "0.37.0-dev17"

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.37.0-dev15"
+__version__ = "0.37.0-dev16"

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.37.0-dev14"
+__version__ = "0.37.0-dev15"

--- a/pennylane_lightning/core/src/gates/GateOperation.hpp
+++ b/pennylane_lightning/core/src/gates/GateOperation.hpp
@@ -44,6 +44,10 @@ enum class GateOperation : uint32_t {
     CY,
     CZ,
     SWAP,
+
+    /* iswap added */
+    ISWAP,
+
     IsingXX,
     IsingXY,
     IsingYY,
@@ -86,6 +90,10 @@ enum class ControlledGateOperation : uint32_t {
     Rot,
     /* Two-qubit gates */
     SWAP,
+
+    /* iswap added */
+    ISWAP,
+    
     IsingXX,
     IsingXY,
     IsingYY,

--- a/pennylane_lightning/core/src/simulators/lightning_qubit/gates/OpToMemberFuncPtr.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_qubit/gates/OpToMemberFuncPtr.hpp
@@ -155,12 +155,6 @@ struct GateOpToMemberFuncPtr<PrecisionT, ParamT, GateImplementation,
         &GateImplementation::template applyISWAP<PrecisionT>;
 };
 
-template <class PrecisionT, class ParamT, class GateImplementation>
-struct ControlledGateOpToMemberFuncPtr<PrecisionT, ParamT, GateImplementation,
-                                       ControlledGateOperation::ISWAP> {
-    constexpr static auto value =
-        &GateImplementation::template applyNCISWAP<PrecisionT>;
-};
 
 template <class PrecisionT, class ParamT, class GateImplementation>
 struct GateOpToMemberFuncPtr<PrecisionT, ParamT, GateImplementation,
@@ -360,6 +354,16 @@ struct ControlledGateOpToMemberFuncPtr<PrecisionT, ParamT, GateImplementation,
     constexpr static auto value =
         &GateImplementation::template applyNCSWAP<PrecisionT>;
 };
+
+/* iswap added */
+template <class PrecisionT, class ParamT, class GateImplementation>
+struct ControlledGateOpToMemberFuncPtr<PrecisionT, ParamT, GateImplementation,
+                                       ControlledGateOperation::ISWAP> {
+    constexpr static auto value =
+        &GateImplementation::template applyNCISWAP<PrecisionT>;
+};
+
+
 template <class PrecisionT, class ParamT, class GateImplementation>
 struct ControlledGateOpToMemberFuncPtr<PrecisionT, ParamT, GateImplementation,
                                        ControlledGateOperation::IsingXX> {

--- a/pennylane_lightning/core/src/simulators/lightning_qubit/gates/OpToMemberFuncPtr.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_qubit/gates/OpToMemberFuncPtr.hpp
@@ -146,6 +146,22 @@ struct GateOpToMemberFuncPtr<PrecisionT, ParamT, GateImplementation,
     constexpr static auto value =
         &GateImplementation::template applySWAP<PrecisionT>;
 };
+
+/* iswap added */
+template <class PrecisionT, class ParamT, class GateImplementation>
+struct GateOpToMemberFuncPtr<PrecisionT, ParamT, GateImplementation,
+                             GateOperation::ISWAP> {
+    constexpr static auto value =
+        &GateImplementation::template applyISWAP<PrecisionT>;
+};
+
+template <class PrecisionT, class ParamT, class GateImplementation>
+struct ControlledGateOpToMemberFuncPtr<PrecisionT, ParamT, GateImplementation,
+                                       ControlledGateOperation::ISWAP> {
+    constexpr static auto value =
+        &GateImplementation::template applyNCISWAP<PrecisionT>;
+};
+
 template <class PrecisionT, class ParamT, class GateImplementation>
 struct GateOpToMemberFuncPtr<PrecisionT, ParamT, GateImplementation,
                              GateOperation::IsingXX> {

--- a/pennylane_lightning/core/src/simulators/lightning_qubit/gates/cpu_kernels/GateImplementationsLM.cpp
+++ b/pennylane_lightning/core/src/simulators/lightning_qubit/gates/cpu_kernels/GateImplementationsLM.cpp
@@ -169,6 +169,16 @@ template void
 GateImplementationsLM::applySWAP<double>(std::complex<double> *, std::size_t,
                                          const std::vector<std::size_t> &,
                                          bool);
+
+/* iswap added */
+template void
+GateImplementationsLM::applyISWAP<float>(std::complex<float> *, std::size_t,
+                                        const std::vector<std::size_t> &, bool);
+template void
+GateImplementationsLM::applyISWAP<double>(std::complex<double> *, std::size_t,
+                                         const std::vector<std::size_t> &,
+                                         bool);
+
 template void GateImplementationsLM::applyCSWAP<float>(
     std::complex<float> *, std::size_t, const std::vector<std::size_t> &, bool);
 template void

--- a/pennylane_lightning/core/src/simulators/lightning_qubit/gates/tests/Test_GateImplementations_Nonparam.cpp
+++ b/pennylane_lightning/core/src/simulators/lightning_qubit/gates/tests/Test_GateImplementations_Nonparam.cpp
@@ -513,6 +513,96 @@ template <typename PrecisionT, class GateImplementation> void testApplySWAP() {
 }
 PENNYLANE_RUN_TEST(SWAP);
 
+/* iswap added */
+template <typename PrecisionT, class GateImplementation> void testApplyISWAP() {
+    using ComplexT = std::complex<PrecisionT>;
+    const size_t num_qubits = 3;
+    auto ini_st_aligned = createProductState<PrecisionT>(
+        "+10"); // Test using |+10> state using AlignedAllocator
+    std::vector<ComplexT> ini_st{
+        ini_st_aligned.begin(),
+        ini_st_aligned
+            .end()}; // Converted aligned data to default vector alignment
+
+    CHECK(ini_st ==
+          std::vector<ComplexT>{ZERO<PrecisionT>(), ZERO<PrecisionT>(),
+                                INVSQRT2<PrecisionT>(), ZERO<PrecisionT>(),
+                                ZERO<PrecisionT>(), ZERO<PrecisionT>(),
+                                INVSQRT2<PrecisionT>(), ZERO<PrecisionT>()});
+
+    DYNAMIC_SECTION(GateImplementation::name
+                    << ", ISWAP 0,1 |+10> -> i|1+0> - "
+                    << PrecisionToName<PrecisionT>::value){
+
+        std::vector<ComplexT> expected{
+            ZERO<PrecisionT>(),
+            ZERO<PrecisionT>(),
+            ZERO<PrecisionT>(),
+            ZERO<PrecisionT>(),
+            std::complex<PrecisionT>(0, INVSQRT2<PrecisionT>()),
+            ZERO<PrecisionT>(),
+            std::complex<PrecisionT>(INVSQRT2<PrecisionT>(), 0),
+            ZERO<PrecisionT>() };
+
+        auto sv01 = ini_st;
+        auto sv10 = ini_st;
+
+        GateImplementation::applyISWAP(sv01.data(), num_qubits, {0, 1}, false);
+        GateImplementation::applyISWAP(sv10.data(), num_qubits, {1, 0}, false);
+
+        CHECK(sv01 == expected);
+        CHECK(sv10 == expected);
+    }
+
+    DYNAMIC_SECTION(GateImplementation::name
+                    << ", SWAP0,2 |+10> -> i|01+> - "
+                    << PrecisionToName<PrecisionT>::value) {
+        std::vector<ComplexT> expected{
+            ZERO<PrecisionT>(),
+            ZERO<PrecisionT>(),
+            std::complex<PrecisionT>(INVSQRT2<PrecisionT>(), 0),
+            std::complex<PrecisionT>(0, INVSQRT2<PrecisionT>()),
+            ZERO<PrecisionT>(),
+            ZERO<PrecisionT>(),
+            ZERO<PrecisionT>(),
+            ZERO<PrecisionT>()};
+
+        auto sv02 = ini_st;
+        auto sv20 = ini_st;
+
+        GateImplementation::applyISWAP(sv02.data(), num_qubits, {0, 2}, false);
+        GateImplementation::applyISWAP(sv20.data(), num_qubits, {2, 0}, false);
+
+        CHECK(sv02 == expected);
+        CHECK(sv20 == expected);
+    }
+
+    DYNAMIC_SECTION(GateImplementation::name
+                    << ", SWAP1,2 |+10> ->i |+01> - "
+                    << PrecisionToName<PrecisionT>::value) {
+        std::vector<ComplexT> expected{
+            ZERO<PrecisionT>(),
+            std::complex<PrecisionT>(0, INVSQRT2<PrecisionT>()),
+            ZERO<PrecisionT>(),
+            ZERO<PrecisionT>(),
+            ZERO<PrecisionT>(),
+            std::complex<PrecisionT>(0, INVSQRT2<PrecisionT>()),
+            ZERO<PrecisionT>(),
+            ZERO<PrecisionT>()};
+
+        auto sv12 = ini_st;
+        auto sv21 = ini_st;
+
+        GateImplementation::applyISWAP(sv12.data(), num_qubits, {1, 2}, false);
+        GateImplementation::applyISWAP(sv21.data(), num_qubits, {2, 1}, false);
+
+        CHECK(sv12 == expected);
+        CHECK(sv21 == expected);
+    }
+
+}
+PENNYLANE_RUN_TEST(ISWAP);
+
 /*******************************************************************************
  * Three-qubit gates
  ******************************************************************************/

--- a/pennylane_lightning/core/src/utils/config.h
+++ b/pennylane_lightning/core/src/utils/config.h
@@ -17,7 +17,8 @@
  * Config file for the path to scipy.libs at compile time.
  */
 
+
 #ifndef CONFIG_H
 #define CONFIG_H
-#define SCIPY_LIBS_PATH ""
+#define SCIPY_LIBS_PATH "/home/xanadu_test/anaconda3/envs/xanadu/lib/python3.11/site-packages/scipy.libs"
 #endif

--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -386,6 +386,9 @@ def test_controlled_qubit_unitary(n_qubits, control_value, tol):
         qml.RZ,
         qml.Rot,
         qml.SWAP,
+        
+        # iswap added
+        qml.ISWAP,
         qml.IsingXX,
         qml.IsingXY,
         qml.IsingYY,


### PR DESCRIPTION
**Context:**
I conducted this ISWAP addition as part of the Xanadu applicant coding test. The following is the ISWAP repository that I added and verified.

**Description of the Change:**
I implemented handling for 7 bullets in the issue, enabling the ISWAP gate, which was not previously available, for use in PennyLane Lightning.

**Benefits:**
Even now, due to Lightning's nature, unnecessary computations are minimized, resulting in significant speed improvements. Furthermore, I will describe a method for achieving even faster execution using parallel programming in Bullet 4. We are limited to processing only one SWAP operation at a time using a single thread. However, by employing multiple threads, we can pair them up without overlap, allowing for the simultaneous update of two states. 

**Possible Drawbacks:**
The most crucial factor is how far apart the memory is. If the memory gap is significant (which occurs when the indices of the qubits to swap are large), there will be a larger difference in memory addresses accessed by each thread. This means that the memory accessed by all multiple threads will be located in different spaces. This will be the most significant difference.

**Related GitHub Issues:**
Nothing at the moment.