### PR TITLE
Fix PTM stable latest. Removing FIXME patch for 0.39

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -14,7 +14,7 @@
 ### Bug fixes
 
 * Fix PTM stable latest. Removing FIXME patch for v0.39
-  [(#961)](https://github.com/PennyLaneAI/pennylane-lightning/pull/961)
+  [(#982)](https://github.com/PennyLaneAI/pennylane-lightning/pull/982)
 
 ### Contributors
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -13,10 +13,14 @@
 
 ### Bug fixes
 
+* Fix PTM stable latest. Removing FIXME patch for v0.39
+  [(#961)](https://github.com/PennyLaneAI/pennylane-lightning/pull/961)
+
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
 
+Luis Alfredo Nuñez Meneses,
 
 ---
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 ### Bug fixes
 
-* Fix PTM stable latest. Removing FIXME patch for v0.39
+* Fix PTM stable latest. Removing FIXME patch for v0.39.
   [(#982)](https://github.com/PennyLaneAI/pennylane-lightning/pull/982)
 
 ### Contributors

--- a/.github/workflows/tests_lgpumpi_python.yml
+++ b/.github/workflows/tests_lgpumpi_python.yml
@@ -142,13 +142,6 @@ jobs:
           git checkout $(git branch -a --list "origin/v0.*rc*" | sort | tail -1)
           python -m pip uninstall -y pennylane && python -m pip install . -vv --no-deps
 
-      - name: Patching tests following deprecation FIXME(remove after v0.39)
-        if: inputs.lightning-version == 'stable' && inputs.pennylane-version == 'latest'
-        run: |
-          pushd mpitests
-          grep -rl "default.qubit.legacy" . | xargs sed -i "s|default.qubit.legacy|default.qubit|g";
-          popd
-  
       - name: Build and install package
         env:
           CUQUANTUM_SDK: $(python -c "import site; print( f'{site.getsitepackages()[0]}/cuquantum')")

--- a/.github/workflows/tests_lkcpu_python.yml
+++ b/.github/workflows/tests_lkcpu_python.yml
@@ -251,7 +251,6 @@ jobs:
 
       - name: Test editable install
         run: |
-          rm -r build
           pip uninstall pennylane-lightning pennylane-lightning-kokkos -y
           python scripts/configure_pyproject_toml.py
           SKIP_COMPILATION=True python -m pip install -e . --config-settings editable_mode=compat

--- a/.github/workflows/tests_lkcpu_python.yml
+++ b/.github/workflows/tests_lkcpu_python.yml
@@ -183,13 +183,6 @@ jobs:
           git log -1 --format='%H'
           git status
 
-      - name: Patching tests following deprecation FIXME(remove after v0.39)
-        if: inputs.lightning-version == 'stable' && inputs.pennylane-version == 'latest'
-        run: |
-          pushd tests
-          grep -rl "default.qubit.legacy" . | xargs sed -i "s|default.qubit.legacy|default.qubit|g";
-          popd
-
       - uses: actions/download-artifact@v4
         with:
           name: ${{ matrix.pl_backend }}-${{ matrix.exec_model }}_name.txt

--- a/.github/workflows/tests_lkcuda_python.yml
+++ b/.github/workflows/tests_lkcuda_python.yml
@@ -259,14 +259,6 @@ jobs:
           PL_BACKEND=${{ matrix.pl_backend }} python scripts/configure_pyproject_toml.py || true
           PL_BACKEND=${{ matrix.pl_backend }} CMAKE_ARGS="-DCMAKE_PREFIX_PATH=${{ github.workspace }}/Kokkos" \
           python -m pip install . -vv
-
-      - name: Patching tests following deprecation FIXME(remove after v0.39)
-        if: inputs.lightning-version == 'stable' && inputs.pennylane-version == 'latest'
-        run: |
-          cd main/
-          pushd tests
-          grep -rl "default.qubit.legacy" . | xargs sed -i "s|default.qubit.legacy|default.qubit|g";
-          popd
   
       - name: Run PennyLane-Lightning unit tests
         if: ${{ matrix.pl_backend != 'all'}}

--- a/.github/workflows/tests_lqcpu_python.yml
+++ b/.github/workflows/tests_lqcpu_python.yml
@@ -194,13 +194,6 @@ jobs:
           git log -1 --format='%H'
           git status
 
-      - name: Patching tests following deprecation FIXME(remove after v0.39)
-        if: inputs.lightning-version == 'stable' && inputs.pennylane-version == 'latest'
-        run: |
-          pushd tests
-          grep -rl "default.qubit.legacy" . | xargs sed -i "s|default.qubit.legacy|default.qubit|g";
-          popd
-
       - name: Run PennyLane-Lightning unit tests
         run: |
           DEVICENAME=`echo ${{ matrix.pl_backend }} | sed "s/_/./g"`

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.40.0-dev0"
+__version__ = "0.40.0-dev1"


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [ ] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [ ] Ensure that the test suite passes, by running `make test`.

- [ ] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [ ] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**
The CIs on the PTM fail due to incompatibilities between deprecated devices.

**Description of the Change:**
Removing the hotfix for deprecated device `default.qubit.legacy` which was planning to be released on v0.39.

**Benefits:**
 No more errors in the PTM stable-latest regarding the `default.qubit.legacy`

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-77687]