### PR TITLE
Fix `qml.MultiControlledX` usage

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -8,9 +8,12 @@
 
 * Update the minimum required version of PennyLane to `v0.40.0`.
   [(#1033)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1033)
-  
+
 * Merge the `v0.40.0-rc` branch to the master and bump version.
   [(#1038)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1038)
+
+* Update two tests that involved `qml.MultiControlledX` to latests PennyLane version.
+  [(#1040)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1040)
 
 ### Documentation
 
@@ -20,7 +23,7 @@
 
 This release contains contributions from (in alphabetical order):
 
-Joseph Lee, Shuli Shu
+Yushao Chen, Joseph Lee, Shuli Shu
 
 ---
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -6,14 +6,14 @@
 
 ### Improvements
 
+* Update `qml.MultiControlledX` tests following the latest updates in PennyLane.
+  [(#1040)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1040)
+
 * Update the minimum required version of PennyLane to `v0.40.0`.
   [(#1033)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1033)
 
 * Merge the `v0.40.0-rc` branch to the master and bump version.
   [(#1038)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1038)
-
-* Update `qml.MultiControlledX` tests following the latest updates in PennyLane.
- [(#1040)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1040)
 
 ### Documentation
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -12,8 +12,8 @@
 * Merge the `v0.40.0-rc` branch to the master and bump version.
   [(#1038)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1038)
 
-* Update two tests that involved `qml.MultiControlledX` to latests PennyLane version.
-  [(#1040)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1040)
+* Update `qml.MultiControlledX` tests following the latest updates in PennyLane.
+ [(#1040)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1040)
 
 ### Documentation
 

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.41.0-dev2"
+__version__ = "0.41.0-dev3"

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.41.0-dev4"
+__version__ = "0.41.0-dev5"

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.41.0-dev3"
+__version__ = "0.41.0-dev4"

--- a/tests/lightning_tensor/test_gates_and_expval.py
+++ b/tests/lightning_tensor/test_gates_and_expval.py
@@ -73,7 +73,7 @@ def circuit_ansatz(params, wires):
         qml.matrix(qml.PauliX([wires[1]])), control_wires=[wires[0]], wires=wires[1]
     )
     qml.DiagonalQubitUnitary(np.array([1, 1]), wires=wires[2])
-    qml.MultiControlledX(wires=[wires[0], wires[1], wires[3]])
+    qml.MultiControlledX(wires=[wires[0], wires[1], wires[3]], control_values=[0, 1])
     qml.PauliX(wires=wires[1])
     qml.PauliY(wires=wires[2])
     qml.PauliZ(wires=wires[3])

--- a/tests/lightning_tensor/test_gates_and_expval.py
+++ b/tests/lightning_tensor/test_gates_and_expval.py
@@ -73,7 +73,7 @@ def circuit_ansatz(params, wires):
         qml.matrix(qml.PauliX([wires[1]])), control_wires=[wires[0]], wires=wires[1]
     )
     qml.DiagonalQubitUnitary(np.array([1, 1]), wires=wires[2])
-    qml.MultiControlledX(wires=[wires[0], wires[1], wires[3]], control_values=[wires[0], wires[1]])
+    qml.MultiControlledX(wires=[wires[0], wires[1], wires[3]])
     qml.PauliX(wires=wires[1])
     qml.PauliY(wires=wires[2])
     qml.PauliZ(wires=wires[3])

--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -89,7 +89,7 @@ def op(op_name):
         "MultiControlledX": [
             qml.MultiControlledX,
             [],
-            {"wires": [0, 1, 2], "control_values": "01"},
+            {"wires": [0, 1, 2], "control_values": [0, 1]},
         ],
         "SingleExcitation": [qml.SingleExcitation, [0.123], {"wires": [0, 1]}],
         "SingleExcitationPlus": [qml.SingleExcitationPlus, [0.123], {"wires": [0, 1]}],


### PR DESCRIPTION
**Context:**
For the operator `qml.MultiControlledX`, two features have been deprecated long ago and will be removed very soon:
 - `str` input of `control_values`, e.g. `"01"`
 - optional arg `control_wires`. Instead, `wires[:-1]` strictly acts as the control wires.

Somehow deprecated usages have been spotted in lightning master branch, therefore we would like to fix them asap.

**Description of the Change:**

 - `tests/test_gates.py`, "01" -> [0, 1]
 - `tests/lightning_tensor/test_gates_and_expval.py`, based on the context, the usage `qml.MultiControlledX(wires=[wires[0], wires[1], wires[3]], control_values=[wires[0], wires[1]])` seems to be mistaking a `qml.MultiControlledX(wires=[wires[0], wires[1], wires[3]], control_wires=[wires[0], wires[1]])`. If the guess is correct, we can fix it by `qml.MultiControlledX(wires=[wires[0], wires[1], wires[3]])` P.S. direct change to `control_wires` couldn't pass the tests; therefore we specified `control_values=[0, 1]` which worked; I guess it's made by a mistake but happen to work, along with adjustments over the corresponding expected res.

**Benefits:**
Compatibility with PL0.41

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-81527]
[sc-81795]