### PR TITLE
Point to the right Lightning root folder independently from the invocation folder

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -163,6 +163,9 @@
 * Fix checkout command in test workflows for rc branches.
   [(#777)](https://github.com/PennyLaneAI/pennylane-lightning/pull/777)
 
+* Point to the right Lightning root folder independently from the invocation location, when configuring the project.
+  [(#874)](https://github.com/PennyLaneAI/pennylane-lightning/pull/874)
+
 ### Contributors
 
 This release contains contributions from (in alphabetical order):

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.38.0-dev51"
+__version__ = "0.38.0-dev52"

--- a/scripts/configure_pyproject_toml.py
+++ b/scripts/configure_pyproject_toml.py
@@ -21,7 +21,7 @@ from pathlib import Path
 import toml
 from backend_support import backend, device_name
 
-path_to_version = Path("pennylane_lightning").absolute() / "core" / "_version.py"
+path_to_version = Path(__file__).parent.parent / Path("pennylane_lightning") / "core" / "_version.py"
 with open(path_to_version, encoding="utf-8") as f:
     version = f.readlines()[-1].split()[-1].strip("\"'")
 

--- a/scripts/configure_pyproject_toml.py
+++ b/scripts/configure_pyproject_toml.py
@@ -21,9 +21,9 @@ from pathlib import Path
 import toml
 from backend_support import backend, device_name
 
-path_to_version = (
-    Path(__file__).parent.parent / Path("pennylane_lightning") / "core" / "_version.py"
-)
+path_to_project = Path(__file__).parent.parent.absolute()
+
+path_to_version = path_to_project / Path("pennylane_lightning") / "core" / "_version.py"
 with open(path_to_version, encoding="utf-8") as f:
     version = f.readlines()[-1].split()[-1].strip("\"'")
 
@@ -51,6 +51,10 @@ def parse_args():
 
 if __name__ == "__main__":
     parsed_args = parse_args()
+
+    if parsed_args.path.strip() == "":
+        parsed_args.path = path_to_project.as_posix()
+
     pyproject_path = os.path.join(parsed_args.path, "pyproject.toml")
 
     pyproject = toml.load(pyproject_path)

--- a/scripts/configure_pyproject_toml.py
+++ b/scripts/configure_pyproject_toml.py
@@ -21,7 +21,9 @@ from pathlib import Path
 import toml
 from backend_support import backend, device_name
 
-path_to_version = Path(__file__).parent.parent / Path("pennylane_lightning") / "core" / "_version.py"
+path_to_version = (
+    Path(__file__).parent.parent / Path("pennylane_lightning") / "core" / "_version.py"
+)
 with open(path_to_version, encoding="utf-8") as f:
     version = f.readlines()[-1].split()[-1].strip("\"'")
 


### PR DESCRIPTION
**Context:** `configure_pyproject_toml.py` assumes it is being invoked from the root directory of Lightning. But the reality is that it can be invoked from anywhere else.

**Description of the Change:** Calculate safely the root folder by traversing back the folder structure starting from  the current file location.

**Benefits:** The file can be invoked from any place.
