### PR TITLE
Increase aarch64-cuda wheel build CI max time

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -60,6 +60,9 @@
 
 ### Bug fixes
 
+* Increase maximum time for aarch64-CUDA Github CI action .
+  [(#1070)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1070)
+
 * Fix `SyntaxWarning` from `is` with a literal in Python tests.
   [(#1070)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1070)
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -60,6 +60,9 @@
 
 ### Bug fixes
 
+* Fix Github CI for aarch64 cuda to clean up after runs.
+  [(#1074)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1074)
+
 * Increase maximum time for aarch64-CUDA Github CI action .
   [(#1070)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1070)
 

--- a/.github/workflows/wheel_linux_aarch64_cuda.yml
+++ b/.github/workflows/wheel_linux_aarch64_cuda.yml
@@ -40,7 +40,7 @@ jobs:
         cuda_version: ["12"]
         cibw_build: ${{ fromJson(needs.set_wheel_build_matrix.outputs.python_version) }}
         container_img: ["quay.io/pypa/manylinux_2_28_aarch64"]
-    timeout-minutes: 90
+    timeout-minutes: 60
     name: ${{ matrix.os }}::${{ matrix.arch }} - ${{ matrix.pl_backend }} (Python ${{ fromJson('{ "cp310-*":"3.10","cp311-*":"3.11", "cp312-*":"3.12" }')[matrix.cibw_build] }})
     runs-on: 
       - single-gpu-arm

--- a/.github/workflows/wheel_linux_aarch64_cuda.yml
+++ b/.github/workflows/wheel_linux_aarch64_cuda.yml
@@ -40,7 +40,7 @@ jobs:
         cuda_version: ["12"]
         cibw_build: ${{ fromJson(needs.set_wheel_build_matrix.outputs.python_version) }}
         container_img: ["quay.io/pypa/manylinux_2_28_aarch64"]
-    timeout-minutes: 45
+    timeout-minutes: 60
     name: ${{ matrix.os }}::${{ matrix.arch }} - ${{ matrix.pl_backend }} (Python ${{ fromJson('{ "cp310-*":"3.10","cp311-*":"3.11", "cp312-*":"3.12" }')[matrix.cibw_build] }})
     runs-on: 
       - single-gpu-arm

--- a/.github/workflows/wheel_linux_aarch64_cuda.yml
+++ b/.github/workflows/wheel_linux_aarch64_cuda.yml
@@ -40,7 +40,7 @@ jobs:
         cuda_version: ["12"]
         cibw_build: ${{ fromJson(needs.set_wheel_build_matrix.outputs.python_version) }}
         container_img: ["quay.io/pypa/manylinux_2_28_aarch64"]
-    timeout-minutes: 60
+    timeout-minutes: 90
     name: ${{ matrix.os }}::${{ matrix.arch }} - ${{ matrix.pl_backend }} (Python ${{ fromJson('{ "cp310-*":"3.10","cp311-*":"3.11", "cp312-*":"3.12" }')[matrix.cibw_build] }})
     runs-on: 
       - single-gpu-arm

--- a/.github/workflows/wheel_linux_aarch64_cuda.yml
+++ b/.github/workflows/wheel_linux_aarch64_cuda.yml
@@ -142,6 +142,13 @@ jobs:
           retention-days: 1
           include-hidden-files: true
 
+      - name: Cleanup
+        if: always()
+        run: |
+          rm -rf ${{ steps.setup_venv.outputs.venv_name }}
+          rm -rf * .git .gitignore .github
+          pip cache purge
+
   upload-pypi:
     needs: [set_wheel_build_matrix, linux-wheels-aarch64]
     strategy:
@@ -168,3 +175,10 @@ jobs:
         with:
           verbose: true
           repository-url: https://test.pypi.org/legacy/
+
+      - name: Cleanup
+        if: always()
+        run: |
+          rm -rf ${{ steps.setup_venv.outputs.venv_name }}
+          rm -rf * .git .gitignore .github
+          pip cache purge

--- a/.github/workflows/wheel_linux_aarch64_cuda.yml
+++ b/.github/workflows/wheel_linux_aarch64_cuda.yml
@@ -142,13 +142,6 @@ jobs:
           retention-days: 1
           include-hidden-files: true
 
-      - name: Cleanup
-        if: always()
-        run: |
-          rm -rf ${{ steps.setup_venv.outputs.venv_name }}
-          rm -rf * .git .gitignore .github
-          pip cache purge
-
   upload-pypi:
     needs: [set_wheel_build_matrix, linux-wheels-aarch64]
     strategy:
@@ -175,10 +168,3 @@ jobs:
         with:
           verbose: true
           repository-url: https://test.pypi.org/legacy/
-
-      - name: Cleanup
-        if: always()
-        run: |
-          rm -rf ${{ steps.setup_venv.outputs.venv_name }}
-          rm -rf * .git .gitignore .github
-          pip cache purge

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.41.0-dev26"
+__version__ = "0.41.0-dev27"

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.41.0-dev25"
+__version__ = "0.41.0-dev26"

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.41.0-dev27"
+__version__ = "0.41.0-dev28"


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [ ] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [ ] Ensure that the test suite passes, by running `make test`.

- [ ] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [ ] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**
Due to added python tests in previous, the CI action for aarch64-cuda LT tests + wheel build as exceeded the maximum time (45min), and are cancelled resulting in CI error (https://github.com/PennyLaneAI/pennylane-lightning/actions/runs/13554922529/job/37931172662)

**Description of the Change:**
Increase the max time from 45 to 60 min

**Benefits:**
CI tests and wheel build survives.

**Possible Drawbacks:**


**Related GitHub Issues:**
