### PR TITLE
Remove PSWAP from matrix ops in LK and LGPU

### DIFF
--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.41.0-rc0"
+__version__ = "0.41.0-rc1"

--- a/pennylane_lightning/lightning_gpu/lightning_gpu.py
+++ b/pennylane_lightning/lightning_gpu/lightning_gpu.py
@@ -79,7 +79,6 @@ _to_matrix_ops = {
     "ControlledQubitUnitary": OperatorProperties(),
     "ECR": OperatorProperties(),
     "ISWAP": OperatorProperties(),
-    "PSWAP": OperatorProperties(),
     "SISWAP": OperatorProperties(),
     "SQISW": OperatorProperties(),
     "OrbitalRotation": OperatorProperties(),

--- a/pennylane_lightning/lightning_kokkos/lightning_kokkos.py
+++ b/pennylane_lightning/lightning_kokkos/lightning_kokkos.py
@@ -69,7 +69,6 @@ _to_matrix_ops = {
     "ECR": OperatorProperties(),
     "ISWAP": OperatorProperties(),
     "OrbitalRotation": OperatorProperties(),
-    "PSWAP": OperatorProperties(),
     "QubitCarry": OperatorProperties(),
     "QubitSum": OperatorProperties(),
     "SISWAP": OperatorProperties(),


### PR DESCRIPTION
**Context:**
Last fixes before release

**Description of the Change:**
Removing PSWAP from `_to_matrix_ops`

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
