### PR TITLE
Fix the issue with initializing LK with zero-qubit and invalid number of control_wires in ctrl_decomp_zyz 

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -85,6 +85,12 @@
 * Fix the `cuda-runtime-12-0` dependency issue on RHEL8.
   [(#739)](https://github.com/PennyLaneAI/pennylane-lightning/pull/739)
 
+* Fix the memory segfault with initializing zero-wire LightningKokkos.
+  [(#757)](https://github.com/PennyLaneAI/pennylane-lightning/pull/757)
+
+* Remove `pennylane.ops.op_math.controlled_decompositions.ctrl_decomp_zyz` tests with `len(control_wires) > 1`.
+  [(#757)](https://github.com/PennyLaneAI/pennylane-lightning/pull/757)
+
 ### Contributors
 
 This release contains contributions from (in alphabetical order):

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.37.0-dev27"
+__version__ = "0.37.0-dev30"

--- a/pennylane_lightning/core/src/simulators/lightning_kokkos/StateVectorKokkos.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_kokkos/StateVectorKokkos.hpp
@@ -111,10 +111,9 @@ class StateVectorKokkos final
                 Kokkos::initialize(kokkos_args);
             }
         }
-        if (num_qubits > 0) {
-            data_ = std::make_unique<KokkosVector>("data_", exp2(num_qubits));
-            setBasisState(0U);
-        }
+
+        data_ = std::make_unique<KokkosVector>("data_", exp2(num_qubits));
+        setBasisState(0U);
     };
 
     /**

--- a/tests/test_adjoint_jacobian.py
+++ b/tests/test_adjoint_jacobian.py
@@ -867,10 +867,8 @@ class TestAdjointJacobianQNode:
                 if operation.num_params == 3:
                     qml.ctrl(
                         operation(*p, wires=range(n_qubits - num_wires, n_qubits)),
-                        control_wires,
-                        control_values=[
-                            control_value or bool(i % 2) for i, _ in enumerate(control_wires)
-                        ],
+                        control_wires[0],
+                        control_values=control_value,
                     )
                 else:
                     qml.RX(p[0], 0)

--- a/tests/test_adjoint_jacobian.py
+++ b/tests/test_adjoint_jacobian.py
@@ -865,6 +865,9 @@ class TestAdjointJacobianQNode:
             def circuit(p):
                 qml.StatePrep(init_state, wires=range(n_qubits))
                 if operation.num_params == 3:
+                    # Check against the first wire in `control_wires` as any
+                    # decomposition to `ctrl_decomp_zyz` works now with only
+                    # one single controlled wire.
                     qml.ctrl(
                         operation(*p, wires=range(n_qubits - num_wires, n_qubits)),
                         control_wires[0],

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -63,3 +63,15 @@ def test_create_device_with_unsupported_mpi_buf_size():
             dev._mpi_init_helper(1)
     except:
         pass
+
+
+def test_device_init_zero_qubit():
+    """Test the device initialization with zero-qubit."""
+
+    dev = qml.device(device_name, wires=0)
+
+    @qml.qnode(dev)
+    def circuit():
+        return qml.state()
+
+    assert np.allclose(circuit(), np.array([1.0]))


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [x] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [x] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [ ] Ensure that the test suite passes, by running `make test`.

- [x] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [x] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**
- [X] Fix the issue with initializing `lightning.kokkos` with zero-qubit and 
- [X] Invalid number of control_wires in ctrl_decomp_zyz (PR https://github.com/PennyLaneAI/pennylane/pull/5735)
- [x] Add test for `device('lightning.kokkos', wires=0)`

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
Fixes #751 