### PR TITLE
Add the support class for the Adjoint Jacobian to the new device

### DIFF
--- a/pennylane_lightning/lightning_kokkos/_adjoint_jacobian.py
+++ b/pennylane_lightning/lightning_kokkos/_adjoint_jacobian.py
@@ -187,18 +187,25 @@ class LightningKokkosAdjointJacobian:
 
         tape_return_type = self._get_return_type(tape.measurements)
 
-        if is_jacobian and not tape_return_type:
-            # the tape does not have measurements
-            return True
+        if is_jacobian:
+            if not tape_return_type:
+                # the tape does not have measurements
+                return True
+            
+            if tape_return_type is State:
+                raise QuantumFunctionError(
+                    "Adjoint differentiation method does not support measurement StateMP."
+                )
 
-        if not is_jacobian and (qml.math.allclose(grad_vec, 0.0) or tape_return_type is None):
-            # the tape does not have measurements or the gradient is 0.0
-            return True
+        if not is_jacobian: 
+            if qml.math.allclose(grad_vec, 0.0) or not tape_return_type:
+                # the tape does not have measurements or the gradient is 0.0
+                return True
 
-        if tape_return_type is State:
-            raise QuantumFunctionError(
-                "Adjoint differentiation does not support State measurements."
-            )
+            if tape_return_type is State:
+                raise QuantumFunctionError(
+                    "Adjoint differentiation does not support State measurements."
+                )
 
         if any(m.return_type is not Expectation for m in tape.measurements):
             raise QuantumFunctionError(

--- a/pennylane_lightning/lightning_kokkos/_adjoint_jacobian.py
+++ b/pennylane_lightning/lightning_kokkos/_adjoint_jacobian.py
@@ -191,13 +191,13 @@ class LightningKokkosAdjointJacobian:
             if not tape_return_type:
                 # the tape does not have measurements
                 return True
-            
+
             if tape_return_type is State:
                 raise QuantumFunctionError(
                     "Adjoint differentiation method does not support measurement StateMP."
                 )
 
-        if not is_jacobian: 
+        if not is_jacobian:
             if qml.math.allclose(grad_vec, 0.0) or not tape_return_type:
                 # the tape does not have measurements or the gradient is 0.0
                 return True

--- a/pennylane_lightning/lightning_kokkos/_adjoint_jacobian.py
+++ b/pennylane_lightning/lightning_kokkos/_adjoint_jacobian.py
@@ -300,13 +300,11 @@ class LightningKokkosAdjointJacobian:
             The vector-Jacobian products of a tape.
         """
 
-        # print(f'FDX01 : {grad_vec} : {qml.math.ndim(grad_vec)}')
         empty_array = self._handle_raises(tape, is_jacobian=False, grad_vec=grad_vec)
 
         if empty_array:
             return qml.math.convert_like(np.zeros(len(tape.trainable_params)), grad_vec)
 
-        # print(f'FDX02 : {grad_vec} : {qml.math.ndim(grad_vec)}')
         # Proceed, because tape_return_type is Expectation.
         if qml.math.ndim(grad_vec) == 0:
             grad_vec = (grad_vec,)

--- a/pennylane_lightning/lightning_kokkos/_adjoint_jacobian.py
+++ b/pennylane_lightning/lightning_kokkos/_adjoint_jacobian.py
@@ -300,11 +300,13 @@ class LightningKokkosAdjointJacobian:
             The vector-Jacobian products of a tape.
         """
 
+        # print(f'FDX01 : {grad_vec} : {qml.math.ndim(grad_vec)}')
         empty_array = self._handle_raises(tape, is_jacobian=False, grad_vec=grad_vec)
 
         if empty_array:
             return qml.math.convert_like(np.zeros(len(tape.trainable_params)), grad_vec)
 
+        # print(f'FDX02 : {grad_vec} : {qml.math.ndim(grad_vec)}')
         # Proceed, because tape_return_type is Expectation.
         if qml.math.ndim(grad_vec) == 0:
             grad_vec = (grad_vec,)

--- a/pennylane_lightning/lightning_kokkos/_adjoint_jacobian.py
+++ b/pennylane_lightning/lightning_kokkos/_adjoint_jacobian.py
@@ -300,7 +300,7 @@ class LightningKokkosAdjointJacobian:
                 "Adjoint differentiation method does not support expectation return type "
                 "mixed with other return types"
             )
