### PR TITLE
Updates for supporting JAX 0.5.3+

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -32,6 +32,9 @@
 
 <h3>Internal changes ⚙️</h3>
 
+- Update type hinting to be compatible with JAX version 0.5.3+.
+  [(#1152)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1152)
+
 - The `LightningBaseStateVector`, `LightningBaseAdjointJacobian`, `LightningBaseMeasurements`, `LightningInterpreter` and `QuantumScriptSerializer` base classes now can be found at `pennylane_lightning.lightning_base`.
 
   The new `lightning_base` module further enables the relocation of core files from `pennylane_lightning/core/src/*` to `pennylane_lightning/core/*`.
@@ -71,6 +74,7 @@ Christina Lee,
 Joseph Lee,
 Anton Naim Ibrahim,
 Luis Alfredo Nuñez Meneses,
+Mudit Pandey,
 Andrija Paurevic,
 
 ---

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 <h3>Improvements 🛠</h3>
 
+- PennyLane-Lightning is compatible with JAX version 0.5.3+.
+  [(#1152)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1152)
+
 - Improve performance of computing expectation values of Pauli Sentences for `lightning.kokkos`.
   [(#1126)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1126)
 
@@ -31,9 +34,6 @@
 <h3>Bug fixes 🐛</h3>
 
 <h3>Internal changes ⚙️</h3>
-
-- Update type hinting to be compatible with JAX version 0.5.3+.
-  [(#1152)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1152)
 
 - The `LightningBaseStateVector`, `LightningBaseAdjointJacobian`, `LightningBaseMeasurements`, `LightningInterpreter` and `QuantumScriptSerializer` base classes now can be found at `pennylane_lightning.lightning_base`.
 

--- a/.github/workflows/tests_gpu_python.yml
+++ b/.github/workflows/tests_gpu_python.yml
@@ -136,7 +136,7 @@ jobs:
       - name: Install required packages
         run: |
           python -m pip install -r requirements-tests.txt
-          python -m pip install "jax[cpu]==0.4.28; python_version<='3.12'" cmake openfermionpyscf
+          python -m pip install "jax[cpu]==0.5.3; python_version<='3.12'" cmake openfermionpyscf
 
       - name: Install required lightning_gpu only packages
         if: matrix.pl_backend == 'lightning_gpu'

--- a/.github/workflows/tests_lkcpu_python.yml
+++ b/.github/workflows/tests_lkcpu_python.yml
@@ -200,7 +200,7 @@ jobs:
           WHEEL_NAME=$(cat ${{ github.workspace }}/${{ matrix.pl_backend }}-${{ matrix.exec_model }}_name.txt)
           mv ${{ github.workspace }}/wheel_${{ matrix.pl_backend }}-${{ matrix.exec_model }}.whl ${{ github.workspace }}/$WHEEL_NAME
           python -m pip install -r requirements-tests.txt
-          python -m pip install "jax[cpu]==0.4.28; python_version<='3.12'" openfermionpyscf
+          python -m pip install "jax[cpu]==0.5.3; python_version<='3.12'" openfermionpyscf
           if [ '${{ inputs.lightning-version }}' != 'stable' ]; then
             python scripts/configure_pyproject_toml.py
             SKIP_COMPILATION=True python -m pip install . -vv

--- a/.github/workflows/tests_lkcuda_python.yml
+++ b/.github/workflows/tests_lkcuda_python.yml
@@ -212,7 +212,7 @@ jobs:
         run: |
           cd main
           python -m pip install -r requirements-tests.txt
-          python -m pip install "jax[cpu]==0.4.28; python_version<='3.12'" openfermionpyscf
+          python -m pip install "jax[cpu]==0.5.3; python_version<='3.12'" openfermionpyscf
 
       - name: Checkout PennyLane for release or latest build
         if: inputs.pennylane-version == 'release' || inputs.pennylane-version == 'latest'

--- a/.github/workflows/tests_lqcpu_python.yml
+++ b/.github/workflows/tests_lqcpu_python.yml
@@ -155,7 +155,7 @@ jobs:
           WHEEL_NAME=$(cat ${{ github.workspace }}/${{ matrix.pl_backend }}-${{ matrix.blas }}_name.txt)
           mv ${{ github.workspace }}/wheel_${{ matrix.pl_backend }}-${{ matrix.blas }}.whl ${{ github.workspace }}/$WHEEL_NAME
           python -m pip install -r requirements-tests.txt
-          python -m pip install "jax[cpu]==0.4.28; python_version<='3.12'" openfermionpyscf semantic-version
+          python -m pip install "jax[cpu]==0.5.3; python_version<='3.12'" openfermionpyscf semantic-version
           python -m pip install ${{ github.workspace }}/$WHEEL_NAME --no-deps --force-reinstall
 
       - name: Checkout PennyLane for release or latest build

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.42.0-dev14"
+__version__ = "0.42.0-dev15"

--- a/pennylane_lightning/lightning_base/jaxpr_jvp.py
+++ b/pennylane_lightning/lightning_base/jaxpr_jvp.py
@@ -41,7 +41,11 @@ def validate_args_tangents(
         raise ValueError("The number of arguments and tangents must match")
 
     def _make_zero(tan, arg):
-        return jax.lax.zeros_like_array(arg) if isinstance(tan, jax.interpreters.ad.Zero) else tan
+        return (
+            jax.lax.zeros_like_array(arg).astype(tan.aval.dtype)
+            if isinstance(tan, jax.interpreters.ad.Zero)
+            else tan
+        )
 
     tangents = tuple(map(_make_zero, tangents, args))
 
@@ -53,12 +57,12 @@ def validate_args_tangents(
     return tangents
 
 
-def get_output_shapes(jaxpr: "jax.core.Jaxpr", num_wires: int) -> Tuple:
+def get_output_shapes(jaxpr: "jax.extend.core.Jaxpr", num_wires: int) -> Tuple:
     """
     Compute the output shapes and Jacobian shapes of a JAXPR.
 
     Args:
-        jaxpr (jax.core.Jaxpr): the JAXPR to analyze
+        jaxpr (jax.extend.core.Jaxpr): the JAXPR to analyze
         num_wires (int): the number of wires
 
     Returns:
@@ -99,13 +103,13 @@ def get_output_shapes(jaxpr: "jax.core.Jaxpr", num_wires: int) -> Tuple:
 
 
 def convert_jaxpr_to_tape(
-    jaxpr: "jax.core.Jaxpr", args: Sequence[TensorLike]
+    jaxpr: "jax.extend.core.Jaxpr", args: Sequence[TensorLike]
 ) -> qml.tape.QuantumTape:
     """
     Convert a jaxpr to a PennyLane tape and ensure parameters match.
 
     Args:
-        jaxpr (jax.core.Jaxpr): the JAXPR to convert
+        jaxpr (jax.extend.core.Jaxpr): the JAXPR to convert
         args (Sequence[TensorLike]): the arguments to the JAXPR
 
     Returns:

--- a/pennylane_lightning/lightning_base/lightning_interpreter.py
+++ b/pennylane_lightning/lightning_base/lightning_interpreter.py
@@ -97,7 +97,7 @@ class LightningInterpreter(PlxprInterpreter):
             )
         self.state.apply_operations([op])
 
-    def interpret_measurement_eqn(self, eqn: "jax.core.JaxprEqn"):
+    def interpret_measurement_eqn(self, eqn: "jax.extend.core.JaxprEqn"):
         """Interpret a given measurement equation."""
         if "mcm" == eqn.primitive.name[-3:]:
             raise NotImplementedError(

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,7 +15,7 @@ clang-format~=16.0
 isort==5.13.2
 click==8.0.4
 cmake
-jax[cpu]==0.4.28; python_version <= "3.12"
+jax[cpu]==0.5.3; python_version <= "3.12"
 custatevec-cu12; sys_platform == "linux"
 cutensornet-cu12>=2.6.0; sys_platform == "linux"
 pylint==2.7.4


### PR DESCRIPTION
* Replace `jax.core` with `jax.extend.core`.
* Change handling of dtype casting for `Zero` tangents.
* Update usage of `pure_callback` to remove the use of the deprecated `vectorized` argument.

[sc-90945]