### PR TITLE
Add support for C(BlockEncode)

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -8,6 +8,9 @@
 * Add `cutensornet` backed `MPS` C++ layer to `lightning.tensor`.
   [(#704)](https://github.com/PennyLaneAI/pennylane-lightning/pull/704)
 
+* Add support for `C(BlockEncode)` in Lightning devices.
+  [(#)]()
+
 ### Breaking changes
 
 * Removed the `QuimbMPS` class and the corresponding interface/backend from `lightning.tensor`.

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -8,8 +8,8 @@
 * Add `cutensornet` backed `MPS` C++ layer to `lightning.tensor`.
   [(#704)](https://github.com/PennyLaneAI/pennylane-lightning/pull/704)
 
-* Add support for `C(BlockEncode)` in Lightning devices.
-  [(#)]()
+* Add support for `C(BlockEncode)` to Lightning devices.
+  [(#743)](https://github.com/PennyLaneAI/pennylane-lightning/pull/743)
 
 ### Breaking changes
 

--- a/.github/workflows/tests_lkcpu_python.yml
+++ b/.github/workflows/tests_lkcpu_python.yml
@@ -246,7 +246,7 @@ jobs:
           python -m pip install pytest-xdist
           cd main/
           DEVICENAME=`echo ${{ matrix.pl_backend }} | sed "s/_/./g"`
-            PL_DEVICE=${DEVICENAME} python -m pytest tests/ --exitfirst $COVERAGE_FLAGS --splits 7 --group ${{ matrix.group }} \
+            PL_DEVICE=${DEVICENAME} python -m pytest tests/ $COVERAGE_FLAGS --splits 7 --group ${{ matrix.group }} \
               --store-durations --durations-path='.github/workflows/python_lightning_kokkos_test_durations.json' --splitting-algorithm=least_duration
             mv .github/workflows/python_lightning_kokkos_test_durations.json ${{ github.workspace }}/.test_durations-${{ matrix.exec_model }}-${{ matrix.group }}
           pl-device-test --device ${DEVICENAME} --skip-ops --shots=20000 $COVERAGE_FLAGS --cov-append

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.37.0-dev20"
+__version__ = "0.37.0-dev21"

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.37.0-dev23"
+__version__ = "0.37.0-dev24"

--- a/pennylane_lightning/lightning_gpu/lightning_gpu.py
+++ b/pennylane_lightning/lightning_gpu/lightning_gpu.py
@@ -174,6 +174,7 @@ allowed_operations = {
     "QFT",
     "ECR",
     "BlockEncode",
+    "C(BlockEncode)",
 }
 
 allowed_observables = {

--- a/pennylane_lightning/lightning_gpu/lightning_gpu.toml
+++ b/pennylane_lightning/lightning_gpu/lightning_gpu.toml
@@ -58,7 +58,8 @@ MultiControlledX       = {}
 # Gates which should be translated to QubitUnitary
 [operators.gates.matrix]
 
-
+BlockEncode            = {properties = [ "controllable" ]}
+'C(GlobalPhase)'       = {}
 ControlledQubitUnitary = {}
 ECR                    = {}
 SX                     = {}
@@ -70,7 +71,6 @@ OrbitalRotation        = {}
 QubitCarry             = {}
 QubitSum               = {}
 DiagonalQubitUnitary   = {}
-BlockEncode            = {}
 
 # Observables supported by the device
 [operators.observables]

--- a/pennylane_lightning/lightning_gpu/lightning_gpu.toml
+++ b/pennylane_lightning/lightning_gpu/lightning_gpu.toml
@@ -59,7 +59,7 @@ MultiControlledX       = {}
 [operators.gates.matrix]
 
 BlockEncode            = {properties = [ "controllable" ]}
-'C(GlobalPhase)'       = {}
+GlobalPhase            = {properties = [ "controllable" ]}
 ControlledQubitUnitary = {}
 ECR                    = {}
 SX                     = {}

--- a/pennylane_lightning/lightning_kokkos/lightning_kokkos.py
+++ b/pennylane_lightning/lightning_kokkos/lightning_kokkos.py
@@ -131,6 +131,7 @@ allowed_operations = {
     "QFT",
     "ECR",
     "BlockEncode",
+    "C(BlockEncode)",
 }
 
 allowed_observables = {

--- a/pennylane_lightning/lightning_kokkos/lightning_kokkos.toml
+++ b/pennylane_lightning/lightning_kokkos/lightning_kokkos.toml
@@ -58,7 +58,8 @@ StatePrep              = {}
 # Gates which should be translated to QubitUnitary
 [operators.gates.matrix]
 
-BlockEncode            = {}
+BlockEncode            = {properties = [ "controllable" ]}
+'C(GlobalPhase)'       = {}
 DiagonalQubitUnitary   = {}
 ECR                    = {}
 ISWAP                  = {}

--- a/pennylane_lightning/lightning_kokkos/lightning_kokkos.toml
+++ b/pennylane_lightning/lightning_kokkos/lightning_kokkos.toml
@@ -59,7 +59,7 @@ StatePrep              = {}
 [operators.gates.matrix]
 
 BlockEncode            = {properties = [ "controllable" ]}
-'C(GlobalPhase)'       = {}
+GlobalPhase            = {properties = [ "controllable" ]}
 DiagonalQubitUnitary   = {}
 ECR                    = {}
 ISWAP                  = {}

--- a/pennylane_lightning/lightning_qubit/lightning_qubit.py
+++ b/pennylane_lightning/lightning_qubit/lightning_qubit.py
@@ -289,6 +289,7 @@ _operations = frozenset(
         "QFT",
         "ECR",
         "BlockEncode",
+        "C(BlockEncode)",
     }
 )
 # The set of supported operations.

--- a/pennylane_lightning/lightning_qubit/lightning_qubit.toml
+++ b/pennylane_lightning/lightning_qubit/lightning_qubit.toml
@@ -53,7 +53,7 @@ QFT                    = {}
 # Gates which should be translated to QubitUnitary
 [operators.gates.matrix]
 
-BlockEncode            = {}
+BlockEncode            = {properties = [ "controllable" ]}
 DiagonalQubitUnitary   = {}
 ECR                    = {}
 ISWAP                  = {}

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -1262,29 +1262,38 @@ class TestLightningDeviceIntegration:
         assert np.allclose(res_sv, expected_sv, atol=tol, rtol=0)
         assert np.allclose(res_probs, expected_prob, atol=tol, rtol=0)
 
+    # Check the BlockEncode PennyLane page for details:
+    # https://docs.pennylane.ai/en/stable/code/api/pennylane.BlockEncode.html
     @pytest.mark.parametrize(
-        "op",
+        "op, op_wires",
         [
-            qml.BlockEncode,
-            qml.ctrl(qml.BlockEncode, control=(1)),
+            [qml.BlockEncode, [0, 2]],
+            [qml.ctrl(qml.BlockEncode, control=(1)), [0, 2]],
+            [qml.ctrl(qml.BlockEncode, control=(2)), [0, 1]],
         ],
     )
-    def test_apply_BlockEncode(self, op, qubit_device, tol):
+    @pytest.mark.parametrize(
+        "A",
+        [
+            np.array([[1, 1], [1, -1]]) / np.sqrt(2),
+            np.array([[1, 1], [1, -1]]),
+        ],
+    )
+    def test_apply_BlockEncode(self, op, op_wires, A, qubit_device, tol):
         """Test apply BlockEncode and C(BlockEncode)"""
 
-        dev = qubit_device(wires=3)
-        dev_default = qml.device("default.qubit", wires=3)
+        num_wires = 3
+        dev = qubit_device(wires=num_wires)
 
         def circuit1(A):
             qml.Hadamard(0)
             qml.Hadamard(1)
-            qml.BlockEncode(A, wires=[0, 2])
-            op(A, wires=[0, 2])
+            op(A, wires=op_wires)
             return qml.state()
 
-        A = np.array([[1, 1], [1, -1]]) / np.sqrt(2)
-
         results = qml.qnode(dev)(circuit1)(A)
+
+        dev_default = qml.device("default.qubit", wires=num_wires)
         expected = qml.qnode(dev_default)(circuit1)(A)
 
         assert np.allclose(results, expected, atol=tol, rtol=0)

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -1262,6 +1262,33 @@ class TestLightningDeviceIntegration:
         assert np.allclose(res_sv, expected_sv, atol=tol, rtol=0)
         assert np.allclose(res_probs, expected_prob, atol=tol, rtol=0)
 
+    @pytest.mark.parametrize(
+        "op",
+        [
+            qml.BlockEncode,
+            qml.ctrl(qml.BlockEncode, control=(1)),
+        ],
+    )
+    def test_apply_BlockEncode(self, op, qubit_device, tol):
+        """Test apply BlockEncode and C(BlockEncode)"""
+
+        dev = qubit_device(wires=3)
+        dev_default = qml.device("default.qubit", wires=3)
+
+        def circuit1(A):
+            qml.Hadamard(0)
+            qml.Hadamard(1)
+            qml.BlockEncode(A, wires=[0, 2])
+            op(A, wires=[0, 2])
+            return qml.state()
+
+        A = np.array([[1, 1], [1, -1]]) / np.sqrt(2)
+
+        results = qml.qnode(dev)(circuit1)(A)
+        expected = qml.qnode(dev_default)(circuit1)(A)
+
+        assert np.allclose(results, expected, atol=tol, rtol=0)
+
 
 class TestApplyLightningMethod:
     """Unit tests for the apply_lightning method."""


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [X] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [X] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [X] Ensure that the test suite passes, by running `make test`.

- [x] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [X] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**
To test the QSVT workflow with Lightning devices, we need support for `C(BlockEncode)`. This PR adds this support via applying the underlying unitary matrix; including python tests to check the correctness of `BlockEncode` and `C(BlockEncode)` and updating the device toml files to maintain the support in Catalyst. 

**Description of the Change:**
- Update the list of operations in Lightning devices
-  Update device toml files to maintain the support in Catalyst
- Add python tests

**Benefits:**
Support `C(BlockEncode)`.

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-64361]