### PR TITLE
Add (check) full support for sampling in full parity with Lightning

### DIFF
--- a/pennylane_lightning/lightning_kokkos/_state_vector.py
+++ b/pennylane_lightning/lightning_kokkos/_state_vector.py
@@ -73,7 +73,7 @@ class LightningKokkosStateVector:  # pylint: disable=too-few-public-methods
         self._kokkos_config = {}
         self._sync = sync
 
-        if dtype not in [np.complex64, np.complex128]:  # pragma: no cover
+        if dtype not in [np.complex64, np.complex128]: 
             raise TypeError(f"Unsupported complex type: {dtype}")
 
         if device_name != "lightning.kokkos":

--- a/pennylane_lightning/lightning_kokkos/_state_vector.py
+++ b/pennylane_lightning/lightning_kokkos/_state_vector.py
@@ -73,7 +73,7 @@ class LightningKokkosStateVector:  # pylint: disable=too-few-public-methods
         self._kokkos_config = {}
         self._sync = sync
 
-        if dtype not in [np.complex64, np.complex128]: 
+        if dtype not in [np.complex64, np.complex128]:
             raise TypeError(f"Unsupported complex type: {dtype}")
 
         if device_name != "lightning.kokkos":

--- a/pennylane_lightning/lightning_kokkos/lightning_kokkos.py
+++ b/pennylane_lightning/lightning_kokkos/lightning_kokkos.py
@@ -307,6 +307,7 @@ _observables = frozenset(
 )
 # The set of supported observables.
 
+
 def stopping_condition(op: Operator) -> bool:
     """A function that determines whether or not an operation is supported by ``lightning.kokkos``."""
     # These thresholds are adapted from `lightning_base.py`
@@ -403,7 +404,6 @@ def _add_adjoint_transforms(program: TransformProgram) -> None:
     )
     program.add_transform(qml.transforms.broadcast_expand)
     program.add_transform(validate_adjoint_trainable_params)
-
 
 
 def _kokkos_configuration():
@@ -518,13 +518,12 @@ class LightningKokkos(Device):
         for option in self._device_options:
             if option not in new_device_options:
                 new_device_options[option] = getattr(self, f"_{option}", None)
-                
-        # add this to fit the Execute confgiuration  
-        mcmc_default = {'mcmc': False, 'kernel_name': None, 'num_burnin': 0}
+
+        # add this to fit the Execute confgiuration
+        mcmc_default = {"mcmc": False, "kernel_name": None, "num_burnin": 0}
         new_device_options.update(mcmc_default)
 
         return replace(config, **updated_values, device_options=new_device_options)
-
 
     def preprocess(self, execution_config: ExecutionConfig = DefaultExecutionConfig):
         """This function defines the device transform program to be applied and an updated device configuration.
@@ -563,7 +562,6 @@ class LightningKokkos(Device):
         )
         program.add_transform(qml.transforms.broadcast_expand)
 
-
         if exec_config.gradient_method == "adjoint":
             _add_adjoint_transforms(program)
         return program, exec_config
@@ -596,7 +594,6 @@ class LightningKokkos(Device):
             )
 
         return tuple(results)
-
 
     def supports_derivatives(
         self,
@@ -644,7 +641,6 @@ class LightningKokkos(Device):
             for circuit in circuits
         )
 
-
     def execute_and_compute_derivatives(
         self,
         circuits: QuantumTape_or_Batch,
@@ -668,7 +664,6 @@ class LightningKokkos(Device):
         )
         return tuple(zip(*results))
 
-
     def supports_vjp(
         self,
         execution_config: Optional[ExecutionConfig] = None,
@@ -682,7 +677,7 @@ class LightningKokkos(Device):
         Returns:
             Bool: Whether or not a derivative can be calculated provided the given information
         """
-        return self.supports_derivatives(execution_config, circuit)    
+        return self.supports_derivatives(execution_config, circuit)
 
     def compute_vjp(
         self,
@@ -722,7 +717,6 @@ class LightningKokkos(Device):
             for circuit, cots in zip(circuits, cotangents)
         )
 
