### PR TITLE
Fix PSWAP generator wires

### DIFF
--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.41.0-rc1"
+__version__ = "0.41.0-rc2"

--- a/pennylane_lightning/core/src/gates/Constant.hpp
+++ b/pennylane_lightning/core/src/gates/Constant.hpp
@@ -325,7 +325,7 @@ using GeneratorNWires = typename std::pair<GeneratorOperation, std::size_t>;
     GeneratorNWires{GeneratorOperation::DoubleExcitationMinus, 4},
     GeneratorNWires{GeneratorOperation::DoubleExcitationPlus, 4},
     GeneratorNWires{GeneratorOperation::GlobalPhase, 1},
-    GeneratorNWires{GeneratorOperation::PSWAP, 1},
+    GeneratorNWires{GeneratorOperation::PSWAP, 2},
 };
 
 using CGeneratorNWires =
@@ -346,7 +346,7 @@ using CGeneratorNWires =
     CGeneratorNWires{ControlledGeneratorOperation::DoubleExcitationMinus, 4},
     CGeneratorNWires{ControlledGeneratorOperation::DoubleExcitationPlus, 4},
     CGeneratorNWires{ControlledGeneratorOperation::GlobalPhase, 1},
-    CGeneratorNWires{ControlledGeneratorOperation::PSWAP, 1},
+    CGeneratorNWires{ControlledGeneratorOperation::PSWAP, 2},
 };
 
 /**

--- a/pennylane_lightning/core/src/simulators/lightning_qubit/gates/cpu_kernels/GateImplementationsLM.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_qubit/gates/cpu_kernels/GateImplementationsLM.hpp
@@ -207,6 +207,7 @@ class GateImplementationsLM : public PauliGenerator<GateImplementationsLM> {
         GeneratorOperation::DoubleExcitation,
         GeneratorOperation::DoubleExcitationMinus,
         GeneratorOperation::DoubleExcitationPlus,
+        GeneratorOperation::PSWAP,
         GeneratorOperation::MultiRZ,
         GeneratorOperation::GlobalPhase,
     };

--- a/pennylane_lightning/core/src/simulators/lightning_qubit/gates/cpu_kernels/GateImplementationsLM.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_qubit/gates/cpu_kernels/GateImplementationsLM.hpp
@@ -227,6 +227,7 @@ class GateImplementationsLM : public PauliGenerator<GateImplementationsLM> {
         ControlledGeneratorOperation::DoubleExcitation,
         ControlledGeneratorOperation::DoubleExcitationMinus,
         ControlledGeneratorOperation::DoubleExcitationPlus,
+        ControlledGeneratorOperation::PSWAP,
         ControlledGeneratorOperation::MultiRZ,
         ControlledGeneratorOperation::GlobalPhase,
     };

--- a/pennylane_lightning/core/src/simulators/lightning_qubit/gates/cpu_kernels/GateImplementationsLM.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_qubit/gates/cpu_kernels/GateImplementationsLM.hpp
@@ -20,7 +20,6 @@
 #include <bit>
 #include <complex>
 #include <functional>
-#include <iostream>
 #include <string>
 #include <tuple>
 #include <vector>


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [ ] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [ ] Ensure that the test suite passes, by running `make test`.

- [ ] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [ ] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**
Currently the PSWAP generator in LQubit is defined with the wrong number of wires, but error was not visible since it is not defined in `implemented_generator`. 

**Description of the Change:**
Fix number of wires for PSWAP generator in LQ and add to implemented_generator.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**

[sc-88743]