### PR TITLE
Fix issue 1115

### DIFF
--- a/pennylane_lightning/lightning_qubit/lightning_qubit.py
+++ b/pennylane_lightning/lightning_qubit/lightning_qubit.py
@@ -389,10 +389,10 @@ class LightningQubit(LightningBase):
 
         program.add_transform(validate_measurements, name=self.name)
         program.add_transform(validate_observables, accepted_observables, name=self.name)
-        program.add_transform(validate_device_wires, self.wires, name=self.name)
         program.add_transform(
             mid_circuit_measurements, device=self, mcm_config=exec_config.mcm_config
         )
+        program.add_transform(validate_device_wires, self.wires, name=self.name)
 
         program.add_transform(
             decompose,


### PR DESCRIPTION
**Context:**
Fix #1115 

**Description of the Change:**
Change the transform function order in the preporcessing to validate that all wires present in the tape are on the device after adding the extra wires from apply `mid_circuit_measurements`.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
