### PR TITLE
Adding semantic-version to workflow reqs

### DIFF
--- a/.github/workflows/tests_lqcpu_python.yml
+++ b/.github/workflows/tests_lqcpu_python.yml
@@ -150,6 +150,7 @@ jobs:
           mv ${{ github.workspace }}/wheel_${{ matrix.pl_backend }}-${{ matrix.blas }}.whl ${{ github.workspace }}/$WHEEL_NAME
           python -m pip install -r requirements-dev.txt
           python -m pip install openfermionpyscf
+          python -m pip install semantic-version
           python -m pip install ${{ github.workspace }}/$WHEEL_NAME --no-deps --force-reinstall
 
       - name: Checkout PennyLane for release build

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.38.0-dev21"
+__version__ = "0.38.0-dev22"


### PR DESCRIPTION
This PR should fix [this test](https://github.com/PennyLaneAI/pennylane-lightning/actions/runs/10208461253/job/28245011292) in the plugin-test-matrix. The latest PL version does not use `semantic-version`, but the stable version still does, so we add such a package to the workflow requirements.
