### PR TITLE
Add the RTLD_NODELETE flag to dlopen

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -95,6 +95,9 @@
 
 ### Bug fixes
 
+* Add `RTLD_NODELETE` flag to `dlopen` in order to mitigate the segfault issues for arm64-macos Catalyst support.
+  [(#1030)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1030)
+
 * Set rpath with `@loader_path` instead of `$ORIGIN` for macOS.
   [(#1029)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1029)
 

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.40.0-dev40"
+__version__ = "0.40.0-dev41"

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.40.0-dev39"
+__version__ = "0.40.0-dev40"

--- a/pennylane_lightning/core/src/utils/SharedLibLoader.hpp
+++ b/pennylane_lightning/core/src/utils/SharedLibLoader.hpp
@@ -56,7 +56,9 @@ class SharedLibLoader final {
   public:
     SharedLibLoader();
     explicit SharedLibLoader(const std::string &filename) {
-        //TODO: RTLD_NODELETE flag could be problematic if the shared library is not static stored in memory and runtime unloaded is needed. Come back to this later.
+        // NOTE: RTLD_NODELETE flag is a temporary solution. It could be
+        // problematic if the shared library is not static stored in memory and
+        // runtime unloaded is needed. Come back to this later.
         handle_ = PL_DLOPEN(filename.c_str(), RTLD_LAZY | RTLD_NODELETE);
         PL_ABORT_IF(!handle_, PL_DLERROR());
     }

--- a/pennylane_lightning/core/src/utils/SharedLibLoader.hpp
+++ b/pennylane_lightning/core/src/utils/SharedLibLoader.hpp
@@ -56,6 +56,7 @@ class SharedLibLoader final {
   public:
     SharedLibLoader();
     explicit SharedLibLoader(const std::string &filename) {
+        //TODO: RTLD_NODELETE flag could be problematic if the shared library is not static stored in memory and runtime unloaded is needed. Come back to this later.
         handle_ = PL_DLOPEN(filename.c_str(), RTLD_LAZY | RTLD_NODELETE);
         PL_ABORT_IF(!handle_, PL_DLERROR());
     }

--- a/pennylane_lightning/core/src/utils/SharedLibLoader.hpp
+++ b/pennylane_lightning/core/src/utils/SharedLibLoader.hpp
@@ -56,7 +56,7 @@ class SharedLibLoader final {
   public:
     SharedLibLoader();
     explicit SharedLibLoader(const std::string &filename) {
-        handle_ = PL_DLOPEN(filename.c_str(), RTLD_LAZY);
+        handle_ = PL_DLOPEN(filename.c_str(), RTLD_LAZY | RTLD_NODELETE);
         PL_ABORT_IF(!handle_, PL_DLERROR());
     }
 


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [ ] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [ ] Ensure that the test suite passes, by running `make test`.

- [x] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [x] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**

There are segfault issue for finite-shot hermitians tests with Catalyst on arm64-macos. It looks like closing `libscipy_openblas.dylib` has a side effect that leads to the segfault and using `RTLD_NODELETE` mitigates that.

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-80901]