### PR TITLE
Use `decomposition` instead of `Operator.expand`

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -70,7 +70,7 @@
 * Move `setBasisState`, `setStateVector` and `resetStateVector` from `StateVectorLQubitManaged` to `StateVectorLQubit`.
   [(#841)](https://github.com/PennyLaneAI/pennylane-lightning/pull/841)
 
-* Remove use of the deprecated `Operator.expand` in favour of `Operator.decomposition`
+* Remove use of the deprecated `Operator.expand` in favour of `Operator.decomposition`.
   [(#846)](https://github.com/PennyLaneAI/pennylane-lightning/pull/846)
 
 ### Documentation

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -70,6 +70,9 @@
 * Move `setBasisState`, `setStateVector` and `resetStateVector` from `StateVectorLQubitManaged` to `StateVectorLQubit`.
   [(#841)](https://github.com/PennyLaneAI/pennylane-lightning/pull/841)
 
+* Remove use of the deprecated `Operator.expand` in favour of `Operator.decomposition`
+  [(#846)](https://github.com/PennyLaneAI/pennylane-lightning/pull/846)
+
 ### Documentation
 
 * Updated the README and added citation format for Lightning arxiv preprint.
@@ -105,7 +108,7 @@
 
 This release contains contributions from (in alphabetical order):
 
-Ali Asadi, Amintor Dusko, Vincent Michaud-Rioux, Erick Ochoa Lopez, Lee J. O'Riordan, Mudit Pandey, Shuli Shu, Paul Haochen Wang
+Ali Asadi, Astral Cai, Amintor Dusko, Vincent Michaud-Rioux, Erick Ochoa Lopez, Lee J. O'Riordan, Mudit Pandey, Shuli Shu, Paul Haochen Wang
 
 ---
 

--- a/pennylane_lightning/core/_serialize.py
+++ b/pennylane_lightning/core/_serialize.py
@@ -404,7 +404,7 @@ class QuantumScriptSerializer:
                 uses_stateprep = True
                 continue
             if isinstance(operation, Rot):
-                op_list = operation.expand().operations
+                op_list = operation.decomposition()
             else:
                 op_list = [operation]
 

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.38.0-dev28"
+__version__ = "0.38.0-dev29"

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -741,6 +741,29 @@ class TestSerializeOps:
         assert s == s_expected
 
     @pytest.mark.parametrize("wires_map", [wires_dict, None])
+    def test_Rot_in_circuit(self, wires_map):
+        """Test expected serialization for a circuit with Rot which should be decomposed"""
+
+        with qml.queuing.AnnotatedQueue() as q:
+            qml.Rot(0.1, 0.2, 0.3, wires=0)
+
+        tape = qml.tape.QuantumScript.from_queue(q)
+        s = QuantumScriptSerializer(device_name).serialize_ops(tape, wires_map)
+        s_expected = (
+            (
+                ["RZ", "RY", "RZ"],
+                [np.array([0.1]), np.array([0.2]), np.array([0.3])],
+                [[0], [0], [0]],
+                [False, False, False],
+                [[], [], []],
+                [[], [], []],
+                [[], [], []],
+            ),
+            False,
+        )
+        assert s == s_expected
+
+    @pytest.mark.parametrize("wires_map", [wires_dict, None])
     def test_basic_circuit_not_implemented_ctrl_ops(self, wires_map):
         """Test expected serialization for a simple circuit"""
         ops = qml.OrbitalRotation(0.1234, wires=range(4))


### PR DESCRIPTION
`Operator.expand` is deprecated (https://github.com/PennyLaneAI/pennylane/pull/5994). `Operator.decomposition` should be used instead.