### PR TITLE
Do not run GPU tests and Docker workflows on release.

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Breaking changes
 
+* Do not run GPU tests and Docker workflows on release.
+  [(#788)](https://github.com/PennyLaneAI/pennylane-lightning/pull/788)
+
 ### Improvements
 
 ### Documentation
@@ -14,11 +17,14 @@
 
 This release contains contributions from (in alphabetical order):
 
+Vincent Michaud-Rioux
+
 ---
 
 # Release 0.37.0
 
 ### New features since last release
+
 * Implement Python interface to the `lightning.tensor` device.
   [(#748)](https://github.com/PennyLaneAI/pennylane-lightning/pull/748)
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,4 +1,22 @@
-# Release 0.37.0-dev
+# Release 0.38.0-dev
+
+### New features since last release
+
+### Breaking changes
+
+### Improvements
+
+### Documentation
+
+### Bug fixes
+
+### Contributors
+
+This release contains contributions from (in alphabetical order):
+
+---
+
+# Release 0.37.0
 
 ### New features since last release
 * Implement Python interface to the `lightning.tensor` device.

--- a/.github/workflows/compat-docker-latest.yml
+++ b/.github/workflows/compat-docker-latest.yml
@@ -1,4 +1,4 @@
-name: Compat Check Docker - Lightning@stable
+name: Compat Check Docker - Lightning@latest
 
 on:
   schedule:
@@ -6,15 +6,15 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: docker_linux_x86_64-stable
+  group: docker_linux_x86_64-latest
   cancel-in-progress: true
 
 jobs:
-  docker_linux_x86_64_stable:
-    name: Docker stable - Linux::x86_64
+  docker_linux_x86_64_develop:
+    name: Docker develop - Linux::x86_64
     uses: ./.github/workflows/docker_linux_x86_64.yml
     with:
-      lightning-version: v0.37.0
-      pennylane-version: v0.37.0
+      lightning-version: latest
+      pennylane-version: latest
       push-to-dockerhub: false
     secrets: inherit # pass all secrets

--- a/.github/workflows/compat-docker-latest.yml
+++ b/.github/workflows/compat-docker-latest.yml
@@ -10,8 +10,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  docker_linux_x86_64_develop:
-    name: Docker develop - Linux::x86_64
+  docker_linux_x86_64_latest:
+    name: Docker latest - Linux::x86_64
     uses: ./.github/workflows/docker_linux_x86_64.yml
     with:
       lightning-version: latest

--- a/.github/workflows/compat-docker-latest.yml
+++ b/.github/workflows/compat-docker-latest.yml
@@ -14,7 +14,7 @@ jobs:
     name: Docker latest - Linux::x86_64
     uses: ./.github/workflows/docker_linux_x86_64.yml
     with:
-      lightning-version: latest
-      pennylane-version: latest
+      lightning-version: master
+      pennylane-version: master
       push-to-dockerhub: false
     secrets: inherit # pass all secrets

--- a/.github/workflows/compat-docker-latest.yml
+++ b/.github/workflows/compat-docker-latest.yml
@@ -1,4 +1,4 @@
-name: Compat Check Docker - Lightning@latest
+name: Compat Check Docker - Lightning@stable
 
 on:
   schedule:
@@ -6,15 +6,15 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: docker_linux_x86_64-latest
+  group: docker_linux_x86_64-stable
   cancel-in-progress: true
 
 jobs:
-  docker_linux_x86_64_latest:
-    name: Docker latest - Linux::x86_64
+  docker_linux_x86_64_stable:
+    name: Docker stable - Linux::x86_64
     uses: ./.github/workflows/docker_linux_x86_64.yml
     with:
-      lightning-version: v0.36.0
-      pennylane-version: v0.36.0
+      lightning-version: v0.37.0
+      pennylane-version: v0.37.0
       push-to-dockerhub: false
     secrets: inherit # pass all secrets

--- a/.github/workflows/compat-docker-master.yml
+++ b/.github/workflows/compat-docker-master.yml
@@ -1,4 +1,4 @@
-name: Compat Check Docker - Lightning@master
+name: Compat Check Docker - Lightning@latest
 
 on:
   schedule:
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: docker_linux_x86_64-master
+  group: docker_linux_x86_64-latest
   cancel-in-progress: true
 
 jobs:
@@ -14,7 +14,7 @@ jobs:
     name: Docker develop - Linux::x86_64
     uses: ./.github/workflows/docker_linux_x86_64.yml
     with:
-      lightning-version: master
-      pennylane-version: master
+      lightning-version: latest
+      pennylane-version: latest
       push-to-dockerhub: false
     secrets: inherit # pass all secrets

--- a/.github/workflows/compat-docker-release.yml
+++ b/.github/workflows/compat-docker-release.yml
@@ -1,17 +1,15 @@
-name: Compat Check Docker - Lightning@latest
+name: Compat Check Docker - Lightning@release
 
 on:
-  schedule:
-    - cron: "0 4 * * 1-5"  # Run daily at 4am Mon-Fri
   workflow_dispatch:
 
 concurrency:
-  group: docker_linux_x86_64-latest
+  group: docker_linux_x86_64-release
   cancel-in-progress: true
 
 jobs:
-  docker_linux_x86_64_latest:
-    name: Docker latest - Linux::x86_64
+  docker_linux_x86_64_release:
+    name: Docker release - Linux::x86_64
     uses: ./.github/workflows/docker_linux_x86_64.yml
     with:
       lightning-version: v0.37.0

--- a/.github/workflows/compat-docker-stable.yml
+++ b/.github/workflows/compat-docker-stable.yml
@@ -1,4 +1,4 @@
-name: Compat Check Docker - Lightning@latest
+name: Compat Check Docker - Lightning@stable
 
 on:
   schedule:
@@ -6,15 +6,15 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: docker_linux_x86_64-latest
+  group: docker_linux_x86_64-stable
   cancel-in-progress: true
 
 jobs:
-  docker_linux_x86_64_develop:
-    name: Docker develop - Linux::x86_64
+  docker_linux_x86_64_stable:
+    name: Docker stable - Linux::x86_64
     uses: ./.github/workflows/docker_linux_x86_64.yml
     with:
-      lightning-version: latest
-      pennylane-version: latest
+      lightning-version: v0.37.0
+      pennylane-version: v0.37.0
       push-to-dockerhub: false
     secrets: inherit # pass all secrets

--- a/.github/workflows/docker_linux_x86_64.yml
+++ b/.github/workflows/docker_linux_x86_64.yml
@@ -81,6 +81,7 @@ jobs:
 
       - name: Build and push version
         uses: docker/build-push-action@v5
+        if: ${{ inputs.push-to-dockerhub == 'true' }}
         with:
           push: ${{ inputs.push-to-dockerhub }}
           context: .
@@ -93,6 +94,7 @@ jobs:
 
       - name: Build and push latest
         uses: docker/build-push-action@v5
+        if: ${{ inputs.push-to-dockerhub == 'true' }}
         with:
           push: ${{ inputs.push-to-dockerhub }}
           context: .

--- a/.github/workflows/docker_linux_x86_64.yml
+++ b/.github/workflows/docker_linux_x86_64.yml
@@ -5,7 +5,6 @@ name: Docker::Linux::x86_64
 # **Who does it impact**: Docker images uploaded to Docker Hub provide yet another way to install and use PennyLane + Lightning. It is especially useful on HPC platforms where environments can be difficult to set up.
 
 on:
-    types: [published]
   workflow_dispatch:
     inputs:
       lightning-version:

--- a/.github/workflows/docker_linux_x86_64.yml
+++ b/.github/workflows/docker_linux_x86_64.yml
@@ -5,7 +5,6 @@ name: Docker::Linux::x86_64
 # **Who does it impact**: Docker images uploaded to Docker Hub provide yet another way to install and use PennyLane + Lightning. It is especially useful on HPC platforms where environments can be difficult to set up.
 
 on:
-  release:
     types: [published]
   workflow_dispatch:
     inputs:

--- a/.github/workflows/tests_lgpu_cpp.yml
+++ b/.github/workflows/tests_lgpu_cpp.yml
@@ -10,7 +10,6 @@ on:
         type: string
         required: true
         description: The version of PennyLane to use. Valid values are either 'release' (most recent release candidate), 'stable' (most recent git-tag) or 'latest' (most recent commit from master)
-  release:
   pull_request:
     paths:
       - .github/workflows/tests_lgpu_cpp.yml

--- a/.github/workflows/tests_lgpu_python.yml
+++ b/.github/workflows/tests_lgpu_python.yml
@@ -10,7 +10,6 @@ on:
         type: string
         required: true
         description: The version of PennyLane to use. Valid values are either 'release' (most recent release candidate), 'stable' (most recent git-tag) or 'latest' (most recent commit from master)
-  release:
   pull_request:
     paths-ignore:
       - .github/**

--- a/.github/workflows/tests_lgpumpi_cpp.yml
+++ b/.github/workflows/tests_lgpumpi_cpp.yml
@@ -10,7 +10,6 @@ on:
         type: string
         required: true
         description: The version of PennyLane to use. Valid values are either 'stable' (most recent git-tag) or 'latest' (most recent commit from master)
-  release:
   push:
     branches:
       - main

--- a/.github/workflows/tests_lgpumpi_python.yml
+++ b/.github/workflows/tests_lgpumpi_python.yml
@@ -10,7 +10,6 @@ on:
         type: string
         required: true
         description: The version of PennyLane to use. Valid values are either 'stable' (most recent git-tag) or 'latest' (most recent commit from master)
-  release:
   push:
     branches:
       - main

--- a/.github/workflows/tests_lmps_tncuda_cpp.yml
+++ b/.github/workflows/tests_lmps_tncuda_cpp.yml
@@ -13,7 +13,6 @@ on:
         type: string
         required: true
         description: The version of PennyLane to use. Valid values are either 'release' (most recent release candidate), 'stable' (most recent git-tag) or 'latest' (most recent commit from master)
-  release:
   pull_request:
     paths:
       - .github/workflows/tests_lmps_tncuda_cpp.yml

--- a/.github/workflows/tests_lmps_tncuda_python.yml
+++ b/.github/workflows/tests_lmps_tncuda_python.yml
@@ -12,7 +12,6 @@ on:
         type: string
         required: true
         description: The version of PennyLane to use. Valid values are either 'release' (most recent release candidate), 'stable' (most recent git-tag) or 'latest' (most recent commit from master)
-  release:
   pull_request:
     paths-ignore:
       - .github/**

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.38.0-dev2"
+__version__ = "0.38.0-dev3"

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.37.0-dev52"
+__version__ = "0.38.0-dev"

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.38.0-dev0"
+__version__ = "0.38.0-dev1"

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.38.0-dev1"
+__version__ = "0.38.0-dev2"


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [x] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [x] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [ ] Ensure that the test suite passes, by running `make test`.

- [x] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [x] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**
Some test workflows are run on release (GPU ones) and not others.
The Docker build workflow is also run, but it it missing required inputs.

**Description of the Change:**
Do not run the mentioned workflows on release. The Docker workflow in particular cannot be run because it requires the new PennyLane release which is not available when Lightning is released. 

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-68101]