### PR TITLE
Fix decomposition of controlled SProd operators

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -128,7 +128,7 @@
 ### Bug fixes
 
 * Fix the issue with decomposing controlled `SProd` operations.
-  [(#XX)](https://github.com/PennyLaneAI/pennylane-lightning/pull/XX)
+  [(#1120)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1120)
 
 * Fix the issue with pip installing PennyLane (and Lightning-Qubit) on Windows.
   [(#1116)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1116)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -127,9 +127,11 @@
 
 ### Bug fixes
 
+* Fix the issue with decomposing controlled `SProd` operations.
+  [(#XX)](https://github.com/PennyLaneAI/pennylane-lightning/pull/XX)
+
 * Fix the issue with pip installing PennyLane (and Lightning-Qubit) on Windows.
   [(#1116)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1116)
-
 
 * Fix the stable/stable issue with missing `pytest-split`.
   [(#1112)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1112)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -127,7 +127,7 @@
 
 ### Bug fixes
 
-* Fix the issue with decomposing controlled `SProd` operations.
+* Fix the issue with decomposing controlled `qml.SProd` and `qml.Exp` operations.
   [(#1120)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1120)
 
 * Fix the issue with pip installing PennyLane (and Lightning-Qubit) on Windows.

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.41.0-dev55"
+__version__ = "0.41.0-dev56"

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.41.0-dev56"
+__version__ = "0.41.0-dev57"

--- a/pennylane_lightning/lightning_gpu/lightning_gpu.py
+++ b/pennylane_lightning/lightning_gpu/lightning_gpu.py
@@ -91,7 +91,7 @@ _to_matrix_ops = {
 
 def stopping_condition(op: Operator) -> bool:
     """A function that determines whether or not an operation is supported by ``lightning.gpu``."""
-    if op.name == "C(SProd)":
+    if op.name in ("C(SProd)", "C(Exp)"):
         return True
     return _supports_operation(op.name)
 

--- a/pennylane_lightning/lightning_gpu/lightning_gpu.py
+++ b/pennylane_lightning/lightning_gpu/lightning_gpu.py
@@ -91,6 +91,8 @@ _to_matrix_ops = {
 
 def stopping_condition(op: Operator) -> bool:
     """A function that determines whether or not an operation is supported by ``lightning.gpu``."""
+    if op.name == "C(SProd)":
+        return True
     return _supports_operation(op.name)
 
 

--- a/pennylane_lightning/lightning_kokkos/lightning_kokkos.py
+++ b/pennylane_lightning/lightning_kokkos/lightning_kokkos.py
@@ -83,7 +83,7 @@ def stopping_condition(op: Operator) -> bool:
         word = op._hyperparameters["pauli_word"]  # pylint: disable=protected-access
         # decomposes to IsingXX, etc. for n <= 2
         return reduce(lambda x, y: x + (y != "I"), word, 0) > 2
-    if op.name == "C(SProd)":
+    if op.name in ("C(SProd)", "C(Exp)"):
         return True
     return _supports_operation(op.name)
 

--- a/pennylane_lightning/lightning_kokkos/lightning_kokkos.py
+++ b/pennylane_lightning/lightning_kokkos/lightning_kokkos.py
@@ -83,6 +83,8 @@ def stopping_condition(op: Operator) -> bool:
         word = op._hyperparameters["pauli_word"]  # pylint: disable=protected-access
         # decomposes to IsingXX, etc. for n <= 2
         return reduce(lambda x, y: x + (y != "I"), word, 0) > 2
+    if op.name == "C(SProd)":
+        return True
     return _supports_operation(op.name)
 
 

--- a/pennylane_lightning/lightning_qubit/_state_vector.py
+++ b/pennylane_lightning/lightning_qubit/_state_vector.py
@@ -239,10 +239,10 @@ class LightningStateVector(LightningBaseStateVector):  # pylint: disable=too-few
             None
         """
         state = self.state_vector
-
         # Skip over identity operations instead of performing
         # matrix multiplication with it.
         for operation in operations:
+            print(operation)
             if isinstance(operation, qml.Identity):
                 continue
             if isinstance(operation, Adjoint):

--- a/pennylane_lightning/lightning_qubit/_state_vector.py
+++ b/pennylane_lightning/lightning_qubit/_state_vector.py
@@ -242,7 +242,6 @@ class LightningStateVector(LightningBaseStateVector):  # pylint: disable=too-few
         # Skip over identity operations instead of performing
         # matrix multiplication with it.
         for operation in operations:
-            print(operation)
             if isinstance(operation, qml.Identity):
                 continue
             if isinstance(operation, Adjoint):

--- a/pennylane_lightning/lightning_qubit/lightning_qubit.py
+++ b/pennylane_lightning/lightning_qubit/lightning_qubit.py
@@ -86,7 +86,7 @@ def stopping_condition(op: Operator) -> bool:
         word = op._hyperparameters["pauli_word"]  # pylint: disable=protected-access
         # decomposes to IsingXX, etc. for n <= 2
         return reduce(lambda x, y: x + (y != "I"), word, 0) > 2
-    if op.name == "C(SProd)":
+    if op.name in ("C(SProd)", "C(Exp)"):
         return True
     return _supports_operation(op.name)
 

--- a/pennylane_lightning/lightning_qubit/lightning_qubit.py
+++ b/pennylane_lightning/lightning_qubit/lightning_qubit.py
@@ -86,6 +86,8 @@ def stopping_condition(op: Operator) -> bool:
         word = op._hyperparameters["pauli_word"]  # pylint: disable=protected-access
         # decomposes to IsingXX, etc. for n <= 2
         return reduce(lambda x, y: x + (y != "I"), word, 0) > 2
+    if op.name == "C(SProd)":
+        return True
     return _supports_operation(op.name)
 
 

--- a/pennylane_lightning/lightning_tensor/lightning_tensor.py
+++ b/pennylane_lightning/lightning_tensor/lightning_tensor.py
@@ -173,7 +173,7 @@ def stopping_condition(op: Operator) -> bool:
     if isinstance(op, qml.MPSPrep):
         return True
 
-    if op.name == "C(SProd)":
+    if op.name in ("C(SProd)", "C(Exp)"):
         return True
 
     return op.has_matrix and op.name in _operations

--- a/pennylane_lightning/lightning_tensor/lightning_tensor.py
+++ b/pennylane_lightning/lightning_tensor/lightning_tensor.py
@@ -173,6 +173,9 @@ def stopping_condition(op: Operator) -> bool:
     if isinstance(op, qml.MPSPrep):
         return True
 
+    if op.name == "C(SProd)":
+        return True
+
     return op.has_matrix and op.name in _operations
 
 

--- a/tests/lightning_base/test_device.py
+++ b/tests/lightning_base/test_device.py
@@ -126,13 +126,23 @@ class TestHelpers:
 
         num_wires = 1
 
-    def test_stopping_condition(self):
-        """Test that stopping_condition returns whether or not an operation
-        is supported by the device."""
-        valid_op = qml.RX(1.23, 0)
-        invalid_op = self.DummyOperator(0)
+    @pytest.mark.parametrize(
+        "valid_op",
+        [
+            qml.RX(1.23, 0),
+            qml.ctrl(-1.0 * qml.Z(0), control=[1]),
+        ],
+    )
+    def test_stopping_condition_valid(self, valid_op):
+        """Test that stopping_condition returns True for operations unsupported by the device."""
 
         assert stopping_condition(valid_op) is True
+
+    def test_stopping_condition_invalid(self):
+        """Test that stopping_condition returns False for operations unsupported by the device."""
+
+        invalid_op = self.DummyOperator(0)
+
         assert stopping_condition(invalid_op) is False
 
     def test_accepted_observables(self):

--- a/tests/lightning_base/test_device.py
+++ b/tests/lightning_base/test_device.py
@@ -131,6 +131,7 @@ class TestHelpers:
         [
             qml.RX(1.23, 0),
             qml.ctrl(-1.0 * qml.Z(0), control=[1]),
+            qml.ctrl(qml.exp(qml.Z(0)), control=[1]),
         ],
     )
     def test_stopping_condition_valid(self, valid_op):

--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -403,7 +403,7 @@ def test_arbitrary_inv_unitary_correct():
 
 @pytest.mark.parametrize("theta,phi", list(zip(THETA, PHI)))
 def test_qubit_RY(theta, phi, tol):
-    """Test that Hadamard expectation value is correct"""
+    """Test that qml.RY is applied correctly"""
     n_qubits = 4
     dev_def = qml.device("default.qubit", wires=n_qubits)
     dev = qml.device(device_name, wires=n_qubits)
@@ -426,7 +426,7 @@ def test_qubit_RY(theta, phi, tol):
 @pytest.mark.parametrize("theta,phi", list(zip(THETA, PHI)))
 @pytest.mark.parametrize("n_wires", range(1, 7))
 def test_qubit_unitary(n_wires, theta, phi, tol):
-    """Test that Hadamard expectation value is correct"""
+    """Test that qml.QubitUnitary value is correct"""
     n_qubits = 10
     dev_def = qml.device("default.qubit", wires=n_qubits)
     dev = qml.device(device_name, wires=n_qubits)

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -813,7 +813,7 @@ class TestPrepSelPrep:
             -1 * qml.Z(0) @ qml.Z(1),
             qml.Hamiltonian([0.5], [qml.Z(0) @ qml.Z(1)]),
             qml.Hamiltonian([0.5], [-1.0 * qml.Z(0) @ qml.Z(1)]),
-            qml.Hamiltonian([0.5], [qml.exp(qml.Z(0) @ qml.Z(1))]),
+            qml.Hamiltonian([1.0], [qml.exp(1j * qml.Z(0) @ qml.Z(1))]),
         ],
     )
     def test_prepselprep(self, lcu):

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -801,16 +801,20 @@ class TestQSVT:
 
         assert np.allclose(res, ref)
 
+
 class TestPrepSelPrep:
     """Test the PrepSelPrep routine."""
 
-    @pytest.mark.parametrize("lcu", [
-        qml.Z(0) + qml.Z(1),
-        qml.Z(0) @ qml.Z(1), 
-        -1 * qml.Z(0) @ qml.Z(1),
-        qml.Hamiltonian([0.5], [qml.Z(0)@qml.Z(1)]),
-        qml.Hamiltonian([0.5], [-1.0 * qml.Z(0)@qml.Z(1)])
-    ])
+    @pytest.mark.parametrize(
+        "lcu",
+        [
+            qml.Z(0) + qml.Z(1),
+            qml.Z(0) @ qml.Z(1),
+            -1 * qml.Z(0) @ qml.Z(1),
+            qml.Hamiltonian([0.5], [qml.Z(0) @ qml.Z(1)]),
+            qml.Hamiltonian([0.5], [-1.0 * qml.Z(0) @ qml.Z(1)]),
+        ],
+    )
     def test_prepselprep(self, lcu):
         n_qubits = 3
         dev = qml.device(device_name, wires=n_qubits)

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -800,3 +800,27 @@ class TestQSVT:
         ref = qml.QNode(circuit, dq, diff_method=None)()
 
         assert np.allclose(res, ref)
+
+class TestPrepSelPrep:
+    """Test the PrepSelPrep routine."""
+
+    @pytest.mark.parametrize("lcu", [
+        qml.Z(0) + qml.Z(1),
+        qml.Z(0) @ qml.Z(1), 
+        -1 * qml.Z(0) @ qml.Z(1),
+        qml.Hamiltonian([0.5], [qml.Z(0)@qml.Z(1)]),
+        qml.Hamiltonian([0.5], [-1.0 * qml.Z(0)@qml.Z(1)])
+    ])
+    def test_prepselprep(self, lcu):
+        n_qubits = 3
+        dev = qml.device(device_name, wires=n_qubits)
+        dq = qml.device("default.qubit", wires=n_qubits)
+
+        def circuit():
+            qml.PrepSelPrep(lcu, control=[2])
+            return qml.expval(qml.Z(0))
+
+        res = qml.QNode(circuit, dev, diff_method=None)()
+        ref = qml.QNode(circuit, dq, diff_method=None)()
+
+        assert np.allclose(res, ref)

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -813,6 +813,7 @@ class TestPrepSelPrep:
             -1 * qml.Z(0) @ qml.Z(1),
             qml.Hamiltonian([0.5], [qml.Z(0) @ qml.Z(1)]),
             qml.Hamiltonian([0.5], [-1.0 * qml.Z(0) @ qml.Z(1)]),
+            qml.Hamiltonian([0.5], [qml.exp(qml.Z(0) @ qml.Z(1))]),
         ],
     )
     def test_prepselprep(self, lcu):


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [ ] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [ ] Ensure that the test suite passes, by running `make test`.

- [ ] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [ ] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**
An error when attempting to decompose controlled SProd operator (e.g. `Controlled(-1 * Z(0), control_wires=[2])`) is reported. 

**Description of the Change:**
Add C(SProd) to stopping condition for all devices, so that this is supported in lightning devices by converting to QubitUnitary matrix.

**Benefits:**
Closes https://github.com/PennyLaneAI/pennylane-lightning/issues/900
Support controlled SProd operator

**Possible Drawbacks:**

**Related GitHub Issues:**

[sc-73351]