-            
+
         # Proceed, because tape_return_type is Expectation.
         if qml.math.ndim(grad_vec) == 0:
             grad_vec = (grad_vec,)

--- a/pennylane_lightning/lightning_kokkos/_state_vector.py
+++ b/pennylane_lightning/lightning_kokkos/_state_vector.py
@@ -24,7 +24,7 @@ try:
         print_configuration,
     )
 except ImportError:
-    pass  
+    pass
 
 from itertools import product
 

--- a/pennylane_lightning/lightning_kokkos/_state_vector.py
+++ b/pennylane_lightning/lightning_kokkos/_state_vector.py
@@ -24,7 +24,7 @@ try:
         print_configuration,
     )
 except ImportError:
-    pass  # Should be a complaint when kokkos_ops module is not available.
+    pass  
 
 from itertools import product
 

--- a/pennylane_lightning/lightning_kokkos/lightning_kokkos.py
+++ b/pennylane_lightning/lightning_kokkos/lightning_kokkos.py
@@ -112,10 +112,12 @@ def jacobian(
         [circuit], _ = qml.map_wires(circuit, wire_map)
     state.reset_state()
     final_state = state.get_final_state(circuit)
-    return LightningKokkosAdjointJacobian(final_state, batch_obs=batch_obs).calculate_jacobian(circuit)
+    return LightningKokkosAdjointJacobian(final_state, batch_obs=batch_obs).calculate_jacobian(
+        circuit
+    )
 
 
-def simulate_and_jacobian(  # pylint: disable=unused-argument
+def simulate_and_jacobian(
     circuit: QuantumTape, state: LightningKokkosStateVector, batch_obs=False, wire_map=None
 ):
     """Simulate a single quantum script and compute its Jacobian.
@@ -140,7 +142,7 @@ def simulate_and_jacobian(  # pylint: disable=unused-argument
     return res, jac
 
 
-def vjp(  # pylint: disable=unused-argument
+def vjp(
     circuit: QuantumTape,
     cotangents: Tuple[Number],
     state: LightningKokkosStateVector,
@@ -172,7 +174,7 @@ def vjp(  # pylint: disable=unused-argument
     )
 
 
-def simulate_and_vjp(  # pylint: disable=unused-argument
+def simulate_and_vjp(
     circuit: QuantumTape,
     cotangents: Tuple[Number],
     state: LightningKokkosStateVector,
@@ -199,9 +201,10 @@ def simulate_and_vjp(  # pylint: disable=unused-argument
     if wire_map is not None:
         [circuit], _ = qml.map_wires(circuit, wire_map)
     res = simulate(circuit, state)
-    _vjp = LightningKokkosAdjointJacobian(state, batch_obs=batch_obs).calculate_vjp(circuit, cotangents)
+    _vjp = LightningKokkosAdjointJacobian(state, batch_obs=batch_obs).calculate_vjp(
+        circuit, cotangents
+    )
     return res, _vjp
-
 
 
 _operations = frozenset(

--- a/pennylane_lightning/lightning_qubit/_adjoint_jacobian.py
+++ b/pennylane_lightning/lightning_qubit/_adjoint_jacobian.py
@@ -205,7 +205,7 @@ class LightningAdjointJacobian:
 
         if tape_return_type is State:
             raise QuantumFunctionError(
-                "Adjoint differentiation method does not support measurement StateMP."
+                "Adjoint differentiation does not support State measurements."
             )
 
         if any(m.return_type is not Expectation for m in tape.measurements):

--- a/pennylane_lightning/lightning_qubit/_adjoint_jacobian.py
+++ b/pennylane_lightning/lightning_qubit/_adjoint_jacobian.py
@@ -205,7 +205,7 @@ class LightningAdjointJacobian:
 
         if tape_return_type is State:
             raise QuantumFunctionError(
-                "Adjoint differentiation does not support State measurements."
+                "Adjoint differentiation method does not support measurement StateMP."
             )
 
         if any(m.return_type is not Expectation for m in tape.measurements):

--- a/tests/lightning_qubit/test_adjoint_jacobian_class.py
+++ b/tests/lightning_qubit/test_adjoint_jacobian_class.py
@@ -143,7 +143,7 @@ class TestAdjointJacobian:
 
         with pytest.raises(
             qml.QuantumFunctionError,
-            match="Adjoint differentiation does not support State measurements.",
+            match="Adjoint differentiation method does not support measurement StateMP.",
         ):
             self.calculate_jacobian(lightning_sv(num_wires=3), tape)
 

--- a/tests/lightning_qubit/test_adjoint_jacobian_class.py
+++ b/tests/lightning_qubit/test_adjoint_jacobian_class.py
@@ -177,7 +177,7 @@ class TestAdjointJacobian:
         with pytest.raises(
             qml.QuantumFunctionError,
             match="Adjoint differentiation method does not support expectation return type "
-                "mixed with other return types",
+            "mixed with other return types",
         ):
             self.calculate_jacobian(lightning_sv(num_wires=1), tape)
 
@@ -574,7 +574,7 @@ class TestVectorJacobianProduct:
         vjp = self.calculate_vjp(statevector, tape, dy)
 
         assert np.all(vjp == np.zeros([len(tape.trainable_params)]))
-        
+
     def test_empty_dy(self, tol, lightning_sv):
         """A zero dy vector will return no tapes and a zero matrix"""
         statevector = lightning_sv(num_wires=2)

--- a/tests/lightning_qubit/test_adjoint_jacobian_class.py
+++ b/tests/lightning_qubit/test_adjoint_jacobian_class.py
@@ -58,6 +58,7 @@ if device_name == "lightning.kokkos":
 
     kokkos_args += [InitializationSettings().set_num_threads(2)]
 
+
 # General LightningStateVector fixture, for any number of wires.
 @pytest.fixture(
     scope="function",

--- a/tests/lightning_qubit/test_adjoint_jacobian_class.py
+++ b/tests/lightning_qubit/test_adjoint_jacobian_class.py
@@ -143,7 +143,7 @@ class TestAdjointJacobian:
 
         with pytest.raises(
             qml.QuantumFunctionError,
-            match="Adjoint differentiation method does not support measurement StateMP.",
+            match="Adjoint differentiation does not support State measurements.",
         ):
             self.calculate_jacobian(lightning_sv(num_wires=3), tape)
 

--- a/tests/lightning_qubit/test_adjoint_jacobian_class.py
+++ b/tests/lightning_qubit/test_adjoint_jacobian_class.py
@@ -37,7 +37,7 @@ if device_name == "lightning.kokkos":
 
 if device_name not in ("lightning.qubit", "lightning.kokkos"):
     pytest.skip(
-        "Exclusive tests for lightning.qubit or lightning.kokkos. Skipping.",
+        "Exclusive tests for new API backends lightning.qubit and lightning.kokkos for LightningAdjointJacobian class. Skipping.",
         allow_module_level=True,
     )
 
@@ -155,6 +155,31 @@ class TestAdjointJacobian:
 
         jac = self.calculate_jacobian(lightning_sv(num_wires=3), tape)
         assert len(jac) == 0
+
+    def test_empty_trainable_params(self, lightning_sv):
+        """Tests if an empty array is returned when the number trainable params is zero."""
+
+        with qml.tape.QuantumTape() as tape:
+            qml.X(wires=[0])
+            qml.expval(qml.PauliZ(0))
+
+        jac = self.calculate_jacobian(lightning_sv(num_wires=3), tape)
+        assert len(jac) == 0
+
+    def test_not_expectation_return_type(self, lightning_sv):
+        """Tests if an empty array is returned when the number trainable params is zero."""
+
+        with qml.tape.QuantumTape() as tape:
+            qml.X(wires=[0])
+            qml.RX(0.4, wires=[0])
+            qml.var(qml.PauliZ(1))
+
+        with pytest.raises(
+            qml.QuantumFunctionError,
+            match="Adjoint differentiation method does not support expectation return type "
+                "mixed with other return types",
+        ):
+            self.calculate_jacobian(lightning_sv(num_wires=1), tape)
 
     @pytest.mark.skipif(
         device_name != "lightning.qubit",
@@ -549,6 +574,26 @@ class TestVectorJacobianProduct:
         vjp = self.calculate_vjp(statevector, tape, dy)
 
         assert np.all(vjp == np.zeros([len(tape.trainable_params)]))
+        
+    def test_empty_dy(self, tol, lightning_sv):
+        """A zero dy vector will return no tapes and a zero matrix"""
+        statevector = lightning_sv(num_wires=2)
+        x = 0.543
+        y = -0.654
+
+        with qml.tape.QuantumTape() as tape:
+            qml.RX(x, wires=[0])
+            qml.RY(y, wires=[1])
+            qml.CNOT(wires=[0, 1])
+            qml.expval(qml.PauliZ(0) @ qml.PauliX(1))
+
+        tape.trainable_params = {0, 1}
+        dy = np.array(1.0)
+
+        vjp = self.calculate_vjp(statevector, tape, dy)
+
+        expected = np.array([-np.sin(y) * np.sin(x), np.cos(y) * np.cos(x)])
+        assert np.allclose(vjp, expected, atol=tol, rtol=0)
 
     def test_single_expectation_value(self, tol, lightning_sv):
         """Tests correct output shape and evaluation for a tape

--- a/tests/lightning_qubit/test_jacobian_method.py
+++ b/tests/lightning_qubit/test_jacobian_method.py
@@ -87,7 +87,7 @@ class TestJacobian:
         return transf_fn(results), jac
 
     @staticmethod
-    def process_and_execute(statevector, tape, execute_and_derivatives=False, obs_batch=False):
+    def process_and_execute(statevector, tape, execute_and_derivatives=False):
 
         if execute_and_derivatives:
             results, jac = simulate_and_jacobian(tape, statevector)
@@ -125,8 +125,6 @@ class TestJacobian:
 
         statevector = lightning_sv(num_wires=3)
         res, jac = self.process_and_execute(statevector, qs, execute_and_derivatives)
-        # print(f'res: {res}')
-        # print(f'jac: {jac}')
 
         if isinstance(obs, qml.Hamiltonian):
             qs = QuantumScript(
@@ -137,8 +135,6 @@ class TestJacobian:
         expected, expected_jac = self.calculate_reference(
             qs, execute_and_derivatives=execute_and_derivatives
         )
-        # print(f'expected: {expected}')
-        # print(f'expected_jac: {expected_jac }')
 
         tol = 1e-5 if statevector.dtype == np.complex64 else 1e-7
         assert np.allclose(res, expected, atol=tol, rtol=0)
@@ -167,7 +163,7 @@ class TestVJP:
         return transf_fn(results), jac
 
     @staticmethod
-    def process_and_execute(statevector, tape, dy, execute_and_derivatives=False, obs_batch=False):
+    def process_and_execute(statevector, tape, dy, execute_and_derivatives=False):
         dy = [dy]
 
         if execute_and_derivatives:
@@ -219,6 +215,5 @@ class TestVJP:
         )
 
         tol = 1e-5 if statevector.dtype == np.complex64 else 1e-7
-        # assert len(res) == len(jac) == 1
         assert np.allclose(res, expected, atol=tol, rtol=0)
         assert np.allclose(jac, expected_jac, atol=tol, rtol=0)

--- a/tests/lightning_qubit/test_jacobian_method.py
+++ b/tests/lightning_qubit/test_jacobian_method.py
@@ -46,7 +46,7 @@ if device_name == "lightning.kokkos":
 
 if device_name not in ("lightning.qubit", "lightning.kokkos"):
     pytest.skip(
-        "Exclusive tests for lightning.qubit and lightning.kokkos. Skipping.",
+        "Exclusive tests for new API backends lightning.qubit and lightning.kokkos for LightningAdjointJacobian class. Skipping.",
         allow_module_level=True,
     )
 
@@ -65,11 +65,6 @@ def lightning_sv(request):
 
     return _statevector
 
-
-@pytest.mark.skipif(
-    device_name == "lightning.tensor",
-    reason="lightning.tensor does not support derivatives",
-)
 class TestJacobian:
     """Unit tests for the jacobian method with the new device API."""
 

--- a/tests/lightning_qubit/test_jacobian_method.py
+++ b/tests/lightning_qubit/test_jacobian_method.py
@@ -22,14 +22,26 @@ from pennylane.tape import QuantumScript
 
 if device_name == "lightning.qubit":
     from pennylane_lightning.lightning_qubit._state_vector import LightningStateVector
-    from pennylane_lightning.lightning_qubit.lightning_qubit import simulate, jacobian, simulate_and_jacobian, vjp, simulate_and_vjp
+    from pennylane_lightning.lightning_qubit.lightning_qubit import (
+        jacobian,
+        simulate,
+        simulate_and_jacobian,
+        simulate_and_vjp,
+        vjp,
+    )
 
 
 if device_name == "lightning.kokkos":
     from pennylane_lightning.lightning_kokkos._state_vector import (
         LightningKokkosStateVector as LightningStateVector,
     )
-    from pennylane_lightning.lightning_kokkos.lightning_kokkos import simulate, jacobian, simulate_and_jacobian, vjp, simulate_and_vjp
+    from pennylane_lightning.lightning_kokkos.lightning_kokkos import (
+        jacobian,
+        simulate,
+        simulate_and_jacobian,
+        simulate_and_vjp,
+        vjp,
+    )
 
 
 if device_name not in ("lightning.qubit", "lightning.kokkos"):
@@ -53,6 +65,7 @@ def lightning_sv(request):
 
     return _statevector
 
+
 @pytest.mark.skipif(
     device_name == "lightning.tensor",
     reason="lightning.tensor does not support derivatives",
@@ -72,18 +85,17 @@ class TestJacobian:
             results = device.execute(tapes, config)
             jac = device.compute_derivatives(tapes, config)
         return transf_fn(results), jac
-    
+
     @staticmethod
     def process_and_execute(statevector, tape, execute_and_derivatives=False, obs_batch=False):
 
         if execute_and_derivatives:
-            results, jac = simulate_and_jacobian(tape,statevector)
+            results, jac = simulate_and_jacobian(tape, statevector)
         else:
             results = simulate(tape, statevector)
             jac = jacobian(tape, statevector)
         return results, jac
 
-    
     @pytest.mark.parametrize("theta, phi", list(zip(THETA, PHI)))
     @pytest.mark.parametrize(
         "obs",
@@ -112,7 +124,7 @@ class TestJacobian:
         )
 
         statevector = lightning_sv(num_wires=3)
-        res, jac = self.process_and_execute(statevector,qs,execute_and_derivatives)
+        res, jac = self.process_and_execute(statevector, qs, execute_and_derivatives)
         # print(f'res: {res}')
         # print(f'jac: {jac}')
 
@@ -157,15 +169,13 @@ class TestVJP:
     @staticmethod
     def process_and_execute(statevector, tape, dy, execute_and_derivatives=False, obs_batch=False):
         dy = [dy]
-    
+
         if execute_and_derivatives:
             results, jac = simulate_and_vjp(tape, dy, statevector)
         else:
             results = simulate(tape, statevector)
             jac = vjp(tape, dy, statevector)
         return results, jac
-
-
 
     @pytest.mark.usefixtures("use_legacy_and_new_opmath")
     @pytest.mark.parametrize("theta, phi", list(zip(THETA, PHI)))

--- a/tests/lightning_qubit/test_jacobian_method.py
+++ b/tests/lightning_qubit/test_jacobian_method.py
@@ -65,6 +65,7 @@ def lightning_sv(request):
 
     return _statevector
 
+
 class TestJacobian:
     """Unit tests for the jacobian method with the new device API."""
 


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [X] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [X] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [X] Ensure that the test suite passes, by running `make test`.

- [ ] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [X] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**
Migrate the lightning.kokkos device to the new device API.

**Description of the Change:**
The 'jacobian' and vjp` methods are necessary to achieve full functionality with the new device API.
We are going to follow the same recipe used with LightningQubit.

**Benefits:**
Add two of the essential methods for the new device API into LightningKokkos.

**Possible Drawbacks:**

**Related GitHub Issues:**
## Partial / Freezzed PR ⚠️ ❄️

To make a smooth integration of LightningKokkos with the new device API, we set the branch kokkosNewAPI_backend as the base branch target for this development.

The branch kokkosNewAPI_backend has the mock of all classes and methods necessary for the new API. Also, several tests were disabled with

```python
if device_name == "lightning.kokkos":
    pytest.skip("Kokkos new API in WIP.  Skipping.",allow_module_level=True)
```

Additionally, the CI testing from PennyLane for LKokkos is temporally disabled through commenting on the following lines in .github/workflows files

```bash
: # pl-device-test --device ${DEVICENAME} --skip-ops --shots=20000 $COVERAGE_FLAGS --cov-append
: # pl-device-test --device ${DEVICENAME} --shots=None --skip-ops $COVERAGE_FLAGS --cov-append
```

However, these tests will unblocked as the implementation progresses.

After all the developments for integrating LightningKokkos with the new API have been completed then the PR will be open to merging to master

[sc-68808] [sc-68814]