### PR TITLE
Optimize LQ::probs for large number of targets

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -15,6 +15,9 @@
 
 ### Improvements
 
+* Optimize the OpenMP parallelization of Lightning-Qubit's `probs` for all number of targets.
+  [(#807)](https://github.com/PennyLaneAI/pennylane-lightning/pull/807)
+
 * Add GPU device compute capability check for Lightning-Tensor.
   [(#803)](https://github.com/PennyLaneAI/pennylane-lightning/pull/803)
 

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.38.0-dev11"
+__version__ = "0.38.0-dev12"

--- a/pennylane_lightning/core/src/simulators/lightning_qubit/measurements/MeasurementsLQubit.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_qubit/measurements/MeasurementsLQubit.hpp
@@ -106,9 +106,11 @@ class Measurements final
         -> std::vector<PrecisionT> {
         const std::size_t n_wires = wires.size();
         if (n_wires == 0) {
-            return {0.0};
+            return {1.0};
         }
         const std::size_t num_qubits = this->_statevector.getNumQubits();
+        // is_equal_to_all_wires is True if `wires` includes all wires in order
+        // and false otherwise
         bool is_equal_to_all_wires = n_wires == num_qubits;
         for (std::size_t k = 0; k < n_wires; k++) {
             if (!is_equal_to_all_wires) {
@@ -122,7 +124,7 @@ class Measurements final
 
         const ComplexT *arr_data = this->_statevector.getData();
 
-        // Templated 1-4 qubit cases
+        // Templated 1-4 wire cases; return probs 
         PROBS_SPECIAL_CASE(1);
         PROBS_SPECIAL_CASE(2);
         PROBS_SPECIAL_CASE(3);
@@ -135,6 +137,10 @@ class Measurements final
         const std::size_t n_probs = PUtil::exp2(n_wires);
         std::vector<PrecisionT> probabilities(n_probs, 0);
         auto *probs = probabilities.data();
+        // For 5 wires and more, there are at least 32 probs entries to
+        // parallelize over This scheme was found most favorable in terms of
+        // memory accesses and it prevents the stack overflow caused by
+        // `reduction(+ : probs[ : n_probs])` when n_probs approaches 2**20
 #if defined PL_LQ_KERNEL_OMP && defined _OPENMP
 #pragma omp parallel for collapse(1)
 #endif

--- a/pennylane_lightning/core/src/simulators/lightning_qubit/measurements/MeasurementsLQubit.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_qubit/measurements/MeasurementsLQubit.hpp
@@ -142,7 +142,7 @@ class Measurements final
         // memory accesses and it prevents the stack overflow caused by
         // `reduction(+ : probs[ : n_probs])` when n_probs approaches 2**20
 #if defined PL_LQ_KERNEL_OMP && defined _OPENMP
-#pragma omp parallel for collapse(1)
+#pragma omp parallel for
 #endif
         for (std::size_t ind_probs = 0; ind_probs < n_probs; ind_probs++) {
             for (auto offset : all_offsets) {


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [x] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [x] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [x] Ensure that the test suite passes, by running `make test`.

- [x] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [x] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**
The parallel performance of `probs` is terrible when the input has many targets. For instance with 16 OpenMP threads:
```
tgt=8,qubits=20,probs,t_avg=5.50773,t_ratio=1/1000
tgt=9,qubits=20,probs,t_avg=8.44628,t_ratio=1/1000
tgt=10,qubits=20,probs,t_avg=17.0945,t_ratio=1/1000
tgt=11,qubits=20,probs,t_avg=43.9831,t_ratio=1/1000
tgt=12,qubits=20,probs,t_avg=135.431,t_ratio=1/1000
tgt=13,qubits=20,probs,t_avg=354.502,t_ratio=1/1000
tgt=14,qubits=20,probs,t_avg=1099.4,t_ratio=1/1000
tgt=15,qubits=20,probs,t_avg=3680.11,t_ratio=1/1000
tgt=16,qubits=20,probs,t_avg=10363.3,t_ratio=1/1000
tgt=17,qubits=20,probs,t_avg=35061.4,t_ratio=1/1000
```
 
**Description of the Change:**
Parallelize the double loop over the loop on `probs` only. 

**Benefits:**
Faster execution for any number of targets on "normal" processor (< 129 cores). I won't show a proper sweep over the number of targets because the current version is too slow to do so.
```
tgt=8,qubits=20,probs,t_avg=2.93886,t_ratio=1/1000
tgt=9,qubits=20,probs,t_avg=3.17052,t_ratio=1/1000
tgt=10,qubits=20,probs,t_avg=2.86489,t_ratio=1/1000
tgt=11,qubits=20,probs,t_avg=2.61477,t_ratio=1/1000
tgt=12,qubits=20,probs,t_avg=2.40587,t_ratio=1/1000
tgt=13,qubits=20,probs,t_avg=2.23169,t_ratio=1/1000
tgt=14,qubits=20,probs,t_avg=2.08594,t_ratio=1/1000
tgt=15,qubits=20,probs,t_avg=1.97252,t_ratio=1/1000
tgt=16,qubits=20,probs,t_avg=2.30553,t_ratio=1/1000
tgt=17,qubits=20,probs,t_avg=2.44993,t_ratio=1/1000
```

**Possible Drawbacks:**
"Abnormal" processors (i.e. 1024 cores) could benefit from a different parallelization strategy in certain edge cases.

**Related GitHub Issues:**
[sc-69165]