### PR TITLE
Fix lightning stable plugin test matrix tests

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,10 +2,10 @@
 
 ### New features since last release
 * Implement Python interface to the `lightning.tensor` device.
-  [(#748)](https://github.com/PennyLaneAI/pennylane-lightning/pull/748) 
+  [(#748)](https://github.com/PennyLaneAI/pennylane-lightning/pull/748)
 
 * Add `inverse` support for gate operations in `lightning.tensor` in the C++ layer.
-  [(#753)](https://github.com/PennyLaneAI/pennylane-lightning/pull/753) 
+  [(#753)](https://github.com/PennyLaneAI/pennylane-lightning/pull/753)
 
 * Add `observable` and `expval` support to `cutensornet` backed `lightning.tensor` C++ layer.
   [(#728)](https://github.com/PennyLaneAI/pennylane-lightning/pull/728)
@@ -45,17 +45,17 @@
   [(#763)](https://github.com/PennyLaneAI/pennylane-lightning/pull/763)
 
 * Change the type of tensor network objects passed to `ObservablesTNCuda` and `MeasurementsTNCuda` class from `StateTensorT` to `TensorNetT`.
-  [(#759)](https://github.com/PennyLaneAI/pennylane-lightning/pull/759) 
-  
+  [(#759)](https://github.com/PennyLaneAI/pennylane-lightning/pull/759)
+
 * Rationalize MCM tests, removing most end-to-end tests from the native MCM test file,
   but keeping one that validates multiple mid-circuit measurements with any allowed return.
   [(#754)](https://github.com/PennyLaneAI/pennylane/pull/754)
 
 * Refactor C++ library names for `lightning.tensor`.
-  [(#755)](https://github.com/PennyLaneAI/pennylane-lightning/pull/755) 
+  [(#755)](https://github.com/PennyLaneAI/pennylane-lightning/pull/755)
 
 * Set `state_tensor` as `const` for the `MeasurementTNCuda` class.
-  [(#753)](https://github.com/PennyLaneAI/pennylane-lightning/pull/753) 
+  [(#753)](https://github.com/PennyLaneAI/pennylane-lightning/pull/753)
 
 * Updated Kokkos version and support to 4.3.01.
   [(#725)](https://github.com/PennyLaneAI/pennylane-lightning/pull/725)
@@ -140,8 +140,11 @@
 * Add support for Scipy v1.14.
   [(#776)](https://github.com/PennyLaneAI/pennylane-lightning/pull/776)
 
-* Add pickle support for the `DevPool` object in `lightning.gpu`. 
+* Add pickle support for the `DevPool` object in `lightning.gpu`.
   [(#772)](https://github.com/PennyLaneAI/pennylane-lightning/pull/772)
+
+* Downgrade Scipy on Lightning stable version tests.
+  [(#783)](https://github.com/PennyLaneAI/pennylane-lightning/pull/783)
 
 ### Contributors
 

--- a/.github/workflows/compat-check-latest-stable.yml
+++ b/.github/workflows/compat-check-latest-stable.yml
@@ -48,4 +48,3 @@ jobs:
       lightning-version: latest
       pennylane-version: stable
     secrets: inherit
-    

--- a/.github/workflows/compat-check-latest-stable.yml
+++ b/.github/workflows/compat-check-latest-stable.yml
@@ -48,3 +48,4 @@ jobs:
       lightning-version: latest
       pennylane-version: stable
     secrets: inherit
+

--- a/.github/workflows/compat-check-stable-latest.yml
+++ b/.github/workflows/compat-check-stable-latest.yml
@@ -48,4 +48,3 @@ jobs:
       lightning-version: stable
       pennylane-version: latest
     secrets: inherit
-  

--- a/.github/workflows/compat-check-stable-latest.yml
+++ b/.github/workflows/compat-check-stable-latest.yml
@@ -48,3 +48,4 @@ jobs:
       lightning-version: stable
       pennylane-version: latest
     secrets: inherit
+

--- a/.github/workflows/tests_lgpumpi_python.yml
+++ b/.github/workflows/tests_lgpumpi_python.yml
@@ -107,8 +107,13 @@ jobs:
         run: |
           source /etc/profile.d/modules.sh && module use /opt/modules/ && module load ${{ matrix.mpilib }}/cuda-${{ matrix.cuda_version_maj }}.${{ matrix.cuda_version_min }}
           python -m pip install -r requirements-dev.txt
+
           python -m pip install custatevec-cu${{ matrix.cuda_version_maj }} mpi4py openfermionpyscf
           PL_BACKEND=lightning_qubit python -m pip install . -vv
+
+      - name: Downgrade Scipy (remove after release)
+        if: inputs.lightning-version == 'stable'
+        run: pip install --force-reinstall "scipy<1.14"
 
       - name: Checkout PennyLane for release build
         if: inputs.pennylane-version == 'release'

--- a/.github/workflows/tests_lqcpu_python.yml
+++ b/.github/workflows/tests_lqcpu_python.yml
@@ -82,6 +82,10 @@ jobs:
           cd main
           python -m pip install -r requirements-dev.txt
 
+      - name: Downgrade Scipy (remove after release)
+        if: inputs.lightning-version == 'stable'
+        run: pip install --force-reinstall "scipy<1.14"
+
       - name: Create device wheel
         id: create_lq_wheel
         run: |

--- a/.github/workflows/tests_lqcpu_python.yml
+++ b/.github/workflows/tests_lqcpu_python.yml
@@ -84,7 +84,9 @@ jobs:
 
       - name: Downgrade Scipy (remove after release)
         if: inputs.lightning-version == 'stable'
-        run: pip install --force-reinstall "scipy<1.14"
+        run: |
+          # TODO: Remove this step with v0.37.0 release
+          python -m pip install --force-reinstall "scipy<1.14"
 
       - name: Create device wheel
         id: create_lq_wheel

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.37.0-dev49"
+__version__ = "0.37.0-dev50"


### PR DESCRIPTION
**Context:** Lightning stable version is incompatible with the latest Scipy version.

**Description of the Change:** We add a downgrade scipy version for some of the latest tests.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
