### PR TITLE
Update lightning_kokkos.toml

### DIFF
--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.37.0-dev41"
+__version__ = "0.37.0-dev42"

--- a/pennylane_lightning/lightning_kokkos/lightning_kokkos.toml
+++ b/pennylane_lightning/lightning_kokkos/lightning_kokkos.toml
@@ -53,6 +53,7 @@ MultiControlledX       = {}
 QFT                    = {}
 QubitStateVector       = {}
 StatePrep              = {}
+ControlledQubitUnitary = {}
 
 # Gates which should be translated to QubitUnitary
 [operators.gates.matrix]


### PR DESCRIPTION
ControlledQubitUnitary is present in the Python device but not the TOML (since https://github.com/PennyLaneAI/pennylane-lightning/pull/758 removed it from native gates), added it back to the decomposition gates since it can be implemented in its alternate form of C(QubitUnitary).

Required for https://github.com/PennyLaneAI/catalyst/pull/785
