### PR TITLE
Ubuntu 24 CI: Remove libopenblas-base package and update Kokkos build OS

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -15,6 +15,9 @@
 ### Documentation
 
 ### Bug fixes
+  
+* Remove libopenblas-base package for Ubuntu 24 github CI
+  [(#1041)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1041)
 
 ### Contributors
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 ### Bug fixes
   
-* Remove libopenblas-base package for Ubuntu 24 github CI
+* Update Github CI to use Ubuntu 24 and remove `libopenblas-base` package.
   [(#1041)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1041)
 
 ### Contributors

--- a/.github/workflows/tests_linux_cpp.yml
+++ b/.github/workflows/tests_linux_cpp.yml
@@ -30,7 +30,7 @@ env:
   TF_VERSION: 2.10.0
   TORCH_VERSION: 1.11.0+cpu
   COVERAGE_FLAGS: "--cov=pennylane_lightning --cov-report=term-missing --no-flaky-report -p no:warnings --tb=native"
-  GCC_VERSION: 11
+  GCC_VERSION: 13
   OMP_NUM_THREADS: "2"
   OMP_PROC_BIND: "false"
 

--- a/.github/workflows/tests_linux_cpp.yml
+++ b/.github/workflows/tests_linux_cpp.yml
@@ -128,7 +128,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get update && sudo apt-get -y -q install cmake gcc-$GCC_VERSION  g++-$GCC_VERSION libopenblas-base libopenblas-dev ninja-build gcovr lcov
+          sudo apt-get update && sudo apt-get -y -q install cmake gcc-$GCC_VERSION  g++-$GCC_VERSION libopenblas-dev ninja-build gcovr lcov
           python -m pip install scipy-openblas32
 
       - name: Build and run unit tests

--- a/.github/workflows/tests_linux_cpp.yml
+++ b/.github/workflows/tests_linux_cpp.yml
@@ -174,14 +174,14 @@ jobs:
     uses: ./.github/workflows/build_and_cache_Kokkos_linux.yml
     with:
       runs_on: pl-4-core-large-runner
-      os: ubuntu-22.04
+      os: ubuntu-latest
 
   cpptestswithKokkos:
     if: ${{ !contains(fromJSON('["schedule", "workflow_dispatch"]'), github.event_name) }}
     needs: [build_and_cache_Kokkos]
     strategy:
       matrix:
-        os: [ubuntu-22.04]
+        os: [ubuntu-latest]
         pl_backend: ["lightning_kokkos"]
         exec_model: ${{ fromJson(needs.build_and_cache_Kokkos.outputs.exec_model) }}
         kokkos_version: ${{ fromJson(needs.build_and_cache_Kokkos.outputs.kokkos_version) }}
@@ -282,7 +282,7 @@ jobs:
     needs: [build_and_cache_Kokkos]
     strategy:
       matrix:
-        os: [ubuntu-22.04]
+        os: [ubuntu-latest]
         exec_model: ${{ fromJson(needs.build_and_cache_Kokkos.outputs.exec_model) }}
         kokkos_version: ${{ fromJson(needs.build_and_cache_Kokkos.outputs.kokkos_version) }}
     timeout-minutes: 60

--- a/.github/workflows/tests_linux_cpp.yml
+++ b/.github/workflows/tests_linux_cpp.yml
@@ -85,7 +85,7 @@ jobs:
             cd ./Build
             mkdir -p ./tests/results
             for file in *runner ; do ./$file --order lex --reporter junit --out ./tests/results/report_$file.xml; done;
-            lcov --directory . -b ../pennylane_lightning/core/src --capture --output-file coverage.info  --ignore-errors mismatch
+            lcov --directory . -b ../pennylane_lightning/core/src --capture --output-file coverage.info  --ignore-errors mismatch # Catch2 causes mismatch errors that needs to be ignored
             lcov --remove coverage.info '/usr/*' --output-file coverage.info
             mv coverage.info coverage-${{ github.job }}-${{ matrix.pl_backend }}-${{ matrix.enable_kernel_avx_streaming }}-${{ matrix.enable_kernel_omp }}.info
 
@@ -146,7 +146,7 @@ jobs:
             cd ./Build
             mkdir -p ./tests/results
             for file in *runner ; do ./$file --order lex --reporter junit --out ./tests/results/report_$file.xml; done;
-            lcov --directory . -b ../pennylane_lightning/core/src --capture --output-file coverage.info  --ignore-errors mismatch
+            lcov --directory . -b ../pennylane_lightning/core/src --capture --output-file coverage.info  --ignore-errors mismatch # Catch2 causes mismatch errors that needs to be ignored
             lcov --remove coverage.info '/usr/*' --output-file coverage.info
             mv coverage.info coverage-${{ github.job }}-${{ matrix.pl_backend }}.info
 
@@ -232,7 +232,7 @@ jobs:
             cd ./Build
             mkdir -p ./tests/results-${{ github.job }}-${{ matrix.pl_backend }}
             for file in *runner ; do ./$file --order lex --reporter junit --out ./tests/results-${{ github.job }}-${{ matrix.pl_backend }}/report_$file.xml; done;
-            lcov --directory . -b ../pennylane_lightning/core/src --capture --output-file coverage.info  --ignore-errors mismatch
+            lcov --directory . -b ../pennylane_lightning/core/src --capture --output-file coverage.info  --ignore-errors mismatch # Catch2 causes mismatch errors that needs to be ignored
             lcov --remove coverage.info '/usr/*' --output-file coverage.info
             mv coverage.info coverage-${{ github.job }}-${{ matrix.pl_backend }}.info
 

--- a/.github/workflows/tests_linux_cpp.yml
+++ b/.github/workflows/tests_linux_cpp.yml
@@ -30,7 +30,7 @@ env:
   TF_VERSION: 2.10.0
   TORCH_VERSION: 1.11.0+cpu
   COVERAGE_FLAGS: "--cov=pennylane_lightning --cov-report=term-missing --no-flaky-report -p no:warnings --tb=native"
-  GCC_VERSION: 12
+  GCC_VERSION: 13
   OMP_NUM_THREADS: "2"
   OMP_PROC_BIND: "false"
 
@@ -85,7 +85,7 @@ jobs:
             cd ./Build
             mkdir -p ./tests/results
             for file in *runner ; do ./$file --order lex --reporter junit --out ./tests/results/report_$file.xml; done;
-            lcov --directory . -b ../pennylane_lightning/core/src --capture --output-file coverage.info
+            lcov --directory . -b ../pennylane_lightning/core/src --capture --output-file coverage.info  --ignore-errors mismatch
             lcov --remove coverage.info '/usr/*' --output-file coverage.info
             mv coverage.info coverage-${{ github.job }}-${{ matrix.pl_backend }}-${{ matrix.enable_kernel_avx_streaming }}-${{ matrix.enable_kernel_omp }}.info
 
@@ -146,7 +146,7 @@ jobs:
             cd ./Build
             mkdir -p ./tests/results
             for file in *runner ; do ./$file --order lex --reporter junit --out ./tests/results/report_$file.xml; done;
-            lcov --directory . -b ../pennylane_lightning/core/src --capture --output-file coverage.info
+            lcov --directory . -b ../pennylane_lightning/core/src --capture --output-file coverage.info  --ignore-errors mismatch
             lcov --remove coverage.info '/usr/*' --output-file coverage.info
             mv coverage.info coverage-${{ github.job }}-${{ matrix.pl_backend }}.info
 
@@ -232,7 +232,7 @@ jobs:
             cd ./Build
             mkdir -p ./tests/results-${{ github.job }}-${{ matrix.pl_backend }}
             for file in *runner ; do ./$file --order lex --reporter junit --out ./tests/results-${{ github.job }}-${{ matrix.pl_backend }}/report_$file.xml; done;
-            lcov --directory . -b ../pennylane_lightning/core/src --capture --output-file coverage.info
+            lcov --directory . -b ../pennylane_lightning/core/src --capture --output-file coverage.info  --ignore-errors mismatch
             lcov --remove coverage.info '/usr/*' --output-file coverage.info
             mv coverage.info coverage-${{ github.job }}-${{ matrix.pl_backend }}.info
 

--- a/.github/workflows/tests_linux_cpp.yml
+++ b/.github/workflows/tests_linux_cpp.yml
@@ -30,7 +30,7 @@ env:
   TF_VERSION: 2.10.0
   TORCH_VERSION: 1.11.0+cpu
   COVERAGE_FLAGS: "--cov=pennylane_lightning --cov-report=term-missing --no-flaky-report -p no:warnings --tb=native"
-  GCC_VERSION: 13
+  GCC_VERSION: 12
   OMP_NUM_THREADS: "2"
   OMP_PROC_BIND: "false"
 

--- a/.github/workflows/tests_lkcpu_python.yml
+++ b/.github/workflows/tests_lkcpu_python.yml
@@ -48,14 +48,14 @@ jobs:
     name: "Build and cache Kokkos"
     uses: ./.github/workflows/build_and_cache_Kokkos_linux.yml
     with:
-      os: ubuntu-22.04
+      os: ubuntu-latest
       kokkos_version: "4.5.00"
 
   build_lightning_kokkos_wheels:
     needs: [build_and_cache_Kokkos]
     strategy:
       matrix:
-        os: [ubuntu-22.04]
+        os: [ubuntu-latest]
         pl_backend: ["lightning_kokkos"]
         exec_model: ${{ fromJson(needs.build_and_cache_Kokkos.outputs.exec_model) }}
         kokkos_version: ${{ fromJson(needs.build_and_cache_Kokkos.outputs.kokkos_version) }}
@@ -144,7 +144,7 @@ jobs:
     needs: [build_and_cache_Kokkos, build_lightning_kokkos_wheels]
     strategy:
       matrix:
-        os: [ubuntu-22.04]
+        os: [ubuntu-latest]
         pl_backend: ["lightning_kokkos"]
         group: [1, 2, 3, 4, 5, 6, 7]
         exec_model: ${{ fromJson(needs.build_and_cache_Kokkos.outputs.exec_model) }}

--- a/.github/workflows/tests_lqcpu_python.yml
+++ b/.github/workflows/tests_lqcpu_python.yml
@@ -24,7 +24,7 @@ env:
   TF_VERSION: 2.10.0
   TORCH_VERSION: 1.11.0+cpu
   COVERAGE_FLAGS: "--cov=pennylane_lightning --cov-report=term-missing --no-flaky-report -p no:warnings --tb=native"
-  GCC_VERSION: 13
+  GCC_VERSION: 12
   OMP_NUM_THREADS: "2"
   OMP_PROC_BIND: "false"
 

--- a/.github/workflows/tests_lqcpu_python.yml
+++ b/.github/workflows/tests_lqcpu_python.yml
@@ -24,7 +24,7 @@ env:
   TF_VERSION: 2.10.0
   TORCH_VERSION: 1.11.0+cpu
   COVERAGE_FLAGS: "--cov=pennylane_lightning --cov-report=term-missing --no-flaky-report -p no:warnings --tb=native"
-  GCC_VERSION: 11
+  GCC_VERSION: 13
   OMP_NUM_THREADS: "2"
   OMP_PROC_BIND: "false"
 

--- a/.github/workflows/tests_lqcpu_python.yml
+++ b/.github/workflows/tests_lqcpu_python.yml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get update && sudo apt-get -y -q install cmake gcc-$GCC_VERSION g++-$GCC_VERSION libopenblas-base libopenblas-dev
+          sudo apt-get update && sudo apt-get -y -q install cmake gcc-$GCC_VERSION g++-$GCC_VERSION libopenblas-dev
           python -m pip install scipy-openblas32 wheel
 
       - name: Get required Python packages

--- a/.github/workflows/tests_lqcpu_python.yml
+++ b/.github/workflows/tests_lqcpu_python.yml
@@ -24,7 +24,7 @@ env:
   TF_VERSION: 2.10.0
   TORCH_VERSION: 1.11.0+cpu
   COVERAGE_FLAGS: "--cov=pennylane_lightning --cov-report=term-missing --no-flaky-report -p no:warnings --tb=native"
-  GCC_VERSION: 12
+  GCC_VERSION: 13
   OMP_NUM_THREADS: "2"
   OMP_PROC_BIND: "false"
 
@@ -143,6 +143,10 @@ jobs:
         with:
           name: wheel_${{ matrix.pl_backend }}-${{ matrix.blas }}.whl
           path: ${{ github.workspace }}
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update && sudo apt-get -y -q install libopenblas-dev
 
       - name: Get required Python packages
         run: |

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.41.0-dev2"
+__version__ = "0.41.0-dev3"


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [ ] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [ ] Ensure that the test suite passes, by running `make test`.

- [x] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [ ] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**
Github Ubuntu CI has upgraded from 22 to 24, and libopenblas-base package is no longer present (leads to [failure](https://github.com/PennyLaneAI/pennylane-lightning/actions/runs/12815891298/job/35735593161#step:7:60)) and needed. 

**Description of the Change:**
Removed libopenblas-base package installation for CI tests.

Since ubuntu24 ship with a new version of gcov, when using GCC11/12, we will get errors like [these](https://github.com/PennyLaneAI/pennylane-lightning/actions/runs/12817006998/job/35739252160#step:5:191):
```
runner_measurements.cpp.gcno:version 'B14*', prefer 'B33*'
geninfo: ERROR: Incompatible GCC/GCOV version found while processing /home/runner/work/pennylane-lightning/pennylane-lightning/Build/pennylane_lightning/core/src/measurements/tests/CMakeFiles/measurements_test_runner.dir/runner_measurements.cpp.gcda:
	Your test was built with 'B14*'.
	You are trying to capture with gcov tool '/usr/bin/gcov' which is version 'B33*'.
	(use "geninfo --ignore-errors version ..." to bypass this error)
```
With GCC13, lcov will fail with:
```
geninfo: ERROR: mismatched end line for _Z43C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_F_U_N_C_0IdEvv at /pennylane-lightning/pennylane_lightning/core/src/utils/tests/Test_Util.cpp:32: 32 -> 49
        (use "geninfo --ignore-errors mismatch ..." to bypass this error)
```
I have checked that the [coverage %](https://github.com/PennyLaneAI/pennylane-lightning/actions/runs/12818512732/job/35744183008#step:5:654) is still correct with adding `--ignore-errors mismatch`

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**

[sc-82360]