### PR TITLE
Add SetBasisState and SetState to `lightning.kokkos`

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -63,8 +63,9 @@
 * Add a Catalyst-specific wrapping class for Lightning Kokkos.
   [(#770)](https://github.com/PennyLaneAI/pennylane-lightning/pull/770)
 
-* Add `initial_state_prep` option to Catalyst TOML file.
+* Add `initial_state_prep` option to TOML files and Lightning Kokkos.
   [(#826)](https://github.com/PennyLaneAI/pennylane-lightning/pull/826)
+  [(#838)](https://github.com/PennyLaneAI/pennylane-lightning/pull/838)
 
 ### Documentation
 

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.38.0-dev25"
+__version__ = "0.38.0-dev26"

--- a/pennylane_lightning/core/src/simulators/lightning_kokkos/catalyst/LightningKokkosSimulator.cpp
+++ b/pennylane_lightning/core/src/simulators/lightning_kokkos/catalyst/LightningKokkosSimulator.cpp
@@ -137,16 +137,16 @@ void LightningKokkosSimulator::PrintState() {
 }
 /// LCOV_EXCL_STOP
 
-void LightningKokkosSimulator::SetState(DataView<std::complex<double>, 1> &data_view)
-{
-    std::vector<Kokkos::complex<double>> data_vector(data_view.begin(), data_view.end());
+void LightningKokkosSimulator::SetState(
+    DataView<std::complex<double>, 1> &data_view) {
+    std::vector<Kokkos::complex<double>> data_vector(data_view.begin(),
+                                                     data_view.end());
     std::vector<std::size_t> count(data_vector.size());
     std::iota(std::begin(count), std::end(count), 0);
     this->device_sv->setStateVector(count, data_vector);
 }
 
-void LightningKokkosSimulator::SetBasisState(const std::size_t index)
-{
+void LightningKokkosSimulator::SetBasisState(const std::size_t index) {
     this->device_sv->setBasisState(index);
 }
 

--- a/pennylane_lightning/core/src/simulators/lightning_kokkos/catalyst/LightningKokkosSimulator.cpp
+++ b/pennylane_lightning/core/src/simulators/lightning_kokkos/catalyst/LightningKokkosSimulator.cpp
@@ -137,6 +137,19 @@ void LightningKokkosSimulator::PrintState() {
 }
 /// LCOV_EXCL_STOP
 
+void LightningKokkosSimulator::SetState(DataView<std::complex<double>, 1> &data_view)
+{
+    std::vector<Kokkos::complex<double>> data_vector(data_view.begin(), data_view.end());
+    std::vector<std::size_t> count(data_vector.size());
+    std::iota(std::begin(count), std::end(count), 0);
+    this->device_sv->setStateVector(count, data_vector);
+}
+
+void LightningKokkosSimulator::SetBasisState(const std::size_t index)
+{
+    this->device_sv->setBasisState(index);
+}
+
 auto LightningKokkosSimulator::Zero() const -> Result {
     return const_cast<Result>(&GLOBAL_RESULT_FALSE_CONST);
 }

--- a/pennylane_lightning/core/src/simulators/lightning_kokkos/catalyst/tests/Test_LightningKokkosSimulator.cpp
+++ b/pennylane_lightning/core/src/simulators/lightning_kokkos/catalyst/tests/Test_LightningKokkosSimulator.cpp
@@ -659,4 +659,30 @@ TEST_CASE("LightningKokkosSimulator::GateSet", "[GateSet]") {
             expected{3, 0, 1, {"Hadamard", "Hadamard", "IsingZZ"}, {}};
         REQUIRE(LKsim->CacheManagerInfo() == expected);
     }
+
+    SECTION("setBasisState")
+    {
+        const size_t num_qubits = 1;
+        std::unique_ptr<LKSimulator> sv1 = std::make_unique<LKSimulator>();
+        std::vector<intptr_t> Qs = sv1->AllocateQubits(num_qubits);
+        sv1->setBasisState(0);
+        std::vector<std::complex<PrecisionT>> expected({{1.0, 0.0}, {0.0, 0.0}});
+        CHECK(sv1->getDataVector() == expected);
+        sv1->setBasisState(1);
+        std::vector<std::complex<PrecisionT>> expected2({{0.0, 0.0}, {1.0, 0.0}});
+        CHECK(sv1->getDataVector() == expected2);
+    }
+
+    SECTION("setStateVector")
+    {
+        const size_t num_qubits = 1;
+        std::unique_ptr<LKSimulator> sv1 = std::make_unique<LKSimulator>();
+        std::vector<intptr_t> Qs = sv1->AllocateQubits(num_qubits);
+        sv1->setStateVector({0}, {{0.5, 0.5}});
+        std::vector<std::complex<PrecisionT>> expected({{0.5, 0.5}, {0.0, 0.0}});
+        CHECK(sv1->getDataVector() == expected);
+        sv1->setStateVector({1}, {{0.5, 0.5}});
+        std::vector<std::complex<PrecisionT>> expected2({{0.5, 0.5}, {0.5, 0.5}});
+        CHECK(sv1->getDataVector() == expected2);
+    }
 }

--- a/pennylane_lightning/core/src/simulators/lightning_kokkos/catalyst/tests/Test_LightningKokkosSimulator.cpp
+++ b/pennylane_lightning/core/src/simulators/lightning_kokkos/catalyst/tests/Test_LightningKokkosSimulator.cpp
@@ -660,29 +660,31 @@ TEST_CASE("LightningKokkosSimulator::GateSet", "[GateSet]") {
         REQUIRE(LKsim->CacheManagerInfo() == expected);
     }
 
-    SECTION("setBasisState")
-    {
+    SECTION("setBasisState") {
         const size_t num_qubits = 1;
         std::unique_ptr<LKSimulator> sv1 = std::make_unique<LKSimulator>();
         std::vector<intptr_t> Qs = sv1->AllocateQubits(num_qubits);
         sv1->setBasisState(0);
-        std::vector<std::complex<PrecisionT>> expected({{1.0, 0.0}, {0.0, 0.0}});
+        std::vector<std::complex<PrecisionT>> expected(
+            {{1.0, 0.0}, {0.0, 0.0}});
         CHECK(sv1->getDataVector() == expected);
         sv1->setBasisState(1);
-        std::vector<std::complex<PrecisionT>> expected2({{0.0, 0.0}, {1.0, 0.0}});
+        std::vector<std::complex<PrecisionT>> expected2(
+            {{0.0, 0.0}, {1.0, 0.0}});
         CHECK(sv1->getDataVector() == expected2);
     }
 
-    SECTION("setStateVector")
-    {
+    SECTION("setStateVector") {
         const size_t num_qubits = 1;
         std::unique_ptr<LKSimulator> sv1 = std::make_unique<LKSimulator>();
         std::vector<intptr_t> Qs = sv1->AllocateQubits(num_qubits);
         sv1->setStateVector({0}, {{0.5, 0.5}});
-        std::vector<std::complex<PrecisionT>> expected({{0.5, 0.5}, {0.0, 0.0}});
+        std::vector<std::complex<PrecisionT>> expected(
+            {{0.5, 0.5}, {0.0, 0.0}});
         CHECK(sv1->getDataVector() == expected);
         sv1->setStateVector({1}, {{0.5, 0.5}});
-        std::vector<std::complex<PrecisionT>> expected2({{0.5, 0.5}, {0.5, 0.5}});
+        std::vector<std::complex<PrecisionT>> expected2(
+            {{0.5, 0.5}, {0.5, 0.5}});
         CHECK(sv1->getDataVector() == expected2);
     }
 }


### PR DESCRIPTION
**Context:** In order for the `StatePrep` and `BasisState` optimizations be implemented, the kokkos device needs to be modified. Since the kokkos device is migrating to the pennylane-lightning repo, it is necessary that these changes are also in the pennylane-lightning repo.

**Description of the Change:** Copies over changes from Catalyst regarding kokkos into the pennylane-lightning repo.

**Related GitHub Issues:** https://github.com/PennyLaneAI/catalyst/pull/955 

**Notes**: The tests won't pass until the PR  https://github.com/PennyLaneAI/catalyst/pull/955 is merged, since it updates the Catalyst Quantum Device API.
