### PR TITLE
Update Lightning-Tensor install docs

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -130,8 +130,9 @@
 
 ### Documentation
 
-* Update `lightning.tensor` usage suggestions.
+* Update Lightning-Tensor installation docs and usage suggestions.
   [(#971)](https://github.com/PennyLaneAI/pennylane-lightning/pull/971)
+  [(#972)](https://github.com/PennyLaneAI/pennylane-lightning/pull/971)
 
 * Update `README.rst` installation instructions for `lightning.gpu` and `lightning.tensor`.
   [(#957)](https://github.com/PennyLaneAI/pennylane-lightning/pull/957)
@@ -165,7 +166,7 @@
 
 This release contains contributions from (in alphabetical order):
 
-Ali Asadi, Amintor Dusko, Joseph Lee, Luis Alfredo Nuñez Meneses, Vincent Michaud-Rioux, Lee J. O'Riordan, Mudit Pandey, Shuli Shu, Haochen Paul Wang
+Ali Asadi, Amintor Dusko, Diego Guala, Joseph Lee, Luis Alfredo Nuñez Meneses, Vincent Michaud-Rioux, Lee J. O'Riordan, Mudit Pandey, Shuli Shu, Haochen Paul Wang
 
 ---
 

--- a/README.rst
+++ b/README.rst
@@ -383,7 +383,7 @@ Lightning-Tensor requires CUDA 12 and the `cuQuantum SDK <https://developer.nvid
 The SDK may be installed within the Python environment ``site-packages`` directory using ``pip`` or ``conda`` or the SDK library path appended to the ``LD_LIBRARY_PATH`` environment variable.
 Please see the `cuQuantum SDK <https://developer.nvidia.com/cuquantum-sdk>`_ install guide for more information.
 
-Lightning-Tensor and cutensornet can be installed via:
+Lightning-Tensor and ``cutensornet-cu12`` can be installed via:
 
 .. code-block:: bash
     

--- a/README.rst
+++ b/README.rst
@@ -383,8 +383,19 @@ Lightning-Tensor requires CUDA 12 and the `cuQuantum SDK <https://developer.nvid
 The SDK may be installed within the Python environment ``site-packages`` directory using ``pip`` or ``conda`` or the SDK library path appended to the ``LD_LIBRARY_PATH`` environment variable.
 Please see the `cuQuantum SDK <https://developer.nvidia.com/cuquantum-sdk>`_ install guide for more information.
 
+Lightning-Tensor can be installed via:
+
+.. code-block:: bash
+    
+    pip install pennylane-lightning[tensor]
+
 Install Lightning-Tensor from source
 ====================================
+
+.. note::
+
+    The below contains instructions for installing Lightning-Tensor ***from source***. For most cases, *this is not required* and one can simply use the installation instructions at `pennylane.ai/install <https://pennylane.ai/install/#high-performance-computing-and-gpus>`__. If those instructions do not work for you, or you have a more complex build environment that requires building from source, then consider reading on.
+
 Lightning-Qubit should be installed before Lightning-Tensor (compilation is not necessary):
 
 .. code-block:: bash

--- a/README.rst
+++ b/README.rst
@@ -383,11 +383,12 @@ Lightning-Tensor requires CUDA 12 and the `cuQuantum SDK <https://developer.nvid
 The SDK may be installed within the Python environment ``site-packages`` directory using ``pip`` or ``conda`` or the SDK library path appended to the ``LD_LIBRARY_PATH`` environment variable.
 Please see the `cuQuantum SDK <https://developer.nvidia.com/cuquantum-sdk>`_ install guide for more information.
 
-Lightning-Tensor can be installed via:
+Lightning-Tensor and cutensornet can be installed via:
 
 .. code-block:: bash
     
-    pip install pennylane-lightning[tensor]
+    pip install cutensornet-cu12
+    pip install pennylane-lightning-tensor
 
 Install Lightning-Tensor from source
 ====================================


### PR DESCRIPTION
### Before submitting

**Context:**
Lightning tensor docs did not describe installation via `pip install`


**Description of the Change:**

- Added instruction to `pip install cutensornet-cu12` and `pip install pennylane-lightning-tensor`
- Added warning about installing from source.

**Benefits:**
Clearer installation docs.

**Possible Drawbacks:**
Duplication of information in docs and pennylane.ai/install

**Related GitHub Issues:**
