### PR TITLE
Patch Measurements.probs(wires) to Measurements.probs() when called with all wires

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -48,9 +48,9 @@
 * Changed the name of `lightning.tensor` to `default.tensor` with the `quimb` backend.
   [(#719)](https://github.com/PennyLaneAI/pennylane-lightning/pull/719)
 
-* Dispatch the C++ `Measurements.probs(wires)` method in Lightning-Qubit and Lighnting-Kokkos to `Measurements.probs()` when requesting the probabilities for all wires.
-  This will trigger a more optimized implementation for calculating the probabilities of the whole system.
-  [(#)]()
+* Patch the C++ `Measurements.probs(wires)` method in Lightning-Qubit and Lighnting-Kokkos to `Measurements.probs()` when called with all wires.
+  This will trigger a more optimized implementation for calculating the probabilities of the entire system.
+  [(#744)](https://github.com/PennyLaneAI/pennylane-lightning/pull/744)
 
 ### Documentation
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -45,6 +45,10 @@
 * Changed the name of `lightning.tensor` to `default.tensor` with the `quimb` backend.
   [(#719)](https://github.com/PennyLaneAI/pennylane-lightning/pull/719)
 
+* Dispatch the C++ `Measurements.probs(wires)` method in Lightning-Qubit and Lighnting-Kokkos to `Measurements.probs()` when requesting the probabilities for all wires.
+  This will trigger a more optimized implementation for calculating the probabilities of the whole system.
+  [(#)]()
+
 ### Documentation
 
 ### Bug fixes

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.37.0-dev21"
+__version__ = "0.37.0-dev22"

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.37.0-dev19"
+__version__ = "0.37.0-dev21"

--- a/pennylane_lightning/core/src/simulators/lightning_kokkos/measurements/MeasurementsKokkos.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_kokkos/measurements/MeasurementsKokkos.hpp
@@ -80,11 +80,12 @@ class Measurements final
      * observables.
      *
      * @tparam functor_t Expectation value functor class for Kokkos dispatcher.
-     * @tparam nqubits Number of wires.
+     * @tparam num_wires Number of wires.
      * @param wires Wires to apply the observable to.
      */
     template <template <class> class functor_t, int num_wires>
-    PrecisionT applyExpValNamedFunctor(const std::vector<std::size_t> &wires) {
+    auto applyExpValNamedFunctor(const std::vector<std::size_t> &wires)
+        -> PrecisionT {
         if constexpr (num_wires > 0)
             PL_ASSERT(wires.size() == num_wires);
 
@@ -101,13 +102,14 @@ class Measurements final
      * matrix-valued operator.
      *
      * @tparam functor_t Expectation value functor class for Kokkos dispatcher.
-     * @tparam nqubits Number of wires.
+     * @tparam num_wires Number of wires.
      * @param matrix Matrix (linearized into a KokkosVector).
      * @param wires Wires to apply the observable to.
      */
     template <template <class> class functor_t, int num_wires>
-    PrecisionT applyExpValFunctor(const KokkosVector matrix,
-                                  const std::vector<std::size_t> &wires) {
+    auto applyExpValFunctor(const KokkosVector matrix,
+                            const std::vector<std::size_t> &wires)
+        -> PrecisionT {
         PL_ASSERT(wires.size() == num_wires);
         const std::size_t num_qubits = this->_statevector.getNumQubits();
         Kokkos::View<ComplexT *> arr_data = this->_statevector.getView();
@@ -178,12 +180,12 @@ class Measurements final
     /**
      * @brief Calculate expectation value for a general Observable.
      *
-     * @param ob Observable.
+     * @param obs An Observable object.
      * @return Expectation value with respect to the given observable.
      */
-    PrecisionT expval(const Observable<StateVectorT> &ob) {
+    auto expval(const Observable<StateVectorT> &obs) -> PrecisionT {
         StateVectorT ob_sv{this->_statevector};
-        ob.applyInPlace(ob_sv);
+        obs.applyInPlace(ob_sv);
         return getRealOfComplexInnerProduct(this->_statevector.getView(),
                                             ob_sv.getView());
     }
@@ -191,13 +193,12 @@ class Measurements final
     /**
      * @brief Calculate expectation value for a HermitianObs.
      *
-     * @param ob HermitianObs.
+     * @param obs A HermitianObs object.
      * @return Expectation value with respect to the given observable.
      */
-    PrecisionT
-    expval(const Pennylane::LightningKokkos::Observables::HermitianObs<
-           StateVectorT> &ob) {
-        return expval(ob.getMatrix(), ob.getWires());
+    auto expval(const Pennylane::LightningKokkos::Observables::HermitianObs<
+                StateVectorT> &obs) -> PrecisionT {
+        return expval(obs.getMatrix(), obs.getWires());
     }
 
     /**
@@ -207,8 +208,8 @@ class Measurements final
      * @param wires Wires where to apply the operator.
      * @return Floating point expected value of the observable.
      */
-    PrecisionT expval(const std::vector<ComplexT> &matrix_,
-                      const std::vector<std::size_t> &wires) {
+    auto expval(const std::vector<ComplexT> &matrix_,
+                const std::vector<std::size_t> &wires) -> PrecisionT {
         PL_ABORT_IF(matrix_.size() != exp2(2 * wires.size()),
                     "The size of matrix does not match with the given "
                     "number of wires");
@@ -225,8 +226,8 @@ class Measurements final
      * @param wires Wires where to apply the operator.
      * @return Floating point expected value of the observable.
      */
-    PrecisionT expval(const std::string &operation,
-                      const std::vector<std::size_t> &wires) {
+    auto expval(const std::string &operation,
+                const std::vector<std::size_t> &wires) -> PrecisionT {
         switch (expval_funcs_[operation]) {
         case ExpValFunc::Identity:
             return applyExpValNamedFunctor<getExpectationValueIdentityFunctor,
@@ -260,9 +261,9 @@ class Measurements final
      * observables.
      */
     template <typename op_type>
-    std::vector<PrecisionT>
-    expval(const std::vector<op_type> &operations_list,
-           const std::vector<std::vector<std::size_t>> &wires_list) {
+    auto expval(const std::vector<op_type> &operations_list,
+                const std::vector<std::vector<std::size_t>> &wires_list)
+        -> std::vector<PrecisionT> {
         PL_ABORT_IF(
             (operations_list.size() != wires_list.size()),
             "The lengths of the list of operations and wires do not match.");
@@ -279,9 +280,9 @@ class Measurements final
     /**
      * @brief Expectation value for a Observable with shots
      *
-     * @param obs Observable.
+     * @param obs An Observable object.
      * @param num_shots Number of shots.
-     * @param shots_range Vector of shot number to measurement.
+     * @param shot_range Vector of shot number to measurement.
      * @return Floating point expected value of the observable.
      */
 
@@ -335,12 +336,12 @@ class Measurements final
     /**
      * @brief Calculate variance of a general Observable.
      *
-     * @param ob Observable.
+     * @param obs An Observable object.
      * @return Variance with respect to the given observable.
      */
-    auto var(const Observable<StateVectorT> &ob) -> PrecisionT {
+    auto var(const Observable<StateVectorT> &obs) -> PrecisionT {
         StateVectorT ob_sv{this->_statevector};
-        ob.applyInPlace(ob_sv);
+        obs.applyInPlace(ob_sv);
 
         const PrecisionT mean_square =
             getRealOfComplexInnerProduct(ob_sv.getView(), ob_sv.getView());
@@ -358,8 +359,8 @@ class Measurements final
      * @param wires Wires where to apply the operator.
      * @return Floating point with the variance of the observable.
      */
-    PrecisionT var(const std::string &operation,
-                   const std::vector<std::size_t> &wires) {
+    auto var(const std::string &operation,
+             const std::vector<std::size_t> &wires) -> PrecisionT {
         StateVectorT ob_sv{this->_statevector};
         ob_sv.applyOperation(operation, wires);
 
@@ -373,14 +374,14 @@ class Measurements final
     };
 
     /**
-     * @brief Variance of an observable.
+     * @brief Variance of a Hermitian matrix.
      *
      * @param matrix Square matrix in row-major order.
      * @param wires Wires where to apply the operator.
      * @return Floating point with the variance of the observable.
      */
-    PrecisionT var(const std::vector<ComplexT> &matrix,
-                   const std::vector<std::size_t> &wires) {
+    auto var(const std::vector<ComplexT> &matrix,
+             const std::vector<std::size_t> &wires) -> PrecisionT {
         StateVectorT ob_sv{this->_statevector};
         ob_sv.applyMatrix(matrix, wires);
 
@@ -404,9 +405,9 @@ class Measurements final
      observables.
      */
     template <typename op_type>
-    std::vector<PrecisionT>
-    var(const std::vector<op_type> &operations_list,
-        const std::vector<std::vector<std::size_t>> &wires_list) {
+    auto var(const std::vector<op_type> &operations_list,
+             const std::vector<std::vector<std::size_t>> &wires_list)
+        -> std::vector<PrecisionT> {
         PL_ABORT_IF(
             (operations_list.size() != wires_list.size()),
             "The lengths of the list of operations and wires do not match.");
@@ -437,9 +438,9 @@ class Measurements final
      * @return Floating point with the variance of the sparse Hamiltonian.
      */
     template <class index_type>
-    PrecisionT var(const index_type *row_map_ptr, const index_type row_map_size,
-                   const index_type *entries_ptr, const ComplexT *values_ptr,
-                   const index_type numNNZ) {
+    auto var(const index_type *row_map_ptr, const index_type row_map_size,
+             const index_type *entries_ptr, const ComplexT *values_ptr,
+             const index_type numNNZ) -> PrecisionT {
         PL_ABORT_IF(
             (this->_statevector.getLength() != (std::size_t(row_map_size) - 1)),
             "Statevector and Hamiltonian have incompatible sizes.");
@@ -506,11 +507,18 @@ class Measurements final
      * @return Floating point std::vector with probabilities.
      * The basis columns are rearranged according to wires.
      */
-    std::vector<PrecisionT> probs(const std::vector<std::size_t> &wires) {
+    auto probs(const std::vector<std::size_t> &wires)
+        -> std::vector<PrecisionT> {
         PL_ABORT_IF_NOT(
             std::is_sorted(wires.cbegin(), wires.cend()),
             "LightningKokkos does not currently support out-of-order wire "
             "indices with probability calculations");
+
+        // If all wires are requested, dispatch to `this->probs()`
+        if (wires.size() == this->_statevector.getNumQubits()) {
+            return this->probs();
+        }
+
         using MDPolicyType_2D =
             Kokkos::MDRangePolicy<Kokkos::Rank<2, Kokkos::Iterate::Left>>;
 
@@ -624,8 +632,8 @@ class Measurements final
      * @return Floating point std::vector with probabilities
      * in lexicographic order.
      */
-    std::vector<PrecisionT> probs(const Observable<StateVectorT> &obs,
-                                  std::size_t num_shots = 0) {
+    auto probs(const Observable<StateVectorT> &obs, std::size_t num_shots = 0)
+        -> std::vector<PrecisionT> {
         return BaseType::probs(obs, num_shots);
     }
 
@@ -636,22 +644,22 @@ class Measurements final
      *
      * @return Floating point std::vector with probabilities.
      */
-    std::vector<PrecisionT> probs(std::size_t num_shots) {
+    auto probs(std::size_t num_shots) -> std::vector<PrecisionT> {
         return BaseType::probs(num_shots);
     }
 
     /**
      * @brief Probabilities with shot-noise for a subset of the full system.
      *
-     * @param num_shots Number of shots.
      * @param wires Wires will restrict probabilities to a subset
      * of the full system.
+     * @param num_shots Number of shots.
      *
      * @return Floating point std::vector with probabilities.
      */
 
-    std::vector<PrecisionT> probs(const std::vector<std::size_t> &wires,
-                                  std::size_t num_shots) {
+    auto probs(const std::vector<std::size_t> &wires, std::size_t num_shots)
+        -> std::vector<PrecisionT> {
         PL_ABORT_IF_NOT(
             std::is_sorted(wires.cbegin(), wires.cend()),
             "LightningKokkos does not currently support out-of-order wire "

--- a/pennylane_lightning/core/src/simulators/lightning_kokkos/measurements/MeasurementsKokkos.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_kokkos/measurements/MeasurementsKokkos.hpp
@@ -515,7 +515,7 @@ class Measurements final
             "indices with probability calculations");
 
         // If all wires are requested, dispatch to `this->probs()`
-        if (wires.size() == this->_statevector.getNumQubits()) {
+        if (wires.empty() || wires.size() == this->_statevector.getNumQubits()) {
             return this->probs();
         }
 

--- a/pennylane_lightning/core/src/simulators/lightning_kokkos/measurements/MeasurementsKokkos.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_kokkos/measurements/MeasurementsKokkos.hpp
@@ -515,7 +515,8 @@ class Measurements final
             "indices with probability calculations");
 
         // If all wires are requested, dispatch to `this->probs()`
-        if (wires.empty() || wires.size() == this->_statevector.getNumQubits()) {
+        if (wires.empty() ||
+            wires.size() == this->_statevector.getNumQubits()) {
             return this->probs();
         }
 


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [X] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [X] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [X] Ensure that the test suite passes, by running `make test`.

- [x] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [X] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**
All calls to `qml.probs` to calculate the probs of the whole system in the analytic mode, patches to the C++ `Measurements.probs(wires, ...)` method that's implemented for computing the probabilities of a subset of wires. There is a more dedicated method (`Measurements.probs()`) that skips part of the logic in `Measurements.probs(wires)` which is indeed required to deal with subsystems. We should call `Measurements.probs()` when computing the probs of the whole system instead. This PR ensures that we patch to `Measurements.probs()` resulting a ~12% performance boost for qubits > 10.

**Description of the Change:**
- Update the C++ `Measurements.probs(wires, ...)` method to call `Measurements.probs()` in LQ and LK when requesting the probs of all wires.
- Tidy up the src code and docs

**Benefits:**
This will skip the unnecessary steps required for calculating the probs of a subsystem by calling the proper C++ `probs` implementation in LQ and LK. 

**Possible Drawbacks:**
Alternatively, we could fix this by calling to the proper `probs` C++ implementation in Python Bindings instead. I need to do a bit of investigation to find the better solution here. Any thoughts would be appreciated :)   

**Related GitHub Issues:**
[sc-63167]