### PR TITLE
Build LK with GCC 11 for testing CIs  

### DIFF
--- a/.github/workflows/build_and_cache_Kokkos_linux.yml
+++ b/.github/workflows/build_and_cache_Kokkos_linux.yml
@@ -1,7 +1,7 @@
 name: Build and Cache Kokkos
 
 env:
-  GCC_VERSION: 13
+  GCC_VERSION: 11
 
 on:
   workflow_call:

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.40.0-dev22"
+__version__ = "0.40.0-dev23"


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [ ] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [ ] Ensure that the test suite passes, by running `make test`.

- [ ] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [ ] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**

PR #1007 forced all CIs to build and test Kokkos and Lightning-Kokkos with GCC-13. [This change broke the LK testing action](https://github.com/PennyLaneAI/pennylane-lightning/actions/runs/12075970714/job/33676642868) as we still use GCC11 for testing Lightning, and GCC13 for building wheels inside manylinux_2_28. This PR reverts that change for now :(  


**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
