### PR TITLE
Add the `CaptureMPSState()` API to LT

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -29,6 +29,9 @@
 
 ### Improvements
 
+* Replace the `dummy_tensor_update` method with the `cutensornetStateCaptureMPS`API to ensure that further gates apply is allowed after the `cutensornetStateCompute` call.
+  [(#1028)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1028/)
+
 * Update the python layer UI of Lightning Tensor.
   [(#1022)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1022/)
 

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.40.0-dev38"
+__version__ = "0.40.0-dev39"

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.40.0-dev39"
+__version__ = "0.40.0-dev40"

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.40.0-dev37"
+__version__ = "0.40.0-dev38"

--- a/pennylane_lightning/core/src/simulators/lightning_tensor/tncuda/MPSTNCuda.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_tensor/tncuda/MPSTNCuda.hpp
@@ -238,20 +238,9 @@ class MPSTNCuda final : public TNCuda<Precision, MPSTNCuda<Precision>> {
             const_cast<int64_t **>(BaseType::getSitesExtentsPtr().data()),
             reinterpret_cast<void **>(BaseType::getTensorsOutDataPtr().data()));
 
-        // TODO: This is a dummy tensor update to allow multiple calls to the
-        // `append_mps_final_state` method as well as appending additional
-        // operations to the graph. This is a temporary solution and this line
-        // can be removed in the future when the `cutensornet` backend allows
-        // multiple calls to the `cutensornetStateFinalizeMPS` method. For more
-        // details, please see the `cutensornet` high-level API workflow logic
-        // [here]
-        // (https://docs.nvidia.com/cuda/cuquantum/latest/cutensornet/api/functions.html#high-level-tensor-network-api).
-        // In order to proceed with the following gate operations or
-        // measurements after calling the `cutensornetStateCompute()` API, we
-        // have to call the `cutensornetStateUpdateTensor()` API, which is
-        // wrapped inside the `dummy_tensor_update()` method.
-        //
-        BaseType::dummy_tensor_update();
+        PL_CUTENSORNET_IS_SUCCESS(cutensornetStateCaptureMPS(
+            /* const cutensornetHandle_t */ BaseType::getTNCudaHandle(),
+            /* cutensornetState_t */ BaseType::getQuantumState()));
     }
 };
 } // namespace Pennylane::LightningTensor::TNCuda

--- a/pennylane_lightning/core/src/simulators/lightning_tensor/tncuda/TNCuda.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_tensor/tncuda/TNCuda.hpp
@@ -529,30 +529,6 @@ class TNCuda : public TNCudaBase<PrecisionT, Derived> {
     }
 
     /**
-     * @brief Dummy tensor operator update to allow multiple calls of
-     * appendMPSFinalize. This is a workaround to avoid the issue of the
-     * cutensornet library not allowing multiple calls of appendMPSFinalize.
-     *
-     * This function either appends a new `Identity` gate to the graph when the
-     * gate cache is empty or update the existing gate operator by itself.
-     */
-    void dummy_tensor_update() {
-        if (identiy_gate_ids_.empty()) {
-            applyOperation("Identity", {0}, false);
-        }
-
-        PL_CUTENSORNET_IS_SUCCESS(cutensornetStateUpdateTensorOperator(
-            /* const cutensornetHandle_t */ BaseType::getTNCudaHandle(),
-            /* cutensornetState_t */ BaseType::getQuantumState(),
-            /* int64_t tensorId*/
-            static_cast<int64_t>(identiy_gate_ids_.front()),
-            /* void* */
-            static_cast<void *>(
-                gate_cache_->get_gate_device_ptr(identiy_gate_ids_.front())),
-            /* int32_t unitary*/ 1));
-    }
-
-    /**
      * @brief Save quantumState information to data provided by a user
      *
      * @param extentsPtr Pointer to extents provided by a user


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [ ] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [ ] Ensure that the test suite passes, by running `make test`.

- [x] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [x] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**

[SC-80074]

Replace the `dummy_tensor_update` method with the `cutensornetStateCaptureMPS`API released `cutensornet-v24.11` to ensure that further gates apply is allowed after the `cutensornetStateCompute` call.

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