-
     def execute_and_compute_vjp(
         self,
         circuits: QuantumTape_or_Batch,
@@ -747,4 +741,3 @@ class LightningKokkos(Device):
             for circuit, cots in zip(circuits, cotangents)
         )
         return tuple(zip(*results))
-

--- a/pennylane_lightning/lightning_kokkos/lightning_kokkos.py
+++ b/pennylane_lightning/lightning_kokkos/lightning_kokkos.py
@@ -501,6 +501,10 @@ class LightningKokkos(Device):
         return self._c_dtype
 
     # dtype = c_dtype
+    @property
+    def dtype(self):
+        """State vector complex data type."""
+        return self._c_dtype
 
     def _setup_execution_config(self, config):
         """

--- a/pennylane_lightning/lightning_kokkos/lightning_kokkos.py
+++ b/pennylane_lightning/lightning_kokkos/lightning_kokkos.py
@@ -224,9 +224,7 @@ def simulate_and_vjp(
 _operations = frozenset(
     {
         "Identity",
-        # "BasisState",
         "QubitStateVector",
-        # "StatePrep",
         "QubitUnitary",
         "ControlledQubitUnitary",
         "MultiControlledX",
@@ -500,7 +498,6 @@ class LightningKokkos(Device):
         """State vector complex data type."""
         return self._c_dtype
 
-    # dtype = c_dtype
     @property
     def dtype(self):
         """State vector complex data type."""

--- a/pennylane_lightning/lightning_kokkos/lightning_kokkos.py
+++ b/pennylane_lightning/lightning_kokkos/lightning_kokkos.py
@@ -319,8 +319,6 @@ def stopping_condition(op: Operator) -> bool:
     # As ControlledQubitUnitary == C(QubitUnitrary),
     # it can be removed from `_operations` to keep
     # consistency with `lightning_qubit.toml`
-    if isinstance(op, qml.ControlledQubitUnitary):
-        return True
 
     return op.name in _operations
 

--- a/pennylane_lightning/lightning_kokkos/lightning_kokkos.py
+++ b/pennylane_lightning/lightning_kokkos/lightning_kokkos.py
@@ -316,10 +316,6 @@ def stopping_condition(op: Operator) -> bool:
     if isinstance(op, qml.GroverOperator):
         return len(op.wires) < 13
 
-    # As ControlledQubitUnitary == C(QubitUnitrary),
-    # it can be removed from `_operations` to keep
-    # consistency with `lightning_qubit.toml`
-
     return op.name in _operations
 
 

--- a/pennylane_lightning/lightning_kokkos/lightning_kokkos.py
+++ b/pennylane_lightning/lightning_kokkos/lightning_kokkos.py
@@ -515,7 +515,7 @@ class LightningKokkos(Device):
             if option not in new_device_options:
                 new_device_options[option] = getattr(self, f"_{option}", None)
 
-        # add this to fit the Execute confgiuration
+        # add this to fit the Execute configuration
         mcmc_default = {"mcmc": False, "kernel_name": None, "num_burnin": 0}
         new_device_options.update(mcmc_default)
 

--- a/pennylane_lightning/lightning_kokkos/lightning_kokkos.py
+++ b/pennylane_lightning/lightning_kokkos/lightning_kokkos.py
@@ -498,10 +498,7 @@ class LightningKokkos(Device):
         """State vector complex data type."""
         return self._c_dtype
 
-    @property
-    def dtype(self):
-        """State vector complex data type."""
-        return self._c_dtype
+    dtype = c_dtype
 
     def _setup_execution_config(self, config):
         """

--- a/pennylane_lightning/lightning_qubit/lightning_qubit.py
+++ b/pennylane_lightning/lightning_qubit/lightning_qubit.py
@@ -543,6 +543,10 @@ class LightningQubit(Device):
         return self._c_dtype
 
     # dtype = c_dtype
