### PR TITLE
Update toml files with sum_observables flag

### DIFF
--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.38.0-dev6"
+__version__ = "0.38.0-dev7"

--- a/pennylane_lightning/lightning_gpu/lightning_gpu.toml
+++ b/pennylane_lightning/lightning_gpu/lightning_gpu.toml
@@ -109,3 +109,6 @@ dynamic_qubit_management = false
 # in a single execution
 non_commuting_observables = true
 
+# whether the device can natively support measuring a sum of observables
+sum_observables = true
+

--- a/pennylane_lightning/lightning_kokkos/lightning_kokkos.toml
+++ b/pennylane_lightning/lightning_kokkos/lightning_kokkos.toml
@@ -112,3 +112,6 @@ dynamic_qubit_management = false
 # in a single execution
 non_commuting_observables = true
 
+# whether the device can natively support measuring a sum of observables
+sum_observables = true
+

--- a/pennylane_lightning/lightning_qubit/lightning_qubit.toml
+++ b/pennylane_lightning/lightning_qubit/lightning_qubit.toml
@@ -107,6 +107,9 @@ dynamic_qubit_management = false
 # in a single execution
 non_commuting_observables = true
 
+# whether the device can natively support measuring a sum of observables
+sum_observables = true
+
 [options]
 
 mcmc = "_mcmc"


### PR DESCRIPTION
**Context:**
Catalyst is adding `sum_observables` as a flag in the TOML file, and conditionally applying the `split_to_single_terms` transform in the QJIT device preprocessing if the backend doesn't allow sum observables (but doesn't need to apply `split_non_commuting`).

**Description of the Change:**
Update the lightning TOML files to indicate that sum observables are supported.

**Benefits:**
Lightning stays consistent with the changes in [this PR](https://github.com/PennyLaneAI/catalyst/pull/927)