### PR TITLE
Fix doxygen doc builds for AVXCommon::FuncReturn

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -10,6 +10,9 @@
 
 <h3>Documentation 📝</h3>
 
+- Fix doxygen doc builds for `AVXCommon::FuncReturn`.
+  [(#1134)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1134)
+
 <h3>Bug fixes 🐛</h3>
 
 <h3>Internal changes ⚙️</h3>
@@ -24,8 +27,9 @@
 
 This release contains contributions from (in alphabetical order):
 
-Luis Alfredo Nuñez Meneses
-Andrija Paurevic
+Ali Asadi,
+Luis Alfredo Nuñez Meneses,
+Andrija Paurevic,
 
 ---
 

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.42.0-dev1"
+__version__ = "0.42.0-dev2"

--- a/pennylane_lightning/core/src/simulators/lightning_qubit/gates/cpu_kernels/avx_common/SingleQubitGateHelper.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_qubit/gates/cpu_kernels/avx_common/SingleQubitGateHelper.hpp
@@ -34,10 +34,10 @@
 #include "TypeTraits.hpp"
 
 namespace Pennylane::LightningQubit::Gates::AVXCommon {
+/// @cond DEV
 using Pennylane::Util::FuncReturn;
 using Pennylane::Util::log2PerfectPower;
 
-/// @cond DEV
 template <class T, class = void>
 struct HasInternalWithoutParam : std::false_type {};
 

--- a/pennylane_lightning/core/src/simulators/lightning_qubit/gates/cpu_kernels/avx_common/TwoQubitGateHelper.hpp
+++ b/pennylane_lightning/core/src/simulators/lightning_qubit/gates/cpu_kernels/avx_common/TwoQubitGateHelper.hpp
@@ -37,10 +37,10 @@
 #include "TypeTraits.hpp"
 
 namespace Pennylane::LightningQubit::Gates::AVXCommon {
+/// @cond DEV
 using Pennylane::Util::FuncReturn;
 using Pennylane::Util::log2PerfectPower;
 
-/// @cond DEV
 template <class T, class = void>
 struct HasInternalInternalWithoutParam : std::false_type {};
 


### PR DESCRIPTION
**Context:**
As a followup to https://github.com/PennyLaneAI/pennylane-lightning/pull/1096, this PR avoids the doc page build of `structPennylane_1_1LightningQubit_1_1Gates_1_1AVXCommon_1_1FuncReturn`

**Benefits:**

- Fix the issue of the missing doc page on the PennyLane website

**Related GitHub Issues:**