+    @property
+    def dtype(self):
+        """State vector complex data type."""
+        return self._c_dtype
 
     def _setup_execution_config(self, config):
         """

--- a/pennylane_lightning/lightning_qubit/lightning_qubit.py
+++ b/pennylane_lightning/lightning_qubit/lightning_qubit.py
@@ -542,7 +542,6 @@ class LightningQubit(Device):
         """State vector complex data type."""
         return self._c_dtype
 
-    # dtype = c_dtype
     @property
     def dtype(self):
         """State vector complex data type."""

--- a/pennylane_lightning/lightning_qubit/lightning_qubit.py
+++ b/pennylane_lightning/lightning_qubit/lightning_qubit.py
@@ -542,10 +542,7 @@ class LightningQubit(Device):
         """State vector complex data type."""
         return self._c_dtype
 
-    @property
-    def dtype(self):
-        """State vector complex data type."""
-        return self._c_dtype
+    dtype = c_dtype
 
     def _setup_execution_config(self, config):
         """

--- a/tests/lightning_qubit/test_measurements_class.py
+++ b/tests/lightning_qubit/test_measurements_class.py
@@ -25,10 +25,6 @@ from pennylane.devices import DefaultQubit
 from pennylane.measurements import VarianceMP
 from scipy.sparse import csr_matrix, random_array
 
-try:
-    from pennylane_lightning.lightning_qubit_ops import MeasurementsC64, MeasurementsC128
-except ImportError:
-    pass
 
 if device_name == "lightning.qubit":
     from pennylane_lightning.lightning_qubit._measurements import LightningMeasurements

--- a/tests/lightning_qubit/test_measurements_class.py
+++ b/tests/lightning_qubit/test_measurements_class.py
@@ -25,7 +25,6 @@ from pennylane.devices import DefaultQubit
 from pennylane.measurements import VarianceMP
 from scipy.sparse import csr_matrix, random_array
 
-
 if device_name == "lightning.qubit":
     from pennylane_lightning.lightning_qubit._measurements import LightningMeasurements
     from pennylane_lightning.lightning_qubit._state_vector import LightningStateVector
@@ -454,7 +453,6 @@ class TestMeasurements:
                 qml.ops.Sum,
                 qml.ops.SProd,
                 qml.ops.Prod,
-                #  qml.Hamiltonian,
                 qml.SparseHamiltonian,
             ),
         ):

--- a/tests/lightning_qubit/test_measurements_class.py
+++ b/tests/lightning_qubit/test_measurements_class.py
@@ -429,6 +429,7 @@ class TestMeasurements:
         return m.measure_final_state(tape)
 
     @flaky(max_runs=5)
+    @pytest.mark.parametrize("shots", [None, 1000000, (900000, 900000)])
     @pytest.mark.parametrize("measurement", [qml.expval, qml.probs, qml.var])
     @pytest.mark.parametrize(
         "observable",
@@ -450,10 +451,15 @@ class TestMeasurements:
             qml.SparseHamiltonian(get_sparse_hermitian_matrix(2**4), wires=range(4)),
         ),
     )
-    def test_single_return_value(self, measurement, observable, lightning_sv, tol):
+    def test_single_return_value(self, shots, measurement, observable, lightning_sv, tol):
         if measurement is qml.probs and isinstance(
             observable,
-            (qml.ops.Sum, qml.ops.SProd, qml.ops.Prod, qml.Hamiltonian, qml.SparseHamiltonian),
+            (qml.ops.Sum, 
+             qml.ops.SProd, 
+             qml.ops.Prod, 
+            #  qml.Hamiltonian, 
+             qml.SparseHamiltonian
+             ),
         ):
             pytest.skip(
                 f"Observable of type {type(observable).__name__} is not supported for rotating probabilities."
@@ -475,16 +481,39 @@ class TestMeasurements:
             if isinstance(observable, list)
             else [measurement(op=observable)]
         )
-        tape = qml.tape.QuantumScript(ops, measurements)
+        tape = qml.tape.QuantumScript(ops, measurements, shots=shots)
 
-        expected = self.calculate_reference(tape, lightning_sv)
         statevector = lightning_sv(n_qubits)
         statevector = statevector.get_final_state(tape)
         m = LightningMeasurements(statevector)
