### PR TITLE
Macos rpath fix

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -95,6 +95,9 @@
 
 ### Bug fixes
 
+* Set rpath with `@loader_path` instead of `$ORIGIN` for macOS.
+  [(#1029)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1029)
+
 * Update CUDA version to 12.4 for GPU tests on CI.
   [(#1023)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1023)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,7 +100,11 @@ message("Python site-packages directory: ${Python_SITELIB}")
 if(DEFINED PY_INSTALL)
     # Note the following setting is only for pyenv and not for conda
     # TODO: Add support for conda
-    set(SCIPY_OPENBLAS32_RUNTIME_LIB_PATH "$ORIGIN/../scipy_openblas32/lib")
+    if(APPLE)
+        set(SCIPY_OPENBLAS32_RUNTIME_LIB_PATH "@loader_path/../scipy_openblas32/lib")
+    else()
+        set(SCIPY_OPENBLAS32_RUNTIME_LIB_PATH "$ORIGIN/../scipy_openblas32/lib")
+    endif()
 else()
     include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/FindSCIPY_OPENBLAS32.cmake")
     if(NOT DEFINED SCIPY_OPENBLAS32_LIB_PATH AND NOT EXISTS ${SCIPY_OPENBLAS32_LIB_PATH})

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.40.0-dev38"
+__version__ = "0.40.0-dev39"

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.40.0-dev37"
+__version__ = "0.40.0-dev38"


### PR DESCRIPTION
**Context:**

`@loader_path` instead of `$ORIGIN` would work for `rpath` setting from `CMake` in `macos`. 

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**

[sc-80803]