### PR TITLE
Fix Lightning GPU Rot adjoint bug and enable Rot in toml

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -39,6 +39,9 @@
 
 ### Bug fixes
 
+* Fix issue with `lightning.gpu` Rot operation with adjoint.
+  [(#1004)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1004)
+
 * Fix issue with adjoint-jacobian of adjoint ops.
   [(#996)](https://github.com/PennyLaneAI/pennylane-lightning/pull/996)
 

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.40.0-dev15"
+__version__ = "0.40.0-dev16"

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.40.0-dev14"
+__version__ = "0.40.0-dev15"

--- a/pennylane_lightning/core/src/simulators/lightning_gpu/StateVectorCudaMPI.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_gpu/StateVectorCudaMPI.hpp
@@ -403,7 +403,9 @@ class StateVectorCudaMPI final
                 adjoint
                     ? cuGates::getRot<CFP_t>(-params[2], -params[1], -params[0])
                     : cuGates::getRot<CFP_t>(params[0], params[1], params[2]);
-            applyDeviceMatrixGate(rot_matrix.data(), ctrls, tgts, false);
+            // Use default adjoint=false for applyDeviceMatrixGate() as reversed
+            // rot_matrix explicitly used
+            applyDeviceMatrixGate(rot_matrix.data(), ctrls, tgts);
         } else if (opName == "Matrix") {
             applyDeviceMatrixGate(gate_matrix.data(), ctrls, tgts, adjoint);
         } else if (par_gates_.find(opName) != par_gates_.end()) {

--- a/pennylane_lightning/core/src/simulators/lightning_gpu/StateVectorCudaMPI.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_gpu/StateVectorCudaMPI.hpp
@@ -401,9 +401,9 @@ class StateVectorCudaMPI final
         } else if (opName == "Rot" || opName == "CRot") {
             auto rot_matrix =
                 adjoint
-                    ? cuGates::getRot<CFP_t>(params[2], params[1], params[0])
+                    ? cuGates::getRot<CFP_t>(-params[2], -params[1], -params[0])
                     : cuGates::getRot<CFP_t>(params[0], params[1], params[2]);
-            applyDeviceMatrixGate(rot_matrix.data(), ctrls, tgts, adjoint);
+            applyDeviceMatrixGate(rot_matrix.data(), ctrls, tgts, false);
         } else if (opName == "Matrix") {
             applyDeviceMatrixGate(gate_matrix.data(), ctrls, tgts, adjoint);
         } else if (par_gates_.find(opName) != par_gates_.end()) {

--- a/pennylane_lightning/core/src/simulators/lightning_gpu/StateVectorCudaMPI.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_gpu/StateVectorCudaMPI.hpp
@@ -400,12 +400,8 @@ class StateVectorCudaMPI final
                                      adjoint);
         } else if (opName == "Rot" || opName == "CRot") {
             auto rot_matrix =
-                adjoint
-                    ? cuGates::getRot<CFP_t>(-params[2], -params[1], -params[0])
-                    : cuGates::getRot<CFP_t>(params[0], params[1], params[2]);
-            // Use default adjoint=false for applyDeviceMatrixGate() as reversed
-            // rot_matrix explicitly used
-            applyDeviceMatrixGate(rot_matrix.data(), ctrls, tgts);
+                cuGates::getRot<CFP_t>(params[0], params[1], params[2]);
+            applyDeviceMatrixGate(rot_matrix.data(), ctrls, tgts, adjoint);
         } else if (opName == "Matrix") {
             applyDeviceMatrixGate(gate_matrix.data(), ctrls, tgts, adjoint);
         } else if (par_gates_.find(opName) != par_gates_.end()) {

--- a/pennylane_lightning/core/src/simulators/lightning_gpu/StateVectorCudaManaged.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_gpu/StateVectorCudaManaged.hpp
@@ -402,8 +402,6 @@ class StateVectorCudaManaged
         } else if (opName == "Rot") {
             auto rot_matrix =
                 cuGates::getRot<CFP_t>(params[0], params[1], params[2]);
-            // Use default adjoint=false for applyDeviceGeneralGate_() as
-            // reversed rot_matrix explicitly used
             applyDeviceGeneralGate_(rot_matrix.data(), ctrlsInt, tgtsInt,
                                     ctrls_valuesInt, adjoint);
         } else if (par_gates_.find(opName) != par_gates_.end()) {

--- a/pennylane_lightning/core/src/simulators/lightning_gpu/StateVectorCudaManaged.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_gpu/StateVectorCudaManaged.hpp
@@ -308,7 +308,9 @@ class StateVectorCudaManaged
                 adjoint
                     ? cuGates::getRot<CFP_t>(-params[2], -params[1], -params[0])
                     : cuGates::getRot<CFP_t>(params[0], params[1], params[2]);
-            applyDeviceMatrixGate_(rot_matrix.data(), ctrls, tgts, false);
+            // Use default adjoint=false for applyDeviceGeneralGate_() as
+            // reversed rot_matrix explicitly used
+            applyDeviceMatrixGate_(rot_matrix.data(), ctrls, tgts);
         } else if (opName == "Matrix") {
             applyDeviceMatrixGate_(gate_matrix.data(), ctrls, tgts, adjoint);
         } else if (par_gates_.find(opName) != par_gates_.end()) {
@@ -406,8 +408,10 @@ class StateVectorCudaManaged
                 adjoint
                     ? cuGates::getRot<CFP_t>(-params[2], -params[1], -params[0])
                     : cuGates::getRot<CFP_t>(params[0], params[1], params[2]);
+            // Use default adjoint=false for applyDeviceGeneralGate_() as
+            // reversed rot_matrix explicitly used
             applyDeviceGeneralGate_(rot_matrix.data(), ctrlsInt, tgtsInt,
-                                    ctrls_valuesInt, false);
+                                    ctrls_valuesInt);
         } else if (par_gates_.find(opName) != par_gates_.end()) {
             // TODO: offload to par_gates_ if available
             auto &gateMap =

--- a/pennylane_lightning/core/src/simulators/lightning_gpu/StateVectorCudaManaged.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_gpu/StateVectorCudaManaged.hpp
@@ -305,12 +305,8 @@ class StateVectorCudaManaged
                                       adjoint);
         } else if (opName == "Rot" || opName == "CRot") {
             auto rot_matrix =
-                adjoint
-                    ? cuGates::getRot<CFP_t>(-params[2], -params[1], -params[0])
-                    : cuGates::getRot<CFP_t>(params[0], params[1], params[2]);
-            // Use default adjoint=false for applyDeviceGeneralGate_() as
-            // reversed rot_matrix explicitly used
-            applyDeviceMatrixGate_(rot_matrix.data(), ctrls, tgts);
+                cuGates::getRot<CFP_t>(params[0], params[1], params[2]);
+            applyDeviceMatrixGate_(rot_matrix.data(), ctrls, tgts, adjoint);
         } else if (opName == "Matrix") {
             applyDeviceMatrixGate_(gate_matrix.data(), ctrls, tgts, adjoint);
         } else if (par_gates_.find(opName) != par_gates_.end()) {
@@ -405,13 +401,11 @@ class StateVectorCudaManaged
                                              params.front(), adjoint);
         } else if (opName == "Rot") {
             auto rot_matrix =
-                adjoint
-                    ? cuGates::getRot<CFP_t>(-params[2], -params[1], -params[0])
-                    : cuGates::getRot<CFP_t>(params[0], params[1], params[2]);
+                cuGates::getRot<CFP_t>(params[0], params[1], params[2]);
             // Use default adjoint=false for applyDeviceGeneralGate_() as
             // reversed rot_matrix explicitly used
             applyDeviceGeneralGate_(rot_matrix.data(), ctrlsInt, tgtsInt,
-                                    ctrls_valuesInt);
+                                    ctrls_valuesInt, adjoint);
         } else if (par_gates_.find(opName) != par_gates_.end()) {
             // TODO: offload to par_gates_ if available
             auto &gateMap =

--- a/pennylane_lightning/core/src/simulators/lightning_gpu/StateVectorCudaManaged.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_gpu/StateVectorCudaManaged.hpp
@@ -304,15 +304,11 @@ class StateVectorCudaManaged
             applyParametricPauliGate_({opName}, ctrls, tgts, params.front(),
                                       adjoint);
         } else if (opName == "Rot" || opName == "CRot") {
-            if (adjoint) {
-                auto rot_matrix =
-                    cuGates::getRot<CFP_t>(params[2], params[1], params[0]);
-                applyDeviceMatrixGate_(rot_matrix.data(), ctrls, tgts, true);
-            } else {
-                auto rot_matrix =
-                    cuGates::getRot<CFP_t>(params[0], params[1], params[2]);
-                applyDeviceMatrixGate_(rot_matrix.data(), ctrls, tgts, false);
-            }
+            auto rot_matrix =
+                adjoint
+                    ? cuGates::getRot<CFP_t>(-params[2], -params[1], -params[0])
+                    : cuGates::getRot<CFP_t>(params[0], params[1], params[2]);
+            applyDeviceMatrixGate_(rot_matrix.data(), ctrls, tgts, false);
         } else if (opName == "Matrix") {
             applyDeviceMatrixGate_(gate_matrix.data(), ctrls, tgts, adjoint);
         } else if (par_gates_.find(opName) != par_gates_.end()) {
@@ -408,10 +404,10 @@ class StateVectorCudaManaged
         } else if (opName == "Rot") {
             auto rot_matrix =
                 adjoint
-                    ? cuGates::getRot<CFP_t>(params[2], params[1], params[0])
+                    ? cuGates::getRot<CFP_t>(-params[2], -params[1], -params[0])
                     : cuGates::getRot<CFP_t>(params[0], params[1], params[2]);
             applyDeviceGeneralGate_(rot_matrix.data(), ctrlsInt, tgtsInt,
-                                    ctrls_valuesInt, adjoint);
+                                    ctrls_valuesInt, false);
         } else if (par_gates_.find(opName) != par_gates_.end()) {
             // TODO: offload to par_gates_ if available
             auto &gateMap =

--- a/pennylane_lightning/core/src/simulators/lightning_gpu/gates/tests/Test_StateVectorCudaManaged_Param.cpp
+++ b/pennylane_lightning/core/src/simulators/lightning_gpu/gates/tests/Test_StateVectorCudaManaged_Param.cpp
@@ -372,7 +372,7 @@ TEMPLATE_TEST_CASE("LightningGPU::applyRot", "[LightningGPU_Param]", float,
     for (std::size_t i = 0; i < angles.size(); i++) {
         const auto rot_mat =
             (adjoint) ? Gates::getRot<std::complex, TestType>(
-                            -angles[i][0], -angles[i][1], -angles[i][2])
+                            -angles[i][2], -angles[i][1], -angles[i][0])
                       : Gates::getRot<std::complex, TestType>(
                             angles[i][0], angles[i][1], angles[i][2]);
         expected_results[i][0] = rot_mat[0];
@@ -419,7 +419,7 @@ TEMPLATE_TEST_CASE("LightningGPU::applyCRot", "[LightningGPU_Param]", float,
 
     std::vector<cp_t> expected_results(8);
     const auto rot_mat = (adjoint) ? Gates::getRot<std::complex, TestType>(
-                                         -angles[0], -angles[1], -angles[2])
+                                         -angles[2], -angles[1], -angles[0])
                                    : Gates::getRot<std::complex, TestType>(
                                          angles[0], angles[1], angles[2]);
 

--- a/pennylane_lightning/lightning_gpu/lightning_gpu.toml
+++ b/pennylane_lightning/lightning_gpu/lightning_gpu.toml
@@ -32,7 +32,7 @@ PhaseShift             = { properties = [ "invertible", "controllable", "differe
 RX                     = { properties = [ "invertible", "controllable", "differentiable" ] }
 RY                     = { properties = [ "invertible", "controllable", "differentiable" ] }
 RZ                     = { properties = [ "invertible", "controllable", "differentiable" ] }
-Rot                    = { properties = [               "controllable", "differentiable" ] }
+Rot                    = { properties = [ "invertible", "controllable", "differentiable" ] }
 CNOT                   = { properties = [ "invertible",                 "differentiable" ] }
 CY                     = { properties = [ "invertible",                 "differentiable" ] }
 CZ                     = { properties = [ "invertible",                 "differentiable" ] }
@@ -47,7 +47,7 @@ ControlledPhaseShift   = { properties = [ "invertible",                 "differe
 CRX                    = { properties = [ "invertible",                 "differentiable" ] }
 CRY                    = { properties = [ "invertible",                 "differentiable" ] }
 CRZ                    = { properties = [ "invertible",                 "differentiable" ] }
-CRot                   = { }
+CRot                   = { properties = [ "invertible"                                   ] }
 SingleExcitation       = { properties = [ "invertible", "controllable", "differentiable" ] }
 SingleExcitationPlus   = { properties = [ "invertible", "controllable", "differentiable" ] }
 SingleExcitationMinus  = { properties = [ "invertible", "controllable", "differentiable" ] }


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [X] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [ ] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [ ] Ensure that the test suite passes, by running `make test`.

- [X] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [X] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**
Previously the implementation of Rot and CRot gates (e.g. `Rot(a, b, c)`) with adjoint in LGPU ended up multiplying `Rot(-a, -b, -c)` instead of `Rot(-c, -b, -a)`. The error was not found in tests since the C++ tests used the wrong adjoint rotation matrix, and since `Adjoint(Rot)` and `Adjoint(CRot)` were not in the frozenset, they were not executed in the Python tests. The error is found when adding the invertible capability for Rot and CRot and [the following test](https://github.com/PennyLaneAI/pennylane-lightning/blob/45a67d495552ca9aca3c05467b16b1b6d2e1d4ab/tests/test_apply.py#L1362) fails. 

**Description of the Change:**
This PR fixes the implementation and C++ tests. The toml file is also updated to enable `Adjoint(Rot)` and `Adjoint(CRot)` from Python.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**

[sc-78931]