### PR TITLE
Fix structured bindings Clang + OpenMP bug

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -92,6 +92,9 @@
 
 ### Bug fixes
 
+* Replace structured bindings by variables in `GateImplementationsLM.hpp`.
+  [(#856)](https://github.com/PennyLaneAI/pennylane-lightning/pull/856)
+
 * Remove wrong -m when calling setup.py.
   [(#854)](https://github.com/PennyLaneAI/pennylane-lightning/pull/854)
 

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.38.0-dev34"
+__version__ = "0.38.0-dev35"

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.38.0-dev35"
+__version__ = "0.38.0-dev36"

--- a/pennylane_lightning/core/src/simulators/lightning_qubit/gates/cpu_kernels/GateImplementationsLM.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_qubit/gates/cpu_kernels/GateImplementationsLM.hpp
@@ -626,10 +626,12 @@ class GateImplementationsLM : public PauliGenerator<GateImplementationsLM> {
             const std::size_t rev_wire = num_qubits - wires[0] - 1;
             const std::size_t rev_wire_shift = (one << rev_wire);
             const auto parities = revWireParity(rev_wire);
+            const auto parity_high = parities.first;
+            const auto parity_low = parities.second;
             PL_LOOP_PARALLEL(1)
             for (std::size_t k = 0; k < exp2(num_qubits - nw_tot); k++) {
                 const std::size_t i0 =
-                    ((k << 1U) & parities.first) | (parities.second & k);
+                    ((k << 1U) & parity_high) | (parity_low & k);
                 const std::size_t i1 = i0 | rev_wire_shift;
                 core_function(arr, i0, i1);
             }
@@ -1262,11 +1264,14 @@ class GateImplementationsLM : public PauliGenerator<GateImplementationsLM> {
             const std::size_t rev_wire1_shift = static_cast<std::size_t>(1U)
                                                 << rev_wire1;
             const auto parities = revWireParity(rev_wire0, rev_wire1);
+            const auto parity_high = std::get<0>(parities);
+            const auto parity_middle = std::get<1>(parities);
+            const auto parity_low = std::get<2>(parities);
             PL_LOOP_PARALLEL(1)
             for (std::size_t k = 0; k < exp2(num_qubits - nw_tot); k++) {
-                const std::size_t i00 = ((k << 2U) & std::get<0>(parities)) |
-                                        ((k << 1U) & std::get<1>(parities)) |
-                                        (k & std::get<2>(parities));
+                const std::size_t i00 = ((k << 2U) & parity_high) |
+                                        ((k << 1U) & parity_middle) |
+                                        (k & parity_low);
                 const std::size_t i10 = i00 | rev_wire1_shift;
                 const std::size_t i01 = i00 | rev_wire0_shift;
                 const std::size_t i11 = i00 | rev_wire0_shift | rev_wire1_shift;


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [ ] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [ ] Ensure that the test suite passes, by running `make test`.

- [x] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [ ] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**
@mlxd [mentioned](https://github.com/PennyLaneAI/pennylane-lightning/pull/834#discussion_r1715237891) that "the use of structured bindings/lambdas when combined with OpenMP often fails to compile with clang due to missing support"

**Description of the Change:**
Replace structured bindings by variables in `GateImplementationsLM.hpp`.

**Benefits:**
Compile with Clang & OpenMP.

**Possible Drawbacks:**

**Related GitHub Issues:**
