### PR TITLE
Cleanup after ARM GPU runner

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -60,6 +60,9 @@
 
 ### Bug fixes
 
+* Fix Github CI for aarch64 cuda to clean up after runs.
+  [(#1074)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1074)
+
 * Fix `SyntaxWarning` from `is` with a literal in Python tests.
   [(#1070)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1070)
 

--- a/.github/workflows/wheel_linux_aarch64_cuda.yml
+++ b/.github/workflows/wheel_linux_aarch64_cuda.yml
@@ -142,6 +142,13 @@ jobs:
           retention-days: 1
           include-hidden-files: true
 
+      - name: Cleanup
+        if: always()
+        run: |
+          rm -rf ${{ steps.setup_venv.outputs.venv_name }}
+          rm -rf * .git .gitignore .github
+          pip cache purge
+
   upload-pypi:
     needs: [set_wheel_build_matrix, linux-wheels-aarch64]
     strategy:
@@ -168,3 +175,10 @@ jobs:
         with:
           verbose: true
           repository-url: https://test.pypi.org/legacy/
+
+      - name: Cleanup
+        if: always()
+        run: |
+          rm -rf ${{ steps.setup_venv.outputs.venv_name }}
+          rm -rf * .git .gitignore .github
+          pip cache purge

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.41.0-dev25"
+__version__ = "0.41.0-dev26"


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [ ] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [ ] Ensure that the test suite passes, by running `make test`.

- [ ] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [ ] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**
Currently Arm GPU CI runners may be reused between runs, and there is no cleanup job after each runs. This means that caches/wheels from previous runs contaminate later runs.

**Description of the Change:**
Clean cache after each Arm GPU CI runs. E.g. [here](https://github.com/PennyLaneAI/pennylane-lightning/actions/runs/13593391314/job/38004671288?pr=1074#step:13:1)

**Benefits:**
No contamination between runs.

**Possible Drawbacks:**

**Related GitHub Issues:**
