### PR TITLE
Install Pytorch 2.5.1 CPU in CIs and Update make python command

### DIFF
--- a/.github/workflows/tests_lkcpu_python.yml
+++ b/.github/workflows/tests_lkcpu_python.yml
@@ -33,7 +33,7 @@ on:
 env:
   TF_VERSION: 2.16.2
   KERAS_VERSION: 3.9.0
-  TORCH_VERSION: 2.3.1+cpu
+  TORCH_VERSION: 2.5.1
   COVERAGE_FLAGS: "--cov=pennylane_lightning --cov-report=term-missing --no-flaky-report -p no:warnings --tb=native"
   GCC_VERSION: 11
   OMP_NUM_THREADS: "2"
@@ -236,7 +236,7 @@ jobs:
 
       - name: Install ML libraries for interfaces
         run: |
-          python -m pip install --upgrade torch==$TORCH_VERSION -f https://download.pytorch.org/whl/cpu/torch_stable.html
+          python -m pip install --upgrade torch==$TORCH_VERSION --index-url https://download.pytorch.org/whl/cpu
           python -m pip install --upgrade tensorflow~=$TF_VERSION keras~=$KERAS_VERSION
 
       - name: Run PennyLane-Lightning integration tests

--- a/.github/workflows/tests_lkcuda_python.yml
+++ b/.github/workflows/tests_lkcuda_python.yml
@@ -35,7 +35,7 @@ env:
   CI_CUDA_ARCH: 86
   TF_VERSION: 2.16.2
   KERAS_VERSION: 3.9.0
-  TORCH_VERSION: 2.3.1+cpu
+  TORCH_VERSION: 2.5.1
   COVERAGE_FLAGS: "--cov=pennylane_lightning --cov-report=term-missing --cov-report=xml:./coverage.xml --no-flaky-report -p no:warnings --tb=native"
 
 concurrency:
@@ -244,7 +244,7 @@ jobs:
 
       - name: Install ML libraries for interfaces
         run: |
-          python -m pip install --upgrade torch==$TORCH_VERSION -f https://download.pytorch.org/whl/cpu/torch_stable.html
+          python -m pip install --upgrade torch==$TORCH_VERSION --index-url https://download.pytorch.org/whl/cpu
           python -m pip install --upgrade tensorflow~=$TF_VERSION keras~=$KERAS_VERSION
 
       - name: Install backend device

--- a/.github/workflows/tests_lqcpu_python.yml
+++ b/.github/workflows/tests_lqcpu_python.yml
@@ -23,7 +23,7 @@ on:
 env:
   TF_VERSION: 2.16.2
   KERAS_VERSION: 3.9.0
-  TORCH_VERSION: 2.3.1+cpu
+  TORCH_VERSION: 2.5.1
   COVERAGE_FLAGS: "--cov=pennylane_lightning --cov-report=term-missing --no-flaky-report -p no:warnings --tb=native"
   GCC_VERSION: 13
   OMP_NUM_THREADS: "2"
@@ -187,7 +187,7 @@ jobs:
 
       - name: Install ML libraries for interfaces
         run: |
-          python -m pip install --upgrade torch==$TORCH_VERSION -f https://download.pytorch.org/whl/cpu/torch_stable.html
+          python -m pip install --upgrade torch==$TORCH_VERSION --index-url https://download.pytorch.org/whl/cpu
           python -m pip install --upgrade tensorflow~=$TF_VERSION keras~=$KERAS_VERSION
 
       - name: Switch to stable tag of Lightning

--- a/Makefile
+++ b/Makefile
@@ -65,11 +65,12 @@ clean:
 	rm -rf .coverage coverage_html_report/
 	rm -rf pennylane_lightning/*_ops*
 	rm -rf *.egg-info
+	rm -rf dist
 
 .PHONY: python python-skip-compile
 python:
 	PL_BACKEND=$(PL_BACKEND) python scripts/configure_pyproject_toml.py
-	pip install -e . --config-settings editable_mode=compat -vv
+	CMAKE_ARGS="-DSCIPY_OPENBLAS=$(SCIPY_OPENBLAS)" pip install -e . --config-settings editable_mode=compat -vv
 
 python-skip-compile:
 	PL_BACKEND=$(PL_BACKEND) python scripts/configure_pyproject_toml.py

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ clean:
 .PHONY: python python-skip-compile
 python:
 	PL_BACKEND=$(PL_BACKEND) python scripts/configure_pyproject_toml.py
-	CMAKE_ARGS="-DSCIPY_OPENBLAS=$(SCIPY_OPENBLAS)" pip install -e . --config-settings editable_mode=compat -vv
+	CMAKE_ARGS="-DSCIPY_OPENBLAS=$(SCIPY_OPENBLAS) $(OPTIONS)" pip install -e . --config-settings editable_mode=compat -vv
 
 python-skip-compile:
 	PL_BACKEND=$(PL_BACKEND) python scripts/configure_pyproject_toml.py

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.41.0-dev53"
+__version__ = "0.41.0-dev54"


### PR DESCRIPTION
**Context:**
- Install Pytorch 2.5.1 CPU in CIs from `https://download.pytorch.org/whl/cpu`
  - [stable/stable](https://github.com/PennyLaneAI/pennylane-lightning/actions/runs/14223435918)
  - [latest/latest](https://github.com/PennyLaneAI/pennylane-lightning/actions/runs/14223272356)

- Fix [sc-86352] via updating the [Makefile](https://github.com/PennyLaneAI/pennylane-lightning/pull/1118/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R73) python command

**Benefits:**
- Upgrade the Torch referenced version in CIs
- Reduce build deps time by installing CPU modules instead of the entire Torch package
- Fix editable install of Lightning not discovering `SCIPY_OPENBLAS`

**Related GitHub Issues:**
[sc-87997]