### PR TITLE
Adding unit test for measurement with shots for LT with `tn` method

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -29,6 +29,9 @@
 
 ### Improvements
 
+* Add unit test for measurement with shots for Lightning Tensor with `tn` method.
+  [(#1027)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1027)
+
 * Update the python layer UI of Lightning Tensor.
   [(#1022)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1022/)
 

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.40.0-dev37"
+__version__ = "0.40.0-dev38"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -195,14 +195,22 @@ def qubit_device(request):
 # General LightningStateVector fixture, for any number of wires.
 @pytest.fixture(
     scope="function",
-    params=[np.complex64, np.complex128] if device_name != "lightning.tensor" else [
-        [c_dtype, method] for c_dtype in [np.complex64, np.complex128] for method in ["mps", "tn"]
-    ],
+    params=(
+        [np.complex64, np.complex128]
+        if device_name != "lightning.tensor"
+        else [
+            [c_dtype, method]
+            for c_dtype in [np.complex64, np.complex128]
+            for method in ["mps", "tn"]
+        ]
+    ),
 )
 def lightning_sv(request):
     def _statevector(num_wires):
         if device_name == "lightning.tensor":
-            return LightningStateVector(num_wires=num_wires, c_dtype=request.param[0], method=request.param[1])
+            return LightningStateVector(
+                num_wires=num_wires, c_dtype=request.param[0], method=request.param[1]
+            )
         return LightningStateVector(num_wires=num_wires, dtype=request.param)
 
     return _statevector

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -195,12 +195,14 @@ def qubit_device(request):
 # General LightningStateVector fixture, for any number of wires.
 @pytest.fixture(
     scope="function",
-    params=[np.complex64, np.complex128],
+    params=[np.complex64, np.complex128] if device_name != "lightning.tensor" else [
+        [c_dtype, method] for c_dtype in [np.complex64, np.complex128] for method in ["mps", "tn"]
+    ],
 )
 def lightning_sv(request):
     def _statevector(num_wires):
         if device_name == "lightning.tensor":
-            return LightningStateVector(num_wires=num_wires, c_dtype=request.param)
+            return LightningStateVector(num_wires=num_wires, c_dtype=request.param[0], method=request.param[1])
         return LightningStateVector(num_wires=num_wires, dtype=request.param)
 
     return _statevector

--- a/tests/lightning_qubit/test_measurements_class.py
+++ b/tests/lightning_qubit/test_measurements_class.py
@@ -545,7 +545,7 @@ class TestMeasurements:
 
         # a few tests may fail in single precision, and hence we increase the tolerance
         if shots is None:
-            assert np.allclose(result, expected, max(tol, 1.0e-4))
+            assert np.allclose(result, expected, max(tol, 1.0e-4), 1e-6 if statevector.dtype == np.complex64 else 1e-8 )
         else:
             # TODO Set better atol and rtol
             dtol = max(tol, 1.0e-2)
@@ -788,6 +788,10 @@ class TestControlledOps:
                 tape = qml.tape.QuantumScript(ops, measurements)
 
                 statevector = lightning_sv(n_qubits)
+                if device_name == "lightning.tensor":
+                    if statevector.method == "tn":
+                        pytest.skip("StatePrep not supported in lightning.tensor with the tn method.")
+                        
                 statevector = get_final_state(statevector, tape)
                 m = LightningMeasurements(statevector)
                 result = measure_final_state(m, tape)
@@ -845,6 +849,11 @@ class TestControlledOps:
         )
 
         statevector = lightning_sv(n_qubits)
+        if device_name == "lightning.tensor":
+            if statevector.method == "tn":
+                pytest.skip("StatePrep not supported in lightning.tensor with the tn method.")
+                        
+
         statevector = get_final_state(statevector, tape)
         m = LightningMeasurements(statevector)
         result = measure_final_state(m, tape)
@@ -889,6 +898,10 @@ class TestControlledOps:
                     [qml.state()],
                 )
                 statevector = lightning_sv(n_qubits)
+                if device_name == "lightning.tensor":
+                    if statevector.method == "tn":
+                        pytest.skip("StatePrep not supported in lightning.tensor with the tn method.")
+                        
                 statevector = get_final_state(statevector, tape)
                 m = LightningMeasurements(statevector)
                 result = measure_final_state(m, tape)
@@ -967,6 +980,10 @@ def test_state_vector_2_qubit_subset(tol, op, par, wires, expected, lightning_sv
     )
 
     statevector = lightning_sv(2)
+    if device_name == "lightning.tensor":
+        if statevector.method == "tn":
+            pytest.skip("StatePrep not supported in lightning.tensor with the tn method.")
+
     statevector = get_final_state(statevector, tape)
 
     m = LightningMeasurements(statevector)

--- a/tests/lightning_qubit/test_measurements_class.py
+++ b/tests/lightning_qubit/test_measurements_class.py
@@ -545,7 +545,12 @@ class TestMeasurements:
 
         # a few tests may fail in single precision, and hence we increase the tolerance
         if shots is None:
-            assert np.allclose(result, expected, max(tol, 1.0e-4), 1e-6 if statevector.dtype == np.complex64 else 1e-8 )
+            assert np.allclose(
+                result,
+                expected,
+                max(tol, 1.0e-4),
+                1e-6 if statevector.dtype == np.complex64 else 1e-8,
+            )
         else:
             # TODO Set better atol and rtol
             dtol = max(tol, 1.0e-2)
@@ -790,8 +795,10 @@ class TestControlledOps:
                 statevector = lightning_sv(n_qubits)
                 if device_name == "lightning.tensor":
                     if statevector.method == "tn":
-                        pytest.skip("StatePrep not supported in lightning.tensor with the tn method.")
-                        
+                        pytest.skip(
+                            "StatePrep not supported in lightning.tensor with the tn method."
+                        )
+
                 statevector = get_final_state(statevector, tape)
                 m = LightningMeasurements(statevector)
                 result = measure_final_state(m, tape)
@@ -852,7 +859,6 @@ class TestControlledOps:
         if device_name == "lightning.tensor":
             if statevector.method == "tn":
                 pytest.skip("StatePrep not supported in lightning.tensor with the tn method.")
-                        
 
         statevector = get_final_state(statevector, tape)
         m = LightningMeasurements(statevector)
@@ -900,8 +906,10 @@ class TestControlledOps:
                 statevector = lightning_sv(n_qubits)
                 if device_name == "lightning.tensor":
                     if statevector.method == "tn":
-                        pytest.skip("StatePrep not supported in lightning.tensor with the tn method.")
-                        
+                        pytest.skip(
+                            "StatePrep not supported in lightning.tensor with the tn method."
+                        )
+
                 statevector = get_final_state(statevector, tape)
                 m = LightningMeasurements(statevector)
                 result = measure_final_state(m, tape)

--- a/tests/lightning_qubit/test_measurements_class.py
+++ b/tests/lightning_qubit/test_measurements_class.py
@@ -793,11 +793,8 @@ class TestControlledOps:
                 tape = qml.tape.QuantumScript(ops, measurements)
 
                 statevector = lightning_sv(n_qubits)
-                if device_name == "lightning.tensor":
-                    if statevector.method == "tn":
-                        pytest.skip(
-                            "StatePrep not supported in lightning.tensor with the tn method."
-                        )
+                if device_name == "lightning.tensor" and statevector.method == "tn":
+                    pytest.skip("StatePrep not supported in lightning.tensor with the tn method.")
 
                 statevector = get_final_state(statevector, tape)
                 m = LightningMeasurements(statevector)
@@ -856,9 +853,8 @@ class TestControlledOps:
         )
 
         statevector = lightning_sv(n_qubits)
-        if device_name == "lightning.tensor":
-            if statevector.method == "tn":
-                pytest.skip("StatePrep not supported in lightning.tensor with the tn method.")
+        if device_name == "lightning.tensor" and statevector.method == "tn":
+            pytest.skip("StatePrep not supported in lightning.tensor with the tn method.")
 
         statevector = get_final_state(statevector, tape)
         m = LightningMeasurements(statevector)
@@ -904,11 +900,8 @@ class TestControlledOps:
                     [qml.state()],
                 )
                 statevector = lightning_sv(n_qubits)
