### PR TITLE
Fix wheel naming in Docker builds for setuptools 75.8.1 compatibility

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ### Improvements
 
+* Fix wheel naming in Docker builds for `setuptools v75.8.1` compatibility.
+  [(#1075)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1075)
+
 * Use native C++ kernels for controlled-adjoint and adjoint-controlled of supported operations.
   [(#1063)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1063)
 
@@ -89,6 +92,7 @@ Christina Lee,
 Joseph Lee,
 Luis Alfredo Nuñez Meneses,
 Andrija Paurevic,
+Alex Preciado,
 Shuli Shu
 
 ---

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -104,7 +104,7 @@ RUN pip install --force-reinstall --no-cache-dir pennylane_lightning*.whl && rm 
 RUN pip install --no-cache-dir git+https://github.com/PennyLaneAI/pennylane.git@${PENNYLANE_VERSION}
 
 # Install CUDA-12 in build venv image
-FROM base-build-python as base-build-cuda
+FROM base-build-python AS base-build-cuda
 WORKDIR /opt/cuda-build
 RUN curl -o cuda-install.run ${CUDA_INSTALLER}
 RUN chmod a+x cuda-install.run
@@ -176,7 +176,7 @@ RUN pip install --no-cache-dir --force-reinstall pennylane_lightning*.whl && rm 
 RUN pip install --no-cache-dir git+https://github.com/PennyLaneAI/pennylane.git@${PENNYLANE_VERSION}
 
 # Install ROCm in build venv image
-FROM base-build-python as base-build-rocm
+FROM base-build-python AS base-build-rocm
 RUN wget --progress=dot:giga ${ROCM_INSTALLER}
 RUN apt-get update \
     && apt-get install --no-install-recommends -y \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -73,7 +73,7 @@ RUN python3 -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 RUN rm -rf tmp && git clone --depth 1 --branch ${LIGHTNING_VERSION} https://github.com/PennyLaneAI/pennylane-lightning.git tmp\
     && mv tmp/* /opt/pennylane-lightning && rm -rf tmp
-RUN pip install --no-cache-dir build cmake ninja pybind11 toml wheel
+RUN pip install --no-cache-dir build cmake ninja pybind11 toml wheel setuptools>=75.8.1
 
 # Download Lightning release and build lightning-qubit backend
 FROM base-build-python AS build-wheel-lightning-qubit
@@ -85,7 +85,7 @@ RUN python -m build --wheel
 # Install lightning-qubit backend
 FROM base-runtime AS wheel-lightning-qubit
 COPY --from=build-wheel-lightning-qubit /opt/pennylane-lightning/dist/ /
-RUN pip install --force-reinstall --no-cache-dir PennyLane_Lightning*.whl && rm PennyLane_Lightning*.whl
+RUN pip install --force-reinstall --no-cache-dir pennylane_lightning*.whl && rm pennylane_lightning*.whl
 RUN pip install --no-cache-dir git+https://github.com/PennyLaneAI/pennylane.git@${PENNYLANE_VERSION}
 
 # Download Lightning release and build lightning-kokkos backend with Kokkos-OpenMP
@@ -100,7 +100,7 @@ RUN CMAKE_ARGS="-DKokkos_ENABLE_SERIAL:BOOL=ON -DKokkos_ENABLE_OPENMP:BOOL=ON" p
 FROM base-runtime AS wheel-lightning-kokkos-openmp
 COPY --from=build-wheel-lightning-kokkos-openmp /opt/pennylane-lightning/dist/ /
 COPY --from=build-wheel-lightning-qubit /opt/pennylane-lightning/dist/ /
-RUN pip install --force-reinstall --no-cache-dir PennyLane_Lightning*.whl && rm PennyLane_Lightning*.whl
+RUN pip install --force-reinstall --no-cache-dir pennylane_lightning*.whl && rm pennylane_lightning*.whl
 RUN pip install --no-cache-dir git+https://github.com/PennyLaneAI/pennylane.git@${PENNYLANE_VERSION}
 
 # Install CUDA-12 in build venv image
@@ -139,7 +139,7 @@ RUN python3 -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 COPY --from=build-wheel-lightning-kokkos-cuda /opt/pennylane-lightning/dist/ /
 COPY --from=build-wheel-lightning-qubit /opt/pennylane-lightning/dist/ /
-RUN pip install --force-reinstall --no-cache-dir PennyLane_Lightning*.whl && rm PennyLane_Lightning*.whl
+RUN pip install --force-reinstall --no-cache-dir pennylane_lightning*.whl && rm pennylane_lightning*.whl
 RUN pip install --no-cache-dir git+https://github.com/PennyLaneAI/pennylane.git@${PENNYLANE_VERSION}
 
 # Download and build Lightning-GPU release
@@ -172,7 +172,7 @@ RUN pip install --no-cache-dir custatevec-cu12
 ENV LD_LIBRARY_PATH="$VIRTUAL_ENV/lib/python3.10/site-packages/cuquantum/lib:$LD_LIBRARY_PATH"
 COPY --from=build-wheel-lightning-gpu /opt/pennylane-lightning/dist/ /
 COPY --from=build-wheel-lightning-qubit /opt/pennylane-lightning/dist/ /
-RUN pip install --no-cache-dir --force-reinstall PennyLane_Lightning*.whl && rm PennyLane_Lightning*.whl
+RUN pip install --no-cache-dir --force-reinstall pennylane_lightning*.whl && rm pennylane_lightning*.whl
 RUN pip install --no-cache-dir git+https://github.com/PennyLaneAI/pennylane.git@${PENNYLANE_VERSION}
 
 # Install ROCm in build venv image
@@ -213,5 +213,5 @@ RUN python3 -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 COPY --from=build-wheel-lightning-kokkos-rocm /opt/pennylane-lightning/dist/ /
 COPY --from=build-wheel-lightning-qubit /opt/pennylane-lightning/dist/ /
-RUN pip install --force-reinstall --no-cache-dir PennyLane_Lightning*.whl && rm PennyLane_Lightning*.whl
+RUN pip install --force-reinstall --no-cache-dir pennylane_lightning*.whl && rm pennylane_lightning*.whl
 RUN pip install --no-cache-dir git+https://github.com/PennyLaneAI/pennylane.git@${PENNYLANE_VERSION}

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.41.0-dev25"
+__version__ = "0.41.0-dev26"


### PR DESCRIPTION
**Context:**
This pull request addresses an issue with the Docker build process caused by the setuptools 75.8.1 release, which enforces stricter PEP naming conventions. For additional context you can take a look at https://github.com/pypa/setuptools/pull/4766, (and the corresponding issue: https://github.com/pypa/setuptools/issues/3777) in the setup tools repo.

**Description of the Change:**
This PR implements the following changes:

* Specifies `setuptools>=75.8.1` in the Docker build environment to ensure consistent and compliant wheel filename generation.
* Updates the `pip install` command to use the correct wheel filename pattern (`pennylane_lightning*.whl`).

Similar changes have been applied to PennyLane in https://github.com/PennyLaneAI/pennylane/pull/7005 and https://github.com/PennyLaneAI/pennylane/pull/7006

**Benefits:**
[docker-stable](https://github.com/PennyLaneAI/pennylane-lightning/actions/workflows/compat-docker-stable.yml) and [docker-latest](https://github.com/PennyLaneAI/pennylane-lightning/actions/workflows/compat-docker-latest.yml) in our [plugin-test-matrix ](https://github.com/PennyLaneAI/plugin-test-matrix?tab=readme-ov-file#lightning-docker-builds) should stop failing.