### PR TITLE
Correctly querying wire IDs for `SetState` and `SetBasisState` in kok…

### DIFF
--- a/pennylane_lightning/core/src/simulators/lightning_kokkos/catalyst/LightningKokkosSimulator.cpp
+++ b/pennylane_lightning/core/src/simulators/lightning_kokkos/catalyst/LightningKokkosSimulator.cpp
@@ -142,16 +142,13 @@ void LightningKokkosSimulator::SetState(DataView<std::complex<double>, 1> &data,
     std::size_t expected_wires = static_cast<std::size_t>(log2(data.size()));
     RT_ASSERT(expected_wires == wires.size());
     std::vector<Kokkos::complex<double>> data_vector(data.begin(), data.end());
-    std::vector<std::size_t> wires_size_t(wires.begin(), wires.end());
-
-    this->device_sv->setStateVector(data_vector, wires_size_t);
+    this->device_sv->setStateVector(data_vector, getDeviceWires(wires));
 }
 
 void LightningKokkosSimulator::SetBasisState(DataView<int8_t, 1> &data,
                                              std::vector<QubitIdType> &wires) {
     std::vector<std::size_t> basis_state(data.begin(), data.end());
-    std::vector<std::size_t> wires_size_t(wires.begin(), wires.end());
-    this->device_sv->setBasisState(basis_state, wires_size_t);
+    this->device_sv->setBasisState(basis_state, getDeviceWires(wires));
 }
 
 auto LightningKokkosSimulator::Zero() const -> Result {


### PR DESCRIPTION
…kos (#869)

**Context:**
Catalyst recently fixed a bug where recycling a device when a previous execution involves stateprep causes a crash:
https://github.com/PennyLaneAI/catalyst/pull/1047

The fix is made to `lightning.qubit`, and thus we need to fix it for `lightning.kokkos` here as well.


**Description of the Change:**
In `LightningKokkosSimulator`, `SetState` and `SetBasisState` now correctly query the DevQubits from the SimQubits in its qubit_manger's map.

**Benefits:**
We can now have multiple qnode functions involving stateprep in a workflow

**Possible Drawbacks:**

**Related GitHub Issues:**
https://github.com/PennyLaneAI/catalyst/issues/1044

---------

### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [ ] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [ ] Ensure that the test suite passes, by running `make test`.

- [ ] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [ ] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
