### PR TITLE
Fix the missing lightning_tensor device in PL/Lightning stable/stable

### DIFF
--- a/.github/workflows/tests_without_binary.yml
+++ b/.github/workflows/tests_without_binary.yml
@@ -38,6 +38,8 @@ jobs:
     strategy:
       matrix:
         pl_backend: ["lightning_qubit", "lightning_kokkos", "lightning_gpu", "lightning_tensor"]
+    # FIXME: Remove this condition with v0.37.0 release
+    if: matrix.pl_backend == 'lightning_kokkos' && inputs.pennylane-version != 'stable'
 
     name: Python Tests without Binary (${{ matrix.pl_backend }})
 

--- a/.github/workflows/tests_without_binary.yml
+++ b/.github/workflows/tests_without_binary.yml
@@ -38,12 +38,17 @@ jobs:
     strategy:
       matrix:
         pl_backend: ["lightning_qubit", "lightning_kokkos", "lightning_gpu", "lightning_tensor"]
-    # FIXME: Remove this condition with v0.37.0 release
-    if: matrix.pl_backend == 'lightning_kokkos' && inputs.pennylane-version != 'stable'
 
     name: Python Tests without Binary (${{ matrix.pl_backend }})
 
     steps:
+      - name: Skip lightning_kokkos temporarily for PL/Lightning stable/stable
+        # FIXME: Remove this condition with v0.37.0 release
+        if: matrix.pl_backend == 'lightning_kokkos' && inputs.pennylane-version != 'stable'
+        run: |
+          echo "Temporarily skipping lightning_kokkos build for stable/stable."
+          exit 0
+
       - name: Checkout PennyLane-Lightning
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/tests_without_binary.yml
+++ b/.github/workflows/tests_without_binary.yml
@@ -44,7 +44,7 @@ jobs:
     steps:
       - name: Skip lightning_tensor temporarily for PL/Lightning stable/stable
         # FIXME: Remove this condition with v0.37.0 release
-        if: matrix.pl_backend == 'lightning_tensor' && inputs.pennylane-version != 'stable'
+        if: matrix.pl_backend == 'lightning_tensor' && inputs.pennylane-version == 'stable' && inputs.lightning-version == 'stable'
         run: |
           echo "Temporarily skipping lightning_tensor build for stable/stable."
           exit 0

--- a/.github/workflows/tests_without_binary.yml
+++ b/.github/workflows/tests_without_binary.yml
@@ -42,13 +42,6 @@ jobs:
     name: Python Tests without Binary (${{ matrix.pl_backend }})
 
     steps:
-      - name: Skip lightning_tensor temporarily for PL/Lightning stable/stable
-        # FIXME: Remove this condition with v0.37.0 release
-        if: matrix.pl_backend == 'lightning_tensor' && inputs.pennylane-version == 'stable' && inputs.lightning-version == 'stable'
-        run: |
-          echo "Temporarily skipping lightning_tensor build for stable/stable."
-          exit 0
-
       - name: Checkout PennyLane-Lightning
         uses: actions/checkout@v4
         with:
@@ -110,6 +103,8 @@ jobs:
           SKIP_COMPILATION=True PL_BACKEND="lightning_qubit" python -m pip install . -vv
 
       - name: Install backend device
+        # FIXME: Remove this condition with v0.37.0 release
+        if: matrix.pl_backend != 'lightning_tensor' && inputs.lightning-version != 'stable'
         env:
           SKIP_COMPILATION: True
           PL_BACKEND: ${{ matrix.pl_backend }}
@@ -118,12 +113,16 @@ jobs:
           python -m pip install . -vv
 
       - name: Run PennyLane-Lightning unit tests for all backends
+        # FIXME: Remove this condition with v0.37.0 release
+        if: matrix.pl_backend != 'lightning_tensor' && inputs.lightning-version != 'stable'
         run: |
           cd main/
           DEVICENAME=`echo ${{ matrix.pl_backend }} | sed "s/_/./g"`
           PL_DEVICE=${DEVICENAME} python -m pytest tests/ $COVERAGE_FLAGS
 
       - name: Upload coverage to Codecov
+        # FIXME: Remove this condition with v0.37.0 release
+        if: matrix.pl_backend != 'lightning_tensor' && inputs.lightning-version != 'stable'
         uses: codecov/codecov-action@v4
         with:
           files: ./main/coverage.xml

--- a/.github/workflows/tests_without_binary.yml
+++ b/.github/workflows/tests_without_binary.yml
@@ -42,11 +42,11 @@ jobs:
     name: Python Tests without Binary (${{ matrix.pl_backend }})
 
     steps:
-      - name: Skip lightning_kokkos temporarily for PL/Lightning stable/stable
+      - name: Skip lightning_tensor temporarily for PL/Lightning stable/stable
         # FIXME: Remove this condition with v0.37.0 release
-        if: matrix.pl_backend == 'lightning_kokkos' && inputs.pennylane-version != 'stable'
+        if: matrix.pl_backend == 'lightning_tensor' && inputs.pennylane-version != 'stable'
         run: |
-          echo "Temporarily skipping lightning_kokkos build for stable/stable."
+          echo "Temporarily skipping lightning_tensor build for stable/stable."
           exit 0
 
       - name: Checkout PennyLane-Lightning

--- a/.github/workflows/tests_without_binary.yml
+++ b/.github/workflows/tests_without_binary.yml
@@ -104,7 +104,7 @@ jobs:
 
       - name: Install backend device
         # FIXME: Remove this condition with v0.37.0 release
-        if: matrix.pl_backend != 'lightning_tensor' && inputs.lightning-version != 'stable'
+        if: matrix.pl_backend != 'lightning_tensor' || inputs.lightning-version != 'stable'
         env:
           SKIP_COMPILATION: True
           PL_BACKEND: ${{ matrix.pl_backend }}
@@ -114,7 +114,7 @@ jobs:
 
       - name: Run PennyLane-Lightning unit tests for all backends
         # FIXME: Remove this condition with v0.37.0 release
-        if: matrix.pl_backend != 'lightning_tensor' && inputs.lightning-version != 'stable'
+        if: matrix.pl_backend != 'lightning_tensor' || inputs.lightning-version != 'stable'
         run: |
           cd main/
           DEVICENAME=`echo ${{ matrix.pl_backend }} | sed "s/_/./g"`
@@ -122,7 +122,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         # FIXME: Remove this condition with v0.37.0 release
-        if: matrix.pl_backend != 'lightning_tensor' && inputs.lightning-version != 'stable'
+        if: matrix.pl_backend != 'lightning_tensor' || inputs.lightning-version != 'stable'
         uses: codecov/codecov-action@v4
         with:
           files: ./main/coverage.xml

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.37.0-dev42"
+__version__ = "0.37.0-dev43"

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.37.0-dev41"
+__version__ = "0.37.0-dev42"


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [ ] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [ ] Ensure that the test suite passes, by running `make test`.

- [ ] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [x] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**
The plugin matrix for PL/Lightning stable/stable is currently failing due to the missing `lightning_tensor` device in the stable version. Check https://github.com/PennyLaneAI/pennylane-lightning/actions/runs/9558259457. This PR adds a temporary patch to skip the build & test for stable/stable until the next release. 

**Description of the Change:**

**Benefits:**
Pass stable/stable plugin matrix https://github.com/PennyLaneAI/pennylane-lightning/actions/runs/9569756079

**Possible Drawbacks:**

**Related GitHub Issues:**

[sc-66324]