### PR TITLE
Update GPU workflow to use the new self-hosted GPU runner infrastructure

### DIFF
--- a/.github/workflows/tests_gpu_cpp.yml
+++ b/.github/workflows/tests_gpu_cpp.yml
@@ -33,9 +33,7 @@ jobs:
   builddeps:
     if: ${{ github.event_name != 'pull_request' || (github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'ci:use-gpu-runner')) }}
     runs-on:
-      - self-hosted
-      - ubuntu-22.04
-      - gpu
+      - single-gpu-x64
 
     strategy:
       max-parallel: 1
@@ -64,9 +62,7 @@ jobs:
 
     name: C++ Tests (${{ matrix.pl_backend }}, cuda-${{ matrix.cuda_version }})
     runs-on:
-      - ubuntu-22.04
-      - self-hosted
-      - gpu
+      - single-gpu-x64
 
     steps:
       - name: Validate GPU version and installed compiler

--- a/.github/workflows/tests_gpu_python.yml
+++ b/.github/workflows/tests_gpu_python.yml
@@ -33,9 +33,7 @@ jobs:
   builddeps:
     if: ${{ github.event_name != 'pull_request' || (github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'ci:use-gpu-runner')) }}
     runs-on:
-      - self-hosted
-      - ubuntu-22.04
-      - gpu
+      - single-gpu-x64
 
     strategy:
       max-parallel: 1
@@ -63,9 +61,7 @@ jobs:
 
     name: Python Tests (${{ matrix.pl_backend }}, cuda-${{ matrix.cuda_version }})
     runs-on:
-      - ubuntu-22.04
-      - self-hosted
-      - gpu
+      - single-gpu-x64
 
     steps:
       - name: Validate GPU version and installed compiler

--- a/.github/workflows/tests_lgpumpi_cpp.yml
+++ b/.github/workflows/tests_lgpumpi_cpp.yml
@@ -40,17 +40,14 @@ jobs:
   cpp_tests:
     if: ${{ github.event.pull_request.draft == false && (contains(github.event.pull_request.labels.*.name, 'ci:use-multi-gpu-runner') || contains(fromJSON('["schedule", "workflow_dispatch"]'), github.event_name)) }}
     runs-on:
-      - self-hosted
-      - linux
-      - x64
-      - ubuntu-22.04
-      - multi-gpu
+      - multi-gpu-x64
+
     strategy:
       max-parallel: 1
       matrix:
         mpilib: ["mpich", "openmpi"]
         cuda_version_maj: ["12"]
-        cuda_version_min: ["2"]
+        cuda_version_min: ["4"]
     timeout-minutes: 35
 
     steps:
@@ -117,17 +114,17 @@ jobs:
 
       - name: Validate Multi-GPU packages
         run: |
-          source /etc/profile.d/modules.sh && module use /opt/modules/ && module load ${{ matrix.mpilib }}/cuda-${{ matrix.cuda_version_maj }}.${{ matrix.cuda_version_min }}
+          source /etc/profile.d/modules.sh && module use /opt/modules/ && module load ${{ matrix.mpilib }}
           echo 'Checking for ${{ matrix.mpilib }}'
           which -a mpirun
           mpirun --version
           which -a mpicxx
           mpicxx --version
-          module unload ${{ matrix.mpilib }}/cuda-${{ matrix.cuda_version_maj }}.${{ matrix.cuda_version_min }}
+          module unload ${{ matrix.mpilib }}
 
       - name: Build and run unit tests
         run: |
-          source /etc/profile.d/modules.sh && module use /opt/modules/ && module load ${{ matrix.mpilib }}/cuda-${{ matrix.cuda_version_maj }}.${{ matrix.cuda_version_min }}
+          source /etc/profile.d/modules.sh && module use /opt/modules/ && module load ${{ matrix.mpilib }}
           export CUQUANTUM_SDK=$(python -c "import site; print( f'{site.getsitepackages()[0]}/cuquantum')")
           export SCIPY_OPENBLAS=$(python -c "import scipy_openblas32; print(scipy_openblas32.get_lib_dir())")
           cmake . -BBuild \

--- a/.github/workflows/tests_lgpumpi_python.yml
+++ b/.github/workflows/tests_lgpumpi_python.yml
@@ -42,11 +42,8 @@ jobs:
   python_tests:
     if: ${{ github.event.pull_request.draft == false && (contains(github.event.pull_request.labels.*.name, 'ci:use-multi-gpu-runner') || contains(fromJSON('["schedule", "workflow_dispatch"]'), github.event_name)) }}
     runs-on:
-      - self-hosted
-      - linux
-      - x64
-      - ubuntu-22.04
-      - multi-gpu
+      - multi-gpu-x64
+
     strategy:
       max-parallel: 1
       matrix:
@@ -113,7 +110,7 @@ jobs:
         env:
           PL_BACKEND: lightning_qubit
         run: |
-          source /etc/profile.d/modules.sh && module use /opt/modules/ && module load ${{ matrix.mpilib }}/cuda-${{ matrix.cuda_version_maj }}.${{ matrix.cuda_version_min }}
+          source /etc/profile.d/modules.sh && module use /opt/modules/ && module load ${{ matrix.mpilib }}
           python -m pip install -r requirements-dev.txt
 
           python -m pip install custatevec-cu${{ matrix.cuda_version_maj }} mpi4py openfermionpyscf
@@ -147,7 +144,7 @@ jobs:
           CUQUANTUM_SDK: $(python -c "import site; print( f'{site.getsitepackages()[0]}/cuquantum')")
           PL_BACKEND: lightning_gpu
         run: |
