### PR TITLE
Remove unnecessary reset_state in execution when state_vector is freshly initialized

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ### Improvements
 
+* Removed redundant `reset_state` calls for circuit execution when state vector is freshly initialized.
+  [(#1076)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1076)
+
 * Use native C++ kernels for controlled-adjoint and adjoint-controlled of supported operations.
   [(#1063)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1063)
 

--- a/mpitests/test_device.py
+++ b/mpitests/test_device.py
@@ -81,7 +81,7 @@ def test_unsupported_dynamic_wires():
 def test_dynamic_wires_from_circuit_fixed_wires(circuit_in, n_wires, wires_list):
     """Test that dynamic_wires_from_circuit creates correct statevector and circuit."""
     dev = qml.device(device_name, mpi=True, wires=n_wires)
-    circuit_out = dev.dynamic_wires_from_circuit(circuit_in, **dev._sv_init_kwargs)
+    circuit_out = dev.dynamic_wires_from_circuit(circuit_in)
 
     assert circuit_out.num_wires == circuit_in.num_wires
     assert circuit_out.wires == qml.wires.Wires(wires_list)

--- a/mpitests/test_device.py
+++ b/mpitests/test_device.py
@@ -81,7 +81,7 @@ def test_unsupported_dynamic_wires():
 def test_dynamic_wires_from_circuit_fixed_wires(circuit_in, n_wires, wires_list):
     """Test that dynamic_wires_from_circuit creates correct statevector and circuit."""
     dev = qml.device(device_name, mpi=True, wires=n_wires)
-    circuit_out = dev.dynamic_wires_from_circuit(circuit_in)
+    circuit_out = dev.dynamic_wires_from_circuit(circuit_in, **dev._sv_init_kwargs)
 
     assert circuit_out.num_wires == circuit_in.num_wires
     assert circuit_out.wires == qml.wires.Wires(wires_list)

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.41.0-dev33"
+__version__ = "0.41.0-dev34"

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.41.0-dev26"
+__version__ = "0.41.0-dev27"

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.41.0-dev31"
+__version__ = "0.41.0-dev32"

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.41.0-dev25"
+__version__ = "0.41.0-dev26"

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.41.0-dev30"
+__version__ = "0.41.0-dev31"

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.41.0-dev28"
+__version__ = "0.41.0-dev29"

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.41.0-dev29"
+__version__ = "0.41.0-dev30"

--- a/pennylane_lightning/core/lightning_base.py
+++ b/pennylane_lightning/core/lightning_base.py
@@ -111,6 +111,7 @@ class LightningBase(Device):
 
         Args:
             circuit (QuantumTape): The circuit to execute.
+            sv_init_kwargs: Additional keyword arguments to pass to the statevector initialization.
 
         Returns:
             QuantumTape: The updated circuit with the wires mapped to the standard wire order.

--- a/pennylane_lightning/core/lightning_base.py
+++ b/pennylane_lightning/core/lightning_base.py
@@ -112,7 +112,6 @@ class LightningBase(Device):
 
         Args:
             circuit (QuantumTape): The circuit to execute.
-            sv_init_kwargs: Additional keyword arguments to pass to the statevector initialization.
 
         Returns:
             QuantumTape: The updated circuit with the wires mapped to the standard wire order.

--- a/pennylane_lightning/core/lightning_base.py
+++ b/pennylane_lightning/core/lightning_base.py
@@ -74,7 +74,7 @@ class LightningBase(Device):
         # State-vector is dynamically allocated just before execution
         self._statevector = None
         self._sv_init_kwargs = {}
-        
+
         if isinstance(wires, int) or wires is None:
             self._wire_map = None  # should just use wires as is
         else:

--- a/pennylane_lightning/core/lightning_base.py
+++ b/pennylane_lightning/core/lightning_base.py
@@ -119,7 +119,7 @@ class LightningBase(Device):
 
         if self.wires is None:
             num_wires = circuit.num_wires
-            # Map to follow default.qubit wire order for dynamic wires
+            # Map to follow the standard wire order for dynamic wires
             circuit = circuit.map_to_standard_wires()
         else:
             num_wires = len(self.wires)

--- a/pennylane_lightning/core/lightning_base.py
+++ b/pennylane_lightning/core/lightning_base.py
@@ -73,7 +73,8 @@ class LightningBase(Device):
 
         # State-vector is dynamically allocated just before execution
         self._statevector = None
-        self._sv_init_kwargs = None
+        self._sv_init_kwargs = {}
+        
         if isinstance(wires, int) or wires is None:
             self._wire_map = None  # should just use wires as is
         else:

--- a/pennylane_lightning/core/lightning_base.py
+++ b/pennylane_lightning/core/lightning_base.py
@@ -107,7 +107,7 @@ class LightningBase(Device):
 
         """
 
-    def dynamic_wires_from_circuit(self, circuit, **sv_init_kwargs):
+    def dynamic_wires_from_circuit(self, circuit):
         """Allocate the underlying quantum state from the pre-defined wires or a given circuit if applicable. Circuit wires will be mapped to Pennylane ``default.qubit`` standard wire order.
 
         Args:
@@ -127,7 +127,7 @@ class LightningBase(Device):
 
         if (self._statevector is None) or (self._statevector.num_wires != num_wires):
             self._statevector = self.LightningStateVector(
-                num_wires=num_wires, dtype=self._c_dtype, **sv_init_kwargs
+                num_wires=num_wires, dtype=self._c_dtype, **self._sv_init_kwargs
             )
         else:
             self._statevector.reset_state()
@@ -349,7 +349,7 @@ class LightningBase(Device):
 
         return tuple(
             self.jacobian(
-                self.dynamic_wires_from_circuit(circuit, **self._sv_init_kwargs),
+                self.dynamic_wires_from_circuit(circuit),
                 self._statevector,
                 batch_obs=batch_obs,
                 wire_map=self._wire_map,
@@ -374,7 +374,7 @@ class LightningBase(Device):
         batch_obs = execution_config.device_options.get("batch_obs", self._batch_obs)
         results = tuple(
             self.simulate_and_jacobian(
-                self.dynamic_wires_from_circuit(circuit, **self._sv_init_kwargs),
+                self.dynamic_wires_from_circuit(circuit),
                 self._statevector,
                 batch_obs=batch_obs,
                 wire_map=self._wire_map,
@@ -433,7 +433,7 @@ class LightningBase(Device):
         batch_obs = execution_config.device_options.get("batch_obs", self._batch_obs)
         return tuple(
             self.vjp(
-                self.dynamic_wires_from_circuit(circuit, **self._sv_init_kwargs),
+                self.dynamic_wires_from_circuit(circuit),
                 cots,
                 self._statevector,
                 batch_obs=batch_obs,
@@ -461,7 +461,7 @@ class LightningBase(Device):
         batch_obs = execution_config.device_options.get("batch_obs", self._batch_obs)
         results = tuple(
             self.simulate_and_vjp(
-                self.dynamic_wires_from_circuit(circuit, **self._sv_init_kwargs),
+                self.dynamic_wires_from_circuit(circuit),
                 cots,
                 self._statevector,
                 batch_obs=batch_obs,

--- a/pennylane_lightning/core/lightning_base.py
+++ b/pennylane_lightning/core/lightning_base.py
@@ -73,7 +73,7 @@ class LightningBase(Device):
 
         # State-vector is dynamically allocated just before execution
         self._statevector = None
-
+        self._sv_init_kwargs = None
         if isinstance(wires, int) or wires is None:
             self._wire_map = None  # should just use wires as is
         else:
@@ -106,8 +106,7 @@ class LightningBase(Device):
 
         """
 
-    @abstractmethod
-    def dynamic_wires_from_circuit(self, circuit):
+    def dynamic_wires_from_circuit(self, circuit, **sv_init_kwargs):
         """Allocate the underlying quantum state from the pre-defined wires or a given circuit if applicable. Circuit wires will be mapped to Pennylane ``default.qubit`` standard wire order.
 
         Args:
@@ -116,6 +115,22 @@ class LightningBase(Device):
         Returns:
             QuantumTape: The updated circuit with the wires mapped to the standard wire order.
         """
+
+        if self.wires is None:
+            num_wires = circuit.num_wires
+            # Map to follow default.qubit wire order for dynamic wires
+            circuit = circuit.map_to_standard_wires()
+        else:
+            num_wires = len(self.wires)
+
+        if (self._statevector is None) or (self._statevector.num_wires != num_wires):
+            self._statevector = self.LightningStateVector(
+                num_wires=num_wires, dtype=self._c_dtype, **sv_init_kwargs
+            )
+        else:
+            self._statevector.reset_state()
+
+        return circuit
 
     @abstractmethod
     def preprocess(self, execution_config: ExecutionConfig = DefaultExecutionConfig):
@@ -332,7 +347,7 @@ class LightningBase(Device):
 
         return tuple(
             self.jacobian(
-                self.dynamic_wires_from_circuit(circuit),
+                self.dynamic_wires_from_circuit(circuit, **self._sv_init_kwargs),
                 self._statevector,
                 batch_obs=batch_obs,
                 wire_map=self._wire_map,
@@ -357,7 +372,7 @@ class LightningBase(Device):
         batch_obs = execution_config.device_options.get("batch_obs", self._batch_obs)
         results = tuple(
             self.simulate_and_jacobian(
-                self.dynamic_wires_from_circuit(circuit),
+                self.dynamic_wires_from_circuit(circuit, **self._sv_init_kwargs),
                 self._statevector,
                 batch_obs=batch_obs,
                 wire_map=self._wire_map,
@@ -416,7 +431,7 @@ class LightningBase(Device):
         batch_obs = execution_config.device_options.get("batch_obs", self._batch_obs)
         return tuple(
             self.vjp(
-                self.dynamic_wires_from_circuit(circuit),
+                self.dynamic_wires_from_circuit(circuit, **self._sv_init_kwargs),
                 cots,
                 self._statevector,
                 batch_obs=batch_obs,
@@ -444,7 +459,7 @@ class LightningBase(Device):
         batch_obs = execution_config.device_options.get("batch_obs", self._batch_obs)
         results = tuple(
             self.simulate_and_vjp(
-                self.dynamic_wires_from_circuit(circuit),
+                self.dynamic_wires_from_circuit(circuit, **self._sv_init_kwargs),
                 cots,
                 self._statevector,
                 batch_obs=batch_obs,

--- a/pennylane_lightning/lightning_gpu/lightning_gpu.py
+++ b/pennylane_lightning/lightning_gpu/lightning_gpu.py
@@ -284,6 +284,7 @@ class LightningGPU(LightningBase):
         else:
             self._statevector = None
             self._mpi_handler = None
+            self._sv_init_kwargs = {"mpi_handler": None, "use_async": self._use_async}
 
     @property
     def name(self):
@@ -322,37 +323,6 @@ class LightningGPU(LightningBase):
         new_device_options.update(mcmc_default)
 
         return replace(config, **updated_values, device_options=new_device_options)
-
-    def dynamic_wires_from_circuit(self, circuit):
-        """Allocate a state-vector from the pre-defined wires or a given circuit if applicable. Circuit wires will be mapped to Pennylane ``default.qubit`` standard wire order.
-
-        Args:
-            circuit (QuantumTape): The circuit to execute.
-
-        Returns:
-            QuantumTape: The updated circuit with the wires mapped to the standard wire order.
-        """
-        if self._mpi_handler and self._mpi_handler.use_mpi:
-            return circuit
-
-        if self.wires is None:
-            num_wires = circuit.num_wires
-            # Map to follow default.qubit wire order for dynamic wires
-            circuit = circuit.map_to_standard_wires()
-        else:
-            num_wires = len(self.wires)
-
-        if (self._statevector is None) or (self._statevector.num_wires != num_wires):
-            self._statevector = self.LightningStateVector(
-                num_wires=num_wires,
-                dtype=self._c_dtype,
-                mpi_handler=None,
-                use_async=self._use_async,
-            )
-        else:
-            self._statevector.reset_state()
-
-        return circuit
 
     def preprocess(self, execution_config: ExecutionConfig = DefaultExecutionConfig):
         """This function defines the device transform program to be applied and an updated device configuration.
@@ -417,7 +387,7 @@ class LightningGPU(LightningBase):
                 [circuit], _ = qml.map_wires(circuit, self._wire_map)
             results.append(
                 self.simulate(
-                    self.dynamic_wires_from_circuit(circuit),
+                    self.dynamic_wires_from_circuit(circuit, **self._sv_init_kwargs),
                     self._statevector,
                     postselect_mode=execution_config.mcm_config.postselect_mode,
                 )

--- a/pennylane_lightning/lightning_gpu/lightning_gpu.py
+++ b/pennylane_lightning/lightning_gpu/lightning_gpu.py
@@ -218,6 +218,8 @@ class LightningGPU(LightningBase):
         use_async (bool): is host-device data copy asynchronized or not.
     """
 
+    # pylint: disable=too-many-instance-attributes
+    
     # General device options
     _device_options = ("c_dtype", "batch_obs")
 

--- a/pennylane_lightning/lightning_gpu/lightning_gpu.py
+++ b/pennylane_lightning/lightning_gpu/lightning_gpu.py
@@ -349,6 +349,8 @@ class LightningGPU(LightningBase):
                 mpi_handler=None,
                 use_async=self._use_async,
             )
+        else:
+            self._statevector.reset_state()
 
         return circuit
 
@@ -494,7 +496,6 @@ class LightningGPU(LightningBase):
                 )
             return tuple(results)
 
-        state.reset_state()
         final_state = state.get_final_state(circuit)
         return self.LightningMeasurements(final_state).measure_final_state(circuit)
 

--- a/pennylane_lightning/lightning_gpu/lightning_gpu.py
+++ b/pennylane_lightning/lightning_gpu/lightning_gpu.py
@@ -389,7 +389,7 @@ class LightningGPU(LightningBase):
                 [circuit], _ = qml.map_wires(circuit, self._wire_map)
             results.append(
                 self.simulate(
-                    self.dynamic_wires_from_circuit(circuit, **self._sv_init_kwargs),
+                    self.dynamic_wires_from_circuit(circuit),
                     self._statevector,
                     postselect_mode=execution_config.mcm_config.postselect_mode,
                 )

--- a/pennylane_lightning/lightning_gpu/lightning_gpu.py
+++ b/pennylane_lightning/lightning_gpu/lightning_gpu.py
@@ -268,7 +268,6 @@ class LightningGPU(LightningBase):
 
         # GPU specific options
         self._dp = DevPool()
-        self._use_async = use_async
 
         # Create the state vector only for MPI, otherwise created dynamically before execution
         if mpi:
@@ -281,12 +280,12 @@ class LightningGPU(LightningBase):
                 num_wires=len(self.wires),
                 dtype=c_dtype,
                 mpi_handler=self._mpi_handler,
-                use_async=self._use_async,
+                use_async=use_async,
             )
         else:
             self._statevector = None
             self._mpi_handler = None
-            self._sv_init_kwargs = {"mpi_handler": None, "use_async": self._use_async}
+            self._sv_init_kwargs = {"mpi_handler": None, "use_async": use_async}
 
     @property
     def name(self):

--- a/pennylane_lightning/lightning_gpu/lightning_gpu.py
+++ b/pennylane_lightning/lightning_gpu/lightning_gpu.py
@@ -219,7 +219,7 @@ class LightningGPU(LightningBase):
     """
 
     # pylint: disable=too-many-instance-attributes
-    
+
     # General device options
     _device_options = ("c_dtype", "batch_obs")
 

--- a/pennylane_lightning/lightning_kokkos/lightning_kokkos.py
+++ b/pennylane_lightning/lightning_kokkos/lightning_kokkos.py
@@ -346,7 +346,7 @@ class LightningKokkos(LightningBase):
                 [circuit], _ = qml.map_wires(circuit, self._wire_map)
             results.append(
                 self.simulate(
-                    self.dynamic_wires_from_circuit(circuit, **self._sv_init_kwargs),
+                    self.dynamic_wires_from_circuit(circuit),
                     self._statevector,
                     postselect_mode=execution_config.mcm_config.postselect_mode,
                 )

--- a/pennylane_lightning/lightning_kokkos/lightning_kokkos.py
+++ b/pennylane_lightning/lightning_kokkos/lightning_kokkos.py
@@ -243,6 +243,7 @@ class LightningKokkos(LightningBase):
         self._kokkos_args = kokkos_args
 
         self._statevector = None
+        self._sv_init_kwargs = {"kokkos_args": self._kokkos_args}
 
     @property
     def name(self):
@@ -281,33 +282,6 @@ class LightningKokkos(LightningBase):
         new_device_options.update(mcmc_default)
 
         return replace(config, **updated_values, device_options=new_device_options)
-
-    def dynamic_wires_from_circuit(self, circuit):
-        """Allocate a state-vector from the pre-defined wires or a given circuit if applicable. Circuit wires will be mapped to Pennylane ``default.qubit`` standard wire order.
-
-        Args:
-            circuit (QuantumTape): The circuit to execute.
-
-        Returns:
-            QuantumTape: The updated circuit with the wires mapped to the standard wire order.
-        """
-
-        if self.wires is None:
-            num_wires = circuit.num_wires
-            # Map to follow default.qubit wire order for dynamic wires
-            circuit = circuit.map_to_standard_wires()
-        else:
-            num_wires = len(self.wires)
-
-        if (self._statevector is None) or (self._statevector.num_wires != num_wires):
-            self._statevector = self.LightningStateVector(
-                num_wires=num_wires, dtype=self._c_dtype, kokkos_args=self._kokkos_args
-            )
-            LightningKokkos.kokkos_config = _kokkos_configuration()
-        else:
-            self._statevector.reset_state()
-
-        return circuit
 
     def preprocess(self, execution_config: ExecutionConfig = DefaultExecutionConfig):
         """This function defines the device transform program to be applied and an updated device configuration.
@@ -372,7 +346,7 @@ class LightningKokkos(LightningBase):
                 [circuit], _ = qml.map_wires(circuit, self._wire_map)
             results.append(
                 self.simulate(
-                    self.dynamic_wires_from_circuit(circuit),
+                    self.dynamic_wires_from_circuit(circuit, **self._sv_init_kwargs),
                     self._statevector,
                     postselect_mode=execution_config.mcm_config.postselect_mode,
                 )

--- a/pennylane_lightning/lightning_kokkos/lightning_kokkos.py
+++ b/pennylane_lightning/lightning_kokkos/lightning_kokkos.py
@@ -304,6 +304,8 @@ class LightningKokkos(LightningBase):
                 num_wires=num_wires, dtype=self._c_dtype, kokkos_args=self._kokkos_args
             )
             LightningKokkos.kokkos_config = _kokkos_configuration()
+        else:
+            self._statevector.reset_state()
 
         return circuit
 
@@ -444,7 +446,6 @@ class LightningKokkos(LightningBase):
                 )
             return tuple(results)
 
-        state.reset_state()
         final_state = state.get_final_state(circuit)
         return self.LightningMeasurements(final_state).measure_final_state(circuit)
 

--- a/pennylane_lightning/lightning_kokkos/lightning_kokkos.py
+++ b/pennylane_lightning/lightning_kokkos/lightning_kokkos.py
@@ -239,11 +239,8 @@ class LightningKokkos(LightningBase):
         # Set the attributes to call the Lightning classes
         self._set_lightning_classes()
 
-        # Kokkos specific options
-        self._kokkos_args = kokkos_args
-
         self._statevector = None
-        self._sv_init_kwargs = {"kokkos_args": self._kokkos_args}
+        self._sv_init_kwargs = {"kokkos_args": kokkos_args}
 
     @property
     def name(self):

--- a/pennylane_lightning/lightning_qubit/lightning_qubit.py
+++ b/pennylane_lightning/lightning_qubit/lightning_qubit.py
@@ -323,8 +323,6 @@ class LightningQubit(LightningBase):
 
         return replace(config, **updated_values, device_options=new_device_options)
 
-        return circuit
-
     def preprocess(self, execution_config: ExecutionConfig = DefaultExecutionConfig):
         """This function defines the device transform program to be applied and an updated device configuration.
 

--- a/pennylane_lightning/lightning_qubit/lightning_qubit.py
+++ b/pennylane_lightning/lightning_qubit/lightning_qubit.py
@@ -287,6 +287,7 @@ class LightningQubit(LightningBase):
         }
 
         self._statevector = None
+        self._sv_init_kwargs = {}
 
     @property
     def name(self):
@@ -321,28 +322,6 @@ class LightningQubit(LightningBase):
                 new_device_options[option] = getattr(self, f"_{option}", None)
 
         return replace(config, **updated_values, device_options=new_device_options)
-
-    def dynamic_wires_from_circuit(self, circuit):
-        """Allocate a state-vector from the pre-defined wires or a given circuit if applicable. Circuit wires will be mapped to Pennylane ``default.qubit`` standard wire order.
-
-        Args:
-            circuit (QuantumTape): The circuit to execute.
-
-        Returns:
-            QuantumTape: The updated circuit with the wires mapped to the standard wire order.
-        """
-
-        if self.wires is None:
-            num_wires = circuit.num_wires
-            # Map to follow default.qubit wire order for dynamic wires
-            circuit = circuit.map_to_standard_wires()
-        else:
-            num_wires = len(self.wires)
-
-        if (self._statevector is None) or (self._statevector.num_wires != num_wires):
-            self._statevector = self.LightningStateVector(num_wires=num_wires, dtype=self._c_dtype)
-        else:
-            self._statevector.reset_state()
 
         return circuit
 
@@ -414,7 +393,7 @@ class LightningQubit(LightningBase):
                 [circuit], _ = qml.map_wires(circuit, self._wire_map)
             results.append(
                 self.simulate(
-                    self.dynamic_wires_from_circuit(circuit),
+                    self.dynamic_wires_from_circuit(circuit, **self._sv_init_kwargs),
                     self._statevector,
                     mcmc=mcmc,
                     postselect_mode=execution_config.mcm_config.postselect_mode,

--- a/pennylane_lightning/lightning_qubit/lightning_qubit.py
+++ b/pennylane_lightning/lightning_qubit/lightning_qubit.py
@@ -341,6 +341,8 @@ class LightningQubit(LightningBase):
 
         if (self._statevector is None) or (self._statevector.num_wires != num_wires):
             self._statevector = self.LightningStateVector(num_wires=num_wires, dtype=self._c_dtype)
+        else:
+            self._statevector.reset_state()
 
         return circuit
 
@@ -493,7 +495,6 @@ class LightningQubit(LightningBase):
                 )
             return tuple(results)
 
-        state.reset_state()
         final_state = state.get_final_state(circuit)
         return self.LightningMeasurements(final_state, **mcmc).measure_final_state(circuit)
 

--- a/pennylane_lightning/lightning_qubit/lightning_qubit.py
+++ b/pennylane_lightning/lightning_qubit/lightning_qubit.py
@@ -391,7 +391,7 @@ class LightningQubit(LightningBase):
                 [circuit], _ = qml.map_wires(circuit, self._wire_map)
             results.append(
                 self.simulate(
-                    self.dynamic_wires_from_circuit(circuit, **self._sv_init_kwargs),
+                    self.dynamic_wires_from_circuit(circuit),
                     self._statevector,
                     mcmc=mcmc,
                     postselect_mode=execution_config.mcm_config.postselect_mode,

--- a/tests/lightning_base/test_device.py
+++ b/tests/lightning_base/test_device.py
@@ -267,7 +267,11 @@ class TestHelpers:
     def test_dynamic_wires_from_circuit(self, circuit_in, n_wires, expected_circuit_out):
         """Test that dynamic_wires_from_circuit returns correct circuit and creates state-vectors properly"""
         device = LightningDevice(wires=None)
-        circuit_out = device.dynamic_wires_from_circuit(circuit_in)
+
+        if device_name == "lightning.tensor":
+            circuit_out = device.dynamic_wires_from_circuit(circuit_in)
+        else:
+            circuit_out = device.dynamic_wires_from_circuit(circuit_in, **device._sv_init_kwargs)
 
         assert circuit_out.num_wires == n_wires
         assert circuit_out.wires == qml.wires.Wires(range(n_wires))
@@ -312,7 +316,11 @@ class TestHelpers:
     def test_dynamic_wires_from_circuit_fixed_wires(self, circuit_in, n_wires, wires_list):
         """Test that dynamic_wires_from_circuit does not alter the circuit if wires are fixed and state-vector is created properly"""
         device = LightningDevice(wires=n_wires)
-        circuit_out = device.dynamic_wires_from_circuit(circuit_in)
+
+        if device_name == "lightning.tensor":
+            circuit_out = device.dynamic_wires_from_circuit(circuit_in)
+        else:
+            circuit_out = device.dynamic_wires_from_circuit(circuit_in, **device._sv_init_kwargs)
 
         assert circuit_out.num_wires == circuit_in.num_wires
         assert circuit_out.wires == qml.wires.Wires(wires_list)
@@ -347,13 +355,19 @@ class TestHelpers:
         device = LightningDevice(wires=None)
 
         # Initialize statevector and apply a state
-        device.dynamic_wires_from_circuit(circuit_0)
+        if device_name == "lightning.tensor":
+            device.dynamic_wires_from_circuit(circuit_0)
+        else:
+            device.dynamic_wires_from_circuit(circuit_0, **device._sv_init_kwargs)
         state = np.zeros(2**n_wires_0)
         state[-1] = 1.0
         device._statevector._apply_state_vector(state, range(n_wires_0))
 
         # Dynamic wires again will reset the state
-        device.dynamic_wires_from_circuit(circuit_1)
+        if device_name == "lightning.tensor":
+            device.dynamic_wires_from_circuit(circuit_1)
+        else:
+            device.dynamic_wires_from_circuit(circuit_1, **device._sv_init_kwargs)
         expected_state = np.zeros(2**n_wires_1)
         expected_state[0] = 1.0
         assert np.allclose(device._statevector.state, expected_state)

--- a/tests/lightning_base/test_device.py
+++ b/tests/lightning_base/test_device.py
@@ -336,17 +336,19 @@ class TestHelpers:
         "circuit_1, n_wires_1",
         [
             (QuantumScript([qml.RX(0.1, 0)], [qml.expval(qml.Z(1))]), 2),
-            (QuantumScript([qml.RX(0.1, 0), qml.RX(0.1, 1)], [qml.expval(qml.Z(2))]), 3),
+            (QuantumScript([qml.RX(0.1, 0), qml.RX(0.1, 2)], [qml.expval(qml.Z(1))]), 3),
+            (QuantumScript([qml.RX(0.1, 0), qml.RX(0.1, 1), qml.RX(0.1, 4), qml.RX(0.1, 6)], [qml.expval(qml.Z(2))]), 5),
         ],
     )
+    @pytest.mark.parametrize("shots", [None, 10])
     @pytest.mark.skipif(
         device_name == "lightning.tensor", reason="lightning.tensor does not have state vector"
     )
     def test_dynamic_wires_from_circuit_reset_state(
-        self, circuit_0, n_wires_0, circuit_1, n_wires_1
+        self, circuit_0, n_wires_0, circuit_1, n_wires_1, shots
     ):
         """Test that dynamic_wires_from_circuit resets state when reusing or initializing new state vector"""
-        device = LightningDevice(wires=None)
+        device = LightningDevice(wires=None, shots=shots)
 
         # Initialize statevector and apply a state
         device.dynamic_wires_from_circuit(circuit_0)

--- a/tests/lightning_base/test_device.py
+++ b/tests/lightning_base/test_device.py
@@ -337,7 +337,13 @@ class TestHelpers:
         [
             (QuantumScript([qml.RX(0.1, 0)], [qml.expval(qml.Z(1))]), 2),
             (QuantumScript([qml.RX(0.1, 0), qml.RX(0.1, 2)], [qml.expval(qml.Z(1))]), 3),
-            (QuantumScript([qml.RX(0.1, 0), qml.RX(0.1, 1), qml.RX(0.1, 4), qml.RX(0.1, 6)], [qml.expval(qml.Z(2))]), 5),
+            (
+                QuantumScript(
+                    [qml.RX(0.1, 0), qml.RX(0.1, 1), qml.RX(0.1, 4), qml.RX(0.1, 6)],
+                    [qml.expval(qml.Z(2))],
+                ),
+                5,
+            ),
         ],
     )
     @pytest.mark.parametrize("shots", [None, 10])

--- a/tests/lightning_base/test_device.py
+++ b/tests/lightning_base/test_device.py
@@ -268,10 +268,7 @@ class TestHelpers:
         """Test that dynamic_wires_from_circuit returns correct circuit and creates state-vectors properly"""
         device = LightningDevice(wires=None)
 
-        if device_name == "lightning.tensor":
-            circuit_out = device.dynamic_wires_from_circuit(circuit_in)
-        else:
-            circuit_out = device.dynamic_wires_from_circuit(circuit_in, **device._sv_init_kwargs)
+        circuit_out = device.dynamic_wires_from_circuit(circuit_in)
 
         assert circuit_out.num_wires == n_wires
         assert circuit_out.wires == qml.wires.Wires(range(n_wires))
@@ -317,10 +314,7 @@ class TestHelpers:
         """Test that dynamic_wires_from_circuit does not alter the circuit if wires are fixed and state-vector is created properly"""
         device = LightningDevice(wires=n_wires)
 
-        if device_name == "lightning.tensor":
-            circuit_out = device.dynamic_wires_from_circuit(circuit_in)
-        else:
-            circuit_out = device.dynamic_wires_from_circuit(circuit_in, **device._sv_init_kwargs)
+        circuit_out = device.dynamic_wires_from_circuit(circuit_in)
 
         assert circuit_out.num_wires == circuit_in.num_wires
         assert circuit_out.wires == qml.wires.Wires(wires_list)
@@ -355,19 +349,13 @@ class TestHelpers:
         device = LightningDevice(wires=None)
 
         # Initialize statevector and apply a state
-        if device_name == "lightning.tensor":
-            device.dynamic_wires_from_circuit(circuit_0)
-        else:
-            device.dynamic_wires_from_circuit(circuit_0, **device._sv_init_kwargs)
+        device.dynamic_wires_from_circuit(circuit_0)
         state = np.zeros(2**n_wires_0)
         state[-1] = 1.0
         device._statevector._apply_state_vector(state, range(n_wires_0))
 
         # Dynamic wires again will reset the state
-        if device_name == "lightning.tensor":
-            device.dynamic_wires_from_circuit(circuit_1)
-        else:
-            device.dynamic_wires_from_circuit(circuit_1, **device._sv_init_kwargs)
+        device.dynamic_wires_from_circuit(circuit_1)
         expected_state = np.zeros(2**n_wires_1)
         expected_state[0] = 1.0
         assert np.allclose(device._statevector.state, expected_state)

--- a/tests/lightning_base/test_device.py
+++ b/tests/lightning_base/test_device.py
@@ -343,7 +343,7 @@ class TestHelpers:
     def test_dynamic_wires_from_circuit_reset_state(
         self, circuit_0, n_wires_0, circuit_1, n_wires_1
     ):
-        """Test that dynamic_wires_from_circuit resets state when reusing state vector"""
+        """Test that dynamic_wires_from_circuit resets state when reusing or initializing new state vector"""
         device = LightningDevice(wires=None)
 
         # Initialize statevector and apply a state


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [ ] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [ ] Ensure that the test suite passes, by running `make test`.

- [ ] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [ ] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**
Previously, when we perform `execute` of a circuit, we reset the statevector within `simulation`. However, the statevector is just freshly initialized when `execute` is called (with the recent changes to allocate state vector dynamically), so the reset_state is redundant.

**Description of the Change:**
We remove `reset_state` within simulation. The only occasion when `reset_state` is necessary is when we reuse the statevector (when multiple circuits to be executed have the same num_wires`) instead of initializing a new one, hence this is moved to `dynamic_wires_from_circuit`.

**Benefits:**
No redundant reset state call - improved performance.

**Possible Drawbacks:**

**Related GitHub Issues:**

[sc-81780]