### PR TITLE
Remove release-release-compat-check action schedule

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -48,6 +48,9 @@
 * Changed the name of `lightning.tensor` to `default.tensor` with the `quimb` backend.
   [(#719)](https://github.com/PennyLaneAI/pennylane-lightning/pull/719)
 
+* Remove the daily schedule from the "Compat Check w/PL - release/release" GitHub action.
+  [(#746)](https://github.com/PennyLaneAI/pennylane-lightning/pull/746)
+
 ### Documentation
 
 ### Bug fixes

--- a/.github/workflows/compat-check-release-release.yml
+++ b/.github/workflows/compat-check-release-release.yml
@@ -1,8 +1,6 @@
 name: Compat Check w/PL - release/release
 
 on:
-  schedule:
-    - cron: "0 4 * * 1-5"  # Run daily at 0am Mon-Fri
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/tests_lkcpu_python.yml
+++ b/.github/workflows/tests_lkcpu_python.yml
@@ -246,7 +246,7 @@ jobs:
           python -m pip install pytest-xdist
           cd main/
           DEVICENAME=`echo ${{ matrix.pl_backend }} | sed "s/_/./g"`
-            PL_DEVICE=${DEVICENAME} python -m pytest tests/ --exitfirst $COVERAGE_FLAGS --splits 7 --group ${{ matrix.group }} \
+            PL_DEVICE=${DEVICENAME} python -m pytest tests/ $COVERAGE_FLAGS --splits 7 --group ${{ matrix.group }} \
               --store-durations --durations-path='.github/workflows/python_lightning_kokkos_test_durations.json' --splitting-algorithm=least_duration
             mv .github/workflows/python_lightning_kokkos_test_durations.json ${{ github.workspace }}/.test_durations-${{ matrix.exec_model }}-${{ matrix.group }}
           pl-device-test --device ${DEVICENAME} --skip-ops --shots=20000 $COVERAGE_FLAGS --cov-append

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.37.0-dev20"
+__version__ = "0.37.0-dev21"


### PR DESCRIPTION
**Context:**
The [Compat Check w/PL - release/release](https://github.com/PennyLaneAI/pennylane-lightning/actions/workflows/compat-check-release-release.yml) is scheduled daily while this action is only required during the release weeks. This PR removes the daily schedule. We can still trigger this manually using `wokflow_dispatch` if needed before starting the next release. 

**Description of the Change:**
as explained above.

**Benefits:**
no daily runs of this unnecessary action!

**Possible Drawbacks:**
n/a

**Related Issues:**