-        result = m.measure_final_state(tape)
 
+        skip_list = (
+            qml.ops.Sum,
+            # qml.Hamiltonian,
+            qml.SparseHamiltonian,
+        )
+        do_skip = measurement is qml.var and isinstance(observable, skip_list)
+        do_skip = do_skip or (
+            measurement is qml.expval
+            and isinstance(observable, qml.SparseHamiltonian)
+        )
+        do_skip = do_skip and shots is not None
+        if do_skip:
+            with pytest.raises(TypeError):
+                _ = m.measure_final_state(tape)
+            return
+        else:
+            result = m.measure_final_state(tape)
+
+        expected = self.calculate_reference(tape, lightning_sv)
+        
         # a few tests may fail in single precision, and hence we increase the tolerance
-        assert np.allclose(result, expected, max(tol, 1.0e-4))
+        if shots is None:
+            assert np.allclose(result, expected, max(tol, 1.0e-4))
+        else: 
+            dtol = max(tol, 1.0e-2)
+            assert np.allclose(result, expected, rtol=dtol, atol=dtol)
+
 
     @flaky(max_runs=5)
     @pytest.mark.parametrize("shots", [None, 1000000, (900000, 900000)])

--- a/tests/lightning_qubit/test_measurements_class.py
+++ b/tests/lightning_qubit/test_measurements_class.py
@@ -454,12 +454,13 @@ class TestMeasurements:
     def test_single_return_value(self, shots, measurement, observable, lightning_sv, tol):
         if measurement is qml.probs and isinstance(
             observable,
-            (qml.ops.Sum, 
-             qml.ops.SProd, 
-             qml.ops.Prod, 
-            #  qml.Hamiltonian, 
-             qml.SparseHamiltonian
-             ),
+            (
+                qml.ops.Sum,
+                qml.ops.SProd,
+                qml.ops.Prod,
+                #  qml.Hamiltonian,
+                qml.SparseHamiltonian,
+            ),
         ):
             pytest.skip(
                 f"Observable of type {type(observable).__name__} is not supported for rotating probabilities."
@@ -494,8 +495,7 @@ class TestMeasurements:
         )
         do_skip = measurement is qml.var and isinstance(observable, skip_list)
         do_skip = do_skip or (
-            measurement is qml.expval
-            and isinstance(observable, qml.SparseHamiltonian)
+            measurement is qml.expval and isinstance(observable, qml.SparseHamiltonian)
         )
         do_skip = do_skip and shots is not None
         if do_skip:
@@ -506,14 +506,13 @@ class TestMeasurements:
             result = m.measure_final_state(tape)
 
         expected = self.calculate_reference(tape, lightning_sv)
-        
+
         # a few tests may fail in single precision, and hence we increase the tolerance
         if shots is None:
             assert np.allclose(result, expected, max(tol, 1.0e-4))
-        else: 
+        else:
             dtol = max(tol, 1.0e-2)
             assert np.allclose(result, expected, rtol=dtol, atol=dtol)
-
 
     @flaky(max_runs=5)
     @pytest.mark.parametrize("shots", [None, 1000000, (900000, 900000)])

--- a/tests/lightning_qubit/test_measurements_samples_MCMC.py
+++ b/tests/lightning_qubit/test_measurements_samples_MCMC.py
@@ -21,7 +21,9 @@ from conftest import LightningDevice as ld
 from conftest import device_name
 
 if device_name != "lightning.qubit":
-    pytest.skip(f"Device {device_name} does not have an mcmc option.", allow_module_level=True)
+    pytest.skip(
+        f"Device {device_name} does not have an mcmc option. Skipping.", allow_module_level=True
+    )
 
 if not ld._CPP_BINARY_AVAILABLE:
     pytest.skip("No binary module found. Skipping.", allow_module_level=True)

--- a/tests/lightning_qubit/test_measurements_samples_MCMC.py
+++ b/tests/lightning_qubit/test_measurements_samples_MCMC.py
@@ -20,9 +20,8 @@ import pytest
 from conftest import LightningDevice as ld
 from conftest import device_name
 
