### PR TITLE
Change `Conditional.then_op` usage to `Conditional.base`

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -68,7 +68,7 @@
 ### Bug fixes
 
 * `lightning.qubit` and `lightning.kokkos` use `qml.ops.Conditional.base` instead of `qml.ops.Conditional.then_op`.
-  [(#)]()
+  [(#752)](https://github.com/PennyLaneAI/pennylane-lightning/pull/752)
 
 * Fix AVX streaming operation support with newer GCC.
   [(#729)](https://github.com/PennyLaneAI/pennylane-lightning/pull/729)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -67,6 +67,9 @@
 
 ### Bug fixes
 
+* `lightning.qubit` and `lightning.kokkos` use `qml.ops.Conditional.base` instead of `qml.ops.Conditional.then_op`.
+  [(#)]()
+
 * Fix AVX streaming operation support with newer GCC.
   [(#729)](https://github.com/PennyLaneAI/pennylane-lightning/pull/729)
 

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.37.0-dev27"
+__version__ = "0.37.0-dev28"

--- a/pennylane_lightning/lightning_kokkos/lightning_kokkos.py
+++ b/pennylane_lightning/lightning_kokkos/lightning_kokkos.py
@@ -432,7 +432,7 @@ class LightningKokkos(LightningBase):
 
             if isinstance(ops, Conditional):
                 if ops.meas_val.concretize(mid_measurements):
-                    self.apply_lightning([ops.then_op])
+                    self.apply_lightning([ops.base])
             elif isinstance(ops, MidMeasureMP):
                 self._apply_lightning_midmeasure(ops, mid_measurements, postselect_mode)
             elif isinstance(ops, qml.ops.op_math.Controlled) and isinstance(

--- a/pennylane_lightning/lightning_qubit/_state_vector.py
+++ b/pennylane_lightning/lightning_qubit/_state_vector.py
@@ -311,7 +311,7 @@ class LightningStateVector:
 
             if isinstance(operation, Conditional):
                 if operation.meas_val.concretize(mid_measurements):
-                    self._apply_lightning([operation.then_op])
+                    self._apply_lightning([operation.base])
             elif isinstance(operation, MidMeasureMP):
                 self._apply_lightning_midmeasure(
                     operation, mid_measurements, postselect_mode=postselect_mode


### PR DESCRIPTION
New work in Pennylane removed `Conditional.then_op` in favour of `Conditional.base`. This PR updates lightning to use the new attribute.