-                if device_name == "lightning.tensor":
-                    if statevector.method == "tn":
-                        pytest.skip(
-                            "StatePrep not supported in lightning.tensor with the tn method."
-                        )
+                if device_name == "lightning.tensor" and statevector.method == "tn":
+                    pytest.skip("StatePrep not supported in lightning.tensor with the tn method.")
 
                 statevector = get_final_state(statevector, tape)
                 m = LightningMeasurements(statevector)
@@ -988,9 +981,8 @@ def test_state_vector_2_qubit_subset(tol, op, par, wires, expected, lightning_sv
     )
 
     statevector = lightning_sv(2)
-    if device_name == "lightning.tensor":
-        if statevector.method == "tn":
-            pytest.skip("StatePrep not supported in lightning.tensor with the tn method.")
+    if device_name == "lightning.tensor" and statevector.method == "tn":
+        pytest.skip("StatePrep not supported in lightning.tensor with the tn method.")
 
     statevector = get_final_state(statevector, tape)
 


### PR DESCRIPTION

**Context:**
With Lightning Tensor, ensure `tn` has feature parity with `mps` method.

**Description of the Change:**
Using the current testing suite for measurement, we change only the `conftest.py` file to make available the `tn` method with Lightning Tensor

**Benefits:**
Change only a few lines in the code. 

**Possible Drawbacks:**
The testing time will increase double for Lightning Tensor :disappointed: 

**Related GitHub Issues:**

[sc-65726]