### PR TITLE
fix use of num_wires

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -32,8 +32,9 @@
 
 <h3>Internal changes ⚙️</h3>
 
-- Updates for depending deprecations to `Observable` and `is_trainable` in pennylane.
+- Updates for depending deprecations to `Observable`, `is_trainable`, and `AnyWires` in pennylane.
   [(#1138)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1138)
+  [(#1146)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1146)
 
 - Import custom PennyLane errors from `pennylane.exceptions` rather than top-level.
   [(#1122)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1122)

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.42.0-dev9"
+__version__ = "0.42.0-dev10"

--- a/tests/lightning_base/test_measurements_class.py
+++ b/tests/lightning_base/test_measurements_class.py
@@ -894,7 +894,7 @@ class TestControlledOps:
     def test_controlled_qubit_gates(self, operation, n_qubits, control_value, tol, lightning_sv):
         """Test that multi-controlled gates are correctly applied to a state"""
         threshold = 250 if device_name != "lightning.tensor" else 5
-        num_wires = max(operation.num_wires, 1)
+        num_wires = max(operation.num_wires, 1) if operation.num_wires else 1
         np.random.seed(0)
 
         if device_name not in ["lightning.qubit", "lightning.gpu"] and operation == qml.PCPhase:
@@ -1028,7 +1028,7 @@ class TestControlledOps:
         """Test that multi-controlled gates are correctly applied to a state"""
         threshold = 250 if device_name != "lightning.tensor" else 5
         operation = qml.GlobalPhase
-        num_wires = max(operation.num_wires, 1)
+        num_wires = max(operation.num_wires, 1) if operation.num_wires else 1
         for n_wires in range(num_wires + 1, num_wires + 4):
             wire_lists = list(itertools.permutations(range(0, n_qubits), n_wires))
             n_perms = len(wire_lists) * n_wires

--- a/tests/test_adjoint_jacobian.py
+++ b/tests/test_adjoint_jacobian.py
@@ -639,7 +639,7 @@ class TestAdjointJacobianQNode:
         init_state /= np.linalg.norm(init_state)
         init_state = np.array(init_state, requires_grad=False)
 
-        num_wires = max(operation.num_wires, 1)
+        num_wires = max(operation.num_wires, 1) if operation.num_wires else 1
         if num_wires > n_qubits:
             return
 
@@ -704,7 +704,7 @@ class TestAdjointJacobianQNode:
         init_state /= np.linalg.norm(init_state)
         init_state = np.array(init_state, requires_grad=False)
 
-        num_wires = max(operation.num_wires, 1)
+        num_wires = max(operation.num_wires, 1) if operation.num_wires else 1
         if num_wires > n_qubits:
             return
 
@@ -766,7 +766,7 @@ class TestAdjointJacobianQNode:
         init_state = np.random.rand(2**n_qubits) + 1.0j * np.random.rand(2**n_qubits)
         init_state /= np.linalg.norm(init_state)
         init_state = np.array(init_state, requires_grad=False)
-        num_wires = max(operation.num_wires, 1)
+        num_wires = max(operation.num_wires, 1) if operation.num_wires else 1
         if num_wires > n_qubits:
             return
 

--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -624,7 +624,7 @@ def test_controlled_qubit_gates(operation, n_qubits, control_value, adjoint, tol
     dev_def = qml.device("default.qubit", wires=n_qubits)
     dev = qml.device(device_name, wires=n_qubits)
     threshold = 5 if device_name == "lightning.tensor" else 250
-    num_wires = max(operation.num_wires, 1)
+    num_wires = max(operation.num_wires, 1) if operation.num_wires else 1
     operation = qml.adjoint(operation) if adjoint else operation
 
     if device_name not in ["lightning.qubit", "lightning.gpu"] and op == qml.PCPhase:
@@ -771,7 +771,7 @@ def test_controlled_globalphase(n_qubits, control_value, tol):
     dev = qml.device(device_name, wires=n_qubits)
     threshold = 250
     operation = qml.GlobalPhase
-    num_wires = max(operation.num_wires, 1)
+    num_wires = max(operation.num_wires, 1) if operation.num_wires else 1
     for n_wires in range(num_wires + 1, num_wires + 4):
         wire_lists = list(itertools.permutations(range(0, n_qubits), n_wires))
         n_perms = len(wire_lists) * n_wires
@@ -840,7 +840,7 @@ def test_adjoint_controlled_qubit_gates(operation, n_qubits, control_value, tol,
     dev_def = qml.device("default.qubit", wires=n_qubits)
     dev = qml.device(device_name, wires=n_qubits)
     threshold = 5 if device_name == "lightning.tensor" else 250
-    num_wires = max(operation.num_wires, 1)
+    num_wires = max(operation.num_wires, 1) if operation.num_wires else 1
     operation = qml.adjoint(operation) if adjoint else operation
 
     for n_wires in range(num_wires + 1, num_wires + 4):


### PR DESCRIPTION

**Context:**

In [(#7312)](https://github.com/PennyLaneAI/pennylane/pull/7312) we switched the default of `Operator.num_wires` to `None` instead of a special enum value. The special enums were "int-like" and could be compared against ints.

**Description of the Change:**

Update handling of `Operator.num_wires` in tests.

**Benefits:**

CI passes again.

**Possible Drawbacks:**

**Related GitHub Issues:**
