### PR TITLE
update usages of ControlledQubitUnitary in tests

### DIFF
--- a/tests/lightning_qubit/test_measurements_class.py
+++ b/tests/lightning_qubit/test_measurements_class.py
@@ -812,7 +812,7 @@ class TestControlledOps:
         tape = qml.tape.QuantumScript(
             [
                 qml.ControlledQubitUnitary(
-                    qml.QubitUnitary(qml.RX.compute_matrix(par), wires=5), control_wires=range(5)
+                    qml.RX.compute_matrix(par), wires=range(6)
                 )
             ],
             [qml.expval(qml.PauliX(0))],
@@ -844,7 +844,7 @@ class TestControlledOps:
         tape = qml.tape.QuantumScript(
             [
                 qml.StatePrep(init_state, wires=range(n_qubits)),
-                qml.ControlledQubitUnitary(U, control_wires=control_wires, wires=target_wires),
+                qml.ControlledQubitUnitary(U, wires=control_wires+target_wires),
             ],
             [qml.state()],
         )

--- a/tests/lightning_tensor/test_gates_and_expval.py
+++ b/tests/lightning_tensor/test_gates_and_expval.py
@@ -70,7 +70,7 @@ def circuit_ansatz(params, wires):
     qml.Identity(wires=wires[0])
     qml.QubitUnitary(random_unitary, wires=[wires[1], wires[3]])
     qml.ControlledQubitUnitary(
-        qml.matrix(qml.PauliX([wires[1]])), control_wires=[wires[0]], wires=wires[1]
+        qml.matrix(qml.PauliX([wires[1]])), wires=[wires[0], wires[1]]
     )
     qml.DiagonalQubitUnitary(np.array([1, 1]), wires=wires[2])
     qml.MultiControlledX(wires=[wires[0], wires[1], wires[3]], control_values=[0, 1])

--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -450,8 +450,7 @@ def test_controlled_qubit_unitary(n_qubits, control_value, tol):
                     qml.StatePrep(init_state, wires=range(n_qubits))
                     qml.ControlledQubitUnitary(
                         U,
-                        control_wires=control_wires,
-                        wires=target_wires,
+                        wires=control_wires+target_wires,
                         control_values=(
                             [control_value or bool(i % 2) for i, _ in enumerate(control_wires)]
                             if device_name != "lightning.tensor"
@@ -550,7 +549,7 @@ def test_controlled_qubit_unitary_from_op(tol):
 
     def circuit(x):
         qml.ControlledQubitUnitary(
-            qml.QubitUnitary(qml.RX.compute_matrix(x), wires=5), control_wires=range(5)
+            qml.RX.compute_matrix(x), wires=range(6)
         )
         return qml.expval(qml.PauliX(0))
 
@@ -617,7 +616,7 @@ def test_cnot_controlled_qubit_unitary(control_wires, target_wires, tol):
 
     def circuit():
         qml.StatePrep(init_state, wires=range(n_qubits))
-        qml.ControlledQubitUnitary(U, control_wires=control_wires, wires=target_wires)
+        qml.ControlledQubitUnitary(U, wires=control_wires+target_wires)
         return qml.state()
 
     def cnot_circuit():


### PR DESCRIPTION
**Context:**
Due to the deprecations of `ControlledQubitUnitary` input args https://github.com/PennyLaneAI/pennylane/pull/6839/ https://github.com/PennyLaneAI/pennylane/pull/6840/, we need to update several tests of lightning that use deprecated interfaces.

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
