### PR TITLE
test Deprecaation in lightning

### DIFF
--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.38.0-dev51"
+__version__ = "0.38.0-dev52"

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.38.0-dev50"
+__version__ = "0.38.0-dev51"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-git+https://github.com/PennyLaneAI/pennylane.git@master
+git+https://github.com/PennyLaneAI/pennylane.git@deprecate-BasisStatePreparation
 build
 ninja
 flaky

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-git+https://github.com/PennyLaneAI/pennylane.git@deprecate-BasisStatePreparation
+git+https://github.com/PennyLaneAI/pennylane.git@deprecate-BasisStatePreparation 
 build
 ninja
 flaky


### PR DESCRIPTION
Verify that BasisStatePrep deprecation does not break anything in Lightning
