### PR TITLE
[WIP] Catalyst support for `qml.CosineWindow`

### DIFF
--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.39.0-dev24"
+__version__ = "0.39.0-dev35"

--- a/pennylane_lightning/lightning_qubit/lightning_qubit.toml
+++ b/pennylane_lightning/lightning_qubit/lightning_qubit.toml
@@ -48,6 +48,7 @@ T                      = { properties = [ "invertible", "controllable", "differe
 # strategy in PennyLane.
 MultiControlledX       = {}
 QFT                    = {}
+CosineWindow           = {}
 
 # Gates which should be translated to QubitUnitary
 [operators.gates.matrix]


### PR DESCRIPTION
Compiling a circuit with QJIT that begins with a CosineWindow state preparation results in a compiler error. This is because Catalyst has optimizations for when the first operation is a state preparation, but these optimizations are not supported for CosineWindow. A workaround is to only perform the state preparation optimizations on the StatePrep and BasisState classes, rather than the more general StatePrepBase class.

This workaround requires additional changes to Catalyst [(PR #1166)](https://github.com/PennyLaneAI/catalyst/pull/1166) and PennyLane [(PR #6318)](https://github.com/PennyLaneAI/pennylane/pull/6318).