### PR TITLE
Move functions to base class

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -67,7 +67,7 @@
 * Add `initial_state_prep` option to Catalyst TOML file.
   [(#826)](https://github.com/PennyLaneAI/pennylane-lightning/pull/826)
 
-* Move `setBasisState`, `setStateVector` and `resetStateVector` from LM to `StateVectorLQubit`.
+* Move `setBasisState`, `setStateVector` and `resetStateVector` from `StateVectorLQubitManaged` to `StateVectorLQubit`.
   [(#841)](https://github.com/PennyLaneAI/pennylane-lightning/pull/841)
 
 ### Documentation

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -67,6 +67,9 @@
 * Add `initial_state_prep` option to Catalyst TOML file.
   [(#826)](https://github.com/PennyLaneAI/pennylane-lightning/pull/826)
 
+* Move `setBasisState`, `setStateVector` and `resetStateVector` from LM to `StateVectorLQubit`.
+  [(#841)](https://github.com/PennyLaneAI/pennylane-lightning/pull/841)
+
 ### Documentation
 
 * Updated the README and added citation format for Lightning arxiv preprint.

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.38.0-dev26"
+__version__ = "0.38.0-dev27"

--- a/pennylane_lightning/core/src/simulators/lightning_qubit/StateVectorLQubit.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_qubit/StateVectorLQubit.hpp
@@ -717,7 +717,7 @@ class StateVectorLQubit : public StateVectorBase<PrecisionT, Derived> {
 
         auto *arr = this->getData();
         auto length = this->getLength();
-std::fill(arr, arr + length, 0.0);
+        std::fill(arr, arr + length, 0.0);
         for (std::size_t i = 0; i < num_indices; i++) {
             PL_ABORT_IF(i >= length, "Invalid index");
             arr[indices[i]] = values[i];

--- a/pennylane_lightning/core/src/simulators/lightning_qubit/StateVectorLQubit.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_qubit/StateVectorLQubit.hpp
@@ -713,7 +713,8 @@ class StateVectorLQubit : public StateVectorBase<PrecisionT, Derived> {
      */
     void setStateVector(const std::vector<std::size_t> &indices,
                         const std::vector<ComplexT> &values) {
-        std::unordered_set<std::size_t> index_set(indices.begin(), indices.end());
+        std::unordered_set<std::size_t> index_set(indices.begin(),
+                                                  indices.end());
         auto num_indices = index_set.size();
         PL_ABORT_IF(num_indices != indices.size(), "Indices must be unique");
         PL_ABORT_IF(num_indices != values.size(),

--- a/pennylane_lightning/core/src/simulators/lightning_qubit/StateVectorLQubit.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_qubit/StateVectorLQubit.hpp
@@ -695,7 +695,10 @@ class StateVectorLQubit : public StateVectorBase<PrecisionT, Derived> {
      */
     void setBasisState(const std::size_t index) {
         auto *arr = this->getData();
-        memset(arr, 0, sizeof(ComplexT) * this->getLength());
+        PL_ABORT_IF(index > this->getLength() - 1, "Invalid wire");
+        for (size_t k = 0; k < this->getLength(); k++) {
+            arr[k] = {0.0, 0.0};
+        }
         arr[index] = {1.0, 0.0};
     }
 

--- a/pennylane_lightning/core/src/simulators/lightning_qubit/StateVectorLQubit.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_qubit/StateVectorLQubit.hpp
@@ -694,9 +694,11 @@ class StateVectorLQubit : public StateVectorBase<PrecisionT, Derived> {
      * @param index Index of the target element.
      */
     void setBasisState(const std::size_t index) {
+        auto length = this->getLength();
+        PL_ABORT_IF(index > length - 1, "Invalid index");
+
         auto *arr = this->getData();
-        PL_ABORT_IF(index > this->getLength() - 1, "Invalid wire");
-        for (size_t k = 0; k < this->getLength(); k++) {
+        for (size_t k = 0; k < length; k++) {
             arr[k] = {0.0, 0.0};
         }
         arr[index] = {1.0, 0.0};
@@ -710,9 +712,18 @@ class StateVectorLQubit : public StateVectorBase<PrecisionT, Derived> {
      */
     void setStateVector(const std::vector<std::size_t> &indices,
                         const std::vector<ComplexT> &values) {
+        std::unordered_set index_set(indices.begin(), indices.end());
+        auto num_indices = index_set.size();
+        PL_ABORT_IF(num_indices != indices.size(), "Indices must be unique");
+        PL_ABORT_IF(num_indices != values.size(),
+                    "Indices and values length must match");
+
         auto *arr = this->getData();
-        for (std::size_t n = 0; n < indices.size(); n++) {
-            arr[indices[n]] = values[n];
+        auto length = this->getLength();
+
+        for (std::size_t i = 0; i < num_indices; i++) {
+            PL_ABORT_IF(i >= length, "Invalid index");
+            arr[indices[i]] = values[i];
         }
     }
 

--- a/pennylane_lightning/core/src/simulators/lightning_qubit/StateVectorLQubit.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_qubit/StateVectorLQubit.hpp
@@ -23,7 +23,6 @@
 #pragma once
 #include <complex>
 #include <unordered_map>
-#include <unordered_set>
 
 #include "CPUMemoryModel.hpp"
 #include "GateOperation.hpp"

--- a/pennylane_lightning/core/src/simulators/lightning_qubit/StateVectorLQubit.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_qubit/StateVectorLQubit.hpp
@@ -59,41 +59,6 @@ class StateVectorLQubit : public StateVectorBase<PrecisionT, Derived> {
     using ComplexT = std::complex<PrecisionT>;
     using MemoryStorageT = Pennylane::Util::MemoryStorageLocation::Undefined;
 
-    /**
-     * @brief Prepares a single computational basis state.
-     *
-     * @param index Index of the target element.
-     */
-    void setBasisState(const std::size_t index) {
-        auto *arr = this->getData();
-        memset(arr, 0, sizeof(ComplexT) * this->getLength());
-        arr[index] = {1.0, 0.0};
-    }
-
-    /**
-     * @brief Set values for a batch of elements of the state-vector.
-     *
-     * @param values Values to be set for the target elements.
-     * @param indices Indices of the target elements.
-     */
-    void setStateVector(const std::vector<std::size_t> &indices,
-                        const std::vector<ComplexT> &values) {
-        auto *arr = this->getData();
-        for (std::size_t n = 0; n < indices.size(); n++) {
-            arr[indices[n]] = values[n];
-        }
-    }
-
-    /**
-     * @brief Reset the data back to the \f$\ket{0}\f$ state.
-     *
-     */
-    void resetStateVector() {
-        if (this->getLength() > 0) {
-            setBasisState(0U);
-        }
-    }
-
   protected:
     const Threading threading_;
     const CPUMemoryModel memory_model_;
@@ -720,6 +685,42 @@ class StateVectorLQubit : public StateVectorBase<PrecisionT, Derived> {
         std::complex<PrecisionT> inv_norm = 1. / norm;
         for (size_t k = 0; k < this->getLength(); k++) {
             arr[k] *= inv_norm;
+        }
+    }
+
+  public:
+    /**
+     * @brief Prepares a single computational basis state.
+     *
+     * @param index Index of the target element.
+     */
+    void setBasisState(const std::size_t index) {
+        auto *arr = this->getData();
+        memset(arr, 0, sizeof(ComplexT) * this->getLength());
+        arr[index] = {1.0, 0.0};
+    }
+
+    /**
+     * @brief Set values for a batch of elements of the state-vector.
+     *
+     * @param values Values to be set for the target elements.
+     * @param indices Indices of the target elements.
+     */
+    void setStateVector(const std::vector<std::size_t> &indices,
+                        const std::vector<ComplexT> &values) {
+        auto *arr = this->getData();
+        for (std::size_t n = 0; n < indices.size(); n++) {
+            arr[indices[n]] = values[n];
+        }
+    }
+
+    /**
+     * @brief Reset the data back to the \f$\ket{0}\f$ state.
+     *
+     */
+    void resetStateVector() {
+        if (this->getLength() > 0) {
+            setBasisState(0U);
         }
     }
 };

--- a/pennylane_lightning/core/src/simulators/lightning_qubit/StateVectorLQubit.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_qubit/StateVectorLQubit.hpp
@@ -717,7 +717,7 @@ class StateVectorLQubit : public StateVectorBase<PrecisionT, Derived> {
 
         auto *arr = this->getData();
         auto length = this->getLength();
-
+std::fill(arr, arr + length, 0.0);
         for (std::size_t i = 0; i < num_indices; i++) {
             PL_ABORT_IF(i >= length, "Invalid index");
             arr[indices[i]] = values[i];

--- a/pennylane_lightning/core/src/simulators/lightning_qubit/StateVectorLQubit.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_qubit/StateVectorLQubit.hpp
@@ -699,9 +699,7 @@ class StateVectorLQubit : public StateVectorBase<PrecisionT, Derived> {
         PL_ABORT_IF(index > length - 1, "Invalid index");
 
         auto *arr = this->getData();
-        for (size_t k = 0; k < length; k++) {
-            arr[k] = {0.0, 0.0};
-        }
+        std::fill(arr, arr + length, 0.0);
         arr[index] = {1.0, 0.0};
     }
 
@@ -713,10 +711,7 @@ class StateVectorLQubit : public StateVectorBase<PrecisionT, Derived> {
      */
     void setStateVector(const std::vector<std::size_t> &indices,
                         const std::vector<ComplexT> &values) {
-        std::unordered_set<std::size_t> index_set(indices.begin(),
-                                                  indices.end());
-        auto num_indices = index_set.size();
-        PL_ABORT_IF(num_indices != indices.size(), "Indices must be unique");
+        auto num_indices = indices.size();
         PL_ABORT_IF(num_indices != values.size(),
                     "Indices and values length must match");
 

--- a/pennylane_lightning/core/src/simulators/lightning_qubit/StateVectorLQubit.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_qubit/StateVectorLQubit.hpp
@@ -688,7 +688,6 @@ class StateVectorLQubit : public StateVectorBase<PrecisionT, Derived> {
         }
     }
 
-  public:
     /**
      * @brief Prepares a single computational basis state.
      *

--- a/pennylane_lightning/core/src/simulators/lightning_qubit/StateVectorLQubit.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_qubit/StateVectorLQubit.hpp
@@ -59,6 +59,41 @@ class StateVectorLQubit : public StateVectorBase<PrecisionT, Derived> {
     using ComplexT = std::complex<PrecisionT>;
     using MemoryStorageT = Pennylane::Util::MemoryStorageLocation::Undefined;
 
+    /**
+     * @brief Prepares a single computational basis state.
+     *
+     * @param index Index of the target element.
+     */
+    void setBasisState(const std::size_t index) {
+        auto *arr = this->getData();
+        memset(arr, 0, sizeof(ComplexT) * this->getLength());
+        arr[index] = {1.0, 0.0};
+    }
+
+    /**
+     * @brief Set values for a batch of elements of the state-vector.
+     *
+     * @param values Values to be set for the target elements.
+     * @param indices Indices of the target elements.
+     */
+    void setStateVector(const std::vector<std::size_t> &indices,
+                        const std::vector<ComplexT> &values) {
+        auto *arr = this->getData();
+        for (std::size_t n = 0; n < indices.size(); n++) {
+            arr[indices[n]] = values[n];
+        }
+    }
+
+    /**
+     * @brief Reset the data back to the \f$\ket{0}\f$ state.
+     *
+     */
+    void resetStateVector() {
+        if (this->getLength() > 0) {
+            setBasisState(0U);
+        }
+    }
+
   protected:
     const Threading threading_;
     const CPUMemoryModel memory_model_;

--- a/pennylane_lightning/core/src/simulators/lightning_qubit/StateVectorLQubit.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_qubit/StateVectorLQubit.hpp
@@ -23,6 +23,7 @@
 #pragma once
 #include <complex>
 #include <unordered_map>
+#include <unordered_set>
 
 #include "CPUMemoryModel.hpp"
 #include "GateOperation.hpp"
@@ -712,7 +713,7 @@ class StateVectorLQubit : public StateVectorBase<PrecisionT, Derived> {
      */
     void setStateVector(const std::vector<std::size_t> &indices,
                         const std::vector<ComplexT> &values) {
-        std::unordered_set index_set(indices.begin(), indices.end());
+        std::unordered_set<std::size_t> index_set(indices.begin(), indices.end());
         auto num_indices = index_set.size();
         PL_ABORT_IF(num_indices != indices.size(), "Indices must be unique");
         PL_ABORT_IF(num_indices != values.size(),

--- a/pennylane_lightning/core/src/simulators/lightning_qubit/StateVectorLQubit.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_qubit/StateVectorLQubit.hpp
@@ -728,7 +728,7 @@ class StateVectorLQubit : public StateVectorBase<PrecisionT, Derived> {
      *
      */
     void resetStateVector() {
-        if (this->getLength() > 0) {
+        if (this->getLength()) {
             setBasisState(0U);
         }
     }

--- a/pennylane_lightning/core/src/simulators/lightning_qubit/StateVectorLQubitManaged.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_qubit/StateVectorLQubitManaged.hpp
@@ -140,39 +140,6 @@ class StateVectorLQubitManaged final
 
     ~StateVectorLQubitManaged() = default;
 
-    /**
-     * @brief Prepares a single computational basis state.
-     *
-     * @param index Index of the target element.
-     */
-    void setBasisState(const std::size_t index) {
-        std::fill(data_.begin(), data_.end(), 0.0);
-        data_[index] = {1.0, 0.0};
-    }
-
-    /**
-     * @brief Set values for a batch of elements of the state-vector.
-     *
-     * @param values Values to be set for the target elements.
-     * @param indices Indices of the target elements.
-     */
-    void setStateVector(const std::vector<std::size_t> &indices,
-                        const std::vector<ComplexT> &values) {
-        for (std::size_t n = 0; n < indices.size(); n++) {
-            data_[indices[n]] = values[n];
-        }
-    }
-
-    /**
-     * @brief Reset the data back to the \f$\ket{0}\f$ state.
-     *
-     */
-    void resetStateVector() {
-        if (this->getLength() > 0) {
-            setBasisState(0U);
-        }
-    }
-
     [[nodiscard]] auto getData() -> ComplexT * { return data_.data(); }
 
     [[nodiscard]] auto getData() const -> const ComplexT * {


### PR DESCRIPTION
**Context:** Some of these functions are needed in Catalyst. Since Catalyst does not use LM, but instead uses LightningDynamic, the least upper bound in the class hierarchy is `StateVectorLQubit`.

**Description of the Change:** Move these functions to `StateVetctorLQubit`.

**Benefits:** Code-reuse

**Possible Drawbacks:**

**Related GitHub Issues:**
