### PR TITLE
fix measurements with dynamic wires

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -66,6 +66,9 @@
 
 ### Bug fixes
 
+* Fix measurements with empty wires and operators for statevectors with dynamically allocated wires.
+  [(#1081)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1081)
+
 * Fix Github CI for aarch64 cuda to clean up after runs.
   [(#1074)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1074)
 

--- a/pennylane_lightning/core/_measurements_base.py
+++ b/pennylane_lightning/core/_measurements_base.py
@@ -17,6 +17,7 @@ Class implementation for state vector measurements.
 
 from abc import ABC, abstractmethod
 from typing import Any, Callable, List, Union
+from copy import copy
 
 import numpy as np
 import pennylane as qml
@@ -317,8 +318,9 @@ class LightningBaseMeasurements(ABC):
         # last N measurements are sampling MCMs in ``dynamic_one_shot`` execution mode
         mps = measurements[0 : -len(mid_measurements)] if mid_measurements else measurements
 
-        for measurement in mps:
-            if not measurement.wires:
+        #for measurement in mps:
+            #if measurement.wires == Wires([]):
+            #if not measurement.obs and not measurement.wires:
                 # This is required for the case where no wires is specific for the statevector
                 # (i.e. dynamically determined from circuit), and no wires (and no observable)
                 # is provided for the measurement (e.g. qml.probs() or qml.counts() or
@@ -326,7 +328,12 @@ class LightningBaseMeasurements(ABC):
                 # the same operation is performed in validate_device_wires during preprocess.
 
                 # pylint:disable=protected-access
-                measurement._wires = Wires(range(self._qubit_state.num_wires))
+                #measurement._wires = Wires(range(self._qubit_state.num_wires))
+                #if measurement.mv is not None and measurement.mv == []:
+                #    measurement.mv.wires = Wires(range(self._qubit_state.num_wires))
+                #else:
+                #    measurement._wires = Wires(range(self._qubit_state.num_wires))
+                #
 
         groups, indices = _group_measurements(mps)
 

--- a/pennylane_lightning/core/_measurements_base.py
+++ b/pennylane_lightning/core/_measurements_base.py
@@ -308,9 +308,10 @@ class LightningBaseMeasurements(ABC):
                 # is provided for the measurement (e.g. qml.probs() or qml.counts() or
                 # qml.samples()). In the case where number of wires is provided for the statevector,
                 # the same operation is performed in validate_device_wires during preprocess.
+                # pylint:disable=protected-access
                 measurement._wires = Wires(
                     range(self._qubit_state.num_wires)
-                )  # pylint:disable=protected-access
+                )  
 
         groups, indices = _group_measurements(mps)
 

--- a/pennylane_lightning/core/_measurements_base.py
+++ b/pennylane_lightning/core/_measurements_base.py
@@ -308,10 +308,9 @@ class LightningBaseMeasurements(ABC):
                 # is provided for the measurement (e.g. qml.probs() or qml.counts() or
                 # qml.samples()). In the case where number of wires is provided for the statevector,
                 # the same operation is performed in validate_device_wires during preprocess.
+
                 # pylint:disable=protected-access
-                measurement._wires = Wires(
-                    range(self._qubit_state.num_wires)
-                )  
+                measurement._wires = Wires(range(self._qubit_state.num_wires))
 
         groups, indices = _group_measurements(mps)
 

--- a/pennylane_lightning/core/_measurements_base.py
+++ b/pennylane_lightning/core/_measurements_base.py
@@ -308,7 +308,9 @@ class LightningBaseMeasurements(ABC):
                 # is provided for the measurement (e.g. qml.probs() or qml.counts() or
                 # qml.samples()). In the case where number of wires is provided for the statevector,
                 # the same operation is performed in validate_device_wires during preprocess.
-                measurement._wires = Wires(range(self._qubit_state.num_wires))
+                measurement._wires = Wires(
+                    range(self._qubit_state.num_wires)
+                )  # pylint:disable=protected-access
 
         groups, indices = _group_measurements(mps)
 

--- a/pennylane_lightning/core/_measurements_base.py
+++ b/pennylane_lightning/core/_measurements_base.py
@@ -141,9 +141,13 @@ class LightningBaseMeasurements(ABC):
             Probabilities of the supplied observable or wires.
         """
         diagonalizing_gates = measurementprocess.diagonalizing_gates()
+
         if diagonalizing_gates:
             self._qubit_state.apply_operations(diagonalizing_gates)
+
         if measurementprocess.wires == Wires([]):
+            # For the case where no wires is specified for statevector
+            # and measurement process, wires are determined here
             measurewires = self._qubit_state.wires
         else:
             measurewires = measurementprocess.wires.tolist()

--- a/pennylane_lightning/core/_measurements_base.py
+++ b/pennylane_lightning/core/_measurements_base.py
@@ -143,7 +143,6 @@ class LightningBaseMeasurements(ABC):
         diagonalizing_gates = measurementprocess.diagonalizing_gates()
         if diagonalizing_gates:
             self._qubit_state.apply_operations(diagonalizing_gates)
-
         if measurementprocess.wires == Wires([]):
             measurewires = self._qubit_state.wires
         else:

--- a/pennylane_lightning/core/_measurements_base.py
+++ b/pennylane_lightning/core/_measurements_base.py
@@ -141,11 +141,14 @@ class LightningBaseMeasurements(ABC):
             Probabilities of the supplied observable or wires.
         """
         diagonalizing_gates = measurementprocess.diagonalizing_gates()
-
         if diagonalizing_gates:
             self._qubit_state.apply_operations(diagonalizing_gates)
 
-        results = self._measurement_lightning.probs(measurementprocess.wires.tolist())
+        if measurementprocess.wires == Wires([]):
+            measurewires = self._qubit_state.wires
+        else:
+            measurewires = measurementprocess.wires.tolist()
+        results = self._measurement_lightning.probs(measurewires)
 
         if diagonalizing_gates:
             self._qubit_state.apply_operations(
@@ -297,6 +300,16 @@ class LightningBaseMeasurements(ABC):
         """
         # last N measurements are sampling MCMs in ``dynamic_one_shot`` execution mode
         mps = measurements[0 : -len(mid_measurements)] if mid_measurements else measurements
+
+        for measurement in mps:
+            if not measurement.wires:
+                # This is required for the case where no wires is specific for the statevector
+                # (i.e. dynamically determined from circuit), and no wires (and no observable)
+                # is provided for the measurement (e.g. qml.probs() or qml.counts() or
+                # qml.samples()). In the case where number of wires is provided for the statevector,
+                # the same operation is performed in validate_device_wires during preprocess.
+                measurement._wires = Wires(range(self._qubit_state.num_wires))
+
         groups, indices = _group_measurements(mps)
 
         all_res = []

--- a/pennylane_lightning/core/_measurements_base.py
+++ b/pennylane_lightning/core/_measurements_base.py
@@ -17,7 +17,6 @@ Class implementation for state vector measurements.
 
 from abc import ABC, abstractmethod
 from typing import Any, Callable, List, Union
-from copy import copy
 
 import numpy as np
 import pennylane as qml
@@ -318,9 +317,8 @@ class LightningBaseMeasurements(ABC):
         # last N measurements are sampling MCMs in ``dynamic_one_shot`` execution mode
         mps = measurements[0 : -len(mid_measurements)] if mid_measurements else measurements
 
-        #for measurement in mps:
-            #if measurement.wires == Wires([]):
-            #if not measurement.obs and not measurement.wires:
+        for measurement in mps:
+            if measurement.wires == Wires([]):
                 # This is required for the case where no wires is specific for the statevector
                 # (i.e. dynamically determined from circuit), and no wires (and no observable)
                 # is provided for the measurement (e.g. qml.probs() or qml.counts() or
@@ -328,12 +326,7 @@ class LightningBaseMeasurements(ABC):
                 # the same operation is performed in validate_device_wires during preprocess.
 
                 # pylint:disable=protected-access
-                #measurement._wires = Wires(range(self._qubit_state.num_wires))
-                #if measurement.mv is not None and measurement.mv == []:
-                #    measurement.mv.wires = Wires(range(self._qubit_state.num_wires))
-                #else:
-                #    measurement._wires = Wires(range(self._qubit_state.num_wires))
-                #
+                measurement._wires = Wires(range(self._qubit_state.num_wires))
 
         groups, indices = _group_measurements(mps)
 

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.41.0-dev32"
+__version__ = "0.41.0-dev33"

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.41.0-dev31"
+__version__ = "0.41.0-dev32"

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.41.0-dev30"
+__version__ = "0.41.0-dev31"

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.41.0-dev29"
+__version__ = "0.41.0-dev30"

--- a/pennylane_lightning/lightning_tensor/_measurements.py
+++ b/pennylane_lightning/lightning_tensor/_measurements.py
@@ -289,7 +289,7 @@ class LightningTensorMeasurements:
         mps = measurements
 
         for measurement in mps:
-            if not measurement.wires:
+            if measurement.wires == Wires([]):
                 # This is required for the case where no wires is specific for the tensornet
                 # (i.e. dynamically determined from circuit), and no wires (and no observable)
                 # is provided for the measurement (e.g. qml.probs() or qml.counts() or

--- a/pennylane_lightning/lightning_tensor/_measurements.py
+++ b/pennylane_lightning/lightning_tensor/_measurements.py
@@ -137,10 +137,14 @@ class LightningTensorMeasurements:
             Probabilities of the supplied observable or wires
         """
         diagonalizing_gates = measurementprocess.diagonalizing_gates()
+
         if diagonalizing_gates:
             self._tensornet.apply_operations(diagonalizing_gates)
             self._tensornet.appendFinalState()
+
         if measurementprocess.wires == Wires([]):
+            # For the case where no wires is specified for tensornet
+            # and measurement process, wires are determined here
             measurewires = self._tensornet._wires
         else:
             measurewires = measurementprocess.wires.tolist()

--- a/pennylane_lightning/lightning_tensor/_measurements.py
+++ b/pennylane_lightning/lightning_tensor/_measurements.py
@@ -140,7 +140,11 @@ class LightningTensorMeasurements:
         if diagonalizing_gates:
             self._tensornet.apply_operations(diagonalizing_gates)
             self._tensornet.appendFinalState()
-        results = self._measurement_lightning.probs(measurementprocess.wires.tolist())
+        if measurementprocess.wires == Wires([]):
+            measurewires = self._tensornet._wires
+        else:
+            measurewires = measurementprocess.wires.tolist()
+        results = self._measurement_lightning.probs(measurewires)
         if diagonalizing_gates:
             self._tensornet.apply_operations(
                 [qml.adjoint(g, lazy=False) for g in reversed(diagonalizing_gates)]
@@ -267,6 +271,18 @@ class LightningTensorMeasurements:
             List[TensorLike[Any]]: Sample measurement results
         """
         mps = measurements
+
+        for measurement in mps:
+            if not measurement.wires:
+                # This is required for the case where no wires is specific for the tensornet
+                # (i.e. dynamically determined from circuit), and no wires (and no observable)
+                # is provided for the measurement (e.g. qml.probs() or qml.counts() or
+                # qml.samples()). In the case where number of wires is provided for the statevector,
+                # the same operation is performed in validate_device_wires during preprocess.
+
+                # pylint:disable=protected-access
+                measurement._wires = Wires(range(self._tensornet.num_wires))
+
         groups, indices = _group_measurements(mps)
 
         all_res = []

--- a/tests/test_measurements.py
+++ b/tests/test_measurements.py
@@ -22,11 +22,9 @@ import numpy as np
 import pennylane as qml
 import pytest
 from conftest import LightningDevice as ld
-from conftest import device_name, lightning_ops, validate_measurements
+from conftest import device_name, lightning_ops, validate_measurements, LightningException
 from flaky import flaky
 from pennylane.measurements import ExpectationMP, Shots, VarianceMP
-
-from pennylane_lightning.lightning_tensor_ops import LightningException
 
 if not ld._CPP_BINARY_AVAILABLE:
     pytest.skip("No binary module found. Skipping.", allow_module_level=True)

--- a/tests/test_measurements.py
+++ b/tests/test_measurements.py
@@ -511,7 +511,8 @@ class TestSample:
 @pytest.mark.parametrize(
     "obs",
     [
-        None, [], 
+        None,
+        [],
         [0],
         [0, 1],
         qml.PauliZ(0),
@@ -556,13 +557,17 @@ def test_shots_single_measure_obs(shots, measure_f, obs, n_wires, mcmc, kernel_n
         qml.RX(x, 2)
         return measure_f(wires=obs) if isinstance(obs, Sequence) else measure_f(op=obs)
 
-    func1 = qml.QNode(func, dev)
-    results1 = func1(*params)
+    if obs == []:
+        with pytest.raises(ValueError, match="Cannot set an empty list of wires"):
+            qml.QNode(func, dev)(*params)
+    else:
+        func1 = qml.QNode(func, dev)
+        results1 = func1(*params)
 
-    func2 = qml.QNode(func, dq)
-    results2 = func2(*params)
+        func2 = qml.QNode(func, dq)
+        results2 = func2(*params)
 
-    validate_measurements(measure_f, shots, results1, results2)
+        validate_measurements(measure_f, shots, results1, results2)
 
 
 # TODO: Add LT after extending the support for shots_vector

--- a/tests/test_measurements.py
+++ b/tests/test_measurements.py
@@ -87,7 +87,7 @@ class TestProbs:
 
         assert np.allclose(circuit(), expected, atol=tol, rtol=0)
 
-    def test_probs_tape_emptywires(self, dev):
+    def test_probs_tape_empty_wires(self, dev):
         """Test that probs with empty list for wires raises an error"""
 
         x, y, z = [0.5, 0.3, -0.7]

--- a/tests/test_measurements.py
+++ b/tests/test_measurements.py
@@ -22,7 +22,7 @@ import numpy as np
 import pennylane as qml
 import pytest
 from conftest import LightningDevice as ld
-from conftest import device_name, lightning_ops, validate_measurements, LightningException
+from conftest import LightningException, device_name, lightning_ops, validate_measurements
 from flaky import flaky
 from pennylane.measurements import ExpectationMP, Shots, VarianceMP
 

--- a/tests/test_measurements.py
+++ b/tests/test_measurements.py
@@ -25,6 +25,7 @@ from conftest import LightningDevice as ld
 from conftest import LightningException, device_name, lightning_ops, validate_measurements
 from flaky import flaky
 from pennylane.measurements import ExpectationMP, Shots, VarianceMP
+from pennylane.wires import Wires
 
 if not ld._CPP_BINARY_AVAILABLE:
     pytest.skip("No binary module found. Skipping.", allow_module_level=True)
@@ -510,7 +511,7 @@ class TestSample:
 @pytest.mark.parametrize(
     "obs",
     [
-        None,
+        None, [], 
         [0],
         [0, 1],
         qml.PauliZ(0),

--- a/tests/test_measurements.py
+++ b/tests/test_measurements.py
@@ -507,7 +507,7 @@ def test_shots_single_measure_obs(shots, measure_f, obs, n_wires, mcmc, kernel_n
     if measure_f in (qml.counts, qml.sample) and shots is None:
         pytest.skip("qml.counts, qml.sample do not work with shots = None.")
 
-    if obs is None and measure_f in (qml.expval, qml.var):
+    if measure_f in (qml.expval, qml.var) and obs is None:
         pytest.skip("qml.expval, qml.var requires observable.")
 
     if device_name in ("lightning.gpu", "lightning.kokkos", "lightning.tensor"):


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [ ] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [ ] Ensure that the test suite passes, by running `make test`.

- [ ] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [ ] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**
Currently when using dynamically determined wire count (e.g. `qml.device("lightning.qubit")` or `qml.device("lightning.qubit", shots = x)`), we have an issue when we perform measurements without specifying any observables or wires, i.e.

- qml.probs()
- qml.counts()
- qml.sample()

incorrect result is returned, since the number of wires is not known.

**Description of the Change:**
For measurements with no wires (i.e. no observables or wires provided), we edit the measurement process to include the number of wires. This is fixed for with and without shots.

**Benefits:**
Get correct results.

**Possible Drawbacks:**

**Related GitHub Issues:**
fixes https://github.com/PennyLaneAI/pennylane-lightning/issues/1086

[sc-85837]