### PR TITLE
Implement get_c_interface method for Kokkos plugin

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -62,6 +62,7 @@
 
 * Add a Catalyst-specific wrapping class for Lightning Kokkos.
   [(#770)](https://github.com/PennyLaneAI/pennylane-lightning/pull/770)
+  [(#837)](https://github.com/PennyLaneAI/pennylane-lightning/pull/837)
 
 * Add `initial_state_prep` option to Catalyst TOML file.
   [(#826)](https://github.com/PennyLaneAI/pennylane-lightning/pull/826)

--- a/.github/workflows/tests_lkcpu_python.yml
+++ b/.github/workflows/tests_lkcpu_python.yml
@@ -246,6 +246,7 @@ jobs:
         run: |
           cd main/
           DEVICENAME=`echo ${{ matrix.pl_backend }} | sed "s/_/./g"`
+            # Remove `python -m` to avoid running tests with relative modules
             PL_DEVICE=${DEVICENAME} pytest tests/ $COVERAGE_FLAGS --splits 7 --group ${{ matrix.group }} \
               --store-durations --durations-path='.github/workflows/python_lightning_kokkos_test_durations.json' --splitting-algorithm=least_duration
             mv .github/workflows/python_lightning_kokkos_test_durations.json ${{ github.workspace }}/.test_durations-${{ matrix.exec_model }}-${{ matrix.group }}

--- a/.github/workflows/tests_lkcpu_python.yml
+++ b/.github/workflows/tests_lkcpu_python.yml
@@ -207,6 +207,8 @@ jobs:
         run: |
           WHEEL_NAME=$(cat ${{ github.workspace }}/${{ matrix.pl_backend }}-${{ matrix.exec_model }}_name.txt)
           mv ${{ github.workspace }}/wheel_${{ matrix.pl_backend }}-${{ matrix.exec_model }}.whl ${{ github.workspace }}/$WHEEL_NAME
+          # Clean all editable mode installations
+          make clean && python -m pip uninstall pennylane-lightning pennylane-lightning-kokkos
           cd main
           python -m pip install -r requirements-dev.txt
           python -m pip install openfermionpyscf
@@ -214,6 +216,7 @@ jobs:
             SKIP_COMPILATION=True python -m pip install . -vv
           fi
           python -m pip install ${{ github.workspace }}/$WHEEL_NAME --no-deps
+          ls
 
       - name: Checkout PennyLane for release build
         if: inputs.pennylane-version == 'release'
@@ -245,6 +248,7 @@ jobs:
       - name: Run PennyLane-Lightning unit tests
         run: |
           cd main/
+          ls
           DEVICENAME=`echo ${{ matrix.pl_backend }} | sed "s/_/./g"`
             PL_DEVICE=${DEVICENAME} python -m pytest tests/ $COVERAGE_FLAGS --splits 7 --group ${{ matrix.group }} \
               --store-durations --durations-path='.github/workflows/python_lightning_kokkos_test_durations.json' --splitting-algorithm=least_duration

--- a/.github/workflows/tests_lkcpu_python.yml
+++ b/.github/workflows/tests_lkcpu_python.yml
@@ -211,10 +211,9 @@ jobs:
           python -m pip install -r requirements-dev.txt
           python -m pip install openfermionpyscf
           if [ '${{ inputs.lightning-version }}' != 'stable' ]; then
-            python -m pip install . -vv
+            SKIP_COMPILATION=True python -m pip install . -vv
           fi
           python -m pip install ${{ github.workspace }}/$WHEEL_NAME --no-deps
-          ls build/lib.*/pennylane_lightning
 
       - name: Checkout PennyLane for release build
         if: inputs.pennylane-version == 'release'
@@ -246,9 +245,8 @@ jobs:
       - name: Run PennyLane-Lightning unit tests
         run: |
           cd main/
-          ls build/lib.*/pennylane_lightning/
           DEVICENAME=`echo ${{ matrix.pl_backend }} | sed "s/_/./g"`
-            PL_DEVICE=${DEVICENAME} python -m pytest tests/ $COVERAGE_FLAGS --splits 7 --group ${{ matrix.group }} \
+            PL_DEVICE=${DEVICENAME} pytest tests/ $COVERAGE_FLAGS --splits 7 --group ${{ matrix.group }} \
               --store-durations --durations-path='.github/workflows/python_lightning_kokkos_test_durations.json' --splitting-algorithm=least_duration
             mv .github/workflows/python_lightning_kokkos_test_durations.json ${{ github.workspace }}/.test_durations-${{ matrix.exec_model }}-${{ matrix.group }}
           pl-device-test --device ${DEVICENAME} --skip-ops --shots=20000 $COVERAGE_FLAGS --cov-append

--- a/.github/workflows/tests_lkcpu_python.yml
+++ b/.github/workflows/tests_lkcpu_python.yml
@@ -205,11 +205,12 @@ jobs:
 
       - name: Get required Python packages
         run: |
+          set -x
           WHEEL_NAME=$(cat ${{ github.workspace }}/${{ matrix.pl_backend }}-${{ matrix.exec_model }}_name.txt)
           mv ${{ github.workspace }}/wheel_${{ matrix.pl_backend }}-${{ matrix.exec_model }}.whl ${{ github.workspace }}/$WHEEL_NAME
+          cd main
           # Clean all editable mode installations
           make clean && python -m pip uninstall pennylane-lightning pennylane-lightning-kokkos
-          cd main
           python -m pip install -r requirements-dev.txt
           python -m pip install openfermionpyscf
           if [ '${{ inputs.lightning-version }}' != 'stable' ]; then
@@ -247,6 +248,7 @@ jobs:
 
       - name: Run PennyLane-Lightning unit tests
         run: |
+          set -x
           cd main/
           ls
           DEVICENAME=`echo ${{ matrix.pl_backend }} | sed "s/_/./g"`

--- a/.github/workflows/tests_lkcpu_python.yml
+++ b/.github/workflows/tests_lkcpu_python.yml
@@ -205,19 +205,16 @@ jobs:
 
       - name: Get required Python packages
         run: |
-          set -x
           WHEEL_NAME=$(cat ${{ github.workspace }}/${{ matrix.pl_backend }}-${{ matrix.exec_model }}_name.txt)
           mv ${{ github.workspace }}/wheel_${{ matrix.pl_backend }}-${{ matrix.exec_model }}.whl ${{ github.workspace }}/$WHEEL_NAME
           cd main
-          # Clean all editable mode installations
-          make clean && python -m pip uninstall pennylane-lightning pennylane-lightning-kokkos
           python -m pip install -r requirements-dev.txt
           python -m pip install openfermionpyscf
           if [ '${{ inputs.lightning-version }}' != 'stable' ]; then
-            SKIP_COMPILATION=True python -m pip install . -vv
+            python -m pip install . -vv
           fi
           python -m pip install ${{ github.workspace }}/$WHEEL_NAME --no-deps
-          ls
+          ls build/lib.*/pennylane_lightning
 
       - name: Checkout PennyLane for release build
         if: inputs.pennylane-version == 'release'
@@ -248,9 +245,8 @@ jobs:
 
       - name: Run PennyLane-Lightning unit tests
         run: |
-          set -x
           cd main/
-          ls
+          ls build/lib.*/pennylane_lightning/
           DEVICENAME=`echo ${{ matrix.pl_backend }} | sed "s/_/./g"`
             PL_DEVICE=${DEVICENAME} python -m pytest tests/ $COVERAGE_FLAGS --splits 7 --group ${{ matrix.group }} \
               --store-durations --durations-path='.github/workflows/python_lightning_kokkos_test_durations.json' --splitting-algorithm=least_duration

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.38.0-dev25"
+__version__ = "0.38.0-dev26"

--- a/pennylane_lightning/lightning_kokkos/lightning_kokkos.py
+++ b/pennylane_lightning/lightning_kokkos/lightning_kokkos.py
@@ -864,7 +864,7 @@ class LightningKokkos(LightningBase):
         # Fixed location at the root of the project
         wheel_mode_location = package_root.parent / lib_name
         if wheel_mode_location.is_file():
-            return "LightningKokkosSimulator", wheel_mode_location
+            return "LightningKokkosSimulator", wheel_mode_location.as_posix()
 
         # Editable mode:
         # The build directory contains a folder which varies according to the platform:

--- a/pennylane_lightning/lightning_kokkos/lightning_kokkos.py
+++ b/pennylane_lightning/lightning_kokkos/lightning_kokkos.py
@@ -154,6 +154,18 @@ allowed_observables = {
     "Exp",
 }
 
+# The absolute path of the plugin shared object varies according to the installation type. 
+# This lookup table keeps track those possible locations
+lib_name = "liblightning_kokkos_catalyst.so"
+package_root = os.path.dirname(__file__)
+wheel_mode_location = os.path.join(package_root, "..", lib_name)
+editable_mode_location = os.path.join(
+    package_root,
+    f"../../build/lib.{platform.system().lower()}-{platform.machine()}-{sys.version_info[0]}.{sys.version_info[1]}/pennylane_lightning",
+    lib_name,
+)
+plugin_locations = [wheel_mode_location, editable_mode_location]
+
 
 class LightningKokkos(LightningBase):
     """PennyLane Lightning Kokkos device.
@@ -844,10 +856,8 @@ class LightningKokkos(LightningBase):
         the location to the shared object with the C/C++ device implementation.
         """
 
-        package_root = os.path.dirname(__file__)
-        plugin_lib_path = os.path.join(
-            package_root,
-            f"../../build/lib.{platform.system().lower()}-{platform.machine()}-{sys.version_info[0]}.{sys.version_info[1]}/pennylane_lightning",
-        )
+        for location in plugin_locations:
+            if os.path.isfile(location):
+                return "LightningKokkosSimulator", location
 
-        return "LightningKokkosSimulator", plugin_lib_path + "/liblightning_kokkos_catalyst.so"
+        raise RuntimeError("Shared object not found")

--- a/pennylane_lightning/lightning_kokkos/lightning_kokkos.py
+++ b/pennylane_lightning/lightning_kokkos/lightning_kokkos.py
@@ -154,7 +154,7 @@ allowed_observables = {
     "Exp",
 }
 
-# The absolute path of the plugin shared object varies according to the installation type. 
+# The absolute path of the plugin shared object varies according to the installation type.
 # This lookup table keeps track those possible locations
 lib_name = "liblightning_kokkos_catalyst.so"
 package_root = os.path.dirname(__file__)

--- a/pennylane_lightning/lightning_kokkos/lightning_kokkos.py
+++ b/pennylane_lightning/lightning_kokkos/lightning_kokkos.py
@@ -17,6 +17,10 @@ This module contains the :class:`~.LightningQubit` class, a PennyLane simulator 
 interfaces with C++ for fast linear algebra calculations.
 """
 
+import os.path
+import platform
+import sys
+
 from os import getenv
 from pathlib import Path
 from typing import List
@@ -834,3 +838,16 @@ class LightningKokkos(LightningBase):
                 return self.adjoint_jacobian(new_tape, starting_state, use_device_state)
 
             return processing_fn
+        
+    @staticmethod
+    def get_c_interface():
+        """ Returns a tuple consisting of the device name, and
+        the location to the shared object with the C/C++ device implementation.
+        """
+
+        package_root = os.path.dirname(__file__)
+        plugin_lib_path = os.path.join(package_root, f"../../build/lib.{platform.platform()}-{platform.machine()}-{sys.version_info[0]}.{sys.version_info[1]}/pennylane_lightning")
+        print(plugin_lib_path)
+        assert False
+
+        return "LightningKokkos", plugin_lib_path + "/liblightning_kokkos_catalyst.so"

--- a/pennylane_lightning/lightning_kokkos/lightning_kokkos.py
+++ b/pennylane_lightning/lightning_kokkos/lightning_kokkos.py
@@ -155,7 +155,7 @@ allowed_observables = {
 }
 
 # The absolute path of the plugin shared object varies according to the installation type.
-# This lookup table keeps track those possible locations
+# This lookup table keeps track of those possible locations
 lib_name = "liblightning_kokkos_catalyst.so"
 package_root = os.path.dirname(__file__)
 wheel_mode_location = os.path.join(package_root, "..", lib_name)

--- a/pennylane_lightning/lightning_kokkos/lightning_kokkos.py
+++ b/pennylane_lightning/lightning_kokkos/lightning_kokkos.py
@@ -20,7 +20,6 @@ interfaces with C++ for fast linear algebra calculations.
 import os.path
 import platform
 import sys
-
 from os import getenv
 from pathlib import Path
 from typing import List
@@ -838,14 +837,17 @@ class LightningKokkos(LightningBase):
                 return self.adjoint_jacobian(new_tape, starting_state, use_device_state)
 
             return processing_fn
-        
+
     @staticmethod
     def get_c_interface():
-        """ Returns a tuple consisting of the device name, and
+        """Returns a tuple consisting of the device name, and
         the location to the shared object with the C/C++ device implementation.
         """
 
         package_root = os.path.dirname(__file__)
-        plugin_lib_path = os.path.join(package_root, f"../../build/lib.{platform.system().lower()}-{platform.machine()}-{sys.version_info[0]}.{sys.version_info[1]}/pennylane_lightning")
+        plugin_lib_path = os.path.join(
+            package_root,
+            f"../../build/lib.{platform.system().lower()}-{platform.machine()}-{sys.version_info[0]}.{sys.version_info[1]}/pennylane_lightning",
+        )
 
         return "LightningKokkosSimulator", plugin_lib_path + "/liblightning_kokkos_catalyst.so"

--- a/pennylane_lightning/lightning_kokkos/lightning_kokkos.py
+++ b/pennylane_lightning/lightning_kokkos/lightning_kokkos.py
@@ -846,8 +846,6 @@ class LightningKokkos(LightningBase):
         """
 
         package_root = os.path.dirname(__file__)
-        plugin_lib_path = os.path.join(package_root, f"../../build/lib.{platform.platform()}-{platform.machine()}-{sys.version_info[0]}.{sys.version_info[1]}/pennylane_lightning")
-        print(plugin_lib_path)
-        assert False
+        plugin_lib_path = os.path.join(package_root, f"../../build/lib.{platform.system().lower()}-{platform.machine()}-{sys.version_info[0]}.{sys.version_info[1]}/pennylane_lightning")
 
-        return "LightningKokkos", plugin_lib_path + "/liblightning_kokkos_catalyst.so"
+        return "LightningKokkosSimulator", plugin_lib_path + "/liblightning_kokkos_catalyst.so"

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -107,3 +107,49 @@ def test_device_init_zero_qubit():
         return qml.state()
 
     assert np.allclose(circuit(), np.array([1.0]))
+
+
+@pytest.mark.skipif(
+    (device_name != "lightning.kokkos" or sys.platform != "win32"),
+    reason="This test is for Kokkos under Windows only.",
+)
+def test_unsupported_windows_platform_kokkos():
+    """Test unsupported Windows platform for Kokkos."""
+
+    dev = qml.device(device_name, wires=0)
+
+    with pytest.raises(
+        RuntimeError,
+        match="'LightningKokkosSimulator' shared library not available for 'win32' platform",
+    ):
+        dev.get_c_interface()
+
+
+@pytest.mark.skipif(
+    (device_name != "lightning.kokkos" or sys.platform != "linux"),
+    reason="This test is for Kokkos under Linux only.",
+)
+def test_supported_linux_platform_kokkos():
+    """Test supported Linux platform for Kokkos."""
+
+    dev = qml.device(device_name, wires=0)
+
+    dev_name, shared_lib_name = dev.get_c_interface()
+
+    assert dev_name == "LightningKokkosSimulator"
+    assert "liblightning_kokkos_catalyst.so" in shared_lib_name
+
+
+@pytest.mark.skipif(
+    (device_name != "lightning.kokkos" or sys.platform != "darwin"),
+    reason="This test is for Kokkos under MacOS only.",
+)
+def test_supported_macos_platform_kokkos():
+    """Test supported MacOS platform for Kokkos."""
+
+    dev = qml.device(device_name, wires=0)
+
+    dev_name, shared_lib_name = dev.get_c_interface()
+
+    assert dev_name == "LightningKokkosSimulator"
+    assert "liblightning_kokkos_catalyst.dylib" in shared_lib_name


### PR DESCRIPTION
**Context:** Catalyst is removing the Kokkos plugin from its code base (https://github.com/PennyLaneAI/catalyst/pull/974) and is attempting to use it directly from Lightning. However, the C interface was not provided via Python.

**Description of the Change:** Implement the C interface provider method in Python.

**Benefits:** Catalyst can use the Kokkos plugin.