-          source /etc/profile.d/modules.sh && module use /opt/modules/ && module load ${{ matrix.mpilib }}/cuda-${{ matrix.cuda_version_maj }}.${{ matrix.cuda_version_min }}
+          source /etc/profile.d/modules.sh && module use /opt/modules/ && module load ${{ matrix.mpilib }}
           python scripts/configure_pyproject_toml.py || true
           CMAKE_ARGS="-DCMAKE_C_COMPILER=mpicc -DCMAKE_CXX_COMPILER=mpicxx -DENABLE_MPI=ON -DCMAKE_CUDA_COMPILER=$(which nvcc) -DCMAKE_CUDA_ARCHITECTURES=${{ env.CI_CUDA_ARCH }} -DPython_EXECUTABLE=${{ steps.python_path.outputs.python }}" \
           python -m pip install . -vv
@@ -156,7 +153,7 @@ jobs:
       # [here](https://github.com/pytest-dev/pytest-cov/issues/237#issuecomment-544824228)
       - name: Run unit tests for MPI-enabled lightning.gpu device
         run: |
-          source /etc/profile.d/modules.sh && module use /opt/modules/ && module load ${{ matrix.mpilib }}/cuda-${{ matrix.cuda_version_maj }}.${{ matrix.cuda_version_min }}
+          source /etc/profile.d/modules.sh && module use /opt/modules/ && module load ${{ matrix.mpilib }}
           PL_DEVICE=lightning.gpu mpirun -np 2 \
           coverage run --rcfile=.coveragerc --source=pennylane_lightning -p -m mpi4py -m pytest ./mpitests --tb=native
           coverage combine

--- a/.github/workflows/tests_lkcuda_cpp.yml
+++ b/.github/workflows/tests_lkcuda_cpp.yml
@@ -40,9 +40,7 @@ jobs:
   builddeps:
     if: ${{ github.event_name != 'pull_request' || (github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'ci:use-gpu-runner')) }}
     runs-on:
-      - self-hosted
-      - ubuntu-22.04
-      - gpu
+      - single-gpu-x64
 
     strategy:
       max-parallel: 1
@@ -119,9 +117,7 @@ jobs:
 
     name: C++ Tests (${{ matrix.pl_backend }}, kokkos-${{ matrix.kokkos_version }}, model-${{ matrix.exec_model }})
     runs-on:
-      - ${{ matrix.os }}
-      - self-hosted
-      - gpu
+      - single-gpu-x64
 
     steps:
       - name: Validate GPU version and installed compiler

--- a/.github/workflows/tests_lkcuda_python.yml
+++ b/.github/workflows/tests_lkcuda_python.yml
@@ -45,9 +45,7 @@ jobs:
   builddeps:
     if: ${{ github.event_name != 'pull_request' || (github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'ci:use-gpu-runner')) }}
     runs-on:
-      - self-hosted
-      - ubuntu-22.04
-      - gpu
+      - single-gpu-x64
 
     strategy:
       max-parallel: 1
@@ -124,9 +122,7 @@ jobs:
 
     name: Python Tests (${{ matrix.pl_backend }}, kokkos-${{ matrix.kokkos_version }}, model-${{ matrix.exec_model }})
     runs-on:
-      - ${{ matrix.os }}
-      - self-hosted
-      - gpu
+      - single-gpu-x64
 
     steps:
       - name: Validate GPU version and installed compiler

--- a/.github/workflows/wheel_linux_aarch64_cuda.yml
+++ b/.github/workflows/wheel_linux_aarch64_cuda.yml
@@ -43,8 +43,7 @@ jobs:
     timeout-minutes: 45
     name: ${{ matrix.os }}::${{ matrix.arch }} - ${{ matrix.pl_backend }} (Python ${{ fromJson('{ "cp310-*":"3.10","cp311-*":"3.11", "cp312-*":"3.12" }')[matrix.cibw_build] }})
     runs-on: 
-      - self-hosted
-      - ${{ matrix.os }}
+      - single-gpu-arm
 
     steps:
       - name: Checkout PennyLane-Lightning

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.41.0-dev17"
+__version__ = "0.41.0-dev18"


### PR DESCRIPTION
**Context:**

Swap the `runs-on` for GPU related workflows to update the infra it uses to the new GPU infra.

**Description of the Change:**

The current GPU tests use runner infrastructure that is quite old and have accumulated a fair amount of technical debt. As part of an overhaul of the infrastructure, net-new instances have been deployed. 

This pull request updates the gpu workflows to use the newly deployed runners.

Though *most* workflows don't require updates, the multi-gpu workflows do require an update. This is due to the fact that all build environments have been aligned, and only CUDA 12.4 is available on all instances.

Due to this the mpi lib, both openmpi and mpich have only been built against cuda 12.4. And we do not need to load them using `<mpilib>/cuda-<version>`.

**Benefits:**

Enable us to use newer infrastructure that have non-deprecated runtimes (backend).

Alignment of multi-gpu build environment to the single gpu build environment.

**Possible Drawbacks:**

It's possible for a test to fail that used to pass on previous gpu runners. I have taken steps to ensure the build environment between the outgoing runners and incoming runners have as much parity as possible.

Of course, we will ensure the gpu tests pass before merging this PR, but maintainers are encouraged to keep an eye on failing gpu tests over the next couple days to ensure no failures are happening that are specifically related to build environment changes.

**Related GitHub Issues:**
[sc-83176](https://app.shortcut.com/xanaduai/story/83176/investigate-and-try-updating-lambda-runtime-for-pl-runners-pennylane-lightning)