### PR TITLE
Updated CI workflows to avoid race conditions on PRs with concurrency label

### DIFF
--- a/.github/workflows/tests_lgpu_cpp.yml
+++ b/.github/workflows/tests_lgpu_cpp.yml
@@ -30,7 +30,7 @@ env:
   TORCH_VERSION: 1.11.0+cpu
 
 concurrency:
-  group: tests_lgpu_cpp-${{ github.ref }}-${{ github.event }}-${{ inputs.lightning-version }}-${{ inputs.pennylane-version }}
+  group: tests_lgpu_cpp-${{ github.ref }}-${{ github.event_name }}-${{ inputs.lightning-version }}-${{ inputs.pennylane-version }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/tests_lgpu_python.yml
+++ b/.github/workflows/tests_lgpu_python.yml
@@ -34,7 +34,7 @@ env:
   TORCH_VERSION: 1.11.0+cpu
 
 concurrency:
-  group: tests_lgpu_python-${{ github.ref }}-${{ github.event }}-${{ inputs.lightning-version }}-${{ inputs.pennylane-version }}
+  group: tests_lgpu_python-${{ github.ref }}-${{ github.event_name }}-${{ inputs.lightning-version }}-${{ inputs.pennylane-version }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/tests_lgpumpi_cpp.yml
+++ b/.github/workflows/tests_lgpumpi_cpp.yml
@@ -29,7 +29,7 @@ env:
   CI_CUDA_ARCH: 86
 
 concurrency:
-  group: tests_lgpumpi_cpp-${{ github.ref }}-${{ github.event }}-${{ inputs.lightning-version }}-${{ inputs.pennylane-version }}
+  group: tests_lgpumpi_cpp-${{ github.ref }}-${{ github.event_name }}-${{ inputs.lightning-version }}-${{ inputs.pennylane-version }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/tests_lgpumpi_python.yml
+++ b/.github/workflows/tests_lgpumpi_python.yml
@@ -30,7 +30,7 @@ env:
   CI_CUDA_ARCH: 86
 
 concurrency:
-  group: tests_lgpumpi_python-${{ github.ref }}-${{ github.event }}-${{ inputs.lightning-version }}-${{ inputs.pennylane-version }}
+  group: tests_lgpumpi_python-${{ github.ref }}-${{ github.event_name }}-${{ inputs.lightning-version }}-${{ inputs.pennylane-version }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/tests_linux_cpp.yml
+++ b/.github/workflows/tests_linux_cpp.yml
@@ -30,7 +30,7 @@ env:
   OMP_PROC_BIND: "false"
 
 concurrency:
-  group: tests_linux_cpp-${{ github.ref }}-${{ github.event }}-${{ inputs.lightning-version }}-${{ inputs.pennylane-version }}
+  group: tests_linux_cpp-${{ github.ref }}-${{ github.event_name }}-${{ inputs.lightning-version }}-${{ inputs.pennylane-version }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/tests_lkcpu_python.yml
+++ b/.github/workflows/tests_lkcpu_python.yml
@@ -34,7 +34,7 @@ env:
   OMP_PROC_BIND: "false"
 
 concurrency:
-  group: tests_lkcpu_python-${{ github.ref }}-${{ github.event }}-${{ inputs.lightning-version }}-${{ inputs.pennylane-version }}
+  group: tests_lkcpu_python-${{ github.ref }}-${{ github.event_name }}-${{ inputs.lightning-version }}-${{ inputs.pennylane-version }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/tests_lkcuda_cpp.yml
+++ b/.github/workflows/tests_lkcuda_cpp.yml
@@ -29,7 +29,7 @@ env:
   TORCH_VERSION: 1.11.0+cpu
 
 concurrency:
-  group: tests_lkcuda_cpp-${{ github.ref }}-${{ github.event }}-${{ inputs.lightning-version }}-${{ inputs.pennylane-version }}
+  group: tests_lkcuda_cpp-${{ github.ref }}-${{ github.event_name }}-${{ inputs.lightning-version }}-${{ inputs.pennylane-version }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/tests_lkcuda_python.yml
+++ b/.github/workflows/tests_lkcuda_python.yml
@@ -33,7 +33,7 @@ env:
   TORCH_VERSION: 1.11.0+cpu
 
 concurrency:
-  group: tests_lkcuda_python-${{ github.ref }}-${{ github.event }}-${{ inputs.lightning-version }}-${{ inputs.pennylane-version }}
+  group: tests_lkcuda_python-${{ github.ref }}-${{ github.event_name }}-${{ inputs.lightning-version }}-${{ inputs.pennylane-version }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/tests_lmps_tncuda_cpp.yml
+++ b/.github/workflows/tests_lmps_tncuda_cpp.yml
@@ -31,7 +31,7 @@ env:
   GCC_VERSION: 11
 
 concurrency:
-  group: tests_lmps_tncuda_cpp-${{ github.ref }}-${{ github.event }}-${{ inputs.lightning-version }}-${{ inputs.pennylane-version }}
+  group: tests_lmps_tncuda_cpp-${{ github.ref }}-${{ github.event_name }}-${{ inputs.lightning-version }}-${{ inputs.pennylane-version }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/tests_lmps_tncuda_python.yml
+++ b/.github/workflows/tests_lmps_tncuda_python.yml
@@ -34,7 +34,7 @@ env:
   GCC_VERSION: 11
 
 concurrency:
-  group: tests_lmps_tncuda_python-${{ github.ref }}-${{ github.event }}-${{ inputs.lightning-version }}-${{ inputs.pennylane-version }}
+  group: tests_lmps_tncuda_python-${{ github.ref }}-${{ github.event_name }}-${{ inputs.lightning-version }}-${{ inputs.pennylane-version }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/tests_lqcpu_python.yml
+++ b/.github/workflows/tests_lqcpu_python.yml
@@ -24,7 +24,7 @@ env:
   OMP_PROC_BIND: "false"
 
 concurrency:
-  group: tests_lqcpu_python-${{ github.ref }}-${{ github.event }}-${{ inputs.lightning-version }}-${{ inputs.pennylane-version }}
+  group: tests_lqcpu_python-${{ github.ref }}-${{ github.event_name }}-${{ inputs.lightning-version }}-${{ inputs.pennylane-version }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/tests_windows_cpp.yml
+++ b/.github/workflows/tests_windows_cpp.yml
@@ -20,7 +20,7 @@ on:
       - '!pennylane_lightning/core/src/simulators/lightning_gpu/**'
 
 concurrency:
-  group: tests_windows_cpp-${{ github.ref }}-${{ github.event }}-${{ inputs.lightning-version }}-${{ inputs.pennylane-version }}
+  group: tests_windows_cpp-${{ github.ref }}-${{ github.event_name }}-${{ inputs.lightning-version }}-${{ inputs.pennylane-version }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/tests_without_binary.yml
+++ b/.github/workflows/tests_without_binary.yml
@@ -21,7 +21,7 @@ env:
   COVERAGE_FLAGS: "--cov=pennylane_lightning --cov-report=term-missing --cov-report=xml:./coverage.xml --no-flaky-report -p no:warnings --tb=native"
 
 concurrency:
-  group: tests_without_binary-${{ github.ref }}-${{ inputs.lightning-version }}-${{ inputs.pennylane-version }}
+  group: tests_without_binary-${{ github.ref }}-${{ github.event_name }}-${{ inputs.lightning-version }}-${{ inputs.pennylane-version }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/update_dev_version.yml
+++ b/.github/workflows/update_dev_version.yml
@@ -4,6 +4,11 @@ on:
     branches:
       - master
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+
 jobs:
   update-dev-version:
     name: Update version for development branches


### PR DESCRIPTION
**Context:**
Currently there exists a race condition within the CI due to misconfiguration of the concurrency label.

This PR updates the affected workflows to fix the concurrency labels.


**Description of the Change:**
`${{ github.event }}` is not a string, but rather an object when you have, that in the concurrency label you get:

```yaml
# Label
group: my-workflow-${{ github.event }}-${{ github.ref }}

# Renders as
group: my-workflow-[object Object]-refs/heads/my-branch
```

This was causing working that had `pull_request` and `workflow_call` triggers to overstep on each other's runtime as they both rendered with the same concurrency label.

This PR changes the attribute to use the correct string name `event_name`.

**Benefits:**
Race conditions averted. No random job cancellations especially when PR needs wheels built.

**Possible Drawbacks:**
None.

**Related GitHub Issues:**
None. [sc-66955](https://app.shortcut.com/xanaduai/story/66955/fix-bug-in-lightning-ci-causing-race-conditions-of-parallel-job-runs)