### PR TITLE
LGPU simulator support controlled ops

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -23,6 +23,9 @@
 
 ### Improvements
 
+* Enable N-controlled gate and matrix support to `lightning.gpu` simulator for Catalyst.
+  [(#1005)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1005)
+
 * Update Kokkos version support to 4.4.1 and enable Lightning-Kokkos[CUDA] C++ tests on CI.
   [(#1000)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1000)
 

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.40.0-dev17"
+__version__ = "0.40.0-dev18"

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.40.0-dev19"
+__version__ = "0.40.0-dev20"

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.40.0-dev16"
+__version__ = "0.40.0-dev17"

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.40.0-dev18"
+__version__ = "0.40.0-dev19"

--- a/pennylane_lightning/core/src/simulators/lightning_gpu/catalyst/LightningGPUSimulator.cpp
+++ b/pennylane_lightning/core/src/simulators/lightning_gpu/catalyst/LightningGPUSimulator.cpp
@@ -165,7 +165,7 @@ void LightningGPUSimulator::NamedOperation(
                "Given controlled wires do not refer to qubits");
 
     // Convert wires to device wires
-    auto &&dev_wires = getDeviceWires(wires);    
+    auto &&dev_wires = getDeviceWires(wires);
     auto &&dev_controlled_wires = getDeviceWires(controlled_wires);
 
     // Update the state-vector
@@ -173,7 +173,8 @@ void LightningGPUSimulator::NamedOperation(
         this->device_sv->applyOperation(name, dev_wires, inverse, params);
     } else {
         this->device_sv->applyOperation(name, dev_controlled_wires,
-                                        controlled_values, dev_wires, inverse, params);
+                                        controlled_values, dev_wires, inverse,
+                                        params);
     }
 
     // Update tape caching if required
@@ -196,13 +197,15 @@ void LightningGPUSimulator::MatrixOperation(
                "Given controlled wires do not refer to qubits");
 
     // Convert wires to device wires
-    auto &&dev_wires = getDeviceWires(wires);    
+    auto &&dev_wires = getDeviceWires(wires);
     auto &&dev_controlled_wires = getDeviceWires(controlled_wires);
 
     if (controlled_wires.empty()) {
-    this->device_sv->applyMatrix(matrix, dev_wires, inverse);
+        this->device_sv->applyMatrix(matrix, dev_wires, inverse);
     } else {
-        this->device_sv->applyOperation("matrix", dev_controlled_wires, controlled_values, dev_wires, inverse, {}, matrix);
+        this->device_sv->applyOperation("matrix", dev_controlled_wires,
+                                        controlled_values, dev_wires, inverse,
+                                        {}, matrix);
     }
 
     // Update tape caching if required

--- a/pennylane_lightning/core/src/simulators/lightning_gpu/catalyst/tests/Test_LightningGPUSimulator.cpp
+++ b/pennylane_lightning/core/src/simulators/lightning_gpu/catalyst/tests/Test_LightningGPUSimulator.cpp
@@ -681,7 +681,8 @@ TEST_CASE("LightningGPUSimulator::GateSet", "[GateSet]") {
     // ============= Controlled operations =============
 
     SECTION("Controlled Pauli-X and RX") {
-        std::unique_ptr<LGPUSimulator> LGPUsim = std::make_unique<LGPUSimulator>();
+        std::unique_ptr<LGPUSimulator> LGPUsim =
+            std::make_unique<LGPUSimulator>();
 
         constexpr std::size_t n_qubits = 2;
         std::vector<intptr_t> Qs;
@@ -693,7 +694,8 @@ TEST_CASE("LightningGPUSimulator::GateSet", "[GateSet]") {
 
         LGPUsim->NamedOperation("Hadamard", {}, {Qs[0]}, false);
         LGPUsim->NamedOperation("PauliX", {}, {Qs[1]}, false, {Qs[0]}, {true});
-        LGPUsim->NamedOperation("RX", {M_PI_2}, {Qs[1]}, false, {Qs[0]}, {true});
+        LGPUsim->NamedOperation("RX", {M_PI_2}, {Qs[1]}, false, {Qs[0]},
+                                {true});
 
         std::vector<std::complex<double>> state(1U << LGPUsim->GetNumQubits());
         DataView<std::complex<double>, 1> view(state);
@@ -711,7 +713,8 @@ TEST_CASE("LightningGPUSimulator::GateSet", "[GateSet]") {
     }
 
     SECTION("Hadamard, CNOT and Matrix") {
-        std::unique_ptr<LGPUSimulator> LGPUsim = std::make_unique<LGPUSimulator>();
+        std::unique_ptr<LGPUSimulator> LGPUsim =
+            std::make_unique<LGPUSimulator>();
 
         constexpr std::size_t n_qubits = 2;
         std::vector<intptr_t> Qs = LGPUsim->AllocateQubits(n_qubits);
@@ -729,7 +732,7 @@ TEST_CASE("LightningGPUSimulator::GateSet", "[GateSet]") {
             {-0.8818365947322423, -0.26456390390903695},
         };
         LGPUsim->MatrixOperation(matrix, wires, false, controlled_wires,
-                               controlled_values);
+                                 controlled_values);
 
         std::vector<std::complex<double>> state(1U << LGPUsim->GetNumQubits());
         DataView<std::complex<double>, 1> view(state);
@@ -748,12 +751,14 @@ TEST_CASE("LightningGPUSimulator::GateSet", "[GateSet]") {
     }
 
     SECTION("Mismatch controlled wires") {
-        std::unique_ptr<LGPUSimulator> LGPUsim = std::make_unique<LGPUSimulator>();
+        std::unique_ptr<LGPUSimulator> LGPUsim =
+            std::make_unique<LGPUSimulator>();
         constexpr std::size_t n_qubits = 2;
         std::vector<intptr_t> Qs = LGPUsim->AllocateQubits(n_qubits);
 
         REQUIRE_THROWS_WITH(
-            LGPUsim->NamedOperation("Hadamard", {}, {Qs[0]}, false, {Qs[1]}, {}),
+            LGPUsim->NamedOperation("Hadamard", {}, {Qs[0]}, false, {Qs[1]},
+                                    {}),
             Catch::Contains("Controlled wires/values size mismatch"));
         std::vector<std::complex<double>> matrix{
             {-0.6709485262524046, -0.6304426335363695},

--- a/pennylane_lightning/core/src/simulators/lightning_gpu/catalyst/tests/Test_LightningGPUSimulator.cpp
+++ b/pennylane_lightning/core/src/simulators/lightning_gpu/catalyst/tests/Test_LightningGPUSimulator.cpp
@@ -761,7 +761,7 @@ TEST_CASE("LightningGPUSimulator::GateSet", "[GateSet]") {
             LGPUsim->NamedOperation("Hadamard", {}, {Qs[0]}, false, {Qs[1]},
                                     {}),
             Catch::Contains("Controlled wires/values size mismatch"));
-        std::vector<std::complex<double>> matrix (4, {0.0, 0.0});
+        std::vector<std::complex<double>> matrix(4, {0.0, 0.0});
         REQUIRE_THROWS_WITH(
             LGPUsim->MatrixOperation(matrix, {Qs[0]}, false, {Qs[1]}, {}),
             Catch::Contains("Controlled wires/values size mismatch"));

--- a/pennylane_lightning/core/src/simulators/lightning_gpu/catalyst/tests/Test_LightningGPUSimulator.cpp
+++ b/pennylane_lightning/core/src/simulators/lightning_gpu/catalyst/tests/Test_LightningGPUSimulator.cpp
@@ -738,6 +738,7 @@ TEST_CASE("LightningGPUSimulator::GateSet", "[GateSet]") {
         DataView<std::complex<double>, 1> view(state);
         LGPUsim->State(view);
 
+        // calculated by pennylane.
         CHECK(state[0] == PLApproxComplex(std::complex<double>{0.70710678, 0.0})
                               .epsilon(1e-5));
         CHECK(state[1] ==
@@ -760,12 +761,7 @@ TEST_CASE("LightningGPUSimulator::GateSet", "[GateSet]") {
             LGPUsim->NamedOperation("Hadamard", {}, {Qs[0]}, false, {Qs[1]},
                                     {}),
             Catch::Contains("Controlled wires/values size mismatch"));
-        std::vector<std::complex<double>> matrix{
-            {-0.6709485262524046, -0.6304426335363695},
-            {-0.14885403153998722, 0.3608498832392019},
-            {-0.2376311670004963, 0.3096798175687841},
-            {-0.8818365947322423, -0.26456390390903695},
-        };
+        std::vector<std::complex<double>> matrix (4, {0.0, 0.0});
         REQUIRE_THROWS_WITH(
             LGPUsim->MatrixOperation(matrix, {Qs[0]}, false, {Qs[1]}, {}),
             Catch::Contains("Controlled wires/values size mismatch"));

--- a/pennylane_lightning/core/src/simulators/lightning_gpu/catalyst/tests/Test_LightningGPUSimulator.cpp
+++ b/pennylane_lightning/core/src/simulators/lightning_gpu/catalyst/tests/Test_LightningGPUSimulator.cpp
@@ -678,8 +678,6 @@ TEST_CASE("LightningGPUSimulator::GateSet", "[GateSet]") {
         REQUIRE(LGPUsim->CacheManagerInfo() == expected);
     }
 
-    // ============= Controlled operations =============
-
     SECTION("Controlled Pauli-X and RX") {
         std::unique_ptr<LGPUSimulator> LGPUsim =
             std::make_unique<LGPUSimulator>();


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [X] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [ ] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [X] Ensure that the test suite passes, by running `make test`.

- [X] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [X] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**
This PR updates the Lightning GPU simulator for Catalyst to support controlled gates and matrices. 

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**

[sc-79061]