### PR TITLE
Remove obsolete commands in CI (post-release fixes)

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Breaking changes
 
+* Remove temporary steps from the CI, such as downgrading Scipy to <1.14 and installing Kokkos v4.2 for `lightning-version == 'stable'`.
+  [(#792)](https://github.com/PennyLaneAI/pennylane-lightning/pull/792)
+
 * Do not run GPU tests and Docker workflows on release.
   [(#788)](https://github.com/PennyLaneAI/pennylane-lightning/pull/788)
 

--- a/.github/workflows/tests_lgpumpi_python.yml
+++ b/.github/workflows/tests_lgpumpi_python.yml
@@ -112,10 +112,6 @@ jobs:
           python -m pip install custatevec-cu${{ matrix.cuda_version_maj }} mpi4py openfermionpyscf
           PL_BACKEND=lightning_qubit python -m pip install . -vv
 
-      - name: Downgrade Scipy (remove after release)
-        if: inputs.lightning-version == 'stable'
-        run: pip install --force-reinstall "scipy<1.14"
-
       - name: Checkout PennyLane for release build
         if: inputs.pennylane-version == 'release'
         uses: actions/checkout@v4

--- a/.github/workflows/tests_lkcpu_python.yml
+++ b/.github/workflows/tests_lkcpu_python.yml
@@ -50,7 +50,7 @@ jobs:
     uses: ./.github/workflows/build_and_cache_Kokkos_linux.yml
     with:
       os: ubuntu-22.04
-      kokkos_version: ${{ inputs.lightning-version == 'stable' && '4.2.00' || '4.3.01' }} #To be updated next Release.
+      kokkos_version: "4.3.01"
 
   build_lightning_kokkos_wheels:
     needs: [determine_runner, build_and_cache_Kokkos]
@@ -244,8 +244,6 @@ jobs:
 
       - name: Run PennyLane-Lightning unit tests
         run: |
-          # TODO: Remove installing pytest-xdist with release v0.36.0
-          python -m pip install pytest-xdist
           cd main/
           DEVICENAME=`echo ${{ matrix.pl_backend }} | sed "s/_/./g"`
             PL_DEVICE=${DEVICENAME} python -m pytest tests/ $COVERAGE_FLAGS --splits 7 --group ${{ matrix.group }} \

--- a/.github/workflows/tests_lkcuda_python.yml
+++ b/.github/workflows/tests_lkcuda_python.yml
@@ -48,7 +48,7 @@ jobs:
       matrix:
         os: [ubuntu-22.04]
         exec_model: ["CUDA"]
-        kokkos_version: ["${{ inputs.lightning-version == 'stable' && '4.2.00' || '4.3.01' }}"] #To be updated next Release.
+        kokkos_version: ["4.3.01"]
 
     steps:
       - name: Validate GPU version and installed compiler
@@ -113,7 +113,7 @@ jobs:
         os: [ubuntu-22.04]
         pl_backend: ["lightning_kokkos", "all"]
         exec_model: ["CUDA"]
-        kokkos_version: ["${{ inputs.lightning-version == 'stable' && '4.2.00' || '4.3.01' }}"] #To be updated next Release.
+        kokkos_version: ["4.3.01"]
 
     name: Python Tests (${{ matrix.pl_backend }}, kokkos-${{ matrix.kokkos_version }}, model-${{ matrix.exec_model }})
     runs-on:

--- a/.github/workflows/tests_lqcpu_python.yml
+++ b/.github/workflows/tests_lqcpu_python.yml
@@ -82,12 +82,6 @@ jobs:
           cd main
           python -m pip install -r requirements-dev.txt
 
-      - name: Downgrade Scipy (remove after release)
-        if: inputs.lightning-version == 'stable'
-        run: |
-          # TODO: Remove this step with v0.37.0 release
-          python -m pip install --force-reinstall "scipy<1.14"
-
       - name: Create device wheel
         id: create_lq_wheel
         run: |
@@ -196,8 +190,6 @@ jobs:
 
       - name: Run PennyLane-Lightning unit tests
         run: |
-          # TODO: Remove installing pytest-xdist with release v0.36.0
-          python -m pip install pytest-xdist
           cd main/
           DEVICENAME=`echo ${{ matrix.pl_backend }} | sed "s/_/./g"`
           OMP_NUM_THREADS=1 PL_DEVICE=${DEVICENAME} python -m pytest -n auto tests/ -k "not unitary_correct" \

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.38.0-dev4"
+__version__ = "0.38.0-dev5"

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.38.0-dev5"
+__version__ = "0.38.0-dev6"


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [x] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [x] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [x] Ensure that the test suite passes, by running `make test`.

- [x] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [x] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**
Compatibility stable workflows are failing after release v0.37.0.

**Description of the Change:**
Remove temporary steps from the CI, such as downgrading Scipy to <1.14 and installing Kokkos v4.2 for `lightning-version == 'stable'`.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-68100]