### PR TITLE
Replace the type checking using property `return_type` with direct is…

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -6,9 +6,6 @@
 
 ### Improvements
 
-* Replace the type checking using the property `return_type` of `MeasurementProcess` with direct `isinstance` checks.
-  [(#1044)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1044)
-
 * Update `qml.MultiControlledX` tests following the latest updates in PennyLane.
   [(#1040)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1040)
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ### Improvements
 
+* Replace the type checking using the property `return_type` of `MeasurementProcess` with direct `isinstance` checks.
+  [(#1044)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1044)
+
 * Update `qml.MultiControlledX` tests following the latest updates in PennyLane.
   [(#1040)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1040)
 

--- a/pennylane_lightning/core/_adjoint_jacobian_base.py
+++ b/pennylane_lightning/core/_adjoint_jacobian_base.py
@@ -85,9 +85,9 @@ class LightningBaseAdjointJacobian(ABC):
             return None
 
         if len(measurements) == 1 and isinstance(measurements[0], StateMP):
-            return State
+            return "state"
 
-        return Expectation
+        return "expval"
 
     def _process_jacobian_tape(self, tape: QuantumTape, split_obs: bool = False):
         """Process a tape, serializing and building a dictionary proper for
@@ -184,7 +184,7 @@ class LightningBaseAdjointJacobian(ABC):
                 # the tape does not have measurements
                 return True
 
-            if tape_return_type is State:
+            if tape_return_type is "state":
                 raise QuantumFunctionError(
                     "Adjoint differentiation method does not support measurement StateMP."
                 )
@@ -194,7 +194,7 @@ class LightningBaseAdjointJacobian(ABC):
                 # the tape does not have measurements or the gradient is 0.0
                 return True
 
-            if tape_return_type is State:
+            if tape_return_type is "state":
                 raise QuantumFunctionError(
                     "Adjoint differentiation does not support State measurements."
                 )

--- a/pennylane_lightning/core/_adjoint_jacobian_base.py
+++ b/pennylane_lightning/core/_adjoint_jacobian_base.py
@@ -21,7 +21,7 @@ from typing import Any, Callable, List
 import numpy as np
 import pennylane as qml
 from pennylane import BasisState, QuantumFunctionError, StatePrep
-from pennylane.measurements import Expectation, MeasurementProcess, State
+from pennylane.measurements import ExpectationMP, MeasurementProcess, StateMP
 from pennylane.operation import Operation
 from pennylane.tape import QuantumTape
 
@@ -84,7 +84,7 @@ class LightningBaseAdjointJacobian(ABC):
         if not measurements:
             return None
 
-        if len(measurements) == 1 and measurements[0].return_type is State:
+        if len(measurements) == 1 and isinstance(measurements[0], StateMP):
             return State
 
         return Expectation
@@ -199,7 +199,7 @@ class LightningBaseAdjointJacobian(ABC):
                     "Adjoint differentiation does not support State measurements."
                 )
 
-        if any(m.return_type is not Expectation for m in tape.measurements):
+        if any(not isinstance(m, ExpectationMP) for m in tape.measurements):
             raise QuantumFunctionError(
                 "Adjoint differentiation method does not support expectation return type "
                 "mixed with other return types"

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.41.0-dev7"
+__version__ = "0.41.0-dev8"

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.41.0-dev6"
+__version__ = "0.41.0-dev7"

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.41.0-dev5"
+__version__ = "0.41.0-dev6"

--- a/pennylane_lightning/core/lightning_base.py
+++ b/pennylane_lightning/core/lightning_base.py
@@ -23,7 +23,6 @@ import numpy as np
 import pennylane as qml
 from pennylane import BasisState, StatePrep
 from pennylane.devices import QubitDevice
-from pennylane.measurements import ExpectationMP, MeasurementProcess, StateMP
 from pennylane.operation import Operation
 from pennylane.ops import Prod, Projector, SProd, Sum
 from pennylane.wires import Wires

--- a/pennylane_lightning/core/lightning_base.py
+++ b/pennylane_lightning/core/lightning_base.py
@@ -23,7 +23,7 @@ import numpy as np
 import pennylane as qml
 from pennylane import BasisState, StatePrep
 from pennylane.devices import QubitDevice
-from pennylane.measurements import Expectation, MeasurementProcess, State
+from pennylane.measurements import ExpectationMP, MeasurementProcess, StateMP
 from pennylane.operation import Operation
 from pennylane.ops import Prod, Projector, SProd, Sum
 from pennylane.wires import Wires
@@ -348,14 +348,14 @@ class LightningBase(QubitDevice):
         if not measurements:
             return None
 
-        if len(measurements) == 1 and measurements[0].return_type is State:
+        if len(measurements) == 1 and isinstance(measurements[0], StateMP):
             # return State
             raise qml.QuantumFunctionError(
                 "Adjoint differentiation does not support State measurements."
             )
 
         # The return_type of measurement processes must be expectation
-        if any(m.return_type is not Expectation for m in measurements):
+        if any(not isinstance(m, ExpectationMP) for m in measurements):
             raise qml.QuantumFunctionError(
                 "Adjoint differentiation method does not support expectation return type "
                 "mixed with other return types"
@@ -363,7 +363,7 @@ class LightningBase(QubitDevice):
 
         for measurement in measurements:
             LightningBase._assert_adjdiff_no_projectors(measurement.obs)
-        return Expectation
+        return "expval"
 
     @staticmethod
     def _adjoint_jacobian_processing(jac):

--- a/pennylane_lightning/core/lightning_base.py
+++ b/pennylane_lightning/core/lightning_base.py
@@ -330,41 +330,6 @@ class LightningBase(QubitDevice):
             for obs in observable:
                 LightningBase._assert_adjdiff_no_projectors(obs)
 
-    # pylint: disable=unnecessary-pass
-    @staticmethod
-    def _check_adjdiff_supported_measurements(measurements: List[MeasurementProcess]):
-        """Check whether given list of measurements is supported by adjoint_differentiation.
-
-        Args:
-            measurements (List[MeasurementProcess]): a list of measurement processes to check.
-
-        Returns:
-            Expectation or State: a common return type of measurements.
-
-        Raises:
-            ~pennylane.QuantumFunctionError: if a measurement is unsupported with adjoint
-            differentiation.
-        """
-        if not measurements:
-            return None
-
-        if len(measurements) == 1 and isinstance(measurements[0], StateMP):
-            # return State
-            raise qml.QuantumFunctionError(
-                "Adjoint differentiation does not support State measurements."
-            )
-
-        # The return_type of measurement processes must be expectation
-        if any(not isinstance(m, ExpectationMP) for m in measurements):
-            raise qml.QuantumFunctionError(
-                "Adjoint differentiation method does not support expectation return type "
-                "mixed with other return types"
-            )
-
-        for measurement in measurements:
-            LightningBase._assert_adjdiff_no_projectors(measurement.obs)
-        return "expval"
-
     @staticmethod
     def _adjoint_jacobian_processing(jac):
         """

--- a/tests/test_measurements.py
+++ b/tests/test_measurements.py
@@ -23,7 +23,7 @@ import pytest
 from conftest import LightningDevice as ld
 from conftest import device_name, lightning_ops, validate_measurements
 from flaky import flaky
-from pennylane.measurements import Expectation, Shots, Variance
+from pennylane.measurements import ExpectationMP, Shots, VarianceMP
 
 if not ld._CPP_BINARY_AVAILABLE:
     pytest.skip("No binary module found. Skipping.", allow_module_level=True)
@@ -387,12 +387,12 @@ class TestExpval:
             circuit()
 
     def test_observable_return_type_is_expectation(self, dev):
-        """Test that the return type of the observable is :attr:`ObservableReturnTypes.Expectation`"""
+        """Test that the return type of the observable is :class:`ExpectationMP`"""
 
         @qml.qnode(dev)
         def circuit():
             res = qml.expval(qml.PauliZ(0))
-            assert res.return_type is Expectation
+            assert isinstance(res, ExpectationMP)
             return res
 
         circuit()
@@ -488,12 +488,12 @@ class TestVar:
             circuit()
 
     def test_observable_return_type_is_variance(self, dev):
-        """Test that the return type of the observable is :attr:`ObservableReturnTypes.Variance`"""
+        """Test that the return type is :class:`VarianceMP`"""
 
         @qml.qnode(dev)
         def circuit():
             res = qml.var(qml.PauliZ(0))
-            assert res.return_type is Variance
+            assert isinstance(res, VarianceMP)
             return res
 
         circuit()


### PR DESCRIPTION
**Context:**
In the deprecations of PL0.41, the property `return_type` of class `MeasurementProcess` will be deprecated very soon https://github.com/PennyLaneAI/pennylane/pull/6841. Therefore, we would like to replace the use of `return_type` with the equivalent direct `isinstance` check. For individual string info use of these return types, we replace them with in-place strings.

**Description of the Change:**
3 files are changed with equivalents in-place:

 - pennylane_lightning/core/_adjoint_jacobian_base.py
 - - Private staticmethod `_get_return_type` of class `LightningBaseAdjointJacobian`  called `return_type` once, so replaced with equivalent `isinstance`
 - - The private staticmethod `_check_adjdiff_supported_measurements` was only called by another private helper `_process_jacobian_tape`, therefore the two Enum type returns were replaced by strings, along with their conditional values in `_process_jacobian_tape`.
 - - `_process_jacobian_tape` also called `return_type` once, therefore replace with equivalent `isinstance`.
 
 - pennylane_lightning/core/lightning_base.py
 - - The private staticmethod `_check_adjdiff_supported_measurements` was identified as not used by any code inside lightning. Therefore, we deleted it directly.
 
 - tests/test_measurements.py
 - - Two `return_type` usages were replaced with `isinstance`

**Benefits:**
Consistent with both v0.40 and v0.41 of PL

**Possible Drawbacks:**
Not aware of yet.

**Related GitHub Issues:**
[[sc-71892](https://app.shortcut.com/xanaduai/story/71892)]
