### PR TITLE
Don't patch probs(wires=[]) to probs(all_wires) in LK

### DIFF
--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.37.0-dev37"
+__version__ = "0.37.0-dev38"

--- a/pennylane_lightning/core/src/simulators/lightning_kokkos/measurements/MeasurementsKokkos.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_kokkos/measurements/MeasurementsKokkos.hpp
@@ -515,8 +515,7 @@ class Measurements final
             "indices with probability calculations");
 
         // If all wires are requested, dispatch to `this->probs()`
-        if (wires.empty() ||
-            wires.size() == this->_statevector.getNumQubits()) {
+        if (wires.size() == this->_statevector.getNumQubits()) {
             return this->probs();
         }
 


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [x] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [x] Ensure that the test suite passes, by running `make test`.

- [ ] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [x] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**
PR #744 patches `probs(wires=[])` to calculate the probabilities of all wires in LightningKokkos. This PR fixes the issue to keep the consistency among all Lightning devices as well as the integration with Catalyst.

**Description of the Change:**

**Benefits:**
Consistent behaviour among all devices for calculating `probs(wires=[]) = [1.0]`.

**Possible Drawbacks:**

**Related GitHub Issues:**
