### PR TITLE
Fix random CI failures of `lightning.tensor` due to the missing of `CUQUANTUM_SDK` env

### DIFF
--- a/.github/workflows/tests_lmps_tncuda_python.yml
+++ b/.github/workflows/tests_lmps_tncuda_python.yml
@@ -160,6 +160,8 @@ jobs:
             python -m pip uninstall -y pennylane && python -m pip install -U pennylane
   
       - name: Build and install package
+        env:
+          CUQUANTUM_SDK: $(python -c "import site; print( f'{site.getsitepackages()[0]}/cuquantum')")
         run: |
           cd main
           rm -rf build


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [ ] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [ ] Ensure that the test suite passes, by running `make test`.

- [ ] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [ ] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**

Currently, there are random CI build failures of `lightning.tensor` due to the missing of `CUQUANTUM_SDK` env

**Description of the Change:**

Add `CUQUANTUM_SDK` env to workflow

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
