### PR TITLE
Generalize seeding for measurements

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -44,6 +44,9 @@
 * Update the `lightning.kokkos` CUDA backend for compatibility with Catalyst.
   [(#942)](https://github.com/PennyLaneAI/pennylane-lightning/pull/942)
 
+* Generalize seeding mechanism for all measurements.
+  [(#1003)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1003)
+
 ### Documentation
 
 * Update Lightning-Tensor installation docs and usage suggestions.

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.40.0-dev13"
+__version__ = "0.40.0-dev14"

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.40.0-dev20"
+__version__ = "0.40.0-dev21"

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.40.0-dev14"
+__version__ = "0.40.0-dev15"

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.40.0-dev21"
+__version__ = "0.40.0-dev22"

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.40.0-dev23"
+__version__ = "0.40.0-dev24"

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.40.0-dev22"
+__version__ = "0.40.0-dev23"

--- a/pennylane_lightning/core/src/measurements/MeasurementsBase.hpp
+++ b/pennylane_lightning/core/src/measurements/MeasurementsBase.hpp
@@ -57,7 +57,7 @@ template <class StateVectorT, class Derived> class MeasurementsBase {
 #else
     const StateVectorT &_statevector;
 #endif
-    std::optional<std::size_t> DeviceSeed = std::nullopt;
+    const std::optional<std::size_t> &DeviceSeed = std::nullopt;
 
     std::mt19937 rng;
 
@@ -275,8 +275,7 @@ template <class StateVectorT, class Derived> class MeasurementsBase {
             sv.updateData(data_storage.data(), data_storage.size());
             obs.applyInPlaceShots(sv, eigenvalues, obs_wires);
             Derived measure(sv);
-            measure.set_DeviceSeed(
-                static_cast<Derived *>(this)->get_DeviceSeed());
+            measure.set_DeviceSeed(this->DeviceSeed);
             if (num_shots > std::size_t{0}) {
                 return measure.probs(obs_wires, num_shots);
             }
@@ -285,8 +284,7 @@ template <class StateVectorT, class Derived> class MeasurementsBase {
             StateVectorT sv(_statevector);
             obs.applyInPlaceShots(sv, eigenvalues, obs_wires);
             Derived measure(sv);
-            measure.set_DeviceSeed(
-                static_cast<Derived *>(this)->get_DeviceSeed());
+            measure.set_DeviceSeed(this->DeviceSeed);
             if (num_shots > std::size_t{0}) {
                 return measure.probs(obs_wires, num_shots);
             }
@@ -379,7 +377,7 @@ template <class StateVectorT, class Derived> class MeasurementsBase {
      */
     auto sample(const std::size_t &num_shots) -> std::vector<std::size_t> {
         Derived measure(_statevector);
-        measure.set_DeviceSeed(static_cast<Derived *>(this)->get_DeviceSeed());
+        measure.set_DeviceSeed(this->DeviceSeed);
         return measure.generate_samples(num_shots);
     }
 
@@ -446,10 +444,6 @@ template <class StateVectorT, class Derived> class MeasurementsBase {
         this->DeviceSeed = deviceSeed;
     }
 
-    const std::optional<std::size_t> &get_DeviceSeed() {
-        return this->DeviceSeed;
-    }
-
     void set_DeviceSeedFromPRNG(std::mt19937 *gen) {
         if (gen != nullptr) {
             this->set_DeviceSeed((*gen)());
@@ -510,15 +504,13 @@ template <class StateVectorT, class Derived> class MeasurementsBase {
             StateVectorT sv(data_storage.data(), data_storage.size());
             obs.applyInPlaceShots(sv, eigenValues, obs_wires);
             Derived measure(sv);
-            measure.set_DeviceSeed(
-                static_cast<Derived *>(this)->get_DeviceSeed());
+            measure.set_DeviceSeed(this->DeviceSeed);
             samples = measure.generate_samples(num_shots);
         } else {
             StateVectorT sv(_statevector);
             obs.applyInPlaceShots(sv, eigenValues, obs_wires);
             Derived measure(sv);
-            measure.set_DeviceSeed(
-                static_cast<Derived *>(this)->get_DeviceSeed());
+            measure.set_DeviceSeed(this->DeviceSeed);
             samples = measure.generate_samples(num_shots);
         }
 

--- a/pennylane_lightning/core/src/measurements/MeasurementsBase.hpp
+++ b/pennylane_lightning/core/src/measurements/MeasurementsBase.hpp
@@ -57,7 +57,7 @@ template <class StateVectorT, class Derived> class MeasurementsBase {
 #else
     const StateVectorT &_statevector;
 #endif
-    const std::optional<std::size_t> &DeviceSeed = std::nullopt;
+    std::optional<std::size_t> DeviceSeed = std::nullopt;
 
     std::mt19937 rng;
 

--- a/pennylane_lightning/core/src/measurements/MeasurementsBase.hpp
+++ b/pennylane_lightning/core/src/measurements/MeasurementsBase.hpp
@@ -275,7 +275,7 @@ template <class StateVectorT, class Derived> class MeasurementsBase {
             sv.updateData(data_storage.data(), data_storage.size());
             obs.applyInPlaceShots(sv, eigenvalues, obs_wires);
             Derived measure(sv);
-            measure.set_DeviceSeed(this->DeviceSeed);
+            measure.setDeviceSeed(this->DeviceSeed);
             if (num_shots > std::size_t{0}) {
                 return measure.probs(obs_wires, num_shots);
             }
@@ -284,7 +284,7 @@ template <class StateVectorT, class Derived> class MeasurementsBase {
             StateVectorT sv(_statevector);
             obs.applyInPlaceShots(sv, eigenvalues, obs_wires);
             Derived measure(sv);
-            measure.set_DeviceSeed(this->DeviceSeed);
+            measure.setDeviceSeed(this->DeviceSeed);
             if (num_shots > std::size_t{0}) {
                 return measure.probs(obs_wires, num_shots);
             }
@@ -377,7 +377,7 @@ template <class StateVectorT, class Derived> class MeasurementsBase {
      */
     auto sample(const std::size_t &num_shots) -> std::vector<std::size_t> {
         Derived measure(_statevector);
-        measure.set_DeviceSeed(this->DeviceSeed);
+        measure.setDeviceSeed(this->DeviceSeed);
         return measure.generate_samples(num_shots);
     }
 
@@ -439,18 +439,18 @@ template <class StateVectorT, class Derived> class MeasurementsBase {
         return outcome_map;
     }
 
-    void set_DeviceSeed(
-        const std::optional<std::size_t> &deviceSeed = std::nullopt) {
+    void
+    setDeviceSeed(const std::optional<std::size_t> &deviceSeed = std::nullopt) {
         this->DeviceSeed = deviceSeed;
     }
 
-    void set_DeviceSeedFromPRNG(std::mt19937 *gen) {
+    void setDeviceSeedFromPRNG(std::mt19937 *gen) {
         if (gen != nullptr) {
-            this->set_DeviceSeed((*gen)());
+            this->setDeviceSeed((*gen)());
         }
     }
 
-    void activate_DeviceSeed() {
+    void activateDeviceSeed() {
         if (this->DeviceSeed.has_value()) {
             setSeed(this->DeviceSeed.value());
         } else {
@@ -504,13 +504,13 @@ template <class StateVectorT, class Derived> class MeasurementsBase {
             StateVectorT sv(data_storage.data(), data_storage.size());
             obs.applyInPlaceShots(sv, eigenValues, obs_wires);
             Derived measure(sv);
-            measure.set_DeviceSeed(this->DeviceSeed);
+            measure.setDeviceSeed(this->DeviceSeed);
             samples = measure.generate_samples(num_shots);
         } else {
             StateVectorT sv(_statevector);
             obs.applyInPlaceShots(sv, eigenValues, obs_wires);
             Derived measure(sv);
-            measure.set_DeviceSeed(this->DeviceSeed);
+            measure.setDeviceSeed(this->DeviceSeed);
             samples = measure.generate_samples(num_shots);
         }
 

--- a/pennylane_lightning/core/src/measurements/MeasurementsBase.hpp
+++ b/pennylane_lightning/core/src/measurements/MeasurementsBase.hpp
@@ -17,6 +17,7 @@
  */
 #pragma once
 
+#include <optional>
 #include <random>
 #include <string>
 #include <vector>
@@ -56,6 +57,8 @@ template <class StateVectorT, class Derived> class MeasurementsBase {
 #else
     const StateVectorT &_statevector;
 #endif
+    std::optional<std::size_t> DeviceSeed = std::nullopt;
+
     std::mt19937 rng;
 
   public:
@@ -66,22 +69,6 @@ template <class StateVectorT, class Derived> class MeasurementsBase {
     explicit MeasurementsBase(const StateVectorT &statevector)
         : _statevector{statevector} {};
 #endif
-
-    /**
-     * @brief Set the seed of the internal random generator
-     *
-     * @param seed Seed
-     */
-    void setSeed(const std::size_t seed) { rng.seed(seed); }
-
-    /**
-     * @brief Randomly set the seed of the internal random generator
-     *
-     */
-    void setRandomSeed() {
-        std::random_device rd;
-        setSeed(rd());
-    }
 
     /**
      * @brief Calculate the expectation value for a general Observable.
@@ -454,7 +441,46 @@ template <class StateVectorT, class Derived> class MeasurementsBase {
         return outcome_map;
     }
 
+    void set_DeviceSeed(
+        const std::optional<std::size_t> &deviceSeed = std::nullopt) {
+        this->DeviceSeed = deviceSeed;
+    }
+
+    const std::optional<std::size_t> &get_DeviceSeed() {
+        return this->DeviceSeed;
+    }
+
+    void set_DeviceSeedFromPRNG(std::mt19937 *gen) {
+        if (gen != nullptr) {
+            this->set_DeviceSeed((*gen)());
+        }
+    }
+
+    void activate_DeviceSeed() {
+        if (this->DeviceSeed.has_value()) {
+            setSeed(this->DeviceSeed.value());
+        } else {
+            setRandomSeed();
+        }
+    }
+
   private:
+    /**
+     * @brief Set the seed of the internal random generator
+     *
+     * @param seed Seed
+     */
+    void setSeed(const std::size_t seed) { rng.seed(seed); }
+
+    /**
+     * @brief Randomly set the seed of the internal random generator
+     *
+     */
+    void setRandomSeed() {
+        std::random_device rd;
+        setSeed(rd());
+    }
+
     /**
      * @brief Return samples of a observable
      *

--- a/pennylane_lightning/core/src/measurements/MeasurementsBase.hpp
+++ b/pennylane_lightning/core/src/measurements/MeasurementsBase.hpp
@@ -17,6 +17,7 @@
  */
 #pragma once
 
+#include <cstddef>
 #include <optional>
 #include <random>
 #include <string>
@@ -451,30 +452,21 @@ template <class StateVectorT, class Derived> class MeasurementsBase {
     }
 
     void activateDeviceSeed() {
-        if (this->DeviceSeed.has_value()) {
-            setSeed(this->DeviceSeed.value());
-        } else {
-            setRandomSeed();
-        }
+        std::size_t seed = this->DeviceSeed.has_value()
+                               ? this->DeviceSeed.value()
+                               : this->generateRandomSeed();
+        rng.seed(seed);
     }
 
   private:
     /**
-     * @brief Set the seed of the internal random generator
-     *
-     * @param seed Seed
-     */
-    void setSeed(const std::size_t seed) { rng.seed(seed); }
-
-    /**
-     * @brief Randomly set the seed of the internal random generator
+     * @brief Generate a random seed
      *
      */
-    void setRandomSeed() {
+    std::size_t generateRandomSeed() {
         std::random_device rd;
-        setSeed(rd());
+        return rd();
     }
-
     /**
      * @brief Return samples of a observable
      *

--- a/pennylane_lightning/core/src/measurements/MeasurementsBase.hpp
+++ b/pennylane_lightning/core/src/measurements/MeasurementsBase.hpp
@@ -17,7 +17,6 @@
  */
 #pragma once
 
-#include <cstddef>
 #include <optional>
 #include <random>
 #include <string>

--- a/pennylane_lightning/core/src/measurements/MeasurementsBase.hpp
+++ b/pennylane_lightning/core/src/measurements/MeasurementsBase.hpp
@@ -288,6 +288,8 @@ template <class StateVectorT, class Derived> class MeasurementsBase {
             sv.updateData(data_storage.data(), data_storage.size());
             obs.applyInPlaceShots(sv, eigenvalues, obs_wires);
             Derived measure(sv);
+            measure.set_DeviceSeed(
+                static_cast<Derived *>(this)->get_DeviceSeed());
             if (num_shots > std::size_t{0}) {
                 return measure.probs(obs_wires, num_shots);
             }
@@ -296,6 +298,8 @@ template <class StateVectorT, class Derived> class MeasurementsBase {
             StateVectorT sv(_statevector);
             obs.applyInPlaceShots(sv, eigenvalues, obs_wires);
             Derived measure(sv);
+            measure.set_DeviceSeed(
+                static_cast<Derived *>(this)->get_DeviceSeed());
             if (num_shots > std::size_t{0}) {
                 return measure.probs(obs_wires, num_shots);
             }
@@ -388,8 +392,8 @@ template <class StateVectorT, class Derived> class MeasurementsBase {
      */
     auto sample(const std::size_t &num_shots) -> std::vector<std::size_t> {
         Derived measure(_statevector);
-        return measure.generate_samples(num_shots,
-                                        static_cast<Derived *>(this));
+        measure.set_DeviceSeed(static_cast<Derived *>(this)->get_DeviceSeed());
+        return measure.generate_samples(num_shots);
     }
 
     /**
@@ -480,14 +484,16 @@ template <class StateVectorT, class Derived> class MeasurementsBase {
             StateVectorT sv(data_storage.data(), data_storage.size());
             obs.applyInPlaceShots(sv, eigenValues, obs_wires);
             Derived measure(sv);
-            samples = measure.generate_samples(num_shots,
-                                               static_cast<Derived *>(this));
+            measure.set_DeviceSeed(
+                static_cast<Derived *>(this)->get_DeviceSeed());
+            samples = measure.generate_samples(num_shots);
         } else {
             StateVectorT sv(_statevector);
             obs.applyInPlaceShots(sv, eigenValues, obs_wires);
             Derived measure(sv);
-            samples = measure.generate_samples(num_shots,
-                                               static_cast<Derived *>(this));
+            measure.set_DeviceSeed(
+                static_cast<Derived *>(this)->get_DeviceSeed());
+            samples = measure.generate_samples(num_shots);
         }
 
         if (!shot_range.empty()) {

--- a/pennylane_lightning/core/src/measurements/MeasurementsBase.hpp
+++ b/pennylane_lightning/core/src/measurements/MeasurementsBase.hpp
@@ -94,14 +94,6 @@ template <class StateVectorT, class Derived> class MeasurementsBase {
     }
 
     /**
-     * @brief Copy a seed for the internal random generator
-     *
-     */
-    void copySeed(const std::optional<std::size_t> &deviceSeed = std::nullopt) {
-        this->_deviceseed = deviceSeed;
-    }
-
-    /**
      * @brief Calculate the expectation value for a general Observable.
      *
      * @param obs Observable.
@@ -306,7 +298,7 @@ template <class StateVectorT, class Derived> class MeasurementsBase {
             sv.updateData(data_storage.data(), data_storage.size());
             obs.applyInPlaceShots(sv, eigenvalues, obs_wires);
             Derived measure(sv);
-            measure.copySeed(this->_deviceseed);
+            measure.setSeed(this->_deviceseed);
             if (num_shots > std::size_t{0}) {
                 return measure.probs(obs_wires, num_shots);
             }
@@ -315,7 +307,7 @@ template <class StateVectorT, class Derived> class MeasurementsBase {
             StateVectorT sv(_statevector);
             obs.applyInPlaceShots(sv, eigenvalues, obs_wires);
             Derived measure(sv);
-            measure.copySeed(this->_deviceseed);
+            measure.setSeed(this->_deviceseed);
             if (num_shots > std::size_t{0}) {
                 return measure.probs(obs_wires, num_shots);
             }
@@ -408,7 +400,7 @@ template <class StateVectorT, class Derived> class MeasurementsBase {
      */
     auto sample(const std::size_t &num_shots) -> std::vector<std::size_t> {
         Derived measure(_statevector);
-        measure.copySeed(this->_deviceseed);
+        measure.setSeed(this->_deviceseed);
         return measure.generate_samples(num_shots);
     }
 
@@ -500,13 +492,13 @@ template <class StateVectorT, class Derived> class MeasurementsBase {
             StateVectorT sv(data_storage.data(), data_storage.size());
             obs.applyInPlaceShots(sv, eigenValues, obs_wires);
             Derived measure(sv);
-            measure.copySeed(this->_deviceseed);
+            measure.setSeed(this->_deviceseed);
             samples = measure.generate_samples(num_shots);
         } else {
             StateVectorT sv(_statevector);
             obs.applyInPlaceShots(sv, eigenValues, obs_wires);
             Derived measure(sv);
-            measure.copySeed(this->_deviceseed);
+            measure.setSeed(this->_deviceseed);
             samples = measure.generate_samples(num_shots);
         }
 

--- a/pennylane_lightning/core/src/measurements/MeasurementsBase.hpp
+++ b/pennylane_lightning/core/src/measurements/MeasurementsBase.hpp
@@ -388,7 +388,8 @@ template <class StateVectorT, class Derived> class MeasurementsBase {
      */
     auto sample(const std::size_t &num_shots) -> std::vector<std::size_t> {
         Derived measure(_statevector);
-        return measure.generate_samples(num_shots);
+        return measure.generate_samples(num_shots,
+                                        static_cast<Derived *>(this));
     }
 
     /**
@@ -479,12 +480,14 @@ template <class StateVectorT, class Derived> class MeasurementsBase {
             StateVectorT sv(data_storage.data(), data_storage.size());
             obs.applyInPlaceShots(sv, eigenValues, obs_wires);
             Derived measure(sv);
-            samples = measure.generate_samples(num_shots);
+            samples = measure.generate_samples(num_shots,
+                                               static_cast<Derived *>(this));
         } else {
             StateVectorT sv(_statevector);
             obs.applyInPlaceShots(sv, eigenValues, obs_wires);
             Derived measure(sv);
-            samples = measure.generate_samples(num_shots);
+            samples = measure.generate_samples(num_shots,
+                                               static_cast<Derived *>(this));
         }
 
         if (!shot_range.empty()) {

--- a/pennylane_lightning/core/src/measurements/tests/Test_MeasurementsBase.cpp
+++ b/pennylane_lightning/core/src/measurements/tests/Test_MeasurementsBase.cpp
@@ -1235,7 +1235,7 @@ TEST_CASE("Var Shot- TensorProdObs", "[MeasurementsBase][Observables]") {
 }
 
 template <typename TypeList>
-void testSamples(std::optional<std::size_t> seed = std::nullopt) {
+void testSamples(const std::optional<std::size_t> &seed = std::nullopt) {
     if constexpr (!std::is_same_v<TypeList, void>) {
         using StateVectorT = typename TypeList::Type;
         using PrecisionT = typename StateVectorT::PrecisionT;

--- a/pennylane_lightning/core/src/measurements/tests/Test_MeasurementsBase.cpp
+++ b/pennylane_lightning/core/src/measurements/tests/Test_MeasurementsBase.cpp
@@ -1257,7 +1257,7 @@ void testSamples(const std::optional<std::size_t> &seed = std::nullopt) {
         // This object attaches to the statevector allowing several
         // measurements.
         Measurements<StateVectorT> Measurer(statevector);
-        Measurer.setDeviceSeed(seed);
+        Measurer.setSeed(seed);
 
         std::vector<PrecisionT> expected_probabilities = {
             0.67078706, 0.03062806, 0.0870997,  0.00397696,

--- a/pennylane_lightning/core/src/measurements/tests/Test_MeasurementsBase.cpp
+++ b/pennylane_lightning/core/src/measurements/tests/Test_MeasurementsBase.cpp
@@ -1257,7 +1257,7 @@ void testSamples(const std::optional<std::size_t> &seed = std::nullopt) {
         // This object attaches to the statevector allowing several
         // measurements.
         Measurements<StateVectorT> Measurer(statevector);
-        Measurer.set_DeviceSeed(seed);
+        Measurer.setDeviceSeed(seed);
 
         std::vector<PrecisionT> expected_probabilities = {
             0.67078706, 0.03062806, 0.0870997,  0.00397696,

--- a/pennylane_lightning/core/src/measurements/tests/Test_MeasurementsBase.cpp
+++ b/pennylane_lightning/core/src/measurements/tests/Test_MeasurementsBase.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 #include "TestHelpers.hpp"
 #include <catch2/catch.hpp>
+#include <cstddef>
 
 /// @cond DEV
 namespace {
@@ -1235,7 +1236,7 @@ TEST_CASE("Var Shot- TensorProdObs", "[MeasurementsBase][Observables]") {
 }
 
 template <typename TypeList>
-void testSamples(const std::optional<std::mt19937 *> &gen = std::nullopt) {
+void testSamples(std::optional<size_t> seed = std::nullopt) {
     if constexpr (!std::is_same_v<TypeList, void>) {
         using StateVectorT = typename TypeList::Type;
         using PrecisionT = typename StateVectorT::PrecisionT;
@@ -1257,9 +1258,7 @@ void testSamples(const std::optional<std::mt19937 *> &gen = std::nullopt) {
         // This object attaches to the statevector allowing several
         // measurements.
         Measurements<StateVectorT> Measurer(statevector);
-        if (gen.has_value()) {
-            Measurer.set_PRNG(gen.value());
-        }
+        Measurer.set_DeviceSeed(seed);
 
         std::vector<PrecisionT> expected_probabilities = {
             0.67078706, 0.03062806, 0.0870997,  0.00397696,
@@ -1294,7 +1293,7 @@ void testSamples(const std::optional<std::mt19937 *> &gen = std::nullopt) {
             REQUIRE_THAT(probabilities,
                          Catch::Approx(expected_probabilities).margin(.05));
         }
-        testSamples<typename TypeList::Next>(gen);
+        testSamples<typename TypeList::Next>(seed);
     }
 }
 
@@ -1307,7 +1306,7 @@ TEST_CASE("Samples", "[MeasurementsBase]") {
 TEST_CASE("Seeded samples", "[MeasurementsBase]") {
     if constexpr (BACKEND_FOUND) {
         std::mt19937 gen(37);
-        testSamples<TestStateVectorBackends>(&gen);
+        testSamples<TestStateVectorBackends>(gen());
     }
 }
 

--- a/pennylane_lightning/core/src/measurements/tests/Test_MeasurementsBase.cpp
+++ b/pennylane_lightning/core/src/measurements/tests/Test_MeasurementsBase.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 #include "TestHelpers.hpp"
 #include <catch2/catch.hpp>
-#include <cstddef>
 
 /// @cond DEV
 namespace {
@@ -1236,7 +1235,7 @@ TEST_CASE("Var Shot- TensorProdObs", "[MeasurementsBase][Observables]") {
 }
 
 template <typename TypeList>
-void testSamples(std::optional<size_t> seed = std::nullopt) {
+void testSamples(std::optional<std::size_t> seed = std::nullopt) {
     if constexpr (!std::is_same_v<TypeList, void>) {
         using StateVectorT = typename TypeList::Type;
         using PrecisionT = typename StateVectorT::PrecisionT;

--- a/pennylane_lightning/core/src/measurements/tests/Test_MeasurementsBase.cpp
+++ b/pennylane_lightning/core/src/measurements/tests/Test_MeasurementsBase.cpp
@@ -1304,8 +1304,7 @@ TEST_CASE("Samples", "[MeasurementsBase]") {
 
 TEST_CASE("Seeded samples", "[MeasurementsBase]") {
     if constexpr (BACKEND_FOUND) {
-        std::mt19937 gen(37);
-        testSamples<TestStateVectorBackends>(gen());
+        testSamples<TestStateVectorBackends>(37);
     }
 }
 

--- a/pennylane_lightning/core/src/simulators/lightning_gpu/catalyst/LightningGPUSimulator.cpp
+++ b/pennylane_lightning/core/src/simulators/lightning_gpu/catalyst/LightningGPUSimulator.cpp
@@ -256,7 +256,7 @@ auto LightningGPUSimulator::Expval(ObsIdType obsKey) -> double {
     Pennylane::LightningGPU::Measures::Measurements<StateVectorT> m{
         *(this->device_sv)};
 
-    m.setDeviceSeedFromPRNG(this->gen);
+    m.setSeed(this->generateSeed());
 
     return device_shots ? m.expval(*obs, device_shots, {}) : m.expval(*obs);
 }
@@ -275,7 +275,7 @@ auto LightningGPUSimulator::Var(ObsIdType obsKey) -> double {
     Pennylane::LightningGPU::Measures::Measurements<StateVectorT> m{
         *(this->device_sv)};
 
-    m.setDeviceSeedFromPRNG(this->gen);
+    m.setSeed(this->generateSeed());
 
     return device_shots ? m.var(*obs, device_shots) : m.var(*obs);
 }
@@ -299,7 +299,7 @@ void LightningGPUSimulator::Probs(DataView<double, 1> &probs) {
     Pennylane::LightningGPU::Measures::Measurements<StateVectorT> m{
         *(this->device_sv)};
 
-    m.setDeviceSeedFromPRNG(this->gen);
+    m.setSeed(this->generateSeed());
 
     auto &&dv_probs = device_shots ? m.probs(device_shots) : m.probs();
 
@@ -321,7 +321,7 @@ void LightningGPUSimulator::PartialProbs(
     Pennylane::LightningGPU::Measures::Measurements<StateVectorT> m{
         *(this->device_sv)};
 
-    m.setDeviceSeedFromPRNG(this->gen);
+    m.setSeed(this->generateSeed());
 
     auto &&dv_probs =
         device_shots ? m.probs(dev_wires, device_shots) : m.probs(dev_wires);
@@ -337,7 +337,7 @@ std::vector<size_t> LightningGPUSimulator::GenerateSamples(size_t shots) {
     Pennylane::LightningGPU::Measures::Measurements<StateVectorT> m{
         *(this->device_sv)};
 
-    m.setDeviceSeedFromPRNG(this->gen);
+    m.setSeed(this->generateSeed());
 
     return m.generate_samples(shots);
 }

--- a/pennylane_lightning/core/src/simulators/lightning_gpu/catalyst/LightningGPUSimulator.cpp
+++ b/pennylane_lightning/core/src/simulators/lightning_gpu/catalyst/LightningGPUSimulator.cpp
@@ -244,7 +244,7 @@ auto LightningGPUSimulator::Expval(ObsIdType obsKey) -> double {
     Pennylane::LightningGPU::Measures::Measurements<StateVectorT> m{
         *(this->device_sv)};
 
-    m.set_PRNG(this->gen);
+    m.set_DeviceSeedFromPRNG(this->gen);
 
     return device_shots ? m.expval(*obs, device_shots, {}) : m.expval(*obs);
 }
@@ -263,7 +263,7 @@ auto LightningGPUSimulator::Var(ObsIdType obsKey) -> double {
     Pennylane::LightningGPU::Measures::Measurements<StateVectorT> m{
         *(this->device_sv)};
 
-    m.set_PRNG(this->gen);
+    m.set_DeviceSeedFromPRNG(this->gen);
 
     return device_shots ? m.var(*obs, device_shots) : m.var(*obs);
 }
@@ -287,7 +287,7 @@ void LightningGPUSimulator::Probs(DataView<double, 1> &probs) {
     Pennylane::LightningGPU::Measures::Measurements<StateVectorT> m{
         *(this->device_sv)};
 
-    m.set_PRNG(this->gen);
+    m.set_DeviceSeedFromPRNG(this->gen);
 
     auto &&dv_probs = device_shots ? m.probs(device_shots) : m.probs();
 
@@ -309,7 +309,7 @@ void LightningGPUSimulator::PartialProbs(
     Pennylane::LightningGPU::Measures::Measurements<StateVectorT> m{
         *(this->device_sv)};
 
-    m.set_PRNG(this->gen);
+    m.set_DeviceSeedFromPRNG(this->gen);
 
     auto &&dv_probs =
         device_shots ? m.probs(dev_wires, device_shots) : m.probs(dev_wires);
@@ -325,7 +325,7 @@ std::vector<size_t> LightningGPUSimulator::GenerateSamples(size_t shots) {
     Pennylane::LightningGPU::Measures::Measurements<StateVectorT> m{
         *(this->device_sv)};
 
-    m.set_PRNG(this->gen);
+    m.set_DeviceSeedFromPRNG(this->gen);
 
     return m.generate_samples(shots);
 }

--- a/pennylane_lightning/core/src/simulators/lightning_gpu/catalyst/LightningGPUSimulator.cpp
+++ b/pennylane_lightning/core/src/simulators/lightning_gpu/catalyst/LightningGPUSimulator.cpp
@@ -244,7 +244,7 @@ auto LightningGPUSimulator::Expval(ObsIdType obsKey) -> double {
     Pennylane::LightningGPU::Measures::Measurements<StateVectorT> m{
         *(this->device_sv)};
 
-    m.set_DeviceSeedFromPRNG(this->gen);
+    m.setDeviceSeedFromPRNG(this->gen);
 
     return device_shots ? m.expval(*obs, device_shots, {}) : m.expval(*obs);
 }
@@ -263,7 +263,7 @@ auto LightningGPUSimulator::Var(ObsIdType obsKey) -> double {
     Pennylane::LightningGPU::Measures::Measurements<StateVectorT> m{
         *(this->device_sv)};
 
-    m.set_DeviceSeedFromPRNG(this->gen);
+    m.setDeviceSeedFromPRNG(this->gen);
 
     return device_shots ? m.var(*obs, device_shots) : m.var(*obs);
 }
@@ -287,7 +287,7 @@ void LightningGPUSimulator::Probs(DataView<double, 1> &probs) {
     Pennylane::LightningGPU::Measures::Measurements<StateVectorT> m{
         *(this->device_sv)};
 
-    m.set_DeviceSeedFromPRNG(this->gen);
+    m.setDeviceSeedFromPRNG(this->gen);
 
     auto &&dv_probs = device_shots ? m.probs(device_shots) : m.probs();
 
@@ -309,7 +309,7 @@ void LightningGPUSimulator::PartialProbs(
     Pennylane::LightningGPU::Measures::Measurements<StateVectorT> m{
         *(this->device_sv)};
 
-    m.set_DeviceSeedFromPRNG(this->gen);
+    m.setDeviceSeedFromPRNG(this->gen);
 
     auto &&dv_probs =
         device_shots ? m.probs(dev_wires, device_shots) : m.probs(dev_wires);
@@ -325,7 +325,7 @@ std::vector<size_t> LightningGPUSimulator::GenerateSamples(size_t shots) {
     Pennylane::LightningGPU::Measures::Measurements<StateVectorT> m{
         *(this->device_sv)};
 
-    m.set_DeviceSeedFromPRNG(this->gen);
+    m.setDeviceSeedFromPRNG(this->gen);
 
     return m.generate_samples(shots);
 }

--- a/pennylane_lightning/core/src/simulators/lightning_gpu/catalyst/LightningGPUSimulator.cpp
+++ b/pennylane_lightning/core/src/simulators/lightning_gpu/catalyst/LightningGPUSimulator.cpp
@@ -244,6 +244,8 @@ auto LightningGPUSimulator::Expval(ObsIdType obsKey) -> double {
     Pennylane::LightningGPU::Measures::Measurements<StateVectorT> m{
         *(this->device_sv)};
 
+    m.set_PRNG(this->gen);
+
     return device_shots ? m.expval(*obs, device_shots, {}) : m.expval(*obs);
 }
 
@@ -260,6 +262,8 @@ auto LightningGPUSimulator::Var(ObsIdType obsKey) -> double {
 
     Pennylane::LightningGPU::Measures::Measurements<StateVectorT> m{
         *(this->device_sv)};
+
+    m.set_PRNG(this->gen);
 
     return device_shots ? m.var(*obs, device_shots) : m.var(*obs);
 }
@@ -282,6 +286,9 @@ void LightningGPUSimulator::State(DataView<std::complex<double>, 1> &state) {
 void LightningGPUSimulator::Probs(DataView<double, 1> &probs) {
     Pennylane::LightningGPU::Measures::Measurements<StateVectorT> m{
         *(this->device_sv)};
+
+    m.set_PRNG(this->gen);
+
     auto &&dv_probs = device_shots ? m.probs(device_shots) : m.probs();
 
     RT_FAIL_IF(probs.size() != dv_probs.size(),
@@ -301,6 +308,9 @@ void LightningGPUSimulator::PartialProbs(
     auto dev_wires = getDeviceWires(wires);
     Pennylane::LightningGPU::Measures::Measurements<StateVectorT> m{
         *(this->device_sv)};
+
+    m.set_PRNG(this->gen);
+
     auto &&dv_probs =
         device_shots ? m.probs(dev_wires, device_shots) : m.probs(dev_wires);
 
@@ -315,9 +325,8 @@ std::vector<size_t> LightningGPUSimulator::GenerateSamples(size_t shots) {
     Pennylane::LightningGPU::Measures::Measurements<StateVectorT> m{
         *(this->device_sv)};
 
-    if (this->gen) {
-        return m.generate_samples(shots, (*(this->gen))());
-    }
+    m.set_PRNG(this->gen);
+
     return m.generate_samples(shots);
 }
 

--- a/pennylane_lightning/core/src/simulators/lightning_gpu/catalyst/LightningGPUSimulator.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_gpu/catalyst/LightningGPUSimulator.hpp
@@ -95,6 +95,14 @@ class LightningGPUSimulator final : public Catalyst::Runtime::QuantumDevice {
         return res;
     }
 
+    inline auto generateSeed() -> std::optional<std::size_t> {
+        if (this->gen != nullptr) {
+            return (*(this->gen))();
+        }
+
+        return std::nullopt;
+    }
+
     auto GenerateSamples(size_t shots) -> std::vector<size_t>;
 
   public:

--- a/pennylane_lightning/core/src/simulators/lightning_gpu/catalyst/tests/Test_LightningGPUMeasures.cpp
+++ b/pennylane_lightning/core/src/simulators/lightning_gpu/catalyst/tests/Test_LightningGPUMeasures.cpp
@@ -1911,3 +1911,49 @@ TEST_CASE("Var with a seeded device", "[Measures]") {
         }
     }
 }
+
+TEST_CASE("Expval with a seeded device", "[Measures]") {
+    std::size_t shots = 1000;
+    std::array<std::unique_ptr<LGPUSimulator>, 2> sims;
+    std::array<std::vector<double>, 2> expvals;
+
+    std::vector<std::mt19937> gens{std::mt19937{37}, std::mt19937{37}};
+
+    auto circuit = [shots](LGPUSimulator &sim, std::vector<double> &expval,
+                           std::mt19937 &gen) {
+        sim.SetDevicePRNG(&gen);
+        sim.SetDeviceShots(shots);
+        // state-vector with #qubits = n
+        constexpr std::size_t n = 4;
+        std::vector<intptr_t> Qs;
+        Qs.reserve(n);
+        for (std::size_t i = 0; i < n; i++) {
+            Qs.push_back(sim.AllocateQubit());
+        }
+        sim.NamedOperation("Hadamard", {}, {Qs[0]}, false);
+        sim.NamedOperation("PauliY", {}, {Qs[1]}, false);
+        sim.NamedOperation("Hadamard", {}, {Qs[2]}, false);
+        sim.NamedOperation("PauliZ", {}, {Qs[3]}, false);
+
+        ObsIdType px = sim.Observable(ObsId::PauliX, {}, {Qs[2]});
+        ObsIdType py = sim.Observable(ObsId::PauliY, {}, {Qs[0]});
+        ObsIdType pz = sim.Observable(ObsId::PauliZ, {}, {Qs[3]});
+
+        expval.push_back(sim.Expval(px));
+        expval.push_back(sim.Expval(py));
+        expval.push_back(sim.Expval(pz));
+    };
+
+    for (std::size_t trial = 0; trial < 5; trial++) {
+        sims[0] = std::make_unique<LGPUSimulator>();
+        sims[1] = std::make_unique<LGPUSimulator>();
+
+        for (std::size_t sim_idx = 0; sim_idx < sims.size(); sim_idx++) {
+            circuit(*(sims[sim_idx]), expvals[sim_idx], gens[sim_idx]);
+        }
+
+        for (std::size_t i = 0; i < expvals[0].size(); i++) {
+            CHECK((expvals[0][i] == expvals[1][i]));
+        }
+    }
+}

--- a/pennylane_lightning/core/src/simulators/lightning_gpu/catalyst/tests/Test_LightningGPUMeasures.cpp
+++ b/pennylane_lightning/core/src/simulators/lightning_gpu/catalyst/tests/Test_LightningGPUMeasures.cpp
@@ -1834,8 +1834,8 @@ TEST_CASE("Probs with a seeded device", "[Measures]") {
 
     std::vector<std::mt19937> gens{std::mt19937{37}, std::mt19937{37}};
 
-    auto circuit = [shots](LGPUSimulator &sim, DataView<double, 1> &view,
-                           std::mt19937 &gen) {
+    auto circuit = [](LGPUSimulator &sim, DataView<double, 1> &view,
+                      std::mt19937 &gen) {
         sim.SetDevicePRNG(&gen);
         sim.SetDeviceShots(shots);
         // state-vector with #qubits = n
@@ -1873,8 +1873,8 @@ TEST_CASE("Var with a seeded device", "[Measures]") {
 
     std::vector<std::mt19937> gens{std::mt19937{37}, std::mt19937{37}};
 
-    auto circuit = [shots](LGPUSimulator &sim, std::vector<double> &var,
-                           std::mt19937 &gen) {
+    auto circuit = [](LGPUSimulator &sim, std::vector<double> &var,
+                      std::mt19937 &gen) {
         sim.SetDevicePRNG(&gen);
         sim.SetDeviceShots(shots);
         // state-vector with #qubits = n
@@ -1919,8 +1919,8 @@ TEST_CASE("Expval with a seeded device", "[Measures]") {
 
     std::vector<std::mt19937> gens{std::mt19937{37}, std::mt19937{37}};
 
-    auto circuit = [shots](LGPUSimulator &sim, std::vector<double> &expval,
-                           std::mt19937 &gen) {
+    auto circuit = [](LGPUSimulator &sim, std::vector<double> &expval,
+                      std::mt19937 &gen) {
         sim.SetDevicePRNG(&gen);
         sim.SetDeviceShots(shots);
         // state-vector with #qubits = n

--- a/pennylane_lightning/core/src/simulators/lightning_gpu/catalyst/tests/Test_LightningGPUMeasures.cpp
+++ b/pennylane_lightning/core/src/simulators/lightning_gpu/catalyst/tests/Test_LightningGPUMeasures.cpp
@@ -1865,3 +1865,49 @@ TEST_CASE("Probs with a seeded device", "[Measures]") {
         }
     }
 }
+
+TEST_CASE("Var with a seeded device", "[Measures]") {
+    std::size_t shots = 1000;
+    std::array<std::unique_ptr<LGPUSimulator>, 2> sims;
+    std::array<std::vector<double>, 2> vars;
+
+    std::vector<std::mt19937> gens{std::mt19937{37}, std::mt19937{37}};
+
+    auto circuit = [shots](LGPUSimulator &sim, std::vector<double> &var,
+                           std::mt19937 &gen) {
+        sim.SetDevicePRNG(&gen);
+        sim.SetDeviceShots(shots);
+        // state-vector with #qubits = n
+        constexpr std::size_t n = 4;
+        std::vector<intptr_t> Qs;
+        Qs.reserve(n);
+        for (std::size_t i = 0; i < n; i++) {
+            Qs.push_back(sim.AllocateQubit());
+        }
+        sim.NamedOperation("Hadamard", {}, {Qs[0]}, false);
+        sim.NamedOperation("PauliY", {}, {Qs[1]}, false);
+        sim.NamedOperation("Hadamard", {}, {Qs[2]}, false);
+        sim.NamedOperation("PauliZ", {}, {Qs[3]}, false);
+
+        ObsIdType px = sim.Observable(ObsId::PauliX, {}, {Qs[2]});
+        ObsIdType py = sim.Observable(ObsId::PauliY, {}, {Qs[0]});
+        ObsIdType pz = sim.Observable(ObsId::PauliZ, {}, {Qs[3]});
+
+        var.push_back(sim.Var(px));
+        var.push_back(sim.Var(py));
+        var.push_back(sim.Var(pz));
+    };
+
+    for (std::size_t trial = 0; trial < 5; trial++) {
+        sims[0] = std::make_unique<LGPUSimulator>();
+        sims[1] = std::make_unique<LGPUSimulator>();
+
+        for (std::size_t sim_idx = 0; sim_idx < sims.size(); sim_idx++) {
+            circuit(*(sims[sim_idx]), vars[sim_idx], gens[sim_idx]);
+        }
+
+        for (std::size_t i = 0; i < vars[0].size(); i++) {
+            CHECK((vars[0][i] == vars[1][i]));
+        }
+    }
+}

--- a/pennylane_lightning/core/src/simulators/lightning_gpu/catalyst/tests/Test_LightningGPUMeasures.cpp
+++ b/pennylane_lightning/core/src/simulators/lightning_gpu/catalyst/tests/Test_LightningGPUMeasures.cpp
@@ -1836,6 +1836,7 @@ TEST_CASE("Probs with a seeded device", "[Measures]") {
     auto circuit = [](LGPUSimulator &sim, DataView<double, 1> &view,
                       std::mt19937 &gen) {
         sim.SetDevicePRNG(&gen);
+        sim.SetDeviceShots(1000);
         // state-vector with #qubits = n
         constexpr std::size_t n = 4;
         std::vector<intptr_t> Qs;
@@ -1859,11 +1860,6 @@ TEST_CASE("Probs with a seeded device", "[Measures]") {
         }
 
         for (std::size_t i = 0; i < probs[0].size(); i++) {
-            if (i == 4 || i == 6 || i == 12 || i == 14) {
-                CHECK(probs[0][i] == Approx(0.25).margin(1e-5));
-            } else {
-                CHECK(probs[0][i] == Approx(0.).margin(1e-5));
-            }
             CHECK((probs[0][i] == probs[1][i]));
         }
     }

--- a/pennylane_lightning/core/src/simulators/lightning_gpu/catalyst/tests/Test_LightningGPUMeasures.cpp
+++ b/pennylane_lightning/core/src/simulators/lightning_gpu/catalyst/tests/Test_LightningGPUMeasures.cpp
@@ -1823,3 +1823,49 @@ TEST_CASE("Sample with a seeded device", "[Measures]") {
         }
     }
 }
+
+TEST_CASE("Probs with a seeded device", "[Measures]") {
+    std::size_t shots = 100;
+    std::array<std::unique_ptr<LGPUSimulator>, 2> sims;
+    std::vector<std::vector<double>> probs(2, std::vector<double>(16));
+
+    std::vector<DataView<double, 1>> views{DataView<double, 1>(probs[0]),
+                                           DataView<double, 1>(probs[1])};
+
+    std::vector<std::mt19937> gens{std::mt19937{37}, std::mt19937{37}};
+
+    auto circuit = [shots](LGPUSimulator &sim, DataView<double, 1> &view,
+                           std::mt19937 &gen) {
+        sim.SetDevicePRNG(&gen);
+        // state-vector with #qubits = n
+        constexpr std::size_t n = 4;
+        std::vector<intptr_t> Qs;
+        Qs.reserve(n);
+        for (std::size_t i = 0; i < n; i++) {
+            Qs.push_back(sim.AllocateQubit());
+        }
+        sim.NamedOperation("Hadamard", {}, {Qs[0]}, false);
+        sim.NamedOperation("PauliY", {}, {Qs[1]}, false);
+        sim.NamedOperation("Hadamard", {}, {Qs[2]}, false);
+        sim.NamedOperation("PauliZ", {}, {Qs[3]}, false);
+        sim.Probs(view);
+    };
+
+    for (std::size_t trial = 0; trial < 5; trial++) {
+        sims[0] = std::make_unique<LGPUSimulator>();
+        sims[1] = std::make_unique<LGPUSimulator>();
+
+        for (std::size_t sim_idx = 0; sim_idx < sims.size(); sim_idx++) {
+            circuit(*(sims[sim_idx]), views[sim_idx], gens[sim_idx]);
+        }
+
+        for (std::size_t i = 0; i < probs[0].size(); i++) {
+            if (i == 4 || i == 6 || i == 12 || i == 14) {
+                CHECK(probs[0][i] == Approx(0.25).margin(1e-5));
+            } else {
+                CHECK(probs[0][i] == Approx(0.).margin(1e-5));
+            }
+            CHECK((probs[0][i] == probs[1][i]));
+        }
+    }
+}

--- a/pennylane_lightning/core/src/simulators/lightning_gpu/catalyst/tests/Test_LightningGPUMeasures.cpp
+++ b/pennylane_lightning/core/src/simulators/lightning_gpu/catalyst/tests/Test_LightningGPUMeasures.cpp
@@ -1825,7 +1825,7 @@ TEST_CASE("Sample with a seeded device", "[Measures]") {
 }
 
 TEST_CASE("Probs with a seeded device", "[Measures]") {
-    std::size_t shots = 1000;
+    constexpr std::size_t shots = 1000;
     std::array<std::unique_ptr<LGPUSimulator>, 2> sims;
     std::vector<std::vector<double>> probs(2, std::vector<double>(16));
 
@@ -1867,7 +1867,7 @@ TEST_CASE("Probs with a seeded device", "[Measures]") {
 }
 
 TEST_CASE("Var with a seeded device", "[Measures]") {
-    std::size_t shots = 1000;
+    constexpr std::size_t shots = 1000;
     std::array<std::unique_ptr<LGPUSimulator>, 2> sims;
     std::array<std::vector<double>, 2> vars;
 
@@ -1913,7 +1913,7 @@ TEST_CASE("Var with a seeded device", "[Measures]") {
 }
 
 TEST_CASE("Expval with a seeded device", "[Measures]") {
-    std::size_t shots = 1000;
+    constexpr std::size_t shots = 1000;
     std::array<std::unique_ptr<LGPUSimulator>, 2> sims;
     std::array<std::vector<double>, 2> expvals;
 

--- a/pennylane_lightning/core/src/simulators/lightning_gpu/catalyst/tests/Test_LightningGPUMeasures.cpp
+++ b/pennylane_lightning/core/src/simulators/lightning_gpu/catalyst/tests/Test_LightningGPUMeasures.cpp
@@ -1825,7 +1825,6 @@ TEST_CASE("Sample with a seeded device", "[Measures]") {
 }
 
 TEST_CASE("Probs with a seeded device", "[Measures]") {
-    std::size_t shots = 100;
     std::array<std::unique_ptr<LGPUSimulator>, 2> sims;
     std::vector<std::vector<double>> probs(2, std::vector<double>(16));
 
@@ -1834,8 +1833,8 @@ TEST_CASE("Probs with a seeded device", "[Measures]") {
 
     std::vector<std::mt19937> gens{std::mt19937{37}, std::mt19937{37}};
 
-    auto circuit = [shots](LGPUSimulator &sim, DataView<double, 1> &view,
-                           std::mt19937 &gen) {
+    auto circuit = [](LGPUSimulator &sim, DataView<double, 1> &view,
+                      std::mt19937 &gen) {
         sim.SetDevicePRNG(&gen);
         // state-vector with #qubits = n
         constexpr std::size_t n = 4;

--- a/pennylane_lightning/core/src/simulators/lightning_gpu/catalyst/tests/Test_LightningGPUMeasures.cpp
+++ b/pennylane_lightning/core/src/simulators/lightning_gpu/catalyst/tests/Test_LightningGPUMeasures.cpp
@@ -1825,6 +1825,7 @@ TEST_CASE("Sample with a seeded device", "[Measures]") {
 }
 
 TEST_CASE("Probs with a seeded device", "[Measures]") {
+    std::size_t shots = 1000;
     std::array<std::unique_ptr<LGPUSimulator>, 2> sims;
     std::vector<std::vector<double>> probs(2, std::vector<double>(16));
 
@@ -1833,10 +1834,10 @@ TEST_CASE("Probs with a seeded device", "[Measures]") {
 
     std::vector<std::mt19937> gens{std::mt19937{37}, std::mt19937{37}};
 
-    auto circuit = [](LGPUSimulator &sim, DataView<double, 1> &view,
-                      std::mt19937 &gen) {
+    auto circuit = [shots](LGPUSimulator &sim, DataView<double, 1> &view,
+                           std::mt19937 &gen) {
         sim.SetDevicePRNG(&gen);
-        sim.SetDeviceShots(1000);
+        sim.SetDeviceShots(shots);
         // state-vector with #qubits = n
         constexpr std::size_t n = 4;
         std::vector<intptr_t> Qs;

--- a/pennylane_lightning/core/src/simulators/lightning_gpu/measurements/MeasurementsGPU.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_gpu/measurements/MeasurementsGPU.hpp
@@ -25,7 +25,6 @@
 #include <cuda.h>
 #include <cusparse.h>
 #include <custatevec.h> // custatevecApplyMatrix
-#include <optional>
 #include <random>
 #include <type_traits>
 #include <unordered_map>
@@ -72,8 +71,6 @@ class Measurements final
     cudaDataType_t data_type_;
 
     GateCache<PrecisionT> gate_cache_;
-
-    std::optional<std::size_t> DeviceSeed = std::nullopt;
 
   public:
     explicit Measurements(StateVectorT &statevector)
@@ -237,11 +234,7 @@ class Measurements final
             data_type = CUDA_C_32F;
         }
 
-        if (this->DeviceSeed.has_value()) {
-            this->setSeed(this->DeviceSeed.value());
-        } else {
-            this->setRandomSeed();
-        }
+        this->activate_DeviceSeed();
         std::uniform_real_distribution<PrecisionT> dis(0.0, 1.0);
         for (std::size_t n = 0; n < num_samples; n++) {
             rand_nums[n] = dis(this->rng);
@@ -712,18 +705,6 @@ class Measurements final
         -> PrecisionT {
         return BaseType::var(obs, num_shots);
     }
-
-    void set_DeviceSeedFromPRNG(std::mt19937 *gen) {
-        if (gen != nullptr) {
-            this->DeviceSeed = (*gen)();
-        }
-    }
-
-    void set_DeviceSeed(std::optional<std::size_t> deviceSeed) {
-        this->DeviceSeed = deviceSeed;
-    }
-
-    std::optional<std::size_t> get_DeviceSeed() { return this->DeviceSeed; }
 
   private:
     /**

--- a/pennylane_lightning/core/src/simulators/lightning_gpu/measurements/MeasurementsGPU.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_gpu/measurements/MeasurementsGPU.hpp
@@ -234,10 +234,9 @@ class Measurements final
             data_type = CUDA_C_32F;
         }
 
-        this->activateDeviceSeed();
         std::uniform_real_distribution<PrecisionT> dis(0.0, 1.0);
         for (std::size_t n = 0; n < num_samples; n++) {
-            rand_nums[n] = dis(this->rng);
+            rand_nums[n] = dis(this->_rng);
         }
         std::vector<std::size_t> samples(num_samples * num_qubits, 0);
         std::unordered_map<std::size_t, std::size_t> cache;

--- a/pennylane_lightning/core/src/simulators/lightning_gpu/measurements/MeasurementsGPU.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_gpu/measurements/MeasurementsGPU.hpp
@@ -217,7 +217,12 @@ class Measurements final
      * be accessed using the stride sample_id*num_qubits, where sample_id is a
      * number between 0 and num_samples-1.
      */
-    auto generate_samples(std::size_t num_samples) -> std::vector<std::size_t> {
+    auto generate_samples(std::size_t num_samples,
+                          const std::optional<Measurements *> &m = std::nullopt)
+        -> std::vector<std::size_t> {
+        if (m.has_value() && m.value() != nullptr) {
+            this->set_PRNG(m.value()->get_PRNG());
+        }
         std::vector<double> rand_nums(num_samples);
         custatevecSamplerDescriptor_t sampler;
 
@@ -237,7 +242,7 @@ class Measurements final
             data_type = CUDA_C_32F;
         }
 
-        if (gen != nullptr) {
+        if (this->gen != nullptr) {
             std::size_t seed = (*(this->gen))();
             this->setSeed(seed);
         } else {
@@ -715,6 +720,8 @@ class Measurements final
     }
 
     void set_PRNG(std::mt19937 *gen) { this->gen = gen; }
+
+    std::mt19937 *get_PRNG() { return this->gen; }
 
   private:
     /**

--- a/pennylane_lightning/core/src/simulators/lightning_gpu/measurements/MeasurementsGPU.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_gpu/measurements/MeasurementsGPU.hpp
@@ -234,7 +234,7 @@ class Measurements final
             data_type = CUDA_C_32F;
         }
 
-        this->activate_DeviceSeed();
+        this->activateDeviceSeed();
         std::uniform_real_distribution<PrecisionT> dis(0.0, 1.0);
         for (std::size_t n = 0; n < num_samples; n++) {
             rand_nums[n] = dis(this->rng);

--- a/pennylane_lightning/core/src/simulators/lightning_gpu/measurements/MeasurementsGPU.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_gpu/measurements/MeasurementsGPU.hpp
@@ -233,6 +233,7 @@ class Measurements final
         } else {
             data_type = CUDA_C_32F;
         }
+        this->setSeed(this->_deviceseed);
 
         std::uniform_real_distribution<PrecisionT> dis(0.0, 1.0);
         for (std::size_t n = 0; n < num_samples; n++) {

--- a/pennylane_lightning/core/src/simulators/lightning_kokkos/catalyst/LightningKokkosSimulator.cpp
+++ b/pennylane_lightning/core/src/simulators/lightning_kokkos/catalyst/LightningKokkosSimulator.cpp
@@ -268,8 +268,7 @@ auto LightningKokkosSimulator::Expval(ObsIdType obsKey) -> double {
     Pennylane::LightningKokkos::Measures::Measurements<StateVectorT> m{
         *(this->device_sv)};
 
-    // LK does not use the measure's internal PRNG, so we only copy the seed
-    m.copySeed(this->generateSeed());
+    m.setSeed(this->generateSeed());
 
     return device_shots ? m.expval(*obs, device_shots, {}) : m.expval(*obs);
 }
@@ -288,8 +287,7 @@ auto LightningKokkosSimulator::Var(ObsIdType obsKey) -> double {
     Pennylane::LightningKokkos::Measures::Measurements<StateVectorT> m{
         *(this->device_sv)};
 
-    // LK does not use the measure's internal PRNG, so we only copy the seed
-    m.copySeed(this->generateSeed());
+    m.setSeed(this->generateSeed());
 
     return device_shots ? m.var(*obs, device_shots) : m.var(*obs);
 }
@@ -321,8 +319,7 @@ void LightningKokkosSimulator::Probs(DataView<double, 1> &probs) {
     Pennylane::LightningKokkos::Measures::Measurements<StateVectorT> m{
         *(this->device_sv)};
 
-    // LK does not use the measure's internal PRNG, so we only copy the seed
-    m.copySeed(this->generateSeed());
+    m.setSeed(this->generateSeed());
 
     auto &&dv_probs = device_shots ? m.probs(device_shots) : m.probs();
 
@@ -344,8 +341,7 @@ void LightningKokkosSimulator::PartialProbs(
     Pennylane::LightningKokkos::Measures::Measurements<StateVectorT> m{
         *(this->device_sv)};
 
-    // LK does not use the measure's internal PRNG, so we only copy the seed
-    m.copySeed(this->generateSeed());
+    m.setSeed(this->generateSeed());
 
     auto &&dv_probs =
         device_shots ? m.probs(dev_wires, device_shots) : m.probs(dev_wires);
@@ -361,8 +357,7 @@ std::vector<size_t> LightningKokkosSimulator::GenerateSamples(size_t shots) {
     Pennylane::LightningKokkos::Measures::Measurements<StateVectorT> m{
         *(this->device_sv)};
 
-    // LK does not use the measure's internal PRNG, so we only copy the seed
-    m.copySeed(this->generateSeed());
+    m.setSeed(this->generateSeed());
 
     // PL-Lightning-Kokkos generates samples using the alias method.
     // Reference: https://en.wikipedia.org/wiki/Inverse_transform_sampling

--- a/pennylane_lightning/core/src/simulators/lightning_kokkos/catalyst/LightningKokkosSimulator.cpp
+++ b/pennylane_lightning/core/src/simulators/lightning_kokkos/catalyst/LightningKokkosSimulator.cpp
@@ -268,7 +268,7 @@ auto LightningKokkosSimulator::Expval(ObsIdType obsKey) -> double {
     Pennylane::LightningKokkos::Measures::Measurements<StateVectorT> m{
         *(this->device_sv)};
 
-    m.set_DeviceSeedFromPRNG(this->gen);
+    m.setDeviceSeedFromPRNG(this->gen);
 
     return device_shots ? m.expval(*obs, device_shots, {}) : m.expval(*obs);
 }
@@ -287,7 +287,7 @@ auto LightningKokkosSimulator::Var(ObsIdType obsKey) -> double {
     Pennylane::LightningKokkos::Measures::Measurements<StateVectorT> m{
         *(this->device_sv)};
 
-    m.set_DeviceSeedFromPRNG(this->gen);
+    m.setDeviceSeedFromPRNG(this->gen);
 
     return device_shots ? m.var(*obs, device_shots) : m.var(*obs);
 }
@@ -319,7 +319,7 @@ void LightningKokkosSimulator::Probs(DataView<double, 1> &probs) {
     Pennylane::LightningKokkos::Measures::Measurements<StateVectorT> m{
         *(this->device_sv)};
 
-    m.set_DeviceSeedFromPRNG(this->gen);
+    m.setDeviceSeedFromPRNG(this->gen);
 
     auto &&dv_probs = device_shots ? m.probs(device_shots) : m.probs();
 
@@ -341,7 +341,7 @@ void LightningKokkosSimulator::PartialProbs(
     Pennylane::LightningKokkos::Measures::Measurements<StateVectorT> m{
         *(this->device_sv)};
 
-    m.set_DeviceSeedFromPRNG(this->gen);
+    m.setDeviceSeedFromPRNG(this->gen);
 
     auto &&dv_probs =
         device_shots ? m.probs(dev_wires, device_shots) : m.probs(dev_wires);
@@ -357,7 +357,7 @@ std::vector<size_t> LightningKokkosSimulator::GenerateSamples(size_t shots) {
     Pennylane::LightningKokkos::Measures::Measurements<StateVectorT> m{
         *(this->device_sv)};
 
-    m.set_DeviceSeedFromPRNG(this->gen);
+    m.setDeviceSeedFromPRNG(this->gen);
 
     // PL-Lightning-Kokkos generates samples using the alias method.
     // Reference: https://en.wikipedia.org/wiki/Inverse_transform_sampling

--- a/pennylane_lightning/core/src/simulators/lightning_kokkos/catalyst/LightningKokkosSimulator.cpp
+++ b/pennylane_lightning/core/src/simulators/lightning_kokkos/catalyst/LightningKokkosSimulator.cpp
@@ -268,7 +268,7 @@ auto LightningKokkosSimulator::Expval(ObsIdType obsKey) -> double {
     Pennylane::LightningKokkos::Measures::Measurements<StateVectorT> m{
         *(this->device_sv)};
 
-    m.set_PRNG(this->gen);
+    m.set_DeviceSeedFromPRNG(this->gen);
 
     return device_shots ? m.expval(*obs, device_shots, {}) : m.expval(*obs);
 }
@@ -287,7 +287,7 @@ auto LightningKokkosSimulator::Var(ObsIdType obsKey) -> double {
     Pennylane::LightningKokkos::Measures::Measurements<StateVectorT> m{
         *(this->device_sv)};
 
-    m.set_PRNG(this->gen);
+    m.set_DeviceSeedFromPRNG(this->gen);
 
     return device_shots ? m.var(*obs, device_shots) : m.var(*obs);
 }
@@ -319,7 +319,7 @@ void LightningKokkosSimulator::Probs(DataView<double, 1> &probs) {
     Pennylane::LightningKokkos::Measures::Measurements<StateVectorT> m{
         *(this->device_sv)};
 
-    m.set_PRNG(this->gen);
+    m.set_DeviceSeedFromPRNG(this->gen);
 
     auto &&dv_probs = device_shots ? m.probs(device_shots) : m.probs();
 
@@ -341,7 +341,7 @@ void LightningKokkosSimulator::PartialProbs(
     Pennylane::LightningKokkos::Measures::Measurements<StateVectorT> m{
         *(this->device_sv)};
 
-    m.set_PRNG(this->gen);
+    m.set_DeviceSeedFromPRNG(this->gen);
 
     auto &&dv_probs =
         device_shots ? m.probs(dev_wires, device_shots) : m.probs(dev_wires);
@@ -357,7 +357,7 @@ std::vector<size_t> LightningKokkosSimulator::GenerateSamples(size_t shots) {
     Pennylane::LightningKokkos::Measures::Measurements<StateVectorT> m{
         *(this->device_sv)};
 
-    m.set_PRNG(this->gen);
+    m.set_DeviceSeedFromPRNG(this->gen);
 
     // PL-Lightning-Kokkos generates samples using the alias method.
     // Reference: https://en.wikipedia.org/wiki/Inverse_transform_sampling

--- a/pennylane_lightning/core/src/simulators/lightning_kokkos/catalyst/LightningKokkosSimulator.cpp
+++ b/pennylane_lightning/core/src/simulators/lightning_kokkos/catalyst/LightningKokkosSimulator.cpp
@@ -268,7 +268,8 @@ auto LightningKokkosSimulator::Expval(ObsIdType obsKey) -> double {
     Pennylane::LightningKokkos::Measures::Measurements<StateVectorT> m{
         *(this->device_sv)};
 
-    m.setDeviceSeedFromPRNG(this->gen);
+    // LK does not use the measure's internal PRNG, so we only copy the seed
+    m.copySeed(this->generateSeed());
 
     return device_shots ? m.expval(*obs, device_shots, {}) : m.expval(*obs);
 }
@@ -287,7 +288,8 @@ auto LightningKokkosSimulator::Var(ObsIdType obsKey) -> double {
     Pennylane::LightningKokkos::Measures::Measurements<StateVectorT> m{
         *(this->device_sv)};
 
-    m.setDeviceSeedFromPRNG(this->gen);
+    // LK does not use the measure's internal PRNG, so we only copy the seed
+    m.copySeed(this->generateSeed());
 
     return device_shots ? m.var(*obs, device_shots) : m.var(*obs);
 }
@@ -319,7 +321,8 @@ void LightningKokkosSimulator::Probs(DataView<double, 1> &probs) {
     Pennylane::LightningKokkos::Measures::Measurements<StateVectorT> m{
         *(this->device_sv)};
 
-    m.setDeviceSeedFromPRNG(this->gen);
+    // LK does not use the measure's internal PRNG, so we only copy the seed
+    m.copySeed(this->generateSeed());
 
     auto &&dv_probs = device_shots ? m.probs(device_shots) : m.probs();
 
@@ -341,7 +344,8 @@ void LightningKokkosSimulator::PartialProbs(
     Pennylane::LightningKokkos::Measures::Measurements<StateVectorT> m{
         *(this->device_sv)};
 
-    m.setDeviceSeedFromPRNG(this->gen);
+    // LK does not use the measure's internal PRNG, so we only copy the seed
+    m.copySeed(this->generateSeed());
 
     auto &&dv_probs =
         device_shots ? m.probs(dev_wires, device_shots) : m.probs(dev_wires);
@@ -357,7 +361,8 @@ std::vector<size_t> LightningKokkosSimulator::GenerateSamples(size_t shots) {
     Pennylane::LightningKokkos::Measures::Measurements<StateVectorT> m{
         *(this->device_sv)};
 
-    m.setDeviceSeedFromPRNG(this->gen);
+    // LK does not use the measure's internal PRNG, so we only copy the seed
+    m.copySeed(this->generateSeed());
 
     // PL-Lightning-Kokkos generates samples using the alias method.
     // Reference: https://en.wikipedia.org/wiki/Inverse_transform_sampling

--- a/pennylane_lightning/core/src/simulators/lightning_kokkos/catalyst/LightningKokkosSimulator.cpp
+++ b/pennylane_lightning/core/src/simulators/lightning_kokkos/catalyst/LightningKokkosSimulator.cpp
@@ -268,6 +268,8 @@ auto LightningKokkosSimulator::Expval(ObsIdType obsKey) -> double {
     Pennylane::LightningKokkos::Measures::Measurements<StateVectorT> m{
         *(this->device_sv)};
 
+    m.set_PRNG(this->gen);
+
     return device_shots ? m.expval(*obs, device_shots, {}) : m.expval(*obs);
 }
 
@@ -284,6 +286,8 @@ auto LightningKokkosSimulator::Var(ObsIdType obsKey) -> double {
 
     Pennylane::LightningKokkos::Measures::Measurements<StateVectorT> m{
         *(this->device_sv)};
+
+    m.set_PRNG(this->gen);
 
     return device_shots ? m.var(*obs, device_shots) : m.var(*obs);
 }
@@ -314,6 +318,9 @@ void LightningKokkosSimulator::State(DataView<std::complex<double>, 1> &state) {
 void LightningKokkosSimulator::Probs(DataView<double, 1> &probs) {
     Pennylane::LightningKokkos::Measures::Measurements<StateVectorT> m{
         *(this->device_sv)};
+
+    m.set_PRNG(this->gen);
+
     auto &&dv_probs = device_shots ? m.probs(device_shots) : m.probs();
 
     RT_FAIL_IF(probs.size() != dv_probs.size(),
@@ -333,6 +340,9 @@ void LightningKokkosSimulator::PartialProbs(
     auto dev_wires = getDeviceWires(wires);
     Pennylane::LightningKokkos::Measures::Measurements<StateVectorT> m{
         *(this->device_sv)};
+
+    m.set_PRNG(this->gen);
+
     auto &&dv_probs =
         device_shots ? m.probs(dev_wires, device_shots) : m.probs(dev_wires);
 
@@ -347,11 +357,10 @@ std::vector<size_t> LightningKokkosSimulator::GenerateSamples(size_t shots) {
     Pennylane::LightningKokkos::Measures::Measurements<StateVectorT> m{
         *(this->device_sv)};
 
+    m.set_PRNG(this->gen);
+
     // PL-Lightning-Kokkos generates samples using the alias method.
     // Reference: https://en.wikipedia.org/wiki/Inverse_transform_sampling
-    if (this->gen) {
-        return m.generate_samples(shots, (*(this->gen))());
-    }
     return m.generate_samples(shots);
 }
 

--- a/pennylane_lightning/core/src/simulators/lightning_kokkos/catalyst/LightningKokkosSimulator.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_kokkos/catalyst/LightningKokkosSimulator.hpp
@@ -95,6 +95,14 @@ class LightningKokkosSimulator final : public Catalyst::Runtime::QuantumDevice {
         return res;
     }
 
+    inline auto generateSeed() -> std::optional<std::size_t> {
+        if (this->gen != nullptr) {
+            return (*(this->gen))();
+        }
+
+        return std::nullopt;
+    }
+
     auto GenerateSamples(size_t shots) -> std::vector<size_t>;
 
   public:

--- a/pennylane_lightning/core/src/simulators/lightning_kokkos/catalyst/tests/Test_LightningKokkosMeasures.cpp
+++ b/pennylane_lightning/core/src/simulators/lightning_kokkos/catalyst/tests/Test_LightningKokkosMeasures.cpp
@@ -1824,7 +1824,7 @@ TEST_CASE("Sample with a seeded device", "[Measures]") {
 }
 
 TEST_CASE("Probs with a seeded device", "[Measures]") {
-    std::size_t shots = 1000;
+    constexpr std::size_t shots = 1000;
     std::array<std::unique_ptr<LKSimulator>, 2> sims;
     std::vector<std::vector<double>> probs(2, std::vector<double>(16));
 
@@ -1866,7 +1866,7 @@ TEST_CASE("Probs with a seeded device", "[Measures]") {
 }
 
 TEST_CASE("Var with a seeded device", "[Measures]") {
-    std::size_t shots = 1000;
+    constexpr std::size_t shots = 1000;
     std::array<std::unique_ptr<LKSimulator>, 2> sims;
     std::array<std::vector<double>, 2> vars;
 
@@ -1912,7 +1912,7 @@ TEST_CASE("Var with a seeded device", "[Measures]") {
 }
 
 TEST_CASE("Expval with a seeded device", "[Measures]") {
-    std::size_t shots = 1000;
+    constexpr std::size_t shots = 1000;
     std::array<std::unique_ptr<LKSimulator>, 2> sims;
     std::array<std::vector<double>, 2> expvals;
 

--- a/pennylane_lightning/core/src/simulators/lightning_kokkos/catalyst/tests/Test_LightningKokkosMeasures.cpp
+++ b/pennylane_lightning/core/src/simulators/lightning_kokkos/catalyst/tests/Test_LightningKokkosMeasures.cpp
@@ -1833,8 +1833,8 @@ TEST_CASE("Probs with a seeded device", "[Measures]") {
 
     std::vector<std::mt19937> gens{std::mt19937{37}, std::mt19937{37}};
 
-    auto circuit = [shots](LKSimulator &sim, DataView<double, 1> &view,
-                           std::mt19937 &gen) {
+    auto circuit = [](LKSimulator &sim, DataView<double, 1> &view,
+                      std::mt19937 &gen) {
         sim.SetDevicePRNG(&gen);
         sim.SetDeviceShots(shots);
         // state-vector with #qubits = n
@@ -1872,8 +1872,8 @@ TEST_CASE("Var with a seeded device", "[Measures]") {
 
     std::vector<std::mt19937> gens{std::mt19937{37}, std::mt19937{37}};
 
-    auto circuit = [shots](LKSimulator &sim, std::vector<double> &var,
-                           std::mt19937 &gen) {
+    auto circuit = [](LKSimulator &sim, std::vector<double> &var,
+                      std::mt19937 &gen) {
         sim.SetDevicePRNG(&gen);
         sim.SetDeviceShots(shots);
         // state-vector with #qubits = n
@@ -1918,8 +1918,8 @@ TEST_CASE("Expval with a seeded device", "[Measures]") {
 
     std::vector<std::mt19937> gens{std::mt19937{37}, std::mt19937{37}};
 
-    auto circuit = [shots](LKSimulator &sim, std::vector<double> &expval,
-                           std::mt19937 &gen) {
+    auto circuit = [](LKSimulator &sim, std::vector<double> &expval,
+                      std::mt19937 &gen) {
         sim.SetDevicePRNG(&gen);
         sim.SetDeviceShots(shots);
         // state-vector with #qubits = n

--- a/pennylane_lightning/core/src/simulators/lightning_kokkos/catalyst/tests/Test_LightningKokkosMeasures.cpp
+++ b/pennylane_lightning/core/src/simulators/lightning_kokkos/catalyst/tests/Test_LightningKokkosMeasures.cpp
@@ -1864,3 +1864,49 @@ TEST_CASE("Probs with a seeded device", "[Measures]") {
         }
     }
 }
+
+TEST_CASE("Var with a seeded device", "[Measures]") {
+    std::size_t shots = 1000;
+    std::array<std::unique_ptr<LKSimulator>, 2> sims;
+    std::array<std::vector<double>, 2> vars;
+
+    std::vector<std::mt19937> gens{std::mt19937{37}, std::mt19937{37}};
+
+    auto circuit = [shots](LKSimulator &sim, std::vector<double> &var,
+                           std::mt19937 &gen) {
+        sim.SetDevicePRNG(&gen);
+        sim.SetDeviceShots(shots);
+        // state-vector with #qubits = n
+        constexpr std::size_t n = 4;
+        std::vector<intptr_t> Qs;
+        Qs.reserve(n);
+        for (std::size_t i = 0; i < n; i++) {
+            Qs.push_back(sim.AllocateQubit());
+        }
+        sim.NamedOperation("Hadamard", {}, {Qs[0]}, false);
+        sim.NamedOperation("PauliY", {}, {Qs[1]}, false);
+        sim.NamedOperation("Hadamard", {}, {Qs[2]}, false);
+        sim.NamedOperation("PauliZ", {}, {Qs[3]}, false);
+
+        ObsIdType px = sim.Observable(ObsId::PauliX, {}, {Qs[2]});
+        ObsIdType py = sim.Observable(ObsId::PauliY, {}, {Qs[0]});
+        ObsIdType pz = sim.Observable(ObsId::PauliZ, {}, {Qs[3]});
+
+        var.push_back(sim.Var(px));
+        var.push_back(sim.Var(py));
+        var.push_back(sim.Var(pz));
+    };
+
+    for (std::size_t trial = 0; trial < 5; trial++) {
+        sims[0] = std::make_unique<LKSimulator>();
+        sims[1] = std::make_unique<LKSimulator>();
+
+        for (std::size_t sim_idx = 0; sim_idx < sims.size(); sim_idx++) {
+            circuit(*(sims[sim_idx]), vars[sim_idx], gens[sim_idx]);
+        }
+
+        for (std::size_t i = 0; i < vars[0].size(); i++) {
+            CHECK((vars[0][i] == vars[1][i]));
+        }
+    }
+}

--- a/pennylane_lightning/core/src/simulators/lightning_kokkos/catalyst/tests/Test_LightningKokkosMeasures.cpp
+++ b/pennylane_lightning/core/src/simulators/lightning_kokkos/catalyst/tests/Test_LightningKokkosMeasures.cpp
@@ -1824,6 +1824,7 @@ TEST_CASE("Sample with a seeded device", "[Measures]") {
 }
 
 TEST_CASE("Probs with a seeded device", "[Measures]") {
+    std::size_t shots = 1000;
     std::array<std::unique_ptr<LKSimulator>, 2> sims;
     std::vector<std::vector<double>> probs(2, std::vector<double>(16));
 
@@ -1832,10 +1833,10 @@ TEST_CASE("Probs with a seeded device", "[Measures]") {
 
     std::vector<std::mt19937> gens{std::mt19937{37}, std::mt19937{37}};
 
-    auto circuit = [](LKSimulator &sim, DataView<double, 1> &view,
-                      std::mt19937 &gen) {
+    auto circuit = [shots](LKSimulator &sim, DataView<double, 1> &view,
+                           std::mt19937 &gen) {
         sim.SetDevicePRNG(&gen);
-        sim.SetDeviceShots(1000);
+        sim.SetDeviceShots(shots);
         // state-vector with #qubits = n
         constexpr std::size_t n = 4;
         std::vector<intptr_t> Qs;

--- a/pennylane_lightning/core/src/simulators/lightning_kokkos/catalyst/tests/Test_LightningKokkosMeasures.cpp
+++ b/pennylane_lightning/core/src/simulators/lightning_kokkos/catalyst/tests/Test_LightningKokkosMeasures.cpp
@@ -1910,3 +1910,49 @@ TEST_CASE("Var with a seeded device", "[Measures]") {
         }
     }
 }
+
+TEST_CASE("Expval with a seeded device", "[Measures]") {
+    std::size_t shots = 1000;
+    std::array<std::unique_ptr<LKSimulator>, 2> sims;
+    std::array<std::vector<double>, 2> expvals;
+
+    std::vector<std::mt19937> gens{std::mt19937{37}, std::mt19937{37}};
+
+    auto circuit = [shots](LKSimulator &sim, std::vector<double> &expval,
+                           std::mt19937 &gen) {
+        sim.SetDevicePRNG(&gen);
+        sim.SetDeviceShots(shots);
+        // state-vector with #qubits = n
+        constexpr std::size_t n = 4;
+        std::vector<intptr_t> Qs;
+        Qs.reserve(n);
+        for (std::size_t i = 0; i < n; i++) {
+            Qs.push_back(sim.AllocateQubit());
+        }
+        sim.NamedOperation("Hadamard", {}, {Qs[0]}, false);
+        sim.NamedOperation("PauliY", {}, {Qs[1]}, false);
+        sim.NamedOperation("Hadamard", {}, {Qs[2]}, false);
+        sim.NamedOperation("PauliZ", {}, {Qs[3]}, false);
+
+        ObsIdType px = sim.Observable(ObsId::PauliX, {}, {Qs[2]});
+        ObsIdType py = sim.Observable(ObsId::PauliY, {}, {Qs[0]});
+        ObsIdType pz = sim.Observable(ObsId::PauliZ, {}, {Qs[3]});
+
+        expval.push_back(sim.Expval(px));
+        expval.push_back(sim.Expval(py));
+        expval.push_back(sim.Expval(pz));
+    };
+
+    for (std::size_t trial = 0; trial < 5; trial++) {
+        sims[0] = std::make_unique<LKSimulator>();
+        sims[1] = std::make_unique<LKSimulator>();
+
+        for (std::size_t sim_idx = 0; sim_idx < sims.size(); sim_idx++) {
+            circuit(*(sims[sim_idx]), expvals[sim_idx], gens[sim_idx]);
+        }
+
+        for (std::size_t i = 0; i < expvals[0].size(); i++) {
+            CHECK((expvals[0][i] == expvals[1][i]));
+        }
+    }
+}

--- a/pennylane_lightning/core/src/simulators/lightning_kokkos/catalyst/tests/Test_LightningKokkosMeasures.cpp
+++ b/pennylane_lightning/core/src/simulators/lightning_kokkos/catalyst/tests/Test_LightningKokkosMeasures.cpp
@@ -1835,6 +1835,7 @@ TEST_CASE("Probs with a seeded device", "[Measures]") {
     auto circuit = [](LKSimulator &sim, DataView<double, 1> &view,
                       std::mt19937 &gen) {
         sim.SetDevicePRNG(&gen);
+        sim.SetDeviceShots(1000);
         // state-vector with #qubits = n
         constexpr std::size_t n = 4;
         std::vector<intptr_t> Qs;
@@ -1858,11 +1859,6 @@ TEST_CASE("Probs with a seeded device", "[Measures]") {
         }
 
         for (std::size_t i = 0; i < probs[0].size(); i++) {
-            if (i == 4 || i == 6 || i == 12 || i == 14) {
-                CHECK(probs[0][i] == Approx(0.25).margin(1e-5));
-            } else {
-                CHECK(probs[0][i] == Approx(0.).margin(1e-5));
-            }
             CHECK((probs[0][i] == probs[1][i]));
         }
     }

--- a/pennylane_lightning/core/src/simulators/lightning_kokkos/catalyst/tests/Test_LightningKokkosMeasures.cpp
+++ b/pennylane_lightning/core/src/simulators/lightning_kokkos/catalyst/tests/Test_LightningKokkosMeasures.cpp
@@ -1824,7 +1824,6 @@ TEST_CASE("Sample with a seeded device", "[Measures]") {
 }
 
 TEST_CASE("Probs with a seeded device", "[Measures]") {
-    std::size_t shots = 100;
     std::array<std::unique_ptr<LKSimulator>, 2> sims;
     std::vector<std::vector<double>> probs(2, std::vector<double>(16));
 
@@ -1833,8 +1832,8 @@ TEST_CASE("Probs with a seeded device", "[Measures]") {
 
     std::vector<std::mt19937> gens{std::mt19937{37}, std::mt19937{37}};
 
-    auto circuit = [shots](LKSimulator &sim, DataView<double, 1> &view,
-                           std::mt19937 &gen) {
+    auto circuit = [](LKSimulator &sim, DataView<double, 1> &view,
+                      std::mt19937 &gen) {
         sim.SetDevicePRNG(&gen);
         // state-vector with #qubits = n
         constexpr std::size_t n = 4;

--- a/pennylane_lightning/core/src/simulators/lightning_kokkos/measurements/MeasurementsKokkos.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_kokkos/measurements/MeasurementsKokkos.hpp
@@ -675,8 +675,8 @@ class Measurements final
 
         // Sampling using Random_XorShift64_Pool
         auto rand_pool =
-            this->DeviceSeed.has_value()
-                ? Kokkos::Random_XorShift64_Pool<>(this->DeviceSeed.value())
+            this->_deviceseed.has_value()
+                ? Kokkos::Random_XorShift64_Pool<>(this->_deviceseed.value())
                 : Kokkos::Random_XorShift64_Pool<>(
                       std::chrono::high_resolution_clock::now()
                           .time_since_epoch()

--- a/pennylane_lightning/core/src/simulators/lightning_kokkos/measurements/MeasurementsKokkos.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_kokkos/measurements/MeasurementsKokkos.hpp
@@ -14,7 +14,6 @@
 #pragma once
 #include <chrono>
 #include <cstdint>
-#include <random>
 
 #include <Kokkos_Core.hpp>
 #include <Kokkos_Random.hpp>

--- a/pennylane_lightning/core/src/simulators/lightning_kokkos/measurements/MeasurementsKokkos.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_kokkos/measurements/MeasurementsKokkos.hpp
@@ -659,7 +659,12 @@ class Measurements final
      * be accessed using the stride sample_id*num_qubits, where sample_id is a
      * number between 0 and num_samples-1.
      */
-    auto generate_samples(std::size_t num_samples) -> std::vector<std::size_t> {
+    auto generate_samples(std::size_t num_samples,
+                          const std::optional<Measurements *> &m = std::nullopt)
+        -> std::vector<std::size_t> {
+        if (m.has_value() && m.value() != nullptr) {
+            this->set_PRNG(m.value()->get_PRNG());
+        }
         const std::size_t num_qubits = this->_statevector.getNumQubits();
         const std::size_t N = this->_statevector.getLength();
         Kokkos::View<std::size_t *> samples("num_samples",
@@ -695,6 +700,8 @@ class Measurements final
     }
 
     void set_PRNG(std::mt19937 *gen) { this->gen = gen; }
+
+    std::mt19937 *get_PRNG() { return this->gen; }
 
   private:
     std::unordered_map<std::string, ExpValFunc> expval_funcs_;

--- a/pennylane_lightning/core/src/simulators/lightning_kokkos/measurements/MeasurementsKokkos.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_kokkos/measurements/MeasurementsKokkos.hpp
@@ -14,7 +14,6 @@
 #pragma once
 #include <chrono>
 #include <cstdint>
-#include <optional>
 #include <random>
 
 #include <Kokkos_Core.hpp>
@@ -72,8 +71,6 @@ class Measurements final
         typename StateVectorT::UnmanagedConstSizeTHostView;
     using ScratchViewComplex = typename StateVectorT::ScratchViewComplex;
     using TeamPolicy = typename StateVectorT::TeamPolicy;
-
-    std::optional<std::size_t> DeviceSeed = std::nullopt;
 
   public:
     explicit Measurements(const StateVectorT &statevector)
@@ -693,18 +690,6 @@ class Measurements final
 
         return view2vector(samples);
     }
-
-    void set_DeviceSeedFromPRNG(std::mt19937 *gen) {
-        if (gen != nullptr) {
-            this->DeviceSeed = (*gen)();
-        }
-    }
-
-    void set_DeviceSeed(std::optional<std::size_t> deviceSeed) {
-        this->DeviceSeed = deviceSeed;
-    }
-
-    std::optional<std::size_t> get_DeviceSeed() { return this->DeviceSeed; }
 
   private:
     std::unordered_map<std::string, ExpValFunc> expval_funcs_;

--- a/pennylane_lightning/core/src/simulators/lightning_qubit/catalyst/LightningSimulator.cpp
+++ b/pennylane_lightning/core/src/simulators/lightning_qubit/catalyst/LightningSimulator.cpp
@@ -251,6 +251,8 @@ auto LightningSimulator::Expval(ObsIdType obsKey) -> double {
     Pennylane::LightningQubit::Measures::Measurements<StateVectorT> m{
         *(this->device_sv)};
 
+    m.set_PRNG(this->gen);
+
     return (device_shots != 0U) ? m.expval(*obs, device_shots, {})
                                 : m.expval(*obs);
 }
@@ -268,6 +270,8 @@ auto LightningSimulator::Var(ObsIdType obsKey) -> double {
     Pennylane::LightningQubit::Measures::Measurements<StateVectorT> m{
         *(this->device_sv)};
 
+    m.set_PRNG(this->gen);
+
     return (device_shots != 0U) ? m.var(*obs, device_shots) : m.var(*obs);
 }
 
@@ -282,6 +286,9 @@ void LightningSimulator::State(DataView<std::complex<double>, 1> &state) {
 void LightningSimulator::Probs(DataView<double, 1> &probs) {
     Pennylane::LightningQubit::Measures::Measurements<StateVectorT> m{
         *(this->device_sv)};
+
+    m.set_PRNG(this->gen);
+
     auto &&dv_probs = (device_shots != 0U) ? m.probs(device_shots) : m.probs();
 
     RT_FAIL_IF(probs.size() != dv_probs.size(),
@@ -301,6 +308,9 @@ void LightningSimulator::PartialProbs(DataView<double, 1> &probs,
     auto dev_wires = getDeviceWires(wires);
     Pennylane::LightningQubit::Measures::Measurements<StateVectorT> m{
         *(this->device_sv)};
+
+    m.set_PRNG(this->gen);
+
     auto &&dv_probs = (device_shots != 0U) ? m.probs(dev_wires, device_shots)
                                            : m.probs(dev_wires);
 
@@ -315,6 +325,8 @@ LightningSimulator::GenerateSamplesMetropolis(size_t shots) {
     // generate_samples_metropolis is a member function of the Measures class.
     Pennylane::LightningQubit::Measures::Measurements<StateVectorT> m{
         *(this->device_sv)};
+
+    m.set_PRNG(this->gen);
 
     // PL-Lightning generates samples using the alias method.
     // Reference: https://en.wikipedia.org/wiki/Alias_method
@@ -335,6 +347,8 @@ std::vector<size_t> LightningSimulator::GenerateSamples(size_t shots) {
     Pennylane::LightningQubit::Measures::Measurements<StateVectorT> m{
         *(this->device_sv)};
 
+    m.set_PRNG(this->gen);
+
     // PL-Lightning generates samples using the alias method.
     // Reference: https://en.wikipedia.org/wiki/Alias_method
     // Given the number of samples, returns 1-D vector of samples
@@ -342,9 +356,6 @@ std::vector<size_t> LightningSimulator::GenerateSamples(size_t shots) {
     // the number of qubits.
     //
     // Return Value Optimization (RVO)
-    if (this->gen != nullptr) {
-        return m.generate_samples(shots, (*(this->gen))());
-    }
     return m.generate_samples(shots);
 }
 

--- a/pennylane_lightning/core/src/simulators/lightning_qubit/catalyst/LightningSimulator.cpp
+++ b/pennylane_lightning/core/src/simulators/lightning_qubit/catalyst/LightningSimulator.cpp
@@ -251,7 +251,7 @@ auto LightningSimulator::Expval(ObsIdType obsKey) -> double {
     Pennylane::LightningQubit::Measures::Measurements<StateVectorT> m{
         *(this->device_sv)};
 
-    m.set_PRNG(this->gen);
+    m.set_DeviceSeedFromPRNG(this->gen);
 
     return (device_shots != 0U) ? m.expval(*obs, device_shots, {})
                                 : m.expval(*obs);
@@ -270,7 +270,7 @@ auto LightningSimulator::Var(ObsIdType obsKey) -> double {
     Pennylane::LightningQubit::Measures::Measurements<StateVectorT> m{
         *(this->device_sv)};
 
-    m.set_PRNG(this->gen);
+    m.set_DeviceSeedFromPRNG(this->gen);
 
     return (device_shots != 0U) ? m.var(*obs, device_shots) : m.var(*obs);
 }
@@ -287,7 +287,7 @@ void LightningSimulator::Probs(DataView<double, 1> &probs) {
     Pennylane::LightningQubit::Measures::Measurements<StateVectorT> m{
         *(this->device_sv)};
 
-    m.set_PRNG(this->gen);
+    m.set_DeviceSeedFromPRNG(this->gen);
 
     auto &&dv_probs = (device_shots != 0U) ? m.probs(device_shots) : m.probs();
 
@@ -309,7 +309,7 @@ void LightningSimulator::PartialProbs(DataView<double, 1> &probs,
     Pennylane::LightningQubit::Measures::Measurements<StateVectorT> m{
         *(this->device_sv)};
 
-    m.set_PRNG(this->gen);
+    m.set_DeviceSeedFromPRNG(this->gen);
 
     auto &&dv_probs = (device_shots != 0U) ? m.probs(dev_wires, device_shots)
                                            : m.probs(dev_wires);
@@ -326,7 +326,7 @@ LightningSimulator::GenerateSamplesMetropolis(size_t shots) {
     Pennylane::LightningQubit::Measures::Measurements<StateVectorT> m{
         *(this->device_sv)};
 
-    m.set_PRNG(this->gen);
+    m.set_DeviceSeedFromPRNG(this->gen);
 
     // PL-Lightning generates samples using the alias method.
     // Reference: https://en.wikipedia.org/wiki/Alias_method
@@ -347,7 +347,7 @@ std::vector<size_t> LightningSimulator::GenerateSamples(size_t shots) {
     Pennylane::LightningQubit::Measures::Measurements<StateVectorT> m{
         *(this->device_sv)};
 
-    m.set_PRNG(this->gen);
+    m.set_DeviceSeedFromPRNG(this->gen);
 
     // PL-Lightning generates samples using the alias method.
     // Reference: https://en.wikipedia.org/wiki/Alias_method

--- a/pennylane_lightning/core/src/simulators/lightning_qubit/catalyst/LightningSimulator.cpp
+++ b/pennylane_lightning/core/src/simulators/lightning_qubit/catalyst/LightningSimulator.cpp
@@ -251,7 +251,7 @@ auto LightningSimulator::Expval(ObsIdType obsKey) -> double {
     Pennylane::LightningQubit::Measures::Measurements<StateVectorT> m{
         *(this->device_sv)};
 
-    m.setDeviceSeedFromPRNG(this->gen);
+    m.setSeed(this->generateSeed());
 
     return (device_shots != 0U) ? m.expval(*obs, device_shots, {})
                                 : m.expval(*obs);
@@ -270,7 +270,7 @@ auto LightningSimulator::Var(ObsIdType obsKey) -> double {
     Pennylane::LightningQubit::Measures::Measurements<StateVectorT> m{
         *(this->device_sv)};
 
-    m.setDeviceSeedFromPRNG(this->gen);
+    m.setSeed(this->generateSeed());
 
     return (device_shots != 0U) ? m.var(*obs, device_shots) : m.var(*obs);
 }
@@ -287,7 +287,7 @@ void LightningSimulator::Probs(DataView<double, 1> &probs) {
     Pennylane::LightningQubit::Measures::Measurements<StateVectorT> m{
         *(this->device_sv)};
 
-    m.setDeviceSeedFromPRNG(this->gen);
+    m.setSeed(this->generateSeed());
 
     auto &&dv_probs = (device_shots != 0U) ? m.probs(device_shots) : m.probs();
 
@@ -309,7 +309,7 @@ void LightningSimulator::PartialProbs(DataView<double, 1> &probs,
     Pennylane::LightningQubit::Measures::Measurements<StateVectorT> m{
         *(this->device_sv)};
 
-    m.setDeviceSeedFromPRNG(this->gen);
+    m.setSeed(this->generateSeed());
 
     auto &&dv_probs = (device_shots != 0U) ? m.probs(dev_wires, device_shots)
                                            : m.probs(dev_wires);
@@ -326,7 +326,7 @@ LightningSimulator::GenerateSamplesMetropolis(size_t shots) {
     Pennylane::LightningQubit::Measures::Measurements<StateVectorT> m{
         *(this->device_sv)};
 
-    m.setDeviceSeedFromPRNG(this->gen);
+    m.setSeed(this->generateSeed());
 
     // PL-Lightning generates samples using the alias method.
     // Reference: https://en.wikipedia.org/wiki/Alias_method
@@ -347,7 +347,7 @@ std::vector<size_t> LightningSimulator::GenerateSamples(size_t shots) {
     Pennylane::LightningQubit::Measures::Measurements<StateVectorT> m{
         *(this->device_sv)};
 
-    m.setDeviceSeedFromPRNG(this->gen);
+    m.setSeed(this->generateSeed());
 
     // PL-Lightning generates samples using the alias method.
     // Reference: https://en.wikipedia.org/wiki/Alias_method

--- a/pennylane_lightning/core/src/simulators/lightning_qubit/catalyst/LightningSimulator.cpp
+++ b/pennylane_lightning/core/src/simulators/lightning_qubit/catalyst/LightningSimulator.cpp
@@ -251,7 +251,7 @@ auto LightningSimulator::Expval(ObsIdType obsKey) -> double {
     Pennylane::LightningQubit::Measures::Measurements<StateVectorT> m{
         *(this->device_sv)};
 
-    m.set_DeviceSeedFromPRNG(this->gen);
+    m.setDeviceSeedFromPRNG(this->gen);
 
     return (device_shots != 0U) ? m.expval(*obs, device_shots, {})
                                 : m.expval(*obs);
@@ -270,7 +270,7 @@ auto LightningSimulator::Var(ObsIdType obsKey) -> double {
     Pennylane::LightningQubit::Measures::Measurements<StateVectorT> m{
         *(this->device_sv)};
 
-    m.set_DeviceSeedFromPRNG(this->gen);
+    m.setDeviceSeedFromPRNG(this->gen);
 
     return (device_shots != 0U) ? m.var(*obs, device_shots) : m.var(*obs);
 }
@@ -287,7 +287,7 @@ void LightningSimulator::Probs(DataView<double, 1> &probs) {
     Pennylane::LightningQubit::Measures::Measurements<StateVectorT> m{
         *(this->device_sv)};
 
-    m.set_DeviceSeedFromPRNG(this->gen);
+    m.setDeviceSeedFromPRNG(this->gen);
 
     auto &&dv_probs = (device_shots != 0U) ? m.probs(device_shots) : m.probs();
 
@@ -309,7 +309,7 @@ void LightningSimulator::PartialProbs(DataView<double, 1> &probs,
     Pennylane::LightningQubit::Measures::Measurements<StateVectorT> m{
         *(this->device_sv)};
 
-    m.set_DeviceSeedFromPRNG(this->gen);
+    m.setDeviceSeedFromPRNG(this->gen);
 
     auto &&dv_probs = (device_shots != 0U) ? m.probs(dev_wires, device_shots)
                                            : m.probs(dev_wires);
@@ -326,7 +326,7 @@ LightningSimulator::GenerateSamplesMetropolis(size_t shots) {
     Pennylane::LightningQubit::Measures::Measurements<StateVectorT> m{
         *(this->device_sv)};
 
-    m.set_DeviceSeedFromPRNG(this->gen);
+    m.setDeviceSeedFromPRNG(this->gen);
 
     // PL-Lightning generates samples using the alias method.
     // Reference: https://en.wikipedia.org/wiki/Alias_method
@@ -347,7 +347,7 @@ std::vector<size_t> LightningSimulator::GenerateSamples(size_t shots) {
     Pennylane::LightningQubit::Measures::Measurements<StateVectorT> m{
         *(this->device_sv)};
 
-    m.set_DeviceSeedFromPRNG(this->gen);
+    m.setDeviceSeedFromPRNG(this->gen);
 
     // PL-Lightning generates samples using the alias method.
     // Reference: https://en.wikipedia.org/wiki/Alias_method

--- a/pennylane_lightning/core/src/simulators/lightning_qubit/catalyst/LightningSimulator.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_qubit/catalyst/LightningSimulator.hpp
@@ -20,6 +20,7 @@
 #include <iostream>
 #include <limits>
 #include <numeric>
+#include <optional>
 #include <span>
 
 #include "StateVectorLQubitManaged.hpp"
@@ -85,6 +86,14 @@ class LightningSimulator final : public Catalyst::Runtime::QuantumDevice {
             wires.begin(), wires.end(), std::back_inserter(res),
             [this](auto w) { return this->qubit_manager.getDeviceId(w); });
         return res;
+    }
+
+    inline auto generateSeed() -> std::optional<std::size_t> {
+        if (this->gen != nullptr) {
+            return (*(this->gen))();
+        }
+
+        return std::nullopt;
     }
 
   public:

--- a/pennylane_lightning/core/src/simulators/lightning_qubit/catalyst/tests/Test_LightningMeasures.cpp
+++ b/pennylane_lightning/core/src/simulators/lightning_qubit/catalyst/tests/Test_LightningMeasures.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <random>
+#include <vector>
 
 #include "CacheManager.hpp"
 #include "LightningSimulator.hpp"
@@ -1870,6 +1871,52 @@ TEST_CASE("Probs with a seeded device", "[Measures]") {
 
         for (std::size_t i = 0; i < probs[0].size(); i++) {
             CHECK((probs[0][i] == probs[1][i]));
+        }
+    }
+}
+
+TEST_CASE("Var with a seeded device", "[Measures]") {
+    std::size_t shots = 1000;
+    std::array<std::unique_ptr<LQSimulator>, 2> sims;
+    std::array<std::vector<double>, 2> vars;
+
+    std::vector<std::mt19937> gens{std::mt19937{37}, std::mt19937{37}};
+
+    auto circuit = [shots](LQSimulator &sim, std::vector<double> &var,
+                           std::mt19937 &gen) {
+        sim.SetDevicePRNG(&gen);
+        sim.SetDeviceShots(shots);
+        // state-vector with #qubits = n
+        constexpr std::size_t n = 4;
+        std::vector<intptr_t> Qs;
+        Qs.reserve(n);
+        for (std::size_t i = 0; i < n; i++) {
+            Qs.push_back(sim.AllocateQubit());
+        }
+        sim.NamedOperation("Hadamard", {}, {Qs[0]}, false);
+        sim.NamedOperation("PauliY", {}, {Qs[1]}, false);
+        sim.NamedOperation("Hadamard", {}, {Qs[2]}, false);
+        sim.NamedOperation("PauliZ", {}, {Qs[3]}, false);
+
+        ObsIdType px = sim.Observable(ObsId::PauliX, {}, {Qs[2]});
+        ObsIdType py = sim.Observable(ObsId::PauliY, {}, {Qs[0]});
+        ObsIdType pz = sim.Observable(ObsId::PauliZ, {}, {Qs[3]});
+
+        var.push_back(sim.Var(px));
+        var.push_back(sim.Var(py));
+        var.push_back(sim.Var(pz));
+    };
+
+    for (std::size_t trial = 0; trial < 5; trial++) {
+        sims[0] = std::make_unique<LQSimulator>();
+        sims[1] = std::make_unique<LQSimulator>();
+
+        for (std::size_t sim_idx = 0; sim_idx < sims.size(); sim_idx++) {
+            circuit(*(sims[sim_idx]), vars[sim_idx], gens[sim_idx]);
+        }
+
+        for (std::size_t i = 0; i < vars[0].size(); i++) {
+            CHECK((vars[0][i] == vars[1][i]));
         }
     }
 }

--- a/pennylane_lightning/core/src/simulators/lightning_qubit/catalyst/tests/Test_LightningMeasures.cpp
+++ b/pennylane_lightning/core/src/simulators/lightning_qubit/catalyst/tests/Test_LightningMeasures.cpp
@@ -1831,3 +1831,49 @@ TEST_CASE("Sample with a seeded device", "[Measures]") {
         }
     }
 }
+
+TEST_CASE("Probs with a seeded device", "[Measures]") {
+    std::size_t shots = 100;
+    std::array<std::unique_ptr<LQSimulator>, 2> sims;
+    std::vector<std::vector<double>> probs(2, std::vector<double>(16));
+
+    std::vector<DataView<double, 1>> views{DataView<double, 1>(probs[0]),
+                                           DataView<double, 1>(probs[1])};
+
+    std::vector<std::mt19937> gens{std::mt19937{37}, std::mt19937{37}};
+
+    auto circuit = [shots](LQSimulator &sim, DataView<double, 1> &view,
+                           std::mt19937 &gen) {
+        sim.SetDevicePRNG(&gen);
+        // state-vector with #qubits = n
+        constexpr std::size_t n = 4;
+        std::vector<intptr_t> Qs;
+        Qs.reserve(n);
+        for (std::size_t i = 0; i < n; i++) {
+            Qs.push_back(sim.AllocateQubit());
+        }
+        sim.NamedOperation("Hadamard", {}, {Qs[0]}, false);
+        sim.NamedOperation("PauliY", {}, {Qs[1]}, false);
+        sim.NamedOperation("Hadamard", {}, {Qs[2]}, false);
+        sim.NamedOperation("PauliZ", {}, {Qs[3]}, false);
+        sim.Probs(view);
+    };
+
+    for (std::size_t trial = 0; trial < 5; trial++) {
+        sims[0] = std::make_unique<LQSimulator>();
+        sims[1] = std::make_unique<LQSimulator>();
+
+        for (std::size_t sim_idx = 0; sim_idx < sims.size(); sim_idx++) {
+            circuit(*(sims[sim_idx]), views[sim_idx], gens[sim_idx]);
+        }
+
+        for (std::size_t i = 0; i < probs[0].size(); i++) {
+            if (i == 4 || i == 6 || i == 12 || i == 14) {
+                CHECK(probs[0][i] == Approx(0.25).margin(1e-5));
+            } else {
+                CHECK(probs[0][i] == Approx(0.).margin(1e-5));
+            }
+            CHECK((probs[0][i] == probs[1][i]));
+        }
+    }
+}

--- a/pennylane_lightning/core/src/simulators/lightning_qubit/catalyst/tests/Test_LightningMeasures.cpp
+++ b/pennylane_lightning/core/src/simulators/lightning_qubit/catalyst/tests/Test_LightningMeasures.cpp
@@ -1844,6 +1844,7 @@ TEST_CASE("Probs with a seeded device", "[Measures]") {
     auto circuit = [](LQSimulator &sim, DataView<double, 1> &view,
                       std::mt19937 &gen) {
         sim.SetDevicePRNG(&gen);
+        sim.SetDeviceShots(1000);
         // state-vector with #qubits = n
         constexpr std::size_t n = 4;
         std::vector<intptr_t> Qs;
@@ -1867,11 +1868,6 @@ TEST_CASE("Probs with a seeded device", "[Measures]") {
         }
 
         for (std::size_t i = 0; i < probs[0].size(); i++) {
-            if (i == 4 || i == 6 || i == 12 || i == 14) {
-                CHECK(probs[0][i] == Approx(0.25).margin(1e-5));
-            } else {
-                CHECK(probs[0][i] == Approx(0.).margin(1e-5));
-            }
             CHECK((probs[0][i] == probs[1][i]));
         }
     }

--- a/pennylane_lightning/core/src/simulators/lightning_qubit/catalyst/tests/Test_LightningMeasures.cpp
+++ b/pennylane_lightning/core/src/simulators/lightning_qubit/catalyst/tests/Test_LightningMeasures.cpp
@@ -1833,6 +1833,7 @@ TEST_CASE("Sample with a seeded device", "[Measures]") {
 }
 
 TEST_CASE("Probs with a seeded device", "[Measures]") {
+    std::size_t shots = 1000;
     std::array<std::unique_ptr<LQSimulator>, 2> sims;
     std::vector<std::vector<double>> probs(2, std::vector<double>(16));
 
@@ -1841,10 +1842,10 @@ TEST_CASE("Probs with a seeded device", "[Measures]") {
 
     std::vector<std::mt19937> gens{std::mt19937{37}, std::mt19937{37}};
 
-    auto circuit = [](LQSimulator &sim, DataView<double, 1> &view,
-                      std::mt19937 &gen) {
+    auto circuit = [shots](LQSimulator &sim, DataView<double, 1> &view,
+                           std::mt19937 &gen) {
         sim.SetDevicePRNG(&gen);
-        sim.SetDeviceShots(1000);
+        sim.SetDeviceShots(shots);
         // state-vector with #qubits = n
         constexpr std::size_t n = 4;
         std::vector<intptr_t> Qs;

--- a/pennylane_lightning/core/src/simulators/lightning_qubit/catalyst/tests/Test_LightningMeasures.cpp
+++ b/pennylane_lightning/core/src/simulators/lightning_qubit/catalyst/tests/Test_LightningMeasures.cpp
@@ -1843,8 +1843,8 @@ TEST_CASE("Probs with a seeded device", "[Measures]") {
 
     std::vector<std::mt19937> gens{std::mt19937{37}, std::mt19937{37}};
 
-    auto circuit = [shots](LQSimulator &sim, DataView<double, 1> &view,
-                           std::mt19937 &gen) {
+    auto circuit = [](LQSimulator &sim, DataView<double, 1> &view,
+                      std::mt19937 &gen) {
         sim.SetDevicePRNG(&gen);
         sim.SetDeviceShots(shots);
         // state-vector with #qubits = n
@@ -1882,8 +1882,8 @@ TEST_CASE("Var with a seeded device", "[Measures]") {
 
     std::vector<std::mt19937> gens{std::mt19937{37}, std::mt19937{37}};
 
-    auto circuit = [shots](LQSimulator &sim, std::vector<double> &var,
-                           std::mt19937 &gen) {
+    auto circuit = [](LQSimulator &sim, std::vector<double> &var,
+                      std::mt19937 &gen) {
         sim.SetDevicePRNG(&gen);
         sim.SetDeviceShots(shots);
         // state-vector with #qubits = n
@@ -1928,8 +1928,8 @@ TEST_CASE("Expval with a seeded device", "[Measures]") {
 
     std::vector<std::mt19937> gens{std::mt19937{37}, std::mt19937{37}};
 
-    auto circuit = [shots](LQSimulator &sim, std::vector<double> &expval,
-                           std::mt19937 &gen) {
+    auto circuit = [](LQSimulator &sim, std::vector<double> &expval,
+                      std::mt19937 &gen) {
         sim.SetDevicePRNG(&gen);
         sim.SetDeviceShots(shots);
         // state-vector with #qubits = n

--- a/pennylane_lightning/core/src/simulators/lightning_qubit/catalyst/tests/Test_LightningMeasures.cpp
+++ b/pennylane_lightning/core/src/simulators/lightning_qubit/catalyst/tests/Test_LightningMeasures.cpp
@@ -1833,7 +1833,6 @@ TEST_CASE("Sample with a seeded device", "[Measures]") {
 }
 
 TEST_CASE("Probs with a seeded device", "[Measures]") {
-    std::size_t shots = 100;
     std::array<std::unique_ptr<LQSimulator>, 2> sims;
     std::vector<std::vector<double>> probs(2, std::vector<double>(16));
 
@@ -1842,8 +1841,8 @@ TEST_CASE("Probs with a seeded device", "[Measures]") {
 
     std::vector<std::mt19937> gens{std::mt19937{37}, std::mt19937{37}};
 
-    auto circuit = [shots](LQSimulator &sim, DataView<double, 1> &view,
-                           std::mt19937 &gen) {
+    auto circuit = [](LQSimulator &sim, DataView<double, 1> &view,
+                      std::mt19937 &gen) {
         sim.SetDevicePRNG(&gen);
         // state-vector with #qubits = n
         constexpr std::size_t n = 4;

--- a/pennylane_lightning/core/src/simulators/lightning_qubit/catalyst/tests/Test_LightningMeasures.cpp
+++ b/pennylane_lightning/core/src/simulators/lightning_qubit/catalyst/tests/Test_LightningMeasures.cpp
@@ -1834,7 +1834,7 @@ TEST_CASE("Sample with a seeded device", "[Measures]") {
 }
 
 TEST_CASE("Probs with a seeded device", "[Measures]") {
-    std::size_t shots = 1000;
+    constexpr std::size_t shots = 1000;
     std::array<std::unique_ptr<LQSimulator>, 2> sims;
     std::vector<std::vector<double>> probs(2, std::vector<double>(16));
 
@@ -1876,7 +1876,7 @@ TEST_CASE("Probs with a seeded device", "[Measures]") {
 }
 
 TEST_CASE("Var with a seeded device", "[Measures]") {
-    std::size_t shots = 1000;
+    constexpr std::size_t shots = 1000;
     std::array<std::unique_ptr<LQSimulator>, 2> sims;
     std::array<std::vector<double>, 2> vars;
 
@@ -1922,7 +1922,7 @@ TEST_CASE("Var with a seeded device", "[Measures]") {
 }
 
 TEST_CASE("Expval with a seeded device", "[Measures]") {
-    std::size_t shots = 1000;
+    constexpr std::size_t shots = 1000;
     std::array<std::unique_ptr<LQSimulator>, 2> sims;
     std::array<std::vector<double>, 2> expvals;
 

--- a/pennylane_lightning/core/src/simulators/lightning_qubit/catalyst/tests/Test_LightningMeasures.cpp
+++ b/pennylane_lightning/core/src/simulators/lightning_qubit/catalyst/tests/Test_LightningMeasures.cpp
@@ -1920,3 +1920,49 @@ TEST_CASE("Var with a seeded device", "[Measures]") {
         }
     }
 }
+
+TEST_CASE("Expval with a seeded device", "[Measures]") {
+    std::size_t shots = 1000;
+    std::array<std::unique_ptr<LQSimulator>, 2> sims;
+    std::array<std::vector<double>, 2> expvals;
+
+    std::vector<std::mt19937> gens{std::mt19937{37}, std::mt19937{37}};
+
+    auto circuit = [shots](LQSimulator &sim, std::vector<double> &expval,
+                           std::mt19937 &gen) {
+        sim.SetDevicePRNG(&gen);
+        sim.SetDeviceShots(shots);
+        // state-vector with #qubits = n
+        constexpr std::size_t n = 4;
+        std::vector<intptr_t> Qs;
+        Qs.reserve(n);
+        for (std::size_t i = 0; i < n; i++) {
+            Qs.push_back(sim.AllocateQubit());
+        }
+        sim.NamedOperation("Hadamard", {}, {Qs[0]}, false);
+        sim.NamedOperation("PauliY", {}, {Qs[1]}, false);
+        sim.NamedOperation("Hadamard", {}, {Qs[2]}, false);
+        sim.NamedOperation("PauliZ", {}, {Qs[3]}, false);
+
+        ObsIdType px = sim.Observable(ObsId::PauliX, {}, {Qs[2]});
+        ObsIdType py = sim.Observable(ObsId::PauliY, {}, {Qs[0]});
+        ObsIdType pz = sim.Observable(ObsId::PauliZ, {}, {Qs[3]});
+
+        expval.push_back(sim.Expval(px));
+        expval.push_back(sim.Expval(py));
+        expval.push_back(sim.Expval(pz));
+    };
+
+    for (std::size_t trial = 0; trial < 5; trial++) {
+        sims[0] = std::make_unique<LQSimulator>();
+        sims[1] = std::make_unique<LQSimulator>();
+
+        for (std::size_t sim_idx = 0; sim_idx < sims.size(); sim_idx++) {
+            circuit(*(sims[sim_idx]), expvals[sim_idx], gens[sim_idx]);
+        }
+
+        for (std::size_t i = 0; i < expvals[0].size(); i++) {
+            CHECK((expvals[0][i] == expvals[1][i]));
+        }
+    }
+}

--- a/pennylane_lightning/core/src/simulators/lightning_qubit/measurements/MeasurementsLQubit.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_qubit/measurements/MeasurementsLQubit.hpp
@@ -488,7 +488,7 @@ class Measurements final
         std::uniform_real_distribution<PrecisionT> distrib(0.0, 1.0);
         std::vector<std::size_t> samples(num_samples * num_qubits, 0);
         std::unordered_map<std::size_t, std::size_t> cache;
-        this->activateDeviceSeed();
+        this->setRandomSeed();
 
         TransitionKernelType transition_kernel = TransitionKernelType::Local;
         if (kernelname == "NonZeroRandom") {
@@ -502,13 +502,13 @@ class Measurements final
 
         // Burn In
         for (std::size_t i = 0; i < num_burnin; i++) {
-            idx = metropolis_step(this->_statevector, tk, this->rng, distrib,
+            idx = metropolis_step(this->_statevector, tk, this->_rng, distrib,
                                   idx); // Burn-in.
         }
 
         // Sample
         for (std::size_t i = 0; i < num_samples; i++) {
-            idx = metropolis_step(this->_statevector, tk, this->rng, distrib,
+            idx = metropolis_step(this->_statevector, tk, this->_rng, distrib,
                                   idx);
 
             if (cache.contains(idx)) {
@@ -596,8 +596,7 @@ class Measurements final
                      const std::size_t num_samples) {
         const std::size_t n_wires = wires.size();
         std::vector<std::size_t> samples(num_samples * n_wires);
-        this->activateDeviceSeed();
-        DiscreteRandomVariable<PrecisionT> drv{this->rng, probs(wires)};
+        DiscreteRandomVariable<PrecisionT> drv{this->_rng, probs(wires)};
         // The Python layer expects a 2D array with dimensions (n_samples x
         // n_wires) and hence the linear index is `s * n_wires + (n_wires - 1 -
         // j)` `s` being the "slow" row index and `j` being the "fast" column

--- a/pennylane_lightning/core/src/simulators/lightning_qubit/measurements/MeasurementsLQubit.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_qubit/measurements/MeasurementsLQubit.hpp
@@ -580,7 +580,12 @@ class Measurements final
      * @return 1-D vector of samples in binary, each sample is
      * separated by a stride equal to the number of qubits.
      */
-    std::vector<std::size_t> generate_samples(const std::size_t num_samples) {
+    std::vector<std::size_t>
+    generate_samples(const std::size_t num_samples,
+                     const std::optional<Measurements *> &m = std::nullopt) {
+        if (m.has_value() && m.value() != nullptr) {
+            this->set_PRNG(m.value()->get_PRNG());
+        }
         const std::size_t num_qubits = this->_statevector.getNumQubits();
         std::vector<std::size_t> wires(num_qubits);
         std::iota(wires.begin(), wires.end(), 0);
@@ -622,6 +627,8 @@ class Measurements final
     }
 
     void set_PRNG(std::mt19937 *gen) { this->gen = gen; }
+
+    std::mt19937 *get_PRNG() { return this->gen; }
 
   private:
     /**

--- a/pennylane_lightning/core/src/simulators/lightning_qubit/measurements/MeasurementsLQubit.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_qubit/measurements/MeasurementsLQubit.hpp
@@ -596,6 +596,7 @@ class Measurements final
                      const std::size_t num_samples) {
         const std::size_t n_wires = wires.size();
         std::vector<std::size_t> samples(num_samples * n_wires);
+        this->setSeed(this->_deviceseed);
         DiscreteRandomVariable<PrecisionT> drv{this->_rng, probs(wires)};
         // The Python layer expects a 2D array with dimensions (n_samples x
         // n_wires) and hence the linear index is `s * n_wires + (n_wires - 1 -

--- a/pennylane_lightning/core/src/simulators/lightning_qubit/measurements/MeasurementsLQubit.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_qubit/measurements/MeasurementsLQubit.hpp
@@ -606,7 +606,7 @@ class Measurements final
                      const std::size_t num_samples) {
         const std::size_t n_wires = wires.size();
         std::vector<std::size_t> samples(num_samples * n_wires);
-        if (gen != nullptr) {
+        if (this->gen != nullptr) {
             std::size_t seed = (*(this->gen))();
             this->setSeed(seed);
         } else {

--- a/pennylane_lightning/core/src/simulators/lightning_qubit/measurements/MeasurementsLQubit.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_qubit/measurements/MeasurementsLQubit.hpp
@@ -488,7 +488,7 @@ class Measurements final
         std::uniform_real_distribution<PrecisionT> distrib(0.0, 1.0);
         std::vector<std::size_t> samples(num_samples * num_qubits, 0);
         std::unordered_map<std::size_t, std::size_t> cache;
-        this->activate_DeviceSeed();
+        this->activateDeviceSeed();
 
         TransitionKernelType transition_kernel = TransitionKernelType::Local;
         if (kernelname == "NonZeroRandom") {
@@ -596,7 +596,7 @@ class Measurements final
                      const std::size_t num_samples) {
         const std::size_t n_wires = wires.size();
         std::vector<std::size_t> samples(num_samples * n_wires);
-        this->activate_DeviceSeed();
+        this->activateDeviceSeed();
         DiscreteRandomVariable<PrecisionT> drv{this->rng, probs(wires)};
         // The Python layer expects a 2D array with dimensions (n_samples x
         // n_wires) and hence the linear index is `s * n_wires + (n_wires - 1 -


### PR DESCRIPTION
**Context:** Currently, only `catalyst.measure()`, `qml.sample()` and `qml.counts()` can be seeded with qjit(seed=N). It would be nice to be able to seed all circuit readout methods, like `probs()`, `expval()`, `var()`, when executing a device with shots.

**Description of the Change:** Let the base measurement class store the device seed so it can be propagated when necessary to newly created derived measurements. Move the logic from the simulator to the base measurement class.

**Benefits:** All measurements using the `generate_samples` method will be seeded.

Measures to test locally:

- [x] `expval`
- [x] `var`
- [x] `probs`
- [x] `sample`
- [x] `counts`

Devices to modify

- [x] LQ
- [x] LK
- [x] LG

TODO

- [x] Simplify design
- [x] Document changes
- [x] Test probs using the LQ, LK and LG plugins
- [x] Test expval using the LQ, LK and LG plugins
- [x] Test var using the LQ, LK and LG plugins
- [x] Update changelog

[sc-77124]