### PR TITLE
Pin CATALYST_GIT_TAG to v0.11.0

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release 0.41.0.post1
 
+<h3>Breaking changes 💔</h3>
+
+- Build Catalyst Lightning plugins against Catalyst Runtime v0.11.0.
+  [(#1148)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1148)
+
 <h3>Documentation 📝</h3>
 
 - Enable `pennylane.ai` search.

--- a/cmake/support_catalyst.cmake
+++ b/cmake/support_catalyst.cmake
@@ -26,7 +26,7 @@ macro(FindCatalyst target_name)
 
     else()
         if(NOT CATALYST_GIT_TAG)
-            set(CATALYST_GIT_TAG "main" CACHE STRING "GIT_TAG value to build Catalyst")
+            set(CATALYST_GIT_TAG "v0.11.0" CACHE STRING "GIT_TAG value to build Catalyst")
         endif()
         message(INFO " Building against Catalyst GIT TAG ${CATALYST_GIT_TAG}")
 


### PR DESCRIPTION
**Context:**
Currently, we build Catalyst Lightning plugins against the Catalyst Runtime header files in the 'main' branch.
PR https://github.com/PennyLaneAI/catalyst/pull/1680 updated these public header files which would break the installation of PL/Lightning v0.41.0 against Catalyst v0.11.0 from source.

**Description of the Change:**
- Build Catalyst Lightning plugins against Catalyst Runtime v0.11.0 to preserve support for building PL/Lightning v0.41.0 against v0.11.0 from source.

