### PR TITLE
Update kokkos files from catalyst repo to support MCM seeding

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -15,8 +15,11 @@
 
 ### Improvements
 
+* Update the Catalyst-specific wrapping class for Lightning Kokkos to track Catalyst's new support for MCM seeding.
+  [(#819)](https://github.com/PennyLaneAI/pennylane-lightning/pull/819)
+
 * Shot batching is made more efficient by executing all the shots in one go on LightningQubit.
-  [#814](https://github.com/PennyLaneAI/pennylane-lightning/pull/814)
+  [(#814)](https://github.com/PennyLaneAI/pennylane-lightning/pull/814)
 
 * LightningQubit calls `generate_samples(wires)` on a minimal subset of wires when executing in finite-shot mode.
   [(#813)](https://github.com/PennyLaneAI/pennylane-lightning/pull/813)
@@ -50,9 +53,6 @@
 
 * Add a Catalyst-specific wrapping class for Lightning Kokkos.
   [(#770)](https://github.com/PennyLaneAI/pennylane-lightning/pull/770)
-
-* Update the Catalyst-specific wrapping class for Lightning Kokkos to track Catalyst's new support for MCM seeding.
-  [(819)](https://github.com/PennyLaneAI/pennylane-lightning/pull/819)
 
 ### Documentation
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -51,6 +51,9 @@
 * Add a Catalyst-specific wrapping class for Lightning Kokkos.
   [(#770)](https://github.com/PennyLaneAI/pennylane-lightning/pull/770)
 
+* Update the Catalyst-specific wrapping class for Lightning Kokkos to track Catalyst's new support for MCM seeding.
+  [(819)](https://github.com/PennyLaneAI/pennylane-lightning/pull/819)
+
 ### Documentation
 
 ### Bug fixes
@@ -74,7 +77,7 @@
 
 This release contains contributions from (in alphabetical order):
 
-Ali Asadi, Amintor Dusko, Vincent Michaud-Rioux, Shuli Shu
+Ali Asadi, Amintor Dusko, Vincent Michaud-Rioux, Shuli Shu, Paul Haochen Wang
 
 ---
 

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.38.0-dev17"
+__version__ = "0.38.0-dev18"

--- a/pennylane_lightning/core/src/simulators/lightning_kokkos/catalyst/LightningKokkosSimulator.cpp
+++ b/pennylane_lightning/core/src/simulators/lightning_kokkos/catalyst/LightningKokkosSimulator.cpp
@@ -106,6 +106,10 @@ auto LightningKokkosSimulator::GetDeviceShots() const -> std::size_t {
     return this->device_shots;
 }
 
+void LightningKokkosSimulator::SetDevicePRNG(std::mt19937 *gen) {
+    this->gen = gen;
+}
+
 /// LCOV_EXCL_START
 void LightningKokkosSimulator::PrintState() {
     using std::cout;
@@ -480,7 +484,7 @@ auto LightningKokkosSimulator::Measure(QubitIdType wire,
     SetDeviceShots(device_shots);
 
     // It represents the measured result, true for 1, false for 0
-    bool mres = Lightning::simulateDraw(probs, postselect);
+    bool mres = Lightning::simulateDraw(probs, postselect, this->gen);
     auto dev_wires = getDeviceWires(wires);
     this->device_sv->collapse(dev_wires[0], mres ? 1 : 0);
     return mres ? this->One() : this->Zero();

--- a/pennylane_lightning/core/src/simulators/lightning_kokkos/catalyst/LightningKokkosSimulator.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_kokkos/catalyst/LightningKokkosSimulator.hpp
@@ -26,6 +26,7 @@
 #include <iostream>
 #include <limits>
 #include <optional>
+#include <random>
 #include <span>
 #include <stdexcept>
 #include <unordered_map>

--- a/pennylane_lightning/core/src/simulators/lightning_kokkos/catalyst/LightningKokkosSimulator.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_kokkos/catalyst/LightningKokkosSimulator.hpp
@@ -63,6 +63,8 @@ class LightningKokkosSimulator final : public Catalyst::Runtime::QuantumDevice {
 
     std::size_t device_shots;
 
+    std::mt19937 *gen = nullptr;
+
     std::unique_ptr<StateVectorT> device_sv = std::make_unique<StateVectorT>(0);
     LightningKokkosObsManager<double> obs_manager{};
 
@@ -116,6 +118,7 @@ class LightningKokkosSimulator final : public Catalyst::Runtime::QuantumDevice {
     void StartTapeRecording() override;
     void StopTapeRecording() override;
     void SetDeviceShots(size_t shots) override;
+    void SetDevicePRNG(std::mt19937 *) override;
     [[nodiscard]] auto GetDeviceShots() const -> size_t override;
     void PrintState() override;
     [[nodiscard]] auto Zero() const -> Result override;

--- a/pennylane_lightning/core/src/simulators/lightning_kokkos/catalyst/LightningKokkosSimulator.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_kokkos/catalyst/LightningKokkosSimulator.hpp
@@ -63,7 +63,7 @@ class LightningKokkosSimulator final : public Catalyst::Runtime::QuantumDevice {
 
     std::size_t device_shots;
 
-    std::mt19937 *gen = nullptr;
+    std::mt19937 *gen{nullptr};
 
     std::unique_ptr<StateVectorT> device_sv = std::make_unique<StateVectorT>(0);
     LightningKokkosObsManager<double> obs_manager{};

--- a/pennylane_lightning/core/src/simulators/lightning_kokkos/catalyst/tests/Test_LightningKokkosMeasures.cpp
+++ b/pennylane_lightning/core/src/simulators/lightning_kokkos/catalyst/tests/Test_LightningKokkosMeasures.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <random>
+
 #include "CacheManager.hpp"
 #include "LightningKokkosSimulator.hpp"
 #include "QuantumDevice.hpp"
@@ -1749,4 +1751,29 @@ TEST_CASE("Counts and PartialCounts tests with numWires=0-4 shots=100",
     }
     CHECK(sum3 == shots);
     CHECK(sum4 == shots);
+}
+
+TEST_CASE("Measurement with a seeded device", "[Measures]") {
+    for (size_t _ = 0; _ < 5; _++) {
+        std::unique_ptr<LKSimulator> sim = std::make_unique<LKSimulator>();
+        std::unique_ptr<LKSimulator> sim1 = std::make_unique<LKSimulator>();
+
+        std::mt19937 gen(37);
+        sim->SetDevicePRNG(&gen);
+        std::vector<intptr_t> Qs;
+        Qs.reserve(1);
+        Qs.push_back(sim->AllocateQubit());
+        sim->NamedOperation("Hadamard", {}, {Qs[0]}, false);
+        auto m = sim->Measure(Qs[0]);
+
+        std::mt19937 gen1(37);
+        sim1->SetDevicePRNG(&gen1);
+        std::vector<intptr_t> Qs1;
+        Qs1.reserve(1);
+        Qs1.push_back(sim1->AllocateQubit());
+        sim1->NamedOperation("Hadamard", {}, {Qs1[0]}, false);
+        auto m1 = sim1->Measure(Qs1[0]);
+
+        CHECK(*m == *m1);
+    }
 }


### PR DESCRIPTION
**Context:**
The lightning kokkos files in the Catalyst repo has changed since #770. We make a small update to track these changes.

The Catalyst PR that made the changes added seeding to qjit: https://github.com/PennyLaneAI/catalyst/pull/936

**Description of the Change:**

**Benefits:** unblocks kokkos with catalyst

**Possible Drawbacks:**

**Related GitHub Issues:**