-
 if device_name != "lightning.qubit":
-    pytest.skip(f"Device {device_name} does not have an mcmc option.",allow_module_level=True)
+    pytest.skip(f"Device {device_name} does not have an mcmc option.", allow_module_level=True)
 
 if not ld._CPP_BINARY_AVAILABLE:
     pytest.skip("No binary module found. Skipping.", allow_module_level=True)

--- a/tests/lightning_qubit/test_simulate_method.py
+++ b/tests/lightning_qubit/test_simulate_method.py
@@ -118,7 +118,7 @@ class TestSimulate:
     @pytest.mark.parametrize("mcmc", [True, False])
     @pytest.mark.parametrize("kernel", ["Local", "NonZeroRandom"])
     def test_sample_values_with_mcmc(self, lightning_sv, tol, mcmc, kernel):
-        """Tests if the samples returned by simulate have the correct values"""
+        """Tests if the samples returned by simulate have the correct values using mcmc"""
         ops = [qml.RX(1.5708, wires=[0])]
         tape = qml.tape.QuantumScript(ops, [qml.sample(op=qml.PauliZ(0))], shots=1000)
 

--- a/tests/lightning_qubit/test_state_vector_class.py
+++ b/tests/lightning_qubit/test_state_vector_class.py
@@ -30,8 +30,14 @@ if device_name == "lightning.qubit":
 if device_name == "lightning.kokkos":
     from pennylane_lightning.lightning_kokkos._state_vector import (
         LightningKokkosStateVector as LightningStateVector,
-        InitializationSettings,
     )
+    
+    try:
+        from pennylane_lightning.lightning_kokkos_ops import InitializationSettings
+    except ImportError:
+        pass
+
+
 
 if device_name not in ("lightning.qubit", "lightning.kokkos"):
     pytest.skip(

--- a/tests/lightning_qubit/test_state_vector_class.py
+++ b/tests/lightning_qubit/test_state_vector_class.py
@@ -31,6 +31,8 @@ if device_name == "lightning.kokkos":
     from pennylane_lightning.lightning_kokkos._state_vector import (
         LightningKokkosStateVector as LightningStateVector,
     )
+    from pennylane_lightning.lightning_kokkos_ops import InitializationSettings
+    
 
 
 if device_name not in ("lightning.qubit", "lightning.kokkos"):
@@ -51,6 +53,16 @@ def test_device_name_and_init(num_wires, dtype):
     assert state_vector.dtype == dtype
     assert state_vector.device_name == device_name
     assert state_vector.wires == Wires(range(num_wires))
+    
+    if device_name == "lightning.kokkos":
+        bad_kokkos_args = np.array([33])
+        with pytest.raises(TypeError,match=f"Argument kokkos_args must be of type {type(InitializationSettings())} but it is of {type(bad_kokkos_args)}."):
+            assert LightningStateVector(num_wires, dtype=dtype, device_name=device_name, kokkos_args=bad_kokkos_args)
+            
+        set_kokkos_args = InitializationSettings().set_num_threads(2)
+        state_vector_3 = LightningStateVector(num_wires, dtype=dtype, device_name=device_name, kokkos_args=set_kokkos_args)
+        
+        assert type(state_vector) == type(state_vector_3)
 
 
 def test_wrong_device_name():

--- a/tests/lightning_qubit/test_state_vector_class.py
+++ b/tests/lightning_qubit/test_state_vector_class.py
@@ -32,7 +32,6 @@ if device_name == "lightning.kokkos":
         LightningKokkosStateVector as LightningStateVector,
     )
     from pennylane_lightning.lightning_kokkos_ops import InitializationSettings
-    
 
 
 if device_name not in ("lightning.qubit", "lightning.kokkos"):
@@ -53,15 +52,22 @@ def test_device_name_and_init(num_wires, dtype):
     assert state_vector.dtype == dtype
     assert state_vector.device_name == device_name
     assert state_vector.wires == Wires(range(num_wires))
-    
+
     if device_name == "lightning.kokkos":
         bad_kokkos_args = np.array([33])
