### PR TITLE
Skip binaries in the docs build script

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,13 +3,6 @@ version: 2
 sphinx:
   configuration: doc/conf.py
 
-python:
-  install:
-    - requirements: doc/requirements.txt
-    - requirements: requirements-dev.txt
-    - method: pip
-      path: .
-
 build:
   os: ubuntu-22.04
   tools:
@@ -18,7 +11,9 @@ build:
     - graphviz
   jobs:
     post_install:
-      - PL_BACKEND="lightning_gpu" python scripts/configure_pyproject_toml.py && SKIP_COMPILATION=True python -m build
+      - python -m pip install --exists-action=w --no-cache-dir -r doc/requirements.txt
+      - PL_BACKEND="lightning_qubit" python scripts/configure_pyproject_toml.py && SKIP_COMPILATION=True python -m build
+      - rm -rf ./build && PL_BACKEND="lightning_gpu" python scripts/configure_pyproject_toml.py && SKIP_COMPILATION=True python -m build
       - rm -rf ./build && PL_BACKEND="lightning_kokkos" python scripts/configure_pyproject_toml.py && SKIP_COMPILATION=True python -m build
       - rm -rf ./build && PL_BACKEND="lightning_tensor" python scripts/configure_pyproject_toml.py && SKIP_COMPILATION=True python -m build
       - python -m pip install ./dist/*.whl

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -16,19 +16,10 @@ build:
   tools:
     python: "3.10"
   apt_packages:
-    - cmake
-    - build-essential
-    - libopenblas-base
-    - libopenblas-dev
     - graphviz
-    - wget
   jobs:
-    pre_install:
-      - wget https://developer.download.nvidia.com/compute/cuda/12.3.2/local_installers/cuda_12.3.2_545.23.08_linux.run
-      - sh cuda_12.3.2_545.23.08_linux.run --silent --toolkit --toolkitpath=${READTHEDOCS_VIRTUALENV_PATH}/cuda-12.3 || cat /tmp/cuda-installer.log
-      - echo "setuptools~=66.0" >> ci_build_requirements.txt
     post_install:
-      - rm -rf ./build && export PATH=${READTHEDOCS_VIRTUALENV_PATH}/cuda-12.3/bin${PATH:+:${PATH}} && export LD_LIBRARY_PATH=${READTHEDOCS_VIRTUALENV_PATH}/cuda-12.3/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}} && PL_BACKEND="lightning_gpu" python scripts/configure_pyproject_toml.py && CMAKE_ARGS="-DPL_DISABLE_CUDA_SAFETY=1" python -m build
-      - rm -rf ./build && PL_BACKEND="lightning_kokkos" python scripts/configure_pyproject_toml.py && python -m build
-      - rm -rf ./build && export PATH=${READTHEDOCS_VIRTUALENV_PATH}/cuda-12.3/bin${PATH:+:${PATH}} && export LD_LIBRARY_PATH=${READTHEDOCS_VIRTUALENV_PATH}/cuda-12.3/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}} && PL_BACKEND="lightning_tensor" python scripts/configure_pyproject_toml.py && CMAKE_ARGS="-DPL_DISABLE_CUDA_SAFETY=1" python -m build
+      - PL_BACKEND="lightning_gpu" python scripts/configure_pyproject_toml.py && SKIP_COMPILATION=True python -m build
+      - rm -rf ./build && PL_BACKEND="lightning_kokkos" python scripts/configure_pyproject_toml.py && SKIP_COMPILATION=True python -m build
+      - rm -rf ./build && PL_BACKEND="lightning_tensor" python scripts/configure_pyproject_toml.py && SKIP_COMPILATION=True python -m build
       - python -m pip install ./dist/*.whl

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,7 +5,6 @@ sphinx:
 
 python:
   install:
-    - requirements: ci_build_requirements.txt
     - requirements: doc/requirements.txt
     - requirements: requirements-dev.txt
     - method: pip

--- a/Makefile
+++ b/Makefile
@@ -63,10 +63,14 @@ clean:
 	rm -rf pennylane_lightning/*_ops*
 	rm -rf *.egg-info
 
-.PHONY: python
+.PHONY: python python-skip-compile
 python:
 	PL_BACKEND=$(PL_BACKEND) python scripts/configure_pyproject_toml.py
 	pip install -e . --config-settings editable_mode=compat -vv
+
+python-skip-compile:
+	PL_BACKEND=$(PL_BACKEND) python scripts/configure_pyproject_toml.py
+	SKIP_COMPILATION=True pip install -e . --config-settings editable_mode=compat -vv
 
 .PHONY: wheel
 wheel:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -21,6 +21,7 @@ import json
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.insert(0, os.path.abspath(""))
+sys.path.insert(0, os.path.abspath("."))
 sys.path.insert(0, os.path.abspath("_ext"))
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath("doc")), "doc"))
 
@@ -188,6 +189,8 @@ today_fmt = "%Y-%m-%d"
 # directories to ignore when looking for source files.
 # This patterns also effect to html_static_path and html_extra_path
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+
+nbsphinx_execute = "never"
 
 # If true, sectionauthor and moduleauthor directives will be shown in the
 # output. They are ignored by default.

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,3 +1,5 @@
+tomlkit
+build
 breathe
 docutils==0.16
 exhale>=0.3.3

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.39.0-dev14"
+__version__ = "0.39.0-dev18"

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.39.0-dev18"
+__version__ = "0.39.0-dev19"


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [ ] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [ ] Ensure that the test suite passes, by running `make test`.

- [ ] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [ ] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**
Skip the build of Lightning sims binaries and dev requirements for pulbic documentations. This will speed up the build of docs from +3000 seconds to 700 seconds. 

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-73505]