### PR TITLE
[Capture] add execution_config kwarg to eval_jaxpr

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -43,6 +43,9 @@
 * `SX` and `C(SX)` gates are natively supported for all lightning devices.
   [(#731)](https://github.com/PennyLaneAI/pennylane-lightning/pull/731)
 
+* Adds an `execution_config` keyword argument to `LightningBase.eval_jaxpr` to accomodate a
+  Device API change.
+
 ### Documentation
 
 ### Bug fixes

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ### Improvements
 
+* Adds an `execution_config` keyword argument to `LightningBase.eval_jaxpr` to accomodate a
+  Device API change.
+  [(#1067)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1067/)
+
 * Lightning devices support dynamically allocated wires (e.g. `qml.device("lightning.qubit")`)
   [(#1043)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1043)
 
@@ -42,10 +46,6 @@
 
 * `SX` and `C(SX)` gates are natively supported for all lightning devices.
   [(#731)](https://github.com/PennyLaneAI/pennylane-lightning/pull/731)
-
-* Adds an `execution_config` keyword argument to `LightningBase.eval_jaxpr` to accomodate a
-  Device API change.
-  [(#1067)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1067/)
 
 ### Documentation
 

--- a/pennylane_lightning/core/lightning_base.py
+++ b/pennylane_lightning/core/lightning_base.py
@@ -454,7 +454,7 @@ class LightningBase(Device):
         return tuple(zip(*results))
 
     # pylint: disable=import-outside-toplevel
-    def eval_jaxpr(self, jaxpr, consts, *args):
+    def eval_jaxpr(self, jaxpr, consts, *args, execution_config: Optional[ExecutionConfig] = None):
         """Execute pennylane variant jaxpr using C++ simulation tools.
 
         Args:

--- a/pennylane_lightning/core/lightning_base.py
+++ b/pennylane_lightning/core/lightning_base.py
@@ -25,7 +25,7 @@ import pennylane as qml
 from pennylane.devices import DefaultExecutionConfig, Device, ExecutionConfig
 from pennylane.devices.modifiers import simulator_tracking, single_tape_support
 from pennylane.tape import QuantumScript, QuantumTape
-from pennylane.typing import Result, ResultBatch
+from pennylane.typing import Result, ResultBatch, TensorLike
 
 from ._measurements_base import LightningBaseMeasurements
 
@@ -454,13 +454,23 @@ class LightningBase(Device):
         return tuple(zip(*results))
 
     # pylint: disable=import-outside-toplevel, unused-argument
-    def eval_jaxpr(self, jaxpr, consts, *args, execution_config: Optional[ExecutionConfig] = None):
+    def eval_jaxpr(
+        self,
+        jaxpr: "jax.core.Jaxpr",
+        consts: list[TensorLike],
+        *args: TensorLike,
+        execution_config: Optional[ExecutionConfig] = None,
+    ) -> list[TensorLike]:
         """Execute pennylane variant jaxpr using C++ simulation tools.
 
         Args:
             jaxpr (jax.core.Jaxpr): jaxpr containing quantum operations
             consts (list[TensorLike]): List of constants for the jaxpr closure variables
             *args (TensorLike): The arguments to the jaxpr.
+
+        Keyword Args:
+            execution_config (Optional[ExecutionConfig]): a datastructure with additional
+                information required for execution
 
         Returns:
             list(TensorLike): the results of the execution

--- a/pennylane_lightning/core/lightning_base.py
+++ b/pennylane_lightning/core/lightning_base.py
@@ -453,7 +453,7 @@ class LightningBase(Device):
         )
         return tuple(zip(*results))
 
-    # pylint: disable=import-outside-toplevel
+    # pylint: disable=import-outside-toplevel, unused-argument
     def eval_jaxpr(self, jaxpr, consts, *args, execution_config: Optional[ExecutionConfig] = None):
         """Execute pennylane variant jaxpr using C++ simulation tools.
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -20,4 +20,4 @@ custatevec-cu12; sys_platform == "linux"
 cutensornet-cu12>=2.6.0; sys_platform == "linux"
 pylint==2.7.4
 scipy-openblas32>=0.3.26
-git+https://github.com/PennyLaneAI/pennylane.git@qnode-prim-execution-config
+git+https://github.com/PennyLaneAI/pennylane.git@master

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -20,4 +20,4 @@ custatevec-cu12; sys_platform == "linux"
 cutensornet-cu12>=2.6.0; sys_platform == "linux"
 pylint==2.7.4
 scipy-openblas32>=0.3.26
-git+https://github.com/PennyLaneAI/pennylane.git@master
+git+https://github.com/PennyLaneAI/pennylane.git@qnode-prim-execution-config

--- a/tests/test_eval_jaxpr.py
+++ b/tests/test_eval_jaxpr.py
@@ -35,6 +35,21 @@ def enable_disable_plxpr():
     qml.capture.disable()
 
 
+def test_accept_execution_config():
+    """Test that eval_jaxpr can accept an ExecutionConfig.
+
+    At this point, it does not do anything, so we do not need to test it's affect.
+    """
+
+    dev = qml.device(device_name, wires=1)
+
+    jaxpr = jax.make_jaxpr(lambda x: x + 1)(0.1)
+
+    execution_config = qml.devices.ExecutionConfig()
+
+    dev.eval_jaxpr(jaxpr.jaxpr, jaxpr.consts, 0.1, execution_config=execution_config)
+
+
 def test_no_partitioned_shots():
     """Test that an error is raised if partitioned shots is requested."""
 

--- a/tests/test_eval_jaxpr.py
+++ b/tests/test_eval_jaxpr.py
@@ -38,7 +38,7 @@ def enable_disable_plxpr():
 def test_accept_execution_config():
     """Test that eval_jaxpr can accept an ExecutionConfig.
 
-    At this point, it does not do anything, so we do not need to test it's affect.
+    At this point, it does not do anything, so we do not need to test its effect.
     """
 
     dev = qml.device(device_name, wires=1)


### PR DESCRIPTION
**Context:**

In https://github.com/PennyLaneAI/pennylane/pull/6991 we are adding an `execution_config` kwarg to `Device.eval_jaxpr`.  We need to make sure this change doesn't break lightning.

**Description of the Change:**

Adds an `execution_config : Optional[ExecutionConfig] = None` keyword argument to `Device.eval_jaxpr`.

**Benefits:**

Lightning won't break when that change gets merged into pennylane. The lightning device jaxpr execution can be configured in the future.

**Possible Drawbacks:**

**Related GitHub Issues:**

[sc-84916]