### PR TITLE
Update toml files with non_commuting_observables

### DIFF
--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.37.0-dev39"
+__version__ = "0.37.0-dev40"

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.37.0-dev37"
+__version__ = "0.37.0-dev38"

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.37.0-dev38"
+__version__ = "0.37.0-dev39"

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.37.0-dev40"
+__version__ = "0.37.0-dev41"

--- a/pennylane_lightning/lightning_gpu/lightning_gpu.toml
+++ b/pennylane_lightning/lightning_gpu/lightning_gpu.toml
@@ -104,3 +104,8 @@ mid_circuit_measurement = false
 # This field is currently unchecked but it is reserved for the purpose of
 # determining if the device supports dynamic qubit allocation/deallocation.
 dynamic_qubit_management = false
+
+# whether the device can support non-commuting measurements together 
+# in a single execution
+non_commuting_observables = true
+

--- a/pennylane_lightning/lightning_kokkos/lightning_kokkos.toml
+++ b/pennylane_lightning/lightning_kokkos/lightning_kokkos.toml
@@ -106,3 +106,8 @@ mid_circuit_measurement = true
 # This field is currently unchecked but it is reserved for the purpose of
 # determining if the device supports dynamic qubit allocation/deallocation.
 dynamic_qubit_management = false
+
+# whether the device can support non-commuting measurements together 
+# in a single execution
+non_commuting_observables = true
+

--- a/pennylane_lightning/lightning_qubit/lightning_qubit.toml
+++ b/pennylane_lightning/lightning_qubit/lightning_qubit.toml
@@ -103,6 +103,10 @@ mid_circuit_measurement = true
 # determining if the device supports dynamic qubit allocation/deallocation.
 dynamic_qubit_management = false
 
+# whether the device can support non-commuting measurements together 
+# in a single execution
+non_commuting_observables = true
+
 [options]
 
 mcmc = "_mcmc"


### PR DESCRIPTION
**Context:**
Catalyst is adding `non_commuting_observables` as a flag in the TOML file, and conditionally applying the `split_non_commuting` transform in the QJIT device preprocessing if the backend doesn't allow non-commuting observables. 

**Description of the Change:**
Update the lightning TOML files to indicate that non-commuting observables are supported.

**Benefits:**
Lightning stays consistent with the changes in [this PR](https://github.com/PennyLaneAI/catalyst/pull/821)

