### PR TITLE
update LQ generator vector insert order

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -23,6 +23,9 @@
 
 ### Improvements
 
+* Reverse Lightning Qubit generators vector insertion order.
+  [(#1009)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1009)
+
 * Update Kokkos version support to 4.4.1 and enable Lightning-Kokkos[CUDA] C++ tests on CI.
   [(#1000)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1000)
 

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.40.0-dev17"
+__version__ = "0.40.0-dev18"

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.40.0-dev18"
+__version__ = "0.40.0-dev19"

--- a/pennylane_lightning/core/src/simulators/lightning_qubit/gates/cpu_kernels/GateImplementationsLM.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_qubit/gates/cpu_kernels/GateImplementationsLM.hpp
@@ -1946,9 +1946,9 @@ class GateImplementationsLM : public PauliGenerator<GateImplementationsLM> {
 
         std::vector<std::size_t> all_wires;
         all_wires.reserve(nw_tot);
-        all_wires.insert(all_wires.begin(), wires.begin(), wires.end());
         all_wires.insert(all_wires.begin(), controlled_wires.begin(),
                          controlled_wires.end());
+        all_wires.insert(all_wires.begin() + n_contr, wires.begin(), wires.end());
         const auto revs = reverseWires(num_qubits, all_wires, {});
         const auto &rev_wires = revs.first;
         const std::vector<std::size_t> parity =
@@ -2166,9 +2166,9 @@ class GateImplementationsLM : public PauliGenerator<GateImplementationsLM> {
 
         std::vector<std::size_t> all_wires;
         all_wires.reserve(nw_tot);
-        all_wires.insert(all_wires.begin(), wires.begin(), wires.end());
         all_wires.insert(all_wires.begin(), controlled_wires.begin(),
                          controlled_wires.end());
+        all_wires.insert(all_wires.begin() + n_contr, wires.begin(), wires.end());
         const auto revs = reverseWires(num_qubits, all_wires, {});
         const auto &rev_wires = revs.first;
         const std::vector<std::size_t> parity =
@@ -2448,9 +2448,9 @@ class GateImplementationsLM : public PauliGenerator<GateImplementationsLM> {
 
         std::vector<std::size_t> all_wires;
         all_wires.reserve(nw_tot);
-        all_wires.insert(all_wires.begin(), wires.begin(), wires.end());
         all_wires.insert(all_wires.begin(), controlled_wires.begin(),
                          controlled_wires.end());
+        all_wires.insert(all_wires.begin() + n_contr, wires.begin(), wires.end());
         const auto revs = reverseWires(num_qubits, all_wires, {});
         const auto &rev_wires = revs.first;
         const std::vector<std::size_t> parity =

--- a/pennylane_lightning/core/src/simulators/lightning_qubit/gates/cpu_kernels/GateImplementationsLM.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_qubit/gates/cpu_kernels/GateImplementationsLM.hpp
@@ -1948,7 +1948,8 @@ class GateImplementationsLM : public PauliGenerator<GateImplementationsLM> {
         all_wires.reserve(nw_tot);
         all_wires.insert(all_wires.begin(), controlled_wires.begin(),
                          controlled_wires.end());
-        all_wires.insert(all_wires.begin() + n_contr, wires.begin(), wires.end());
+        all_wires.insert(all_wires.begin() + n_contr, wires.begin(),
+                         wires.end());
         const auto revs = reverseWires(num_qubits, all_wires, {});
         const auto &rev_wires = revs.first;
         const std::vector<std::size_t> parity =
@@ -2168,7 +2169,8 @@ class GateImplementationsLM : public PauliGenerator<GateImplementationsLM> {
         all_wires.reserve(nw_tot);
         all_wires.insert(all_wires.begin(), controlled_wires.begin(),
                          controlled_wires.end());
-        all_wires.insert(all_wires.begin() + n_contr, wires.begin(), wires.end());
+        all_wires.insert(all_wires.begin() + n_contr, wires.begin(),
+                         wires.end());
         const auto revs = reverseWires(num_qubits, all_wires, {});
         const auto &rev_wires = revs.first;
         const std::vector<std::size_t> parity =
@@ -2450,7 +2452,8 @@ class GateImplementationsLM : public PauliGenerator<GateImplementationsLM> {
         all_wires.reserve(nw_tot);
         all_wires.insert(all_wires.begin(), controlled_wires.begin(),
                          controlled_wires.end());
-        all_wires.insert(all_wires.begin() + n_contr, wires.begin(), wires.end());
+        all_wires.insert(all_wires.begin() + n_contr, wires.begin(),
+                         wires.end());
         const auto revs = reverseWires(num_qubits, all_wires, {});
         const auto &rev_wires = revs.first;
         const std::vector<std::size_t> parity =


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [ ] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [X] Ensure that the test suite passes, by running `make test`.

- [X] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [X] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**
Currently in `GateImplementationsLM.hpp` some generator functions performs two std::vector insertions to the same vector, both to the beginning of the destination vectors.

**Description of the Change:**
The order is swapped, and the second vector is inserted to the end of the vector. This should be more performant.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**

[sc-78933]