-        with pytest.raises(TypeError,match=f"Argument kokkos_args must be of type {type(InitializationSettings())} but it is of {type(bad_kokkos_args)}."):
-            assert LightningStateVector(num_wires, dtype=dtype, device_name=device_name, kokkos_args=bad_kokkos_args)
-            
+        with pytest.raises(
+            TypeError,
+            match=f"Argument kokkos_args must be of type {type(InitializationSettings())} but it is of {type(bad_kokkos_args)}.",
+        ):
+            assert LightningStateVector(
+                num_wires, dtype=dtype, device_name=device_name, kokkos_args=bad_kokkos_args
+            )
+
         set_kokkos_args = InitializationSettings().set_num_threads(2)
-        state_vector_3 = LightningStateVector(num_wires, dtype=dtype, device_name=device_name, kokkos_args=set_kokkos_args)
-        
+        state_vector_3 = LightningStateVector(
+            num_wires, dtype=dtype, device_name=device_name, kokkos_args=set_kokkos_args
+        )
+
         assert type(state_vector) == type(state_vector_3)
 
 

--- a/tests/lightning_qubit/test_state_vector_class.py
+++ b/tests/lightning_qubit/test_state_vector_class.py
@@ -30,9 +30,8 @@ if device_name == "lightning.qubit":
 if device_name == "lightning.kokkos":
     from pennylane_lightning.lightning_kokkos._state_vector import (
         LightningKokkosStateVector as LightningStateVector,
+        InitializationSettings,
     )
