### PR TITLE
Add `sample(wires)` support in LightningQubit

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 ### Improvements
 
-* Add `sample(wires)` support in LightningQubit.
+* Add `generate_samples(wires)` support in LightningQubit.
   [(#809)](https://github.com/PennyLaneAI/pennylane-lightning/pull/809)
   
 * Optimize the OpenMP parallelization of Lightning-Qubit's `probs` for all number of targets.

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -15,6 +15,9 @@
 
 ### Improvements
 
+* Add `sample(wires)` support in LightningQubit.
+  [(#809)](https://github.com/PennyLaneAI/pennylane-lightning/pull/809)
+
 * Add GPU device compute capability check for Lightning-Tensor.
   [(#803)](https://github.com/PennyLaneAI/pennylane-lightning/pull/803)
 

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.38.0-dev11"
+__version__ = "0.38.0-dev12"

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.38.0-dev12"
+__version__ = "0.38.0-dev13"

--- a/pennylane_lightning/core/src/bindings/Bindings.hpp
+++ b/pennylane_lightning/core/src/bindings/Bindings.hpp
@@ -189,7 +189,7 @@ auto alignedNumpyArray(CPUMemoryModel memory_model, std::size_t size,
  * @param size Size of the array to create
  * @param dt Pybind11's datatype object
  */
-auto allocateAlignedArray(std::size_t size, const py::dtype &dt,
+auto allocateAlignedArray(size_t size, const py::dtype &dt,
                           bool zeroInit = false) -> py::array {
     // TODO: Move memset operations to here to reduce zeroInit pass-throughs.
     auto memory_model = bestCPUMemoryModel();
@@ -474,25 +474,24 @@ void registerBackendAgnosticMeasurements(PyClass &pyclass) {
                 return M.var(*ob);
             },
             "Variance of an observable object.")
-        .def("generate_samples",
-             [](Measurements<StateVectorT> &M, std::size_t num_wires,
-                std::size_t num_shots) {
-                 auto &&result = M.generate_samples(num_shots);
-                 const std::size_t ndim = 2;
-                 const std::vector<std::size_t> shape{num_shots, num_wires};
-                 constexpr auto sz = sizeof(std::size_t);
-                 const std::vector<std::size_t> strides{sz * num_wires, sz};
-                 // return 2-D NumPy array
-                 return py::array(py::buffer_info(
-                     result.data(), /* data as contiguous array  */
-                     sz,            /* size of one scalar        */
-                     py::format_descriptor<std::size_t>::format(), /* data type
-                                                                    */
-                     ndim,   /* number of dimensions      */
-                     shape,  /* shape of the matrix       */
-                     strides /* strides for each axis     */
-                     ));
-             });
+        .def("generate_samples", [](Measurements<StateVectorT> &M,
+                                    std::size_t num_wires,
+                                    std::size_t num_shots) {
+            auto &&result = M.generate_samples(num_shots);
+            const std::size_t ndim = 2;
+            const std::vector<std::size_t> shape{num_shots, num_wires};
+            constexpr auto sz = sizeof(size_t);
+            const std::vector<std::size_t> strides{sz * num_wires, sz};
+            // return 2-D NumPy array
+            return py::array(py::buffer_info(
+                result.data(), /* data as contiguous array  */
+                sz,            /* size of one scalar        */
+                py::format_descriptor<std::size_t>::format(), /* data type */
+                ndim,   /* number of dimensions      */
+                shape,  /* shape of the matrix       */
+                strides /* strides for each axis     */
+                ));
+        });
 }
 
 /**
@@ -560,7 +559,7 @@ void registerBackendAgnosticAlgorithms(py::module_ &m) {
         .def("__repr__", [](const OpsData<StateVectorT> &ops) {
             using namespace Pennylane::Util;
             std::ostringstream ops_stream;
-            for (std::size_t op = 0; op < ops.getSize(); op++) {
+            for (size_t op = 0; op < ops.getSize(); op++) {
                 ops_stream << "{'name': " << ops.getOpsName()[op];
                 ops_stream << ", 'params': " << ops.getOpsParams()[op];
                 ops_stream << ", 'inv': " << ops.getOpsInverses()[op];
@@ -592,7 +591,7 @@ void registerBackendAgnosticAlgorithms(py::module_ &m) {
            const std::vector<std::vector<bool>> &ops_controlled_values) {
             std::vector<std::vector<ComplexT>> conv_matrices(
                 ops_matrices.size());
-            for (std::size_t op = 0; op < ops_name.size(); op++) {
+            for (size_t op = 0; op < ops_name.size(); op++) {
                 const auto m_buffer = ops_matrices[op].request();
                 if (m_buffer.size) {
                     const auto m_ptr =

--- a/pennylane_lightning/core/src/bindings/Bindings.hpp
+++ b/pennylane_lightning/core/src/bindings/Bindings.hpp
@@ -492,26 +492,7 @@ void registerBackendAgnosticMeasurements(PyClass &pyclass) {
                      shape,  /* shape of the matrix       */
                      strides /* strides for each axis     */
                      ));
-             })
-        .def("generate_samples", [](Measurements<StateVectorT> &M,
-                                    const std::vector<std::size_t> &wires,
-                                    const std::size_t num_shots) {
-            const std::size_t num_wires = wires.size();
-            auto &&result = M.generate_samples(wires, num_shots);
-            const std::size_t ndim = 2;
-            const std::vector<std::size_t> shape{num_shots, num_wires};
-            constexpr auto sz = sizeof(std::size_t);
-            const std::vector<std::size_t> strides{sz * num_wires, sz};
-            // return 2-D NumPy array
-            return py::array(py::buffer_info(
-                result.data(), /* data as contiguous array  */
-                sz,            /* size of one scalar        */
-                py::format_descriptor<std::size_t>::format(), /* data type */
-                ndim,   /* number of dimensions      */
-                shape,  /* shape of the matrix       */
-                strides /* strides for each axis     */
-                ));
-        });
+             });
 }
 
 /**

--- a/pennylane_lightning/core/src/simulators/lightning_qubit/bindings/LQubitBindings.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_qubit/bindings/LQubitBindings.hpp
@@ -292,6 +292,27 @@ void registerBackendSpecificMeasurements(PyClass &pyclass) {
                     static_cast<sparse_index_type>(values.request().size));
             },
             "Variance of a sparse Hamiltonian.")
+        .def("generate_samples",
+             [](Measurements<StateVectorT> &M,
+                const std::vector<std::size_t> &wires,
+                const std::size_t num_shots) {
+                 const std::size_t num_wires = wires.size();
+                 auto &&result = M.generate_samples(wires, num_shots);
+                 const std::size_t ndim = 2;
+                 const std::vector<std::size_t> shape{num_shots, num_wires};
+                 constexpr auto sz = sizeof(std::size_t);
+                 const std::vector<std::size_t> strides{sz * num_wires, sz};
+                 // return 2-D NumPy array
+                 return py::array(py::buffer_info(
+                     result.data(), /* data as contiguous array  */
+                     sz,            /* size of one scalar        */
+                     py::format_descriptor<std::size_t>::format(), /* data type
+                                                                    */
+                     ndim,   /* number of dimensions      */
+                     shape,  /* shape of the matrix       */
+                     strides /* strides for each axis     */
+                     ));
+             })
         .def("generate_mcmc_samples", [](Measurements<StateVectorT> &M,
                                          std::size_t num_wires,
                                          const std::string &kernelname,

--- a/pennylane_lightning/core/src/simulators/lightning_qubit/measurements/MeasurementKernels.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_qubit/measurements/MeasurementKernels.hpp
@@ -19,7 +19,9 @@
 #pragma once
 
 #include <complex>
+#include <random>
 #include <stack>
+#include <utility>
 #include <vector>
 
 #include "BitUtil.hpp"

--- a/pennylane_lightning/core/src/simulators/lightning_qubit/measurements/MeasurementKernels.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_qubit/measurements/MeasurementKernels.hpp
@@ -348,7 +348,7 @@ template <typename PrecisionT> class DiscreteRandomVariable {
         std::stack<std::size_t> underfull_bucket_ids;
         std::stack<std::size_t> overfull_bucket_ids;
 
-        for (std::size_t i = 0; i < n_probs_; ++i) {
+        for (std::size_t i = 0; i < n_probs_; i++) {
             bucket_partners[i].first = n_probs_ * probs[i];
             if (bucket_partners[i].first < 1.0) {
                 underfull_bucket_ids.push(i);

--- a/pennylane_lightning/core/src/simulators/lightning_qubit/measurements/MeasurementKernels.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_qubit/measurements/MeasurementKernels.hpp
@@ -302,24 +302,24 @@ namespace Pennylane::LightningQubit::Measures {
  *
  * @tparam PrecisionT Precision data type
  */
-template <typename PrecisionT> class discrete_random_variable {
+template <typename PrecisionT> class DiscreteRandomVariable {
   private:
     static constexpr std::size_t default_index =
         std::numeric_limits<std::size_t>::max();
     const std::vector<std::pair<double, std::size_t>> bucket_partners_;
     std::mt19937 &gen_;
-    const std::size_t n_probs;
-    mutable std::uniform_real_distribution<PrecisionT> distribution{0.0, 1.0};
+    const std::size_t _n_probs;
+    mutable std::uniform_real_distribution<PrecisionT> _distribution{0.0, 1.0};
 
   public:
     /**
-     * @brief Create a discrete_random_variable object.
+     * @brief Create a DiscreteRandomVariable object.
      *
      * @param gen Random number generator reference.
      * @param probs Probabilities for values 0 up to N - 1, where N =
      * probs.size().
      */
-    discrete_random_variable(std::mt19937 &gen,
+    DiscreteRandomVariable(std::mt19937 &gen,
                              const std::vector<PrecisionT> &probs)
         : bucket_partners_(init_bucket_partners_(probs)), gen_{gen},
           n_probs{probs.size()} {}
@@ -348,7 +348,7 @@ template <typename PrecisionT> class discrete_random_variable {
         std::stack<std::size_t> underfull_bucket_ids;
         std::stack<std::size_t> overfull_bucket_ids;
 
-        for (std::size_t i = 0; i < n_probs; ++i) {
+        for (std::size_t i = 0; i < n_probs; i++) {
             bucket_partners[i].first = n_probs * probs[i];
             if (bucket_partners[i].first < 1.0) {
                 underfull_bucket_ids.push(i);

--- a/pennylane_lightning/core/src/simulators/lightning_qubit/measurements/MeasurementKernels.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_qubit/measurements/MeasurementKernels.hpp
@@ -309,6 +309,8 @@ namespace Pennylane::LightningQubit::Measures {
  */
 template <typename PrecisionT> class discrete_random_variable {
   private:
+    static constexpr std::size_t default_index =
+        std::numeric_limits<std::size_t>::max();
     const std::vector<std::pair<double, std::size_t>> bucket_partners_;
     std::mt19937 &gen_;
     const std::size_t n_probs;
@@ -331,15 +333,12 @@ template <typename PrecisionT> class discrete_random_variable {
      * @brief Return a discrete random value.
      */
     std::size_t operator()() const {
-        const std::size_t idx =
-            static_cast<std::size_t>(distribution(gen_) * n_probs);
+        const auto idx = static_cast<std::size_t>(distribution(gen_) * n_probs);
         if (distribution(gen_) >= bucket_partners_[idx].first and
-            bucket_partners_[idx].second !=
-                std::numeric_limits<std::size_t>::max()) {
+            bucket_partners_[idx].second != default_index) {
             return bucket_partners_[idx].second;
-        } else {
-            return idx;
         }
+        return idx;
     }
 
   private:
@@ -350,7 +349,7 @@ template <typename PrecisionT> class discrete_random_variable {
     init_bucket_partners_(const std::vector<PrecisionT> &probs) {
         const std::size_t n_probs = probs.size();
         std::vector<std::pair<double, std::size_t>> bucket_partners(
-            n_probs, {0.0, std::numeric_limits<std::size_t>::max()});
+            n_probs, {0.0, default_index});
         std::stack<std::size_t> underfull_bucket_ids;
         std::stack<std::size_t> overfull_bucket_ids;
 

--- a/pennylane_lightning/core/src/simulators/lightning_qubit/measurements/MeasurementKernels.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_qubit/measurements/MeasurementKernels.hpp
@@ -18,11 +18,6 @@
  */
 #pragma once
 
-// #include <algorithm>
-// #include <functional>
-// #include <limits>
-// #include <random>
-
 #include <complex>
 #include <stack>
 #include <vector>
@@ -353,14 +348,8 @@ template <typename PrecisionT> class discrete_random_variable {
         std::stack<std::size_t> underfull_bucket_ids;
         std::stack<std::size_t> overfull_bucket_ids;
 
-#if defined PL_LQ_KERNEL_OMP && defined _OPENMP
-#pragma omp parallel for
-#endif
         for (std::size_t i = 0; i < n_probs; ++i) {
             bucket_partners[i].first = n_probs * probs[i];
-        }
-
-        for (std::size_t i = 0; i < n_probs; ++i) {
             if (bucket_partners[i].first < 1.0) {
                 underfull_bucket_ids.push(i);
             } else {

--- a/pennylane_lightning/core/src/simulators/lightning_qubit/measurements/MeasurementsLQubit.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_qubit/measurements/MeasurementsLQubit.hpp
@@ -599,6 +599,9 @@ class Measurements final
         std::vector<std::size_t> samples(num_samples * n_wires);
         this->setRandomSeed();
         discrete_random_variable<PrecisionT> drv{this->rng, probs(wires)};
+#if defined PL_LQ_KERNEL_OMP && defined _OPENMP
+#pragma omp parallel for
+#endif
         for (std::size_t s = 0; s < num_samples; s++) {
             const std::size_t idx = drv();
             for (std::size_t j = 0; j < n_wires; j++) {

--- a/pennylane_lightning/core/src/simulators/lightning_qubit/measurements/MeasurementsLQubit.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_qubit/measurements/MeasurementsLQubit.hpp
@@ -598,6 +598,10 @@ class Measurements final
         std::vector<std::size_t> samples(num_samples * n_wires);
         this->setRandomSeed();
         DiscreteRandomVariable<PrecisionT> drv{this->rng, probs(wires)};
+        // The Python layer expects a 2D array with dimensions (n_samples x
+        // n_wires) and hence the linear index is `s * n_wires + (n_wires - 1 -
+        // j)` `s` being the "slow" row index and `j` being the "fast" column
+        // index
         for (std::size_t s = 0; s < num_samples; s++) {
             const std::size_t idx = drv();
             for (std::size_t j = 0; j < n_wires; j++) {

--- a/pennylane_lightning/core/src/simulators/lightning_qubit/measurements/MeasurementsLQubit.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_qubit/measurements/MeasurementsLQubit.hpp
@@ -599,9 +599,6 @@ class Measurements final
         std::vector<std::size_t> samples(num_samples * n_wires);
         this->setRandomSeed();
         discrete_random_variable<PrecisionT> drv{this->rng, probs(wires)};
-#if defined PL_LQ_KERNEL_OMP && defined _OPENMP
-#pragma omp parallel for
-#endif
         for (std::size_t s = 0; s < num_samples; s++) {
             const std::size_t idx = drv();
             for (std::size_t j = 0; j < n_wires; j++) {

--- a/pennylane_lightning/core/src/simulators/lightning_qubit/measurements/MeasurementsLQubit.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_qubit/measurements/MeasurementsLQubit.hpp
@@ -24,7 +24,6 @@
 #include <complex>
 #include <cstdio>
 #include <random>
-#include <stack>
 #include <type_traits>
 #include <unordered_map>
 #include <vector>

--- a/pennylane_lightning/core/src/simulators/lightning_qubit/measurements/MeasurementsLQubit.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_qubit/measurements/MeasurementsLQubit.hpp
@@ -611,20 +611,6 @@ class Measurements final
         return samples;
     }
 
-    std::vector<std::size_t>
-    generate_counts(const std::vector<std::size_t> &wires,
-                    const std::size_t num_samples) {
-        const std::size_t n_wires = wires.size();
-        this->setRandomSeed();
-        discrete_random_variable<PrecisionT> drv{this->rng, probs(wires)};
-
-        std::vector<std::size_t> counts(PUtil::exp2(n_wires), 0UL);
-        for (std::size_t i = 0; i < num_samples; i++) {
-            counts[drv()] += 1;
-        }
-        return counts;
-    }
-
   private:
     /**
      * @brief Support function that calculates <bra|obs|ket> to obtain the

--- a/pennylane_lightning/core/src/simulators/lightning_qubit/measurements/MeasurementsLQubit.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_qubit/measurements/MeasurementsLQubit.hpp
@@ -598,7 +598,7 @@ class Measurements final
         const std::size_t n_wires = wires.size();
         std::vector<std::size_t> samples(num_samples * n_wires);
         this->setRandomSeed();
-        discrete_random_variable<PrecisionT> drv{this->rng, probs(wires)};
+        DiscreteRandomVariable<PrecisionT> drv{this->rng, probs(wires)};
         for (std::size_t s = 0; s < num_samples; s++) {
             const std::size_t idx = drv();
             for (std::size_t j = 0; j < n_wires; j++) {

--- a/pennylane_lightning/core/src/simulators/lightning_qubit/measurements/MeasurementsLQubit.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_qubit/measurements/MeasurementsLQubit.hpp
@@ -588,11 +588,23 @@ class Measurements final
     generate_samples(const std::vector<std::size_t> &wires,
                      const std::size_t num_samples) {
         const std::size_t n_wires = wires.size();
+        const std::size_t n_counts = PUtil::exp2(n_wires);
+        std::vector<std::size_t> samples(num_samples * n_wires);
+        if (n_counts > num_samples) {
+            this->setRandomSeed();
+            discrete_random_variable<PrecisionT> drv{this->rng, probs(wires)};
+            for (std::size_t s = 0; s < num_samples; s++) {
+                const std::size_t idx = drv();
+                for (std::size_t j = 0; j < n_wires; j++) {
+                    samples[s * n_wires + (n_wires - 1 - j)] = (idx >> j) & 1U;
+                }
+            }
+            return samples;
+        }
         const std::vector<std::size_t> counts =
             generate_counts(wires, num_samples);
-        std::vector<std::size_t> samples(num_samples * n_wires);
         std::size_t cum_count{0};
-        for (std::size_t idx = 0; idx < counts.size(); idx++) {
+        for (std::size_t idx = 0; idx < n_counts; idx++) {
             const std::size_t count = counts[idx];
             if (count == 0) {
                 continue;

--- a/pennylane_lightning/core/src/simulators/lightning_qubit/measurements/MeasurementsLQubit.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_qubit/measurements/MeasurementsLQubit.hpp
@@ -124,7 +124,7 @@ class Measurements final
 
         const ComplexT *arr_data = this->_statevector.getData();
 
-        // Templated 1-4 wire cases; return probs 
+        // Templated 1-4 wire cases; return probs
         PROBS_SPECIAL_CASE(1);
         PROBS_SPECIAL_CASE(2);
         PROBS_SPECIAL_CASE(3);
@@ -596,37 +596,13 @@ class Measurements final
     generate_samples(const std::vector<std::size_t> &wires,
                      const std::size_t num_samples) {
         const std::size_t n_wires = wires.size();
-        const std::size_t n_counts = PUtil::exp2(n_wires);
         std::vector<std::size_t> samples(num_samples * n_wires);
-        if (n_counts > num_samples) {
-            this->setRandomSeed();
-            discrete_random_variable<PrecisionT> drv{this->rng, probs(wires)};
-            for (std::size_t s = 0; s < num_samples; s++) {
-                const std::size_t idx = drv();
-                for (std::size_t j = 0; j < n_wires; j++) {
-                    samples[s * n_wires + (n_wires - 1 - j)] = (idx >> j) & 1U;
-                }
-            }
-            return samples;
-        }
-        const std::vector<std::size_t> counts =
-            generate_counts(wires, num_samples);
-        std::size_t cum_count{0};
-        for (std::size_t idx = 0; idx < n_counts; idx++) {
-            const std::size_t count = counts[idx];
-            if (count == 0) {
-                continue;
-            }
+        this->setRandomSeed();
+        discrete_random_variable<PrecisionT> drv{this->rng, probs(wires)};
+        for (std::size_t s = 0; s < num_samples; s++) {
+            const std::size_t idx = drv();
             for (std::size_t j = 0; j < n_wires; j++) {
-                samples[cum_count * n_wires + (n_wires - 1 - j)] =
-                    (idx >> j) & 1U;
-            }
-            const auto iterator = samples.begin() + cum_count * n_wires;
-            cum_count += 1;
-            for (std::size_t c = 1; c < count; c++) {
-                std::copy(iterator, iterator + n_wires,
-                          samples.begin() + cum_count * n_wires);
-                cum_count += 1;
+                samples[s * n_wires + (n_wires - 1 - j)] = (idx >> j) & 1U;
             }
         }
         return samples;

--- a/pennylane_lightning/core/src/simulators/lightning_qubit/measurements/tests/Test_MeasurementsLQubit.cpp
+++ b/pennylane_lightning/core/src/simulators/lightning_qubit/measurements/tests/Test_MeasurementsLQubit.cpp
@@ -635,69 +635,7 @@ TEMPLATE_PRODUCT_TEST_CASE("Sample with Metropolis (Local Kernel)",
     std::size_t num_samples = 100000;
     std::size_t num_burnin = 1000;
 
-    std::string kernel = "Local";
-    auto &&samples =
-        Measurer.generate_samples_metropolis(kernel, num_burnin, num_samples);
-
-    std::vector<std::size_t> counts(N, 0);
-    std::vector<std::size_t> samples_decimal(num_samples, 0);
-
-    // convert samples to decimal and then bin them in counts
-    for (size_t i = 0; i < num_samples; i++) {
-        for (size_t j = 0; j < num_qubits; j++) {
-            if (samples[i * num_qubits + j] != 0) {
-                samples_decimal[i] += twos[(num_qubits - 1 - j)];
-            }
-        }
-        counts[samples_decimal[i]] += 1;
-    }
-
-    // compute estimated probabilities from histogram
-    std::vector<PrecisionT> probabilities(counts.size());
-    for (size_t i = 0; i < counts.size(); i++) {
-        probabilities[i] = counts[i] / (PrecisionT)num_samples;
-    }
-
-    // compare estimated probabilities to real probabilities
-    SECTION("No wires provided:") {
-        CHECK_THAT(probabilities,
-                   Catch::Approx(expected_probabilities).margin(.05));
-    }
-}
-
-TEMPLATE_PRODUCT_TEST_CASE("Sample with Metropolis (NonZeroRandom Kernel)",
-                           "[Measurements][MCMC]",
-                           (StateVectorLQubitManaged, StateVectorLQubitRaw),
-                           (float, double)) {
-    using StateVectorT = TestType;
-    using PrecisionT = typename StateVectorT::PrecisionT;
-
-    constexpr uint32_t twos[] = {
-        1U << 0U,  1U << 1U,  1U << 2U,  1U << 3U,  1U << 4U,  1U << 5U,
-        1U << 6U,  1U << 7U,  1U << 8U,  1U << 9U,  1U << 10U, 1U << 11U,
-        1U << 12U, 1U << 13U, 1U << 14U, 1U << 15U, 1U << 16U, 1U << 17U,
-        1U << 18U, 1U << 19U, 1U << 20U, 1U << 21U, 1U << 22U, 1U << 23U,
-        1U << 24U, 1U << 25U, 1U << 26U, 1U << 27U, 1U << 28U, 1U << 29U,
-        1U << 30U, 1U << 31U};
-
-    // Defining the State Vector that will be measured.
-    auto statevector_data = createNonTrivialState<StateVectorT>();
-    StateVectorT statevector(statevector_data.data(), statevector_data.size());
-
-    // Initializing the measurements class.
-    // This object attaches to the statevector allowing several measurements.
-    Measurements<StateVectorT> Measurer(statevector);
-
-    std::vector<PrecisionT> expected_probabilities = {
-        0.67078706, 0.03062806, 0.0870997,  0.00397696,
-        0.17564072, 0.00801973, 0.02280642, 0.00104134};
-
-    std::size_t num_qubits = 3;
-    std::size_t N = std::pow(2, num_qubits);
-    std::size_t num_samples = 100000;
-    std::size_t num_burnin = 1000;
-
-    const std::string kernel = "NonZeroRandom";
+    const std::string kernel = GENERATE("Local", "NonZeroRandom");
     auto &&samples =
         Measurer.generate_samples_metropolis(kernel, num_burnin, num_samples);
 

--- a/pennylane_lightning/lightning_qubit/_measurements.py
+++ b/pennylane_lightning/lightning_qubit/_measurements.py
@@ -411,7 +411,7 @@ class LightningMeasurements:
                         ).astype(int, copy=False)
                     else:
                         samples = self._measurement_lightning.generate_samples(
-                            len(wires), s
+                            list(wires), s
                         ).astype(int, copy=False)
                 except ValueError as e:
                     if str(e) != "probabilities contain NaN":

--- a/pennylane_lightning/lightning_qubit/_measurements.py
+++ b/pennylane_lightning/lightning_qubit/_measurements.py
@@ -429,7 +429,7 @@ class LightningMeasurements:
                 ).astype(int, copy=False)
             else:
                 samples = self._measurement_lightning.generate_samples(
-                    len(wires), shots.total_shots
+                    list(wires), shots.total_shots
                 ).astype(int, copy=False)
         except ValueError as e:
             if str(e) != "probabilities contain NaN":

--- a/pennylane_lightning/lightning_qubit/_state_vector.py
+++ b/pennylane_lightning/lightning_qubit/_state_vector.py
@@ -267,10 +267,10 @@ class LightningStateVector:
         """
         wires = self.wires.indices(operation.wires)
         wire = list(wires)[0]
-        circuit = QuantumScript([], [qml.sample(wires=operation.wires)], shots=1)
         if postselect_mode == "fill-shots" and operation.postselect is not None:
             sample = operation.postselect
         else:
+            circuit = QuantumScript([], [qml.sample(wires=operation.wires)], shots=1)
             sample = LightningMeasurements(self).measure_final_state(circuit)
             sample = np.squeeze(sample)
         mid_measurements[operation] = sample

--- a/tests/test_measurements.py
+++ b/tests/test_measurements.py
@@ -669,7 +669,7 @@ class TestSample:
     @pytest.mark.parametrize("nwires", range(1, 11))
     def test_sample_variations(self, qubit_device, nwires, seed):
         """Tests if `sample(wires)` returns correct statistics."""
-        shots = 100000
+        shots = 20000
         n_qubits = max(5, nwires + 1)
         np.random.seed(seed)
         wires = qml.wires.Wires(np.random.permutation(nwires))
@@ -694,7 +694,7 @@ class TestSample:
             reshape_samples(samples), wire_order=wires
         )
 
-        assert np.allclose(probs, ref, atol=1.0e-2, rtol=1.0e-4)
+        assert np.allclose(probs, ref, atol=2.0e-2, rtol=1.0e-4)
 
 
 @pytest.mark.skipif(

--- a/tests/test_measurements.py
+++ b/tests/test_measurements.py
@@ -665,6 +665,37 @@ class TestSample:
         # they square to 1
         assert np.allclose(s1**2, 1, atol=tol, rtol=0)
 
+    @pytest.mark.parametrize("seed", range(0, 10))
+    @pytest.mark.parametrize("nwires", range(1, 11))
+    def test_sample_variations(self, qubit_device, nwires, seed):
+        """Tests if `sample(wires)` returns correct statistics."""
+        shots = 100000
+        n_qubits = max(5, nwires + 1)
+        np.random.seed(seed)
+        wires = qml.wires.Wires(np.random.permutation(nwires))
+        state = np.random.rand(2**n_qubits) + 1j * np.random.rand(2**n_qubits)
+        state[np.random.randint(0, 2**n_qubits, 1)] += state.size / 10
+        state /= np.linalg.norm(state)
+        ops = [qml.StatePrep(state, wires=range(n_qubits))]
+        tape = qml.tape.QuantumScript(ops, [qml.sample(wires=wires)], shots=shots)
+
+        def reshape_samples(samples):
+            return np.atleast_3d(samples) if len(wires) == 1 else np.atleast_2d(samples)
+
+        dev = qubit_device(wires=n_qubits, shots=shots)
+        samples = dev.execute(tape)
+        probs = qml.measurements.ProbabilityMP(wires=wires).process_samples(
+            reshape_samples(samples), wire_order=wires
+        )
+
+        dev = qml.device("default.qubit", wires=n_qubits, shots=shots)
+        samples = dev.execute(tape)
+        ref = qml.measurements.ProbabilityMP(wires=wires).process_samples(
+            reshape_samples(samples), wire_order=wires
+        )
+
+        assert np.allclose(probs, ref, atol=1.0e-2, rtol=1.0e-4)
+
 
 @pytest.mark.skipif(
     device_name == "lightning.tensor",


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [x] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [x] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [x] Ensure that the test suite passes, by running `make test`.

- [x] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [x] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**
`sample` call `generate_samples` which computes the full probabilities and uses the alias method to generate samples for all wires. This is wasteful whenever samples are required only for a subset of all wires.

**Description of the Change:**
Move alias method logic to the `discrete_random_variable` class.

**Benefits:**
Compute minimal probs and samples.
We benchmark the current changes against `master`, which already benefits from some good speed-ups introduce in #795 and #800 . 

We use ISAIC's AMD EPYC-Milan Processor using a single core/thread. The times are obtained using at least 5 experiments and running for at least 250 milliseconds. We begin comparing `master`'s `generate_samples(num_samples)` with ours `generate_samples({0}, num_samples)`. For 4-12 qubits, overheads dominate the calculation (the absolute times range from 6 microseconds to 18 milliseconds, which is not a lot. Already at 12 qubits however, a trend appears where our implementation is significantly faster. This is to be expected for two reason: `probs(wires)` itself is faster than `probs()` (for enough qubits) and `sample(wires)` starts also requiring significantly less work than `sample()`. 

![speedup_vs_nthreads_1w](https://github.com/user-attachments/assets/472748e9-d812-489c-a00f-2b2b74c7e682)

Next we turn to comparing `master`'s `generate_samples(num_samples)` with ours `generate_samples({0..num_qubits/2}, num_samples)`. The situation there is similar, with speed-ups close to 1 for the smaller qubit counts and (sometimes) beyond 20x for qubit counts above 20. 

![speedup_vs_nthreads_hfw](https://github.com/user-attachments/assets/f39e3ccd-8051-4a57-a857-9cd13f547865)

Finally we compare `master`'s `generate_samples(num_samples)` with ours `generate_samples({0..num_qubits-1}, num_samples)` (i.e. computing samples on all wires). We expect similar performance since the main difference comes from the caching mechanism in `master`'s discrete random variable generator. The data suggests caching samples is counter-productive compared with calculating the sample values on the fly. 

![speedup_vs_nthreads_fullw](https://github.com/user-attachments/assets/2c70ed21-2236-479e-be3d-6017b42fdc5e)

Turning OMP ON, using 16 threads and comparing `master`'s `generate_samples(num_samples)` with ours `generate_samples({0}, num_samples)` we get good speed-ups above 12 qubits. Below that the overhead of spawning threads isn't repaid, but absolute times remain low.

![speedup_vs_omp16_1w](https://github.com/user-attachments/assets/e3e90a55-399f-4a5b-b90e-7059a0486228)

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-65127]