### PR TITLE
Set PL_BACKEND in L-GPU docker build and misc improvements

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -9,12 +9,18 @@
 
 ### Improvements
 
+* Enable setting the PennyLane version when invoking, for example, `make docker-build version=master pl_version=master`.
+  [(#791)](https://github.com/PennyLaneAI/pennylane-lightning/pull/791)
+
 * Add a Catalyst-specific wrapping class for Lightning Kokkos.
   [(#770)](https://github.com/PennyLaneAI/pennylane-lightning/pull/770)
 
 ### Documentation
 
 ### Bug fixes
+
+* Set `PL_BACKEND` for the entire `build-wheel-lightning-gpu` Docker-build stage to properly build the Lightning-GPU wheel.
+  [(#791)](https://github.com/PennyLaneAI/pennylane-lightning/pull/791)
 
 * Fix conditions for skipping build & push steps in the Docker build workflows.
   [(#790)](https://github.com/PennyLaneAI/pennylane-lightning/pull/790)

--- a/Makefile
+++ b/Makefile
@@ -150,28 +150,33 @@ endif
 ifdef version
     VERSION := $(version)
 else
-    VERSION := v0.36.0
+    VERSION := master
+endif
+ifdef pl_version
+    PL_VERSION := $(pl_version)
+else
+    PL_VERSION := master
 endif
 
 docker-build:
 	docker build -f docker/Dockerfile \
 		  --tag=pennylaneai/pennylane:$(VERSION)-$(TARGET) \
 		  --target wheel-$(TARGET) \
-		  --build-arg='LIGHTNING_VERSION=$(VERSION)' .
+		  --build-arg='LIGHTNING_VERSION=$(VERSION)' --build-arg='PENNYLANE_VERSION=$(PL_VERSION)' .
 docker-push:
 	docker push pennylaneai/pennylane:$(VERSION)-$(TARGET)
 docker-build-all:
-	$(MAKE) docker-build target=lightning-qubit
-	$(MAKE) docker-build target=lightning-gpu
-	$(MAKE) docker-build target=lightning-kokkos-openmp
-	$(MAKE) docker-build target=lightning-kokkos-cuda
-	$(MAKE) docker-build target=lightning-kokkos-rocm
+	$(MAKE) docker-build target=lightning-qubit 		pl_version=$(PL_VERSION) version=$(VERSION)
+	$(MAKE) docker-build target=lightning-gpu 			pl_version=$(PL_VERSION) version=$(VERSION)
+	$(MAKE) docker-build target=lightning-kokkos-openmp pl_version=$(PL_VERSION) version=$(VERSION)
+	$(MAKE) docker-build target=lightning-kokkos-cuda 	pl_version=$(PL_VERSION) version=$(VERSION)
+	$(MAKE) docker-build target=lightning-kokkos-rocm 	pl_version=$(PL_VERSION) version=$(VERSION)
 docker-push-all:
-	$(MAKE) docker-push target=lightning-qubit
-	$(MAKE) docker-push target=lightning-gpu
-	$(MAKE) docker-push target=lightning-kokkos-openmp
-	$(MAKE) docker-push target=lightning-kokkos-cuda
-	$(MAKE) docker-push target=lightning-kokkos-rocm
+	$(MAKE) docker-push target=lightning-qubit 			pl_version=$(PL_VERSION) version=$(VERSION)
+	$(MAKE) docker-push target=lightning-gpu 			pl_version=$(PL_VERSION) version=$(VERSION)
+	$(MAKE) docker-push target=lightning-kokkos-openmp 	pl_version=$(PL_VERSION) version=$(VERSION)
+	$(MAKE) docker-push target=lightning-kokkos-cuda 	pl_version=$(PL_VERSION) version=$(VERSION)
+	$(MAKE) docker-push target=lightning-kokkos-rocm 	pl_version=$(PL_VERSION) version=$(VERSION)
 docker-all:
 	$(MAKE) docker-build-all
 	$(MAKE) docker-push-all

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,27 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Define build arguments
-ARG CUDA_ARCH=AMPERE80
-ARG AMD_ARCH=AMD_GFX90A
-ARG CUDA_INSTALLER=https://developer.download.nvidia.com/compute/cuda/12.2.2/local_installers/cuda_12.2.2_535.104.05_linux.run
-ARG DEBIAN_FRONTEND=noninteractive
-ARG GCC_VERSION=11
-ARG LIGHTNING_VERSION=master
+# Define global build defaults
 ARG PENNYLANE_VERSION=master
-ARG ROCM_INSTALLER=https://repo.radeon.com/amdgpu-install/5.7/ubuntu/jammy/amdgpu-install_5.7.50700-1_all.deb
 
 # Create basic runtime environment base on Ubuntu 22.04 (jammy)
 # Create and activate runtime virtual environment
 FROM ubuntu:jammy AS base-runtime
-ARG CUDA_ARCH
-ARG AMD_ARCH
-ARG CUDA_INSTALLER
-ARG DEBIAN_FRONTEND
-ARG GCC_VERSION
-ARG LIGHTNING_VERSION
+ARG AMD_ARCH=AMD_GFX90A
+ARG CUDA_ARCH=AMPERE80
+ARG CUDA_INSTALLER=https://developer.download.nvidia.com/compute/cuda/12.2.2/local_installers/cuda_12.2.2_535.104.05_linux.run
+ARG DEBIAN_FRONTEND=noninteractive
+ARG GCC_VERSION=11
+ARG LIGHTNING_VERSION=master
 ARG PENNYLANE_VERSION
-ARG ROCM_INSTALLER
+ARG ROCM_INSTALLER=https://repo.radeon.com/amdgpu-install/5.7/ubuntu/jammy/amdgpu-install_5.7.50700-1_all.deb
 RUN apt-get update \
     && apt-get install --no-install-recommends -y \
     apt-utils \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,18 +12,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Create basic runtime environment base on Ubuntu 22.04 (jammy)
 # Define build arguments
-# Create and activate runtime virtual environment
-FROM ubuntu:jammy AS base-runtime
 ARG CUDA_ARCH=AMPERE80
 ARG AMD_ARCH=AMD_GFX90A
 ARG CUDA_INSTALLER=https://developer.download.nvidia.com/compute/cuda/12.2.2/local_installers/cuda_12.2.2_535.104.05_linux.run
 ARG DEBIAN_FRONTEND=noninteractive
 ARG GCC_VERSION=11
-ARG LIGHTNING_VERSION=v0.36.0
-ARG PENNYLANE_VERSION=v0.36.0
+ARG LIGHTNING_VERSION=master
+ARG PENNYLANE_VERSION=master
 ARG ROCM_INSTALLER=https://repo.radeon.com/amdgpu-install/5.7/ubuntu/jammy/amdgpu-install_5.7.50700-1_all.deb
+
+# Create basic runtime environment base on Ubuntu 22.04 (jammy)
+# Create and activate runtime virtual environment
+FROM ubuntu:jammy AS base-runtime
+ARG CUDA_ARCH
+ARG AMD_ARCH
+ARG CUDA_INSTALLER
+ARG DEBIAN_FRONTEND
+ARG GCC_VERSION
+ARG LIGHTNING_VERSION
+ARG PENNYLANE_VERSION
+ARG ROCM_INSTALLER
 RUN apt-get update \
     && apt-get install --no-install-recommends -y \
     apt-utils \
@@ -122,7 +131,7 @@ RUN python setup.py bdist_wheel
 # Install python3 and setup runtime virtual env in CUDA-12-runtime image (includes CUDA runtime and math libraries)
 # Install lightning-kokkos CUDA backend
 FROM nvidia/cuda:12.2.0-base-ubuntu22.04 AS wheel-lightning-kokkos-cuda
-ARG PENNYLANE_VERSION=v0.36.0
+ARG PENNYLANE_VERSION
 RUN apt-get update \
     && apt-get install --no-install-recommends -y \
     libgomp1 \
@@ -143,15 +152,16 @@ RUN pip install --no-cache-dir git+https://github.com/PennyLaneAI/pennylane.git@
 # Download and build Lightning-GPU release
 FROM base-build-cuda AS build-wheel-lightning-gpu
 WORKDIR /opt/pennylane-lightning
+ENV PL_BACKEND=lightning_gpu
 RUN pip install --no-cache-dir wheel custatevec-cu12
 RUN pip uninstall -y pennylane-lightning
-RUN CUQUANTUM_SDK=$(python -c "import site; print( f'{site.getsitepackages()[0]}/cuquantum/lib')") PL_BACKEND=lightning_gpu python setup.py build_ext
+RUN CUQUANTUM_SDK=$(python -c "import site; print( f'{site.getsitepackages()[0]}/cuquantum/lib')") python setup.py build_ext
 RUN python setup.py bdist_wheel
 
 # Install python3 and setup runtime virtual env in CUDA-12-runtime image (includes CUDA runtime and math libraries)
 # Install lightning-kokkos CUDA backend
 FROM nvidia/cuda:12.2.0-runtime-ubuntu22.04 AS wheel-lightning-gpu
-ARG PENNYLANE_VERSION=v0.36.0
+ARG PENNYLANE_VERSION
 RUN apt-get update \
     && apt-get install --no-install-recommends -y \
     git \
@@ -189,12 +199,12 @@ ENV CMAKE_PREFIX_PATH=/opt/rocm:$CMAKE_PREFIX_PATH
 ENV CXX=hipcc
 ENV PL_BACKEND=lightning_kokkos
 RUN pip uninstall -y pennylane-lightning
-RUN python setup.py build_ext -i --define="PL_BACKEND=lightning_kokkos;Kokkos_ENABLE_SERIAL:BOOL=ON;Kokkos_ENABLE_OPENMP:BOOL=ON;Kokkos_ENABLE_HIP:BOOL=ON;Kokkos_ARCH_${AMD_ARCH}=ON"
+RUN python setup.py build_ext -i --define="Kokkos_ENABLE_SERIAL:BOOL=ON;Kokkos_ENABLE_OPENMP:BOOL=ON;Kokkos_ENABLE_HIP:BOOL=ON;Kokkos_ARCH_${AMD_ARCH}=ON"
 RUN python setup.py bdist_wheel
 
 # Install lightning-kokkos HIP backend
 FROM rocm/dev-ubuntu-22.04:5.7 AS wheel-lightning-kokkos-rocm
-ARG PENNYLANE_VERSION=v0.36.0
+ARG PENNYLANE_VERSION
 RUN apt-get update \
     && apt-get install --no-install-recommends -y \
     git \

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.38.0-dev4"
+__version__ = "0.38.0-dev5"


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [x] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [x] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [x] Ensure that the test suite passes, by running `make test`.

- [x] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [x] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**
The Lightning-GPU Docker image has not installed the wheel correctly as the wheel-building command was missing the environment variable `PL_BACKEND=lightning_gpu`. 

**Description of the Change:**
Set the environment variable `PL_BACKEND=lightning_gpu` in the `build-wheel-lightning-gpu` Docker-build stage.
Enhance Docker-related `make` commands.
Enable Dockerfile level defaults for build arguments.
Set the default Lightning and PennyLane versions to `master`.

**Benefits:**
L-GPU installs the correct wheels.
No need to update hardcoded tags/versions since `master` is moving.

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-68127]