-    from pennylane_lightning.lightning_kokkos_ops import InitializationSettings
-
 
 if device_name not in ("lightning.qubit", "lightning.kokkos"):
     pytest.skip(

--- a/tests/lightning_qubit/test_state_vector_class.py
+++ b/tests/lightning_qubit/test_state_vector_class.py
@@ -31,12 +31,11 @@ if device_name == "lightning.kokkos":
     from pennylane_lightning.lightning_kokkos._state_vector import (
         LightningKokkosStateVector as LightningStateVector,
     )
-    
+
     try:
         from pennylane_lightning.lightning_kokkos_ops import InitializationSettings
     except ImportError:
         pass
-
 
 
 if device_name not in ("lightning.qubit", "lightning.kokkos"):

--- a/tests/new_api/test_device.py
+++ b/tests/new_api/test_device.py
@@ -16,8 +16,6 @@ This module contains unit tests for new device API Lightning classes.
 """
 # pylint: disable=too-many-arguments, unused-argument
 
-from itertools import zip_longest
-
 import numpy as np
 import pennylane as qml
 import pytest

--- a/tests/new_api/test_device.py
+++ b/tests/new_api/test_device.py
@@ -276,9 +276,10 @@ class TestExecution:
                         "num_burnin": 0,
                     },
                 ),
-                marks=pytest.mark.skipif(device_name != "lightning.qubit",
-                                         reason=f"The device {device_name} does not support mcmc",
-                )
+                marks=pytest.mark.skipif(
+                    device_name != "lightning.qubit",
+                    reason=f"The device {device_name} does not support mcmc",
+                ),
             ),
             (
                 ExecutionConfig(
@@ -843,18 +844,17 @@ class TestDerivatives:
         qs2 = QuantumScript(ops, [qml.expval(qml.prod(qml.Z(0), qml.Z(1)))], trainable_params=[0])
 
         expected_device = DefaultQubit(wires=4, max_workers=1)
-        
+
         if execute_and_derivatives:
             results, jacs = device.execute_and_compute_derivatives((qs1, qs2))
-        
+
             expected, expected_jac = expected_device.execute_and_compute_derivatives((qs1, qs2))
         else:
             results = device.execute((qs1, qs2))
             jacs = device.compute_derivatives((qs1, qs2))
-            
+
             expected = expected_device.execute((qs1, qs2))
             expected_jac = expected_device.compute_derivatives((qs1, qs2))
-
 
         # Assert results
         assert len(results) == len(expected)
@@ -1178,15 +1178,15 @@ class TestVJP:
         dy = [(1.5, 2.5), 1.0]
 
         expected_device = DefaultQubit(wires=4, max_workers=1)
-        
+
         if execute_and_derivatives:
             results, jacs = device.execute_and_compute_vjp((qs1, qs2), dy)
-        
+
             expected, expected_jac = expected_device.execute_and_compute_vjp((qs1, qs2), dy)
         else:
             results = device.execute((qs1, qs2))
             jacs = device.compute_vjp((qs1, qs2), dy)
-            
+
             expected = expected_device.execute((qs1, qs2))
             expected_jac = expected_device.compute_vjp((qs1, qs2), dy)
 

--- a/tests/new_api/test_device.py
+++ b/tests/new_api/test_device.py
@@ -822,12 +822,11 @@ class TestDerivatives:
         tapes."""
         device = LightningDevice(wires=4, batch_obs=batch_obs)
 
-        ops = [
-            qml.X(0),
-            qml.X(1),
-            # qml.ctrl(qml.RX(phi, 2), (0, 1, 3), control_values=[1, 1, 0]),
-            qml.RX(phi, 2),
-        ]
+        ops = [qml.X(0), qml.X(1)]
+        if device_name == "lighlightning.qubit":
+            ops.append(qml.ctrl(qml.RX(phi, 2), (0, 1, 3), control_values=[1, 1, 0]))
+        else:
+            ops.append(qml.RX(phi, 2))
 
         qs1 = QuantumScript(
             ops,
@@ -1159,8 +1158,11 @@ class TestVJP:
         ops = [
             qml.X(0),
             qml.X(1),
-            qml.RX(phi, 2),
         ]
+        if device_name == "lighlightning.qubit":
+            ops.append(qml.ctrl(qml.RX(phi, 2), (0, 1, 3), control_values=[1, 1, 0]))
+        else:
+            ops.append(qml.RX(phi, 2))
 
         qs1 = QuantumScript(
             ops,

--- a/tests/new_api/test_device.py
+++ b/tests/new_api/test_device.py
@@ -823,7 +823,7 @@ class TestDerivatives:
         device = LightningDevice(wires=4, batch_obs=batch_obs)
 
         ops = [qml.X(0), qml.X(1)]
-        if device_name == "lighlightning.qubit":
+        if device_name == "lightning.qubit":
             ops.append(qml.ctrl(qml.RX(phi, 2), (0, 1, 3), control_values=[1, 1, 0]))
         else:
             ops.append(qml.RX(phi, 2))

--- a/tests/new_api/test_device.py
+++ b/tests/new_api/test_device.py
@@ -1159,7 +1159,7 @@ class TestVJP:
             qml.X(0),
             qml.X(1),
         ]
-        if device_name == "lighlightning.qubit":
+        if device_name == "lightning.qubit":
             ops.append(qml.ctrl(qml.RX(phi, 2), (0, 1, 3), control_values=[1, 1, 0]))
         else:
             ops.append(qml.RX(phi, 2))

--- a/tests/new_api/test_expval.py
+++ b/tests/new_api/test_expval.py
@@ -21,7 +21,6 @@ import pytest
 from conftest import PHI, THETA, VARPHI, LightningDevice, device_name
 from pennylane.devices import DefaultQubit
 
-
 if not LightningDevice._new_API:
     pytest.skip("Exclusive tests for new API. Skipping.", allow_module_level=True)
 

--- a/tests/test_native_mcm.py
+++ b/tests/test_native_mcm.py
@@ -22,8 +22,6 @@ from conftest import LightningDevice, device_name, validate_measurements
 from flaky import flaky
 from pennylane._device import DeviceError
 
-if device_name == "lightning.kokkos":
-    pytest.skip("Kokkos new API in WIP.  Skipping.", allow_module_level=True)
 
 if device_name not in ("lightning.qubit", "lightning.kokkos"):
     pytest.skip("Native MCM not supported. Skipping.", allow_module_level=True)
@@ -31,12 +29,6 @@ if device_name not in ("lightning.qubit", "lightning.kokkos"):
 if not LightningDevice._CPP_BINARY_AVAILABLE:  # pylint: disable=protected-access
     pytest.skip("No binary module found. Skipping.", allow_module_level=True)
 
-# TODO: remove this after the new device API implementation for Kokkos is implemented
-if device_name == "lightning.kokkos":
-    pytest.skip(
-        "Native Kokkos device has compatible issues with the new device API. Skipping.",
-        allow_module_level=True,
-    )
 
 
 def get_device(wires, **kwargs):
@@ -82,7 +74,7 @@ def test_all_invalid_shots_circuit():
 
 
 def test_unsupported_measurement():
-    """Test unsupported ``qml.classical_shadow`` measurement on ``lightning.qubit``."""
+    """Test unsupported ``qml.classical_shadow`` measurement on ``lightning.qubit`` or ``lightning.kokkos`` ."""
 
     dev = qml.device(device_name, wires=2, shots=1000)
     params = np.pi / 4 * np.ones(2)
@@ -100,10 +92,11 @@ def test_unsupported_measurement():
             match=f"not accepted with finite shots on lightning.qubit",
         ):
             func(*params)
-    else:
+    if device_name == "lightning.kokkos":
+        
         with pytest.raises(
-            TypeError,
-            match=f"Native mid-circuit measurement mode does not support ClassicalShadowMP measurements.",
+            DeviceError,
+            match=r"Measurement shadow\(wires=\[0\]\) not accepted with finite shots on " + device_name,
         ):
             func(*params)
 

--- a/tests/test_native_mcm.py
+++ b/tests/test_native_mcm.py
@@ -22,13 +22,11 @@ from conftest import LightningDevice, device_name, validate_measurements
 from flaky import flaky
 from pennylane._device import DeviceError
 
-
 if device_name not in ("lightning.qubit", "lightning.kokkos"):
     pytest.skip("Native MCM not supported. Skipping.", allow_module_level=True)
 
 if not LightningDevice._CPP_BINARY_AVAILABLE:  # pylint: disable=protected-access
     pytest.skip("No binary module found. Skipping.", allow_module_level=True)
-
 
 
 def get_device(wires, **kwargs):
@@ -93,10 +91,11 @@ def test_unsupported_measurement():
         ):
             func(*params)
     if device_name == "lightning.kokkos":
