### PR TITLE
Fix syntax warning from `is` with a literal

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -57,7 +57,7 @@
 
 ### Bug fixes
 
-* Fix SyntaxWarning from `is` with a literal
+* Fix `SyntaxWarning` from `is` with a literal in Python tests.
   [(#1070)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1070)
 
 * Fix CI to collect Python code coverage for Lightning-Qubit and Lightning-Kokkos CPU.

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -57,6 +57,9 @@
 
 ### Bug fixes
 
+* Fix SyntaxWarning from `is` with a literal
+  [(#1070)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1070)
+
 * Fix CI to collect Python code coverage for Lightning-Qubit and Lightning-Kokkos CPU.
   [(#1053)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1053)
 

--- a/pennylane_lightning/core/_adjoint_jacobian_base.py
+++ b/pennylane_lightning/core/_adjoint_jacobian_base.py
@@ -184,7 +184,7 @@ class LightningBaseAdjointJacobian(ABC):
                 # the tape does not have measurements
                 return True
 
-            if tape_return_type is "state":
+            if tape_return_type == "state":
                 raise QuantumFunctionError(
                     "Adjoint differentiation method does not support measurement StateMP."
                 )
@@ -194,7 +194,7 @@ class LightningBaseAdjointJacobian(ABC):
                 # the tape does not have measurements or the gradient is 0.0
                 return True
 
-            if tape_return_type is "state":
+            if tape_return_type == "state":
                 raise QuantumFunctionError(
                     "Adjoint differentiation does not support State measurements."
                 )

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.41.0-dev23"
+__version__ = "0.41.0-dev24"


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [ ] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [ ] Ensure that the test suite passes, by running `make test`.

- [ ] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [ ] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**
[This PR ](https://github.com/PennyLaneAI/pennylane-lightning/pull/1044) added two instances of `if tape_return_type is "state"` in `_adjoint_jacobian_base.py` , that introduces python SyntaxWarning, e.g. :
```
_adjoint_jacobian_base.py:197: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if tape_return_type is "state":
```
which is also observed in CI logs during testing (e.g. [here](https://github.com/PennyLaneAI/pennylane-lightning/actions/runs/13533320431/job/37820142204#step:14:23) )

**Description of the Change:**
This PR changes `is` to `==`.

**Benefits:**
No more syntax warning - equivalent test [here](https://github.com/PennyLaneAI/pennylane-lightning/actions/runs/13552303713/job/37878601833?pr=1070#step:14:21)

**Possible Drawbacks:**

**Related GitHub Issues:**

[sc-85337]