### PR TITLE
Fix LGPU-MPI CI to run on push to master branch

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -90,7 +90,7 @@
 ### Bug fixes
 
 * Fix Github CI to run `Lightning-GPU-MPI` tests when pushed to master branch.
-  [(#XX)](https://github.com/PennyLaneAI/pennylane-lightning/pull/XX)
+  [(#1101)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1101)
 
 * Fix the `test_preprocess` test skip condition for `lightning.tensor`.
   [(#1092)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1092)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -89,6 +89,9 @@
 
 ### Bug fixes
 
+* Fix Github CI to run `Lightning-GPU-MPI` tests when pushed to master branch.
+  [(#XX)](https://github.com/PennyLaneAI/pennylane-lightning/pull/XX)
+
 * Fix the `test_preprocess` test skip condition for `lightning.tensor`.
   [(#1092)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1092)
 

--- a/.github/workflows/tests_lgpumpi_cpp.yml
+++ b/.github/workflows/tests_lgpumpi_cpp.yml
@@ -12,7 +12,7 @@ on:
         description: The version of PennyLane to use. Valid values are either 'stable' (most recent git-tag) or 'latest' (most recent commit from master)
   push:
     branches:
-      - main
+      - master
   pull_request:
     types:
       - opened

--- a/.github/workflows/tests_lgpumpi_python.yml
+++ b/.github/workflows/tests_lgpumpi_python.yml
@@ -12,7 +12,7 @@ on:
         description: The version of PennyLane to use. Valid values are either 'stable' (most recent git-tag) or 'latest' (most recent commit from master)
   push:
     branches:
-      - main
+      - master
   pull_request:
     types:
       - opened

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.41.0-dev37"
+__version__ = "0.41.0-dev38"


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [ ] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [ ] Ensure that the test suite passes, by running `make test`.

- [ ] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [ ] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**
Currently the LGPU-MPI tests do not run on push to master branch, since the branch is incorrectly set to `main`, instead of `master.

**Description of the Change:**
Update Github workflow file to check master instead of main branch.

**Benefits:**
Run LGPU-MPI tests for push to master, more checks. 

**Possible Drawbacks:**

**Related GitHub Issues:**

[sc-86768]