### PR TITLE
Prune lightning_tensor files in LQ wheels

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -33,16 +33,16 @@
 * Hide internal C++ APIs in Lightning docs.
   [(#1096)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1096)
 
-* Implemented the `jaxpr_jvp` method to compute the jvp of a jaxpr using `lightning.qubit`.
+* Implement the `jaxpr_jvp` method to compute the jvp of a jaxpr using `lightning.qubit`.
   This method currently only support the adjoint differentiation method.
-  [(#1087)](https://github.com/PennyLaneAI/pennylane/pull/1087)
-  [(#1106)](https://github.com/PennyLaneAI/pennylane/pull/1106)
+  [(#1087)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1087)
+  [(#1106)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1106)
 
 * Modify expval of named operators in Lightning-Qubit for in-place computation of expectation value, to avoid creating an intermediate statevector
   [(#1079)] (https://github.com/PennyLaneAI/pennylane-lightning/pull/1079)
   [(#565)] (https://github.com/PennyLaneAI/pennylane-lightning/pull/565)
 
-* Device (`"lightning.qubit"`, `"lightning.gpu"`, `"lightning.kokkos"`) pre-processing is now included in the 
+* Device (`"lightning.qubit"`, `"lightning.gpu"`, `"lightning.kokkos"`) pre-processing is now included in the
   execution pipeline when program capture is enabled.
   [(#1084)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1084)
 
@@ -51,17 +51,17 @@
 
 * Expand test structure to efficiently handle sparse data.
   [(#1085)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1085)
-  
-* Removed redundant `reset_state` calls for circuit execution when state vector is freshly initialized.
+
+* Remove redundant `reset_state` calls for circuit execution when state vector is freshly initialized.
   [(#1076)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1076)
 
-* Added support for sparse `qml.QubitUnitary` gates for `lightning.qubit`, `lightning.gpu`, and `lightning.kokkos` backends.
+* Add support for sparse `qml.QubitUnitary` gates for `lightning.qubit`, `lightning.gpu`, and `lightning.kokkos` backends.
   [(#1068)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1068).
 
 * Introduce a generalized sparse gate selection system via the `_observable_is_sparse` method in the base measurement class, enabling future expansion for any number of sparse observables.
   [(#1068)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1068).
 
-* Optimize the copy of a input state-vector into the LGPU #1071 
+* Optimize the copy of a input state-vector into Lightning-GPU.
   [(#1071)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1071)
 
 * Fix wheel naming in Docker builds for `setuptools v75.8.1` compatibility.
@@ -76,7 +76,7 @@
 * Capture execution via `dev.eval_jaxpr` can now be used with `jax.jit` and `jax.vmap`.
   [(#1055)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1055)
 
-* Adds an `execution_config` keyword argument to `LightningBase.eval_jaxpr` to accomodate a
+* Add an `execution_config` keyword argument to `LightningBase.eval_jaxpr` to accomodate a
   Device API change.
   [(#1067)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1067/)
 
@@ -117,7 +117,7 @@
 * `SX` and `C(SX)` gates are natively supported for all lightning devices.
   [(#731)](https://github.com/PennyLaneAI/pennylane-lightning/pull/731)
 
-* Programs transformed by `qml.defer_measurements` can be executed on `lightning.qubit`.
+* Program transformed by `qml.defer_measurements` can be executed on `lightning.qubit`.
   [(#1069)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1069)
 
 * `lightning.qubit` supports `ctrl` and `adjoint` with program capture.
@@ -126,6 +126,10 @@
 ### Documentation
 
 ### Bug fixes
+
+* Fix the issue with pip installing PennyLane (and Lightning-Qubit) on Windows.
+  [(#1116)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1116)
+
 
 * Fix the stable/stable issue with missing `pytest-split`.
   [(#1112)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1112)
@@ -166,7 +170,7 @@
 * Update Github CI to use Ubuntu 24 and remove `libopenblas-base` package.
   [(#1041)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1041)
 
-* Updates the `eval_jaxpr` method to handle the new signatures for the `cond`, `while`, and
+* Update the `eval_jaxpr` method to handle the new signatures for the `cond`, `while`, and
   `for` primitives.
   [(#1051)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1051)
 
@@ -785,7 +789,7 @@ Ali Asadi, Astral Cai, Ahmed Darwish, Amintor Dusko, Vincent Michaud-Rioux, Luis
   [(#750)](https://github.com/PennyLaneAI/pennylane-lightning/pull/750)
 
 * Rationalize MCM tests, removing most end-to-end tests from the native MCM test file, but keeping one that validates multiple mid-circuit measurements with any allowed return.
-  [(#754)](https://github.com/PennyLaneAI/pennylane/pull/754)
+  [(#754)](https://github.com/PennyLaneAI/pennylane-lightning/pull/754)
 
 * Rename `lightning.tensor` C++ libraries.
   [(#755)](https://github.com/PennyLaneAI/pennylane-lightning/pull/755)

--- a/.github/workflows/wheel_win_x86_64.yml
+++ b/.github/workflows/wheel_win_x86_64.yml
@@ -135,7 +135,7 @@ jobs:
           CIBW_BEFORE_BUILD: |
             python -m pip install pybind11 cmake~=3.27.0 build
             # Prone lightning_tensor src files to be included in the wheel
-            echo "prune pennylane_lightning/core/simulators/lightning_tensor" >> MANIFEST.in
+            echo "prune pennylane_lightning/core/src/simulators/lightning_tensor" >> MANIFEST.in
 
           CIBW_ENVIRONMENT: |
             CMAKE_ARGS="-DCMAKE_BUILD_TYPE=Release"

--- a/.github/workflows/wheel_win_x86_64.yml
+++ b/.github/workflows/wheel_win_x86_64.yml
@@ -134,8 +134,6 @@ jobs:
           # Python build settings
           CIBW_BEFORE_BUILD: |
             python -m pip install pybind11 cmake~=3.27.0 build
-            # Prone lightning_tensor src files to be included in the wheel
-            echo "prune pennylane_lightning/core/src/simulators/lightning_tensor" >> MANIFEST.in
 
           CIBW_ENVIRONMENT: |
             CMAKE_ARGS="-DCMAKE_BUILD_TYPE=Release"
@@ -146,7 +144,11 @@ jobs:
 
           CIBW_BUILD_FRONTEND: build
 
-        run: python -m cibuildwheel --output-dir wheelhouse
+        run: |
+          # Prone lightning_tensor src files to be included in the wheel
+          echo "prune pennylane_lightning/core/src/simulators/lightning_tensor" >> MANIFEST.in
+          cat MANIFEST.in
+          python -m cibuildwheel --output-dir wheelhouse
 
       - name: Patch wheels
         run: |
@@ -203,11 +205,11 @@ jobs:
           regex: '.*[0-9]+.[0-9]+.[0-9]+[-_]?rc[0-9]+'
 
       - uses: actions/upload-artifact@v4
-        # if: |
-        #   github.event_name == 'release' ||
-        #   github.event_name == 'workflow_dispatch' ||
-        #   github.ref == 'refs/heads/master' ||
-        #   steps.rc_build.outputs.match != ''
+        if: |
+          github.event_name == 'release' ||
+          github.event_name == 'workflow_dispatch' ||
+          github.ref == 'refs/heads/master' ||
+          steps.rc_build.outputs.match != ''
         with:
           name: ${{ runner.os }}-wheels-${{ matrix.pl_backend }}-${{ fromJson('{ "cp310-*":"py310","cp311-*":"py311","cp312-*":"py312","cp313-*":"py313" }')[matrix.cibw_build] }}-${{ matrix.arch }}.zip
           path: ./wheelhouse/*.whl

--- a/.github/workflows/wheel_win_x86_64.yml
+++ b/.github/workflows/wheel_win_x86_64.yml
@@ -203,11 +203,11 @@ jobs:
           regex: '.*[0-9]+.[0-9]+.[0-9]+[-_]?rc[0-9]+'
 
       - uses: actions/upload-artifact@v4
-        if: |
-          github.event_name == 'release' ||
-          github.event_name == 'workflow_dispatch' ||
-          github.ref == 'refs/heads/master' ||
-          steps.rc_build.outputs.match != ''
+        # if: |
+        #   github.event_name == 'release' ||
+        #   github.event_name == 'workflow_dispatch' ||
+        #   github.ref == 'refs/heads/master' ||
+        #   steps.rc_build.outputs.match != ''
         with:
           name: ${{ runner.os }}-wheels-${{ matrix.pl_backend }}-${{ fromJson('{ "cp310-*":"py310","cp311-*":"py311","cp312-*":"py312","cp313-*":"py313" }')[matrix.cibw_build] }}-${{ matrix.arch }}.zip
           path: ./wheelhouse/*.whl

--- a/.github/workflows/wheel_win_x86_64.yml
+++ b/.github/workflows/wheel_win_x86_64.yml
@@ -145,7 +145,7 @@ jobs:
           CIBW_BUILD_FRONTEND: build
 
         run: |
-          # Prone lightning_tensor src files to be included in the wheel
+          # Prune lightning_tensor src files to be included in the wheel
           echo "prune pennylane_lightning/core/src/simulators/lightning_tensor" >> MANIFEST.in
           cat MANIFEST.in
           python -m cibuildwheel --output-dir wheelhouse

--- a/.github/workflows/wheel_win_x86_64.yml
+++ b/.github/workflows/wheel_win_x86_64.yml
@@ -158,6 +158,11 @@ jobs:
             python -m wheel unpack $i.Name
             $name = $i.Name
             $dirName = python -c "s = '$name'; print('-'.join(s.split('-')[0:2]))"
+            echo ""
+            echo $dirName
+            echo ""
+            ls
+            echo ""
             if (Test-Path -Path $dirName\pennylane_lightning\RelWithDebInfo) {
               Move-Item -Path $dirName\pennylane_lightning\RelWithDebInfo\* -Destination $dirName\pennylane_lightning
               Remove-Item $dirName\pennylane_lightning\RelWithDebInfo -Recurse
@@ -167,6 +172,10 @@ jobs:
             Remove-Item $dirName -Recurse
           }
           cd ..
+          echo ""
+          ls
+          echo ""
+
 
       - name: Determine Python version
         id: pyvs

--- a/.github/workflows/wheel_win_x86_64.yml
+++ b/.github/workflows/wheel_win_x86_64.yml
@@ -134,6 +134,8 @@ jobs:
           # Python build settings
           CIBW_BEFORE_BUILD: |
             python -m pip install pybind11 cmake~=3.27.0 build
+            # Prone lightning_tensor src files to be included in the wheel
+            echo "prune pennylane_lightning/core/simulators/lightning_tensor" >> MANIFEST.in
 
           CIBW_ENVIRONMENT: |
             CMAKE_ARGS="-DCMAKE_BUILD_TYPE=Release"
@@ -180,10 +182,6 @@ jobs:
           python -m ensurepip --upgrade
           python -m pip install setuptools
           python -m pip install -r requirements-tests.txt
-          if (${{ matrix.pl_backend == 'lightning_kokkos'}}) {
-            PL_BACKEND="lightning_qubit" python scripts/configure_pyproject_toml.py
-            SKIP_COMPILATION=True python -m pip install . -vv
-          }
           pushd wheelhouse
           $wheels = Get-ChildItem "./" -Filter *.whl
           foreach ($i in $wheels){

--- a/.github/workflows/wheel_win_x86_64.yml
+++ b/.github/workflows/wheel_win_x86_64.yml
@@ -147,7 +147,6 @@ jobs:
         run: |
           # Prune lightning_tensor src files to be included in the wheel
           echo "prune pennylane_lightning/core/src/simulators/lightning_tensor" >> MANIFEST.in
-          cat MANIFEST.in
           python -m cibuildwheel --output-dir wheelhouse
 
       - name: Patch wheels
@@ -158,11 +157,6 @@ jobs:
             python -m wheel unpack $i.Name
             $name = $i.Name
             $dirName = python -c "s = '$name'; print('-'.join(s.split('-')[0:2]))"
-            echo ""
-            echo $dirName
-            echo ""
-            ls
-            echo ""
             if (Test-Path -Path $dirName\pennylane_lightning\RelWithDebInfo) {
               Move-Item -Path $dirName\pennylane_lightning\RelWithDebInfo\* -Destination $dirName\pennylane_lightning
               Remove-Item $dirName\pennylane_lightning\RelWithDebInfo -Recurse
@@ -172,10 +166,6 @@ jobs:
             Remove-Item $dirName -Recurse
           }
           cd ..
-          echo ""
-          ls
-          echo ""
-
 
       - name: Determine Python version
         id: pyvs
@@ -193,6 +183,10 @@ jobs:
           python -m ensurepip --upgrade
           python -m pip install setuptools
           python -m pip install -r requirements-tests.txt
+          if (${{ matrix.pl_backend == 'lightning_kokkos'}}) {
+            PL_BACKEND="lightning_qubit" python scripts/configure_pyproject_toml.py
+            SKIP_COMPILATION=True python -m pip install . -vv
+          }
           pushd wheelhouse
           $wheels = Get-ChildItem "./" -Filter *.whl
           foreach ($i in $wheels){

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.41.0-dev53"
+__version__ = "0.41.0-dev54"

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.41.0-dev54"
+__version__ = "0.41.0-dev55"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13", 
     "Topic :: Scientific/Engineering :: Physics",
 ]
-dependencies = ["pennylane>=0.40", "scipy-openblas32>0.3.26"]
+dependencies = ["pennylane>=0.40", "scipy-openblas32>=0.3.26"]
 dynamic = [ "version",]
 [[project.maintainers]]
 name = "Xanadu Quantum Technologies Inc."

--- a/setup.py
+++ b/setup.py
@@ -178,7 +178,7 @@ with open(os.path.join("pennylane_lightning", "core", "_version.py"), encoding="
 packages_list = ["pennylane_lightning." + backend]
 
 if backend == "lightning_qubit":
-    packages_list += [""pennylane_lightning.core"]
+    packages_list += ["pennylane_lightning.core"]
 
 info = {
     "version": version,

--- a/setup.py
+++ b/setup.py
@@ -178,7 +178,7 @@ with open(os.path.join("pennylane_lightning", "core", "_version.py"), encoding="
 packages_list = ["pennylane_lightning." + backend]
 
 if backend == "lightning_qubit":
-    packages_list += ["pennylane_lightning.core"]
+    packages_list += [""pennylane_lightning.core"]
 
 info = {
     "version": version,

--- a/setup.py
+++ b/setup.py
@@ -191,16 +191,4 @@ info = {
     "ext_package": "pennylane_lightning",
 }
 
-if backend == "lightning_qubit":
-    info.update(
-        {
-            "package_data": {
-                "pennylane_lightning.core": [
-                    os.path.join("src", "*"),
-                    os.path.join("src", "**", "*"),
-                ]
-            },
-        }
-    )
-
 setup(**(info))


### PR DESCRIPTION
**Context:**
The following issue with pip installing PennyLane (and Lighnting-Qubit) on Windows was reported by a user:

```
I’m trying to install pennylane on a windows 11 machine issuing
pip install pennylane —upgrade
And I get the following error:
"ERROR: Could not install packages due to an OSError: [Errno 2] No such file or directory: 'C:\\Users\\cesko\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.11_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python311\\site-packages\\pennylane_lightning\\core\\src\\simulators\\lightning_tensor\\tncuda\\measurements\\tests\\runner_lightning_tensor_measurements.cpp'
HINT: This error might have occurred since this system does not have Windows Long Path support enabled. You can find information on how to enable this at https://pip.pypa.io/warnings/enable-long-paths"
```

This issue can be fixed by removing LightningTensor source files in our Windows wheels.

For more context: older versions of Windows had a maximum limit on the length of a file path and as Lightning currently pull the entire src subdirectly into the Windows wheels, the user will get Maximum Path Length Limitation - Win32 error.

**Related GitHub Issues:**
[sc-82977]