### PR TITLE
Fix LQubit editable mode path

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -25,7 +25,7 @@
 
 * Enable N-controlled gate and matrix support to `lightning.gpu` simulator for Catalyst.
   [(#1005)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1005)
-  
+
 * Reverse Lightning Qubit generators vector insertion order.
   [(#1009)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1009)
 
@@ -50,6 +50,9 @@
   [(#979)](https://github.com/PennyLaneAI/pennylane-lightning/pull/979)
 
 ### Bug fixes
+
+* Fix Lightning Kokkos editable mode path.
+  [(#1010)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1010)
 
 * Fix version switch condition the GPU workflow tests for LGPU and LKokkos.
   [(#1006)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1006)

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.40.0-dev20"
+__version__ = "0.40.0-dev21"

--- a/pennylane_lightning/lightning_qubit/lightning_qubit.py
+++ b/pennylane_lightning/lightning_qubit/lightning_qubit.py
@@ -507,7 +507,7 @@ class LightningQubit(LightningBase):
         #   lib.<system>-<architecture>-<python-id>"
         # To avoid mismatching the folder name, we search for the shared object instead.
         # TODO: locate where the naming convention of the folder is decided and replicate it here.
-        editable_mode_path = package_root.parent.parent / "build"
+        editable_mode_path = package_root.parent.parent / "build_lightning_qubit"
         for path, _, files in os.walk(editable_mode_path):
             if lib_name in files:
                 lib_location = (Path(path) / lib_name).as_posix()


### PR DESCRIPTION
**Context:** LQubit editable mode path is wrong. This PR fixes that. Please ignore the references to LKokkos.

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**

[sc-79333]