### PR TITLE
Fix test_preprocess skip condition

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -86,6 +86,9 @@
 
 ### Bug fixes
 
+* Fix test_preprocess test skip condition.
+  [(#XX)](https://github.com/PennyLaneAI/pennylane-lightning/pull/X)
+
 * Fix measurements with empty wires and operators for statevectors with dynamically allocated wires.
   [(#1081)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1081)
 

--- a/tests/lightning_base/test_device.py
+++ b/tests/lightning_base/test_device.py
@@ -570,7 +570,7 @@ class TestExecution:
         assert new_config == expected_config
 
     @pytest.mark.skipif(
-        device_name="lightning.tensor", reason="lightning.tensor does not support adjoint"
+        device_name == "lightning.tensor", reason="lightning.tensor does not support adjoint"
     )
     @pytest.mark.parametrize("adjoint", [True, False])
     def test_preprocess(self, adjoint):


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [ ] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [ ] Ensure that the test suite passes, by running `make test`.

- [ ] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [ ] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**
Currently test_preprocess in test_device.py has an incorrect skip condition, leading to skipped test for every device instead of just lightning tensor.

**Description of the Change:**
change skip condition from `device_name = "lightning.tensor"` to `device_name == "lightning.tensor`

**Benefits:**
Actually run test on devices.

**Possible Drawbacks:**

**Related GitHub Issues:**
