### PR TITLE
Shot batching is made more efficient by executing all the shots in one go on Lightning Qubit

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -15,6 +15,9 @@
 
 ### Improvements
 
+* Shot batching is made more efficient by executing all the shots in one go on LightningQubit.
+  [#814](https://github.com/PennyLaneAI/pennylane-lightning/pull/814)
+
 * LightningQubit calls `generate_samples(wires)` on a minimal subset of wires when executing in finite-shot mode.
   [(#813)](https://github.com/PennyLaneAI/pennylane-lightning/pull/813)
 
@@ -47,9 +50,6 @@
 
 * Add a Catalyst-specific wrapping class for Lightning Kokkos.
   [(#770)](https://github.com/PennyLaneAI/pennylane-lightning/pull/770)
-
-* Shot batching is made more efficient by executing all the shots in one go on LightningQubit.
-  [#814](https://github.com/PennyLaneAI/pennylane-lightning/pull/814)
 
 ### Documentation
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -20,10 +20,10 @@
 
 * Avoid unnecessary memory reset in LightningQubit's state vector class constructor.
   [(#811)](https://github.com/PennyLaneAI/pennylane-lightning/pull/811)
-  
+
 * Add `generate_samples(wires)` support in LightningQubit.
   [(#809)](https://github.com/PennyLaneAI/pennylane-lightning/pull/809)
-  
+
 * Optimize the OpenMP parallelization of Lightning-Qubit's `probs` for all number of targets.
   [(#807)](https://github.com/PennyLaneAI/pennylane-lightning/pull/807)
 
@@ -48,6 +48,9 @@
 * Add a Catalyst-specific wrapping class for Lightning Kokkos.
   [(#770)](https://github.com/PennyLaneAI/pennylane-lightning/pull/770)
 
+* Shot batching is made more efficient by executing all the shots in one go on LightningQubit.
+  [#814](https://github.com/PennyLaneAI/pennylane-lightning/pull/814)
+
 ### Documentation
 
 ### Bug fixes
@@ -71,7 +74,7 @@
 
 This release contains contributions from (in alphabetical order):
 
-Amintor Dusko, Vincent Michaud-Rioux, Shuli Shu
+Ali Asadi, Amintor Dusko, Vincent Michaud-Rioux, Shuli Shu
 
 ---
 

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.38.0-dev16"
+__version__ = "0.38.0-dev17"

--- a/pennylane_lightning/core/src/simulators/lightning_qubit/measurements/MeasurementsLQubit.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_qubit/measurements/MeasurementsLQubit.hpp
@@ -124,7 +124,7 @@ class Measurements final
 
         const ComplexT *arr_data = this->_statevector.getData();
 
-        // Templated 1-4 wire cases; return probs 
+        // Templated 1-4 wire cases; return probs
         PROBS_SPECIAL_CASE(1);
         PROBS_SPECIAL_CASE(2);
         PROBS_SPECIAL_CASE(3);

--- a/pennylane_lightning/lightning_qubit/_measurements.py
+++ b/pennylane_lightning/lightning_qubit/_measurements.py
@@ -421,8 +421,8 @@ class LightningMeasurements:
         # split samples w.r.t. the shots
         processed_samples = []
         for lower, upper in shots.bins():
-            shot = _process_single_shot(samples[..., lower:upper, :])
-            processed_samples.append(shot)
+            result = _process_single_shot(samples[..., lower:upper, :])
+            processed_samples.append(result)
 
         return (
             tuple(zip(*processed_samples)) if shots.has_partitioned_shots else processed_samples[0]

--- a/pennylane_lightning/lightning_qubit/_measurements.py
+++ b/pennylane_lightning/lightning_qubit/_measurements.py
@@ -440,6 +440,29 @@ class LightningMeasurements:
 
         return _process_single_shot(samples)
 
+        # try:
+        #     if self._mcmc:
+        #         samples = self._measurement_lightning.generate_mcmc_samples(
+        #             len(wires), self._kernel_name, self._num_burnin, shots.total_shots
+        #         ).astype(int, copy=False)
+        #     else:
+        #         samples = self._measurement_lightning.generate_samples(
+        #             len(wires), shots.total_shots
+        #         ).astype(int, copy=False)
+        # except ValueError as e:
+        #     if str(e) != "probabilities contain NaN":
+        #         raise e
+        #     samples = qml.math.full((shots.total_shots, len(wires)), 0)
+
+        # self._apply_diagonalizing_gates(mps, adjoint=True)
+
+        # processed_samples = []
+        # for lower, upper in shots.bins():
+        #     shot = _process_single_shot(samples[..., lower:upper, :])
+        #     processed_samples.append(shot)
+
+        # return tuple(zip(*processed_samples)) if shots.has_partitioned_shots else processed_samples[0]
+
     def _measure_hamiltonian_with_samples(
         self,
         mp: List[SampleMeasurement],

--- a/pennylane_lightning/lightning_qubit/_measurements.py
+++ b/pennylane_lightning/lightning_qubit/_measurements.py
@@ -397,31 +397,6 @@ class LightningMeasurements:
 
             return tuple(processed)
 
-        # if there is a shot vector, build a list containing results for each shot entry
-        if shots.has_partitioned_shots:
-            processed_samples = []
-            for s in shots:
-                # currently we call sample_state for each shot entry, but it may be
-                # better to call sample_state just once with total_shots, then use
-                # the shot_range keyword argument
-                try:
-                    if self._mcmc:
-                        samples = self._measurement_lightning.generate_mcmc_samples(
-                            len(wires), self._kernel_name, self._num_burnin, s
-                        ).astype(int, copy=False)
-                    else:
-                        samples = self._measurement_lightning.generate_samples(
-                            len(wires), s
-                        ).astype(int, copy=False)
-                except ValueError as e:
-                    if str(e) != "probabilities contain NaN":
-                        raise e
-                    samples = qml.math.full((s, len(wires)), 0)
-
-                processed_samples.append(_process_single_shot(samples))
-            self._apply_diagonalizing_gates(mps, adjoint=True)
-            return tuple(zip(*processed_samples))
-
         try:
             if self._mcmc:
                 samples = self._measurement_lightning.generate_mcmc_samples(
@@ -438,30 +413,16 @@ class LightningMeasurements:
 
         self._apply_diagonalizing_gates(mps, adjoint=True)
 
-        return _process_single_shot(samples)
+        # if there is a shot vector, use the shots.bins generator to
+        # split samples w.r.t. the shots
+        processed_samples = []
+        for lower, upper in shots.bins():
+            shot = _process_single_shot(samples[..., lower:upper, :])
+            processed_samples.append(shot)
 
-        # try:
-        #     if self._mcmc:
-        #         samples = self._measurement_lightning.generate_mcmc_samples(
-        #             len(wires), self._kernel_name, self._num_burnin, shots.total_shots
-        #         ).astype(int, copy=False)
-        #     else:
-        #         samples = self._measurement_lightning.generate_samples(
-        #             len(wires), shots.total_shots
-        #         ).astype(int, copy=False)
-        # except ValueError as e:
-        #     if str(e) != "probabilities contain NaN":
-        #         raise e
-        #     samples = qml.math.full((shots.total_shots, len(wires)), 0)
-
-        # self._apply_diagonalizing_gates(mps, adjoint=True)
-
-        # processed_samples = []
-        # for lower, upper in shots.bins():
-        #     shot = _process_single_shot(samples[..., lower:upper, :])
-        #     processed_samples.append(shot)
-
-        # return tuple(zip(*processed_samples)) if shots.has_partitioned_shots else processed_samples[0]
+        return (
+            tuple(zip(*processed_samples)) if shots.has_partitioned_shots else processed_samples[0]
+        )
 
     def _measure_hamiltonian_with_samples(
         self,

--- a/tests/test_measurements.py
+++ b/tests/test_measurements.py
@@ -839,9 +839,13 @@ def test_shots_single_measure_obs(shots, measure_f, obs, mcmc, kernel_name):
 def test_shots_bins(shots, qubit_device):
     """Tests that Lightning handles multiple shots."""
 
-    @qml.qnode(qubit_device(wires=1, shots=shots))
+    dev = qubit_device(wires=1, shots=shots)
+
+    @qml.qnode(dev)
     def circuit():
         return qml.expval(qml.PauliZ(wires=0))
 
-    assert np.sum(shots) == circuit.device.shots.total_shots
+    if dev.name == "lightning.qubit":
+        assert np.sum(shots) == circuit.device.shots.total_shots
+
     assert np.allclose(circuit(), 1.0)

--- a/tests/test_measurements.py
+++ b/tests/test_measurements.py
@@ -830,11 +830,10 @@ def test_shots_single_measure_obs(shots, measure_f, obs, mcmc, kernel_name):
     validate_measurements(measure_f, shots, results1, results2)
 
 
-# TODO: Add LK and LGPU after migrating to the new device API
 # TODO: Add LT after extending the support for shots_vector
 @pytest.mark.skipif(
-    device_name != "lightning.qubit",
-    reason="lightning.qubit only has support for vector_shots",
+    device_name == "lightning.tensor",
+    reason="lightning.tensor does not support shot vectors.",
 )
 @pytest.mark.parametrize("shots", ((1, 10), (1, 10, 100), (1, 10, 10, 100, 100, 100)))
 def test_shots_bins(shots, qubit_device):

--- a/tests/test_measurements.py
+++ b/tests/test_measurements.py
@@ -830,6 +830,12 @@ def test_shots_single_measure_obs(shots, measure_f, obs, mcmc, kernel_name):
     validate_measurements(measure_f, shots, results1, results2)
 
 
+# TODO: Add LK and LGPU after migrating to the new device API
+# TODO: Add LT after extending the support for shots_vector
+@pytest.mark.skipif(
+    device_name != "lightning.qubit",
+    reason="lightning.qubit only has support for vector_shots",
+)
 @pytest.mark.parametrize("shots", ((1, 10), (1, 10, 100), (1, 10, 10, 100, 100, 100)))
 def test_shots_bins(shots, qubit_device):
     """Tests that Lightning handles multiple shots."""


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [x] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [x] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [x] Ensure that the test suite passes, by running `make test`.

- [x] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [x] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**
Shot batching is made more efficient by executing all the shots in one go on LightningQubit using `shots.bin`.

**Description of the Change:**
- Update `_measure_with_samples_diagonalizing_gates`
- Add `shots_vector` tests.

**Benefits:**
``` python
dev = qml.device('lightning.qubit', wires=20, shots=(10_000, ) * N)
for i in range(1000):
    @qml.qnode(dev)
    def circuit():
        return qml.counts(wires=0)
```
![image](https://github.com/user-attachments/assets/17fb7350-8a2c-46c5-a126-c3fc5a0585da)
![image](https://github.com/user-attachments/assets/dcc39ce7-09f7-42c9-923a-109710a06e82)



``` python
dev = qml.device('lightning.qubit', wires=20, shots=(10, ) * N)
for i in range(1000):
    @qml.qnode(dev)
    def circuit():
        return qml.counts(wires=0)
```
![image](https://github.com/user-attachments/assets/a068b91a-9f44-4726-b77b-21e26e0d72bf)
![image](https://github.com/user-attachments/assets/396af063-724a-4f54-90f6-bf8ed29bc571)

**Possible Drawbacks:**
n/a

**Related GitHub Issues:**

[sc-66537]