-        
+
         with pytest.raises(
             DeviceError,
-            match=r"Measurement shadow\(wires=\[0\]\) not accepted with finite shots on " + device_name,
+            match=r"Measurement shadow\(wires=\[0\]\) not accepted with finite shots on "
+            + device_name,
         ):
             func(*params)
 


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [X] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [X] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [X] Ensure that the test suite passes, by running `make test`.

- [ ] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [X] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**
Migrate the lightning.kokkos device to the new device API.

**Description of the Change:**
Add the necessary method for the LightningKokkos that allows the use of new device API. It should have a similar structure as the LightningQubit class.

Note: Lightning Kokkos does not support MCMC sampling.

**Benefits:**
Integration of LighntingKokkos with the new device API.

**Possible Drawbacks:**

**Related GitHub Issues:**
## Partial / Freezzed PR ⚠️ ❄️

To make a smooth integration of LightningKokkos with the new device API, we set the branch `kokkosNewAPI_backend` as the base branch target for this development.

The branch `kokkosNewAPI_backend` has the mock of all classes and methods necessary for the new API. Also, several tests were disabled with

```python
if device_name == "lightning.kokkos":
    pytest.skip("Kokkos new API in WIP.  Skipping.",allow_module_level=True)
```

Additionally, the CI testing from PennyLane for LKokkos is temporally disabled through commenting on the following lines in .github/workflows files

```
: # pl-device-test --device ${DEVICENAME} --skip-ops --shots=20000 $COVERAGE_FLAGS --cov-append
: # pl-device-test --device ${DEVICENAME} --shots=None --skip-ops $COVERAGE_FLAGS --cov-append
```

However, these tests will unblocked as the implementation progresses.

After all the developments for integrating LightningKokkos with the new API have been completed then the PR will be open to merging to master

[sc-68820]