### PR TITLE
Fix Docker container for ROCM

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -33,7 +33,8 @@
 
 <h3>Bug fixes 🐛</h3>
 
-- Fix Docker build for Lighting-Kokkos with ROCM library e.g. using AMD GPUs. 
+- Fix Docker build for Lighting-Kokkos with ROCM library e.g. using AMD GPUs.
+  Update Ubuntu version from 22.04 to 24.04 for Docker images.
   [(#1156)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1156)
 
 <h3>Internal changes ⚙️</h3>
@@ -66,7 +67,7 @@
   [(1144)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1144)
 
 - Bump `readthedocs` Github action runner to use Ubuntu-24.04.
-[(#1151)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1151)
+  [(#1151)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1151)
 
 
 <h3>Contributors ✍️</h3>

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -33,6 +33,9 @@
 
 <h3>Bug fixes 🐛</h3>
 
+- Fix Docker build for Lighting-Kokkos with ROCM library e.g. using AMD GPUs. 
+  [(#1156)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1156)
+
 <h3>Internal changes ⚙️</h3>
 
 - The `LightningBaseStateVector`, `LightningBaseAdjointJacobian`, `LightningBaseMeasurements`, `LightningInterpreter` and `QuantumScriptSerializer` base classes now can be found at `pennylane_lightning.lightning_base`.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,9 +15,9 @@
 # Define global build defaults
 ARG PENNYLANE_VERSION=master
 
-# Create basic runtime environment base on Ubuntu 22.04 (jammy)
+# Create basic runtime environment base on Ubuntu 24.04
 # Create and activate runtime virtual environment
-FROM ubuntu:jammy AS base-runtime
+FROM ubuntu:24.04 AS base-runtime
 ARG AMD_ARCH=AMD_GFX90A
 ARG CUDA_ARCH=AMPERE80
 ARG CUDA_INSTALLER=https://developer.download.nvidia.com/compute/cuda/12.2.2/local_installers/cuda_12.2.2_535.104.05_linux.run
@@ -25,7 +25,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 ARG GCC_VERSION=11
 ARG LIGHTNING_VERSION=master
 ARG PENNYLANE_VERSION
-ARG ROCM_INSTALLER=https://repo.radeon.com/amdgpu-install/5.7/ubuntu/jammy/amdgpu-install_5.7.50700-1_all.deb
+ARG ROCM_INSTALLER=https://repo.radeon.com/amdgpu-install/6.4/ubuntu/noble/amdgpu-install_6.4.60400-1_all.deb
 RUN apt-get update \
     && apt-get install --no-install-recommends -y \
     apt-utils \
@@ -123,7 +123,7 @@ RUN CMAKE_ARGS="-DKokkos_ENABLE_SERIAL:BOOL=ON -DKokkos_ENABLE_OPENMP:BOOL=ON -D
 
 # Install python3 and setup runtime virtual env in CUDA-12-runtime image (includes CUDA runtime and math libraries)
 # Install lightning-kokkos CUDA backend
-FROM nvidia/cuda:12.2.0-base-ubuntu22.04 AS wheel-lightning-kokkos-cuda
+FROM nvidia/cuda:12.2.0-base-ubuntu24.04 AS wheel-lightning-kokkos-cuda
 ARG PENNYLANE_VERSION
 RUN apt-get update \
     && apt-get install --no-install-recommends -y \
@@ -154,7 +154,7 @@ RUN CUQUANTUM_SDK=$(python -c "import site; print( f'{site.getsitepackages()[0]}
 
 # Install python3 and setup runtime virtual env in CUDA-12-runtime image (includes CUDA runtime and math libraries)
 # Install lightning-kokkos CUDA backend
-FROM nvidia/cuda:12.2.0-runtime-ubuntu22.04 AS wheel-lightning-gpu
+FROM nvidia/cuda:12.2.0-runtime-ubuntu24.04 AS wheel-lightning-gpu
 ARG PENNYLANE_VERSION
 RUN apt-get update \
     && apt-get install --no-install-recommends -y \
@@ -182,9 +182,7 @@ RUN wget --progress=dot:giga ${ROCM_INSTALLER}
 # to linux-headers-6.8.0-1021-azure, this should be fixed in the future
 RUN apt-get update \
     && apt-get install --no-install-recommends -y "linux-headers-$(uname -r)" \
-    || apt-get install --no-install-recommends -y linux-headers-6.8.0-1021-azure \
     && apt-get install --no-install-recommends -y "linux-modules-extra-$(uname -r)" \
-    || apt-get install --no-install-recommends -y linux-modules-extra-6.8.0-1021-azure \
     && apt-get install --no-install-recommends -y ./$(echo ${ROCM_INSTALLER} | xargs -I {} basename {}) \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
@@ -201,7 +199,7 @@ RUN python scripts/configure_pyproject_toml.py || true
 RUN CMAKE_ARGS="-DKokkos_ENABLE_SERIAL:BOOL=ON -DKokkos_ENABLE_OPENMP:BOOL=ON -DKokkos_ENABLE_HIP:BOOL=ON -DKokkos_ARCH_${AMD_ARCH}=ON" python -m build --wheel
 
 # Install lightning-kokkos HIP backend
-FROM rocm/dev-ubuntu-22.04:5.7 AS wheel-lightning-kokkos-rocm
+FROM rocm/dev-ubuntu-24.04:6.4 AS wheel-lightning-kokkos-rocm
 ARG PENNYLANE_VERSION
 RUN apt-get update \
     && apt-get install --no-install-recommends -y \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -179,11 +179,11 @@ RUN pip install --no-cache-dir git+https://github.com/PennyLaneAI/pennylane.git@
 FROM base-build-python AS base-build-rocm
 RUN wget --progress=dot:giga ${ROCM_INSTALLER}
 RUN apt-cache search linux-headers \
-    && apt-cache search linux-modules-extra\
+    && apt-cache search linux-modules-extra
 RUN apt-get update \
-    && apt-get install --no-install-recommends -y "linux-headers-$(uname -r)" 
-    || true && apt-get install --no-install-recommends -y linux-headers-generic 
-    && apt-get install --no-install-recommends -y "linux-modules-extra-$(uname -r)" 
+    && apt-get install --no-install-recommends -y "linux-headers-$(uname -r)" \
+    || true && apt-get install --no-install-recommends -y linux-headers-generic \
+    && apt-get install --no-install-recommends -y "linux-modules-extra-$(uname -r)" \
     || true && apt-get install --no-install-recommends -y linux-modules-extra-generic \
     ./$(echo ${ROCM_INSTALLER} | xargs -I {} basename {}) \
     && apt-get clean \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -182,9 +182,12 @@ RUN apt-cache search linux-headers \
     && apt-cache search linux-modules-extra
 RUN apt-get update \
     && apt-get install --no-install-recommends -y "linux-headers-$(uname -r)" \
-    || true && apt-get install --no-install-recommends -y linux-headers-generic \
+    || true \
+    && apt-get install --no-install-recommends -y linux-headers-generic \
     && apt-get install --no-install-recommends -y "linux-modules-extra-$(uname -r)" \
-    || true && apt-get install --no-install-recommends -y linux-modules-extra-generic \
+    || true \
+    && apt-get install --no-install-recommends -y linux-modules-extra-generic \
+    && apt-get install --no-install-recommends -y \
     ./$(echo ${ROCM_INSTALLER} | xargs -I {} basename {}) \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -196,7 +196,7 @@ ENV CXX=hipcc
 ENV PL_BACKEND=lightning_kokkos
 RUN pip uninstall -y pennylane-lightning
 RUN python scripts/configure_pyproject_toml.py || true
-RUN CMAKE_ARGS="-DKokkos_ENABLE_SERIAL:BOOL=ON -DKokkos_ENABLE_OPENMP:BOOL=ON -DKokkos_ENABLE_HIP:BOOL=ON -DKokkos_ARCH_${AMD_ARCH}=ON" python -m build --wheel
+RUN CMAKE_ARGS="-DKokkos_ENABLE_SERIAL:BOOL=ON -DKokkos_ENABLE_OPENMP:BOOL=ON -DKokkos_ENABLE_HIP:BOOL=ON -DKokkos_ARCH_${AMD_ARCH}=ON -DCMAKE_CXX_FLAGS='/usr/lib/gcc/x86_64-linux-gnu/11/'" python -m build --wheel
 
 # Install lightning-kokkos HIP backend
 FROM rocm/dev-ubuntu-24.04:6.3.4 AS wheel-lightning-kokkos-rocm

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -178,8 +178,6 @@ RUN pip install --no-cache-dir git+https://github.com/PennyLaneAI/pennylane.git@
 # Install ROCm in build venv image
 FROM base-build-python AS base-build-rocm
 RUN wget --progress=dot:giga ${ROCM_INSTALLER}
-RUN apt-cache search linux-headers \
-    && apt-cache search linux-modules-extra
 # FIXME: the linux-headers-6.11.0-1021-azure package is not available in the repo then is hardcoded
 # to linux-headers-6.8.0-1021-azure, this should be fixed in the future
 RUN apt-get update \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -178,12 +178,20 @@ RUN pip install --no-cache-dir git+https://github.com/PennyLaneAI/pennylane.git@
 # Install ROCm in build venv image
 FROM base-build-python AS base-build-rocm
 RUN wget --progress=dot:giga ${ROCM_INSTALLER}
-RUN apt-get update \
-    && apt-get install --no-install-recommends -y \
-    "linux-headers-$(uname -r)" "linux-modules-extra-$(uname -r)" \
+RUN apt-get update && \
+    apt-cache search linux-headers \
+    apt-cache search linux-modules-extra\
+    apt-get install --no-install-recommends -y \
+    "linux-headers-$(uname -r)" || true && \
+    apt-get install --no-install-recommends -y \
+    linux-headers-generic && \
+    apt-get install --no-install-recommends -y \
+    "linux-modules-extra-$(uname -r)" || true && \
+    apt-get install --no-install-recommends -y \
+    linux-modules-extra-generic \
     ./$(echo ${ROCM_INSTALLER} | xargs -I {} basename {}) \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 RUN amdgpu-install -y --accept-eula --usecase=rocm,hiplibsdk --no-dkms
 
 # Download Lightning release and build lightning-kokkos backend with Kokkos-ROCm

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -196,7 +196,7 @@ ENV CXX=hipcc
 ENV PL_BACKEND=lightning_kokkos
 RUN pip uninstall -y pennylane-lightning
 RUN python scripts/configure_pyproject_toml.py || true
-RUN CMAKE_ARGS="-DKokkos_ENABLE_SERIAL:BOOL=ON -DKokkos_ENABLE_OPENMP:BOOL=ON -DKokkos_ENABLE_HIP:BOOL=ON -DKokkos_ARCH_${AMD_ARCH}=ON -DCMAKE_CXX_FLAGS='/usr/lib/gcc/x86_64-linux-gnu/11/'" python -m build --wheel
+RUN CMAKE_ARGS="-DKokkos_ENABLE_SERIAL:BOOL=ON -DKokkos_ENABLE_OPENMP:BOOL=ON -DKokkos_ENABLE_HIP:BOOL=ON -DKokkos_ARCH_${AMD_ARCH}=ON -DCMAKE_CXX_FLAGS='--gcc-install-dir=/usr/lib/gcc/x86_64-linux-gnu/11/'" python -m build --wheel
 
 # Install lightning-kokkos HIP backend
 FROM rocm/dev-ubuntu-24.04:6.3.4 AS wheel-lightning-kokkos-rocm

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,7 +20,7 @@ ARG PENNYLANE_VERSION=master
 FROM ubuntu:24.04 AS base-runtime
 ARG AMD_ARCH=AMD_GFX90A
 ARG CUDA_ARCH=AMPERE80
-ARG CUDA_INSTALLER=https://developer.download.nvidia.com/compute/cuda/12.2.2/local_installers/cuda_12.2.2_535.104.05_linux.run
+ARG CUDA_INSTALLER=https://developer.download.nvidia.com/compute/cuda/12.9.0/local_installers/cuda_12.9.0_575.51.03_linux.run
 ARG DEBIAN_FRONTEND=noninteractive
 ARG GCC_VERSION=11
 ARG LIGHTNING_VERSION=master
@@ -123,7 +123,7 @@ RUN CMAKE_ARGS="-DKokkos_ENABLE_SERIAL:BOOL=ON -DKokkos_ENABLE_OPENMP:BOOL=ON -D
 
 # Install python3 and setup runtime virtual env in CUDA-12-runtime image (includes CUDA runtime and math libraries)
 # Install lightning-kokkos CUDA backend
-FROM nvidia/cuda:12.2.0-base-ubuntu24.04 AS wheel-lightning-kokkos-cuda
+FROM nvidia/cuda:12.9.0-base-ubuntu24.04 AS wheel-lightning-kokkos-cuda
 ARG PENNYLANE_VERSION
 RUN apt-get update \
     && apt-get install --no-install-recommends -y \
@@ -154,7 +154,7 @@ RUN CUQUANTUM_SDK=$(python -c "import site; print( f'{site.getsitepackages()[0]}
 
 # Install python3 and setup runtime virtual env in CUDA-12-runtime image (includes CUDA runtime and math libraries)
 # Install lightning-kokkos CUDA backend
-FROM nvidia/cuda:12.2.0-runtime-ubuntu24.04 AS wheel-lightning-gpu
+FROM nvidia/cuda:12.9.0-runtime-ubuntu24.04 AS wheel-lightning-gpu
 ARG PENNYLANE_VERSION
 RUN apt-get update \
     && apt-get install --no-install-recommends -y \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,7 +25,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 ARG GCC_VERSION=11
 ARG LIGHTNING_VERSION=master
 ARG PENNYLANE_VERSION
-ARG ROCM_INSTALLER=https://repo.radeon.com/amdgpu-install/6.4/ubuntu/noble/amdgpu-install_6.4.60400-1_all.deb
+ARG ROCM_INSTALLER=https://repo.radeon.com/amdgpu-install/6.3.4/ubuntu/noble/amdgpu-install_6.3.60304-1_all.deb
 RUN apt-get update \
     && apt-get install --no-install-recommends -y \
     apt-utils \
@@ -199,7 +199,7 @@ RUN python scripts/configure_pyproject_toml.py || true
 RUN CMAKE_ARGS="-DKokkos_ENABLE_SERIAL:BOOL=ON -DKokkos_ENABLE_OPENMP:BOOL=ON -DKokkos_ENABLE_HIP:BOOL=ON -DKokkos_ARCH_${AMD_ARCH}=ON" python -m build --wheel
 
 # Install lightning-kokkos HIP backend
-FROM rocm/dev-ubuntu-24.04:6.4 AS wheel-lightning-kokkos-rocm
+FROM rocm/dev-ubuntu-24.04:6.3.4 AS wheel-lightning-kokkos-rocm
 ARG PENNYLANE_VERSION
 RUN apt-get update \
     && apt-get install --no-install-recommends -y \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -181,11 +181,11 @@ RUN wget --progress=dot:giga ${ROCM_INSTALLER}
 RUN apt-cache search linux-headers \
     && apt-cache search linux-modules-extra
 RUN apt-get update \
-    && apt-get install --no-install-recommends -y "linux-headers-$(uname -r)" \
-    || true \
+    # && apt-get install --no-install-recommends -y "linux-headers-$(uname -r)" \
+    # || true \
     && apt-get install --no-install-recommends -y linux-headers-generic \
-    && apt-get install --no-install-recommends -y "linux-modules-extra-$(uname -r)" \
-    || true \
+    # && apt-get install --no-install-recommends -y "linux-modules-extra-$(uname -r)" \
+    # || true \
     && apt-get install --no-install-recommends -y linux-modules-extra-generic \
     && apt-get install --no-install-recommends -y \
     ./$(echo ${ROCM_INSTALLER} | xargs -I {} basename {}) \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -180,13 +180,13 @@ FROM base-build-python AS base-build-rocm
 RUN wget --progress=dot:giga ${ROCM_INSTALLER}
 RUN apt-cache search linux-headers \
     && apt-cache search linux-modules-extra
+# FIXME: the linux-headers-6.11.0-1021-azure package is not available in the repo then is hardcoded
+# to linux-headers-6.8.0-1021-azure, this should be fixed in the future
 RUN apt-get update \
-    # && apt-get install --no-install-recommends -y "linux-headers-$(uname -r)" \
-    # || true \
-    && apt-get install --no-install-recommends -y linux-headers-generic \
-    # && apt-get install --no-install-recommends -y "linux-modules-extra-$(uname -r)" \
-    # || true \
-    && apt-get install --no-install-recommends -y linux-modules-extra-generic \
+    && apt-get install --no-install-recommends -y "linux-headers-$(uname -r)" \
+    || apt-get install --no-install-recommends -y linux-headers-6.8.0-1021-azure \ 
+    && apt-get install --no-install-recommends -y "linux-modules-extra-$(uname -r)" \
+    || apt-get install --no-install-recommends -y linux-modules-extra-6.8.0-1021-azure \
     && apt-get install --no-install-recommends -y \
     ./$(echo ${ROCM_INSTALLER} | xargs -I {} basename {}) \
     && apt-get clean \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -184,11 +184,10 @@ RUN apt-cache search linux-headers \
 # to linux-headers-6.8.0-1021-azure, this should be fixed in the future
 RUN apt-get update \
     && apt-get install --no-install-recommends -y "linux-headers-$(uname -r)" \
-    || apt-get install --no-install-recommends -y linux-headers-6.8.0-1021-azure \ 
+    || apt-get install --no-install-recommends -y linux-headers-6.8.0-1021-azure \
     && apt-get install --no-install-recommends -y "linux-modules-extra-$(uname -r)" \
     || apt-get install --no-install-recommends -y linux-modules-extra-6.8.0-1021-azure \
-    && apt-get install --no-install-recommends -y \
-    ./$(echo ${ROCM_INSTALLER} | xargs -I {} basename {}) \
+    && apt-get install --no-install-recommends -y ./$(echo ${ROCM_INSTALLER} | xargs -I {} basename {}) \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 RUN amdgpu-install -y --accept-eula --usecase=rocm,hiplibsdk --no-dkms

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -178,20 +178,16 @@ RUN pip install --no-cache-dir git+https://github.com/PennyLaneAI/pennylane.git@
 # Install ROCm in build venv image
 FROM base-build-python AS base-build-rocm
 RUN wget --progress=dot:giga ${ROCM_INSTALLER}
-RUN apt-get update && \
-    apt-cache search linux-headers \
-    apt-cache search linux-modules-extra\
-    apt-get install --no-install-recommends -y \
-    "linux-headers-$(uname -r)" || true && \
-    apt-get install --no-install-recommends -y \
-    linux-headers-generic && \
-    apt-get install --no-install-recommends -y \
-    "linux-modules-extra-$(uname -r)" || true && \
-    apt-get install --no-install-recommends -y \
-    linux-modules-extra-generic \
+RUN apt-cache search linux-headers \
+    && apt-cache search linux-modules-extra\
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y "linux-headers-$(uname -r)" 
+    || true && apt-get install --no-install-recommends -y linux-headers-generic 
+    && apt-get install --no-install-recommends -y "linux-modules-extra-$(uname -r)" 
+    || true && apt-get install --no-install-recommends -y linux-modules-extra-generic \
     ./$(echo ${ROCM_INSTALLER} | xargs -I {} basename {}) \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 RUN amdgpu-install -y --accept-eula --usecase=rocm,hiplibsdk --no-dkms
 
 # Download Lightning release and build lightning-kokkos backend with Kokkos-ROCm

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.42.0-dev16"
+__version__ = "0.42.0-dev17"


### PR DESCRIPTION
**Context:**
The Docker image for Lightning-Kokkos is [failing](https://github.com/PennyLaneAI/pennylane-lightning/actions/runs/14987894472) due to linux-headers-6.11.0-1012-azure incompatibility on this OS. We used to build the image against linux-headers-6.8.0-1021-azure

**Description of the Change:**
The solution is updating the Ubuntu version from 22.04 to 24.04
Add the CMAKE argument 
```
DCMAKE_CXX_FLAGS='--gcc-install-dir=/usr/lib/gcc/x86_64-linux-gnu/11/'
```
when using `hipcc` compiler.

Correct build for Docker [images](https://github.com/PennyLaneAI/pennylane-lightning/actions/runs/14984154575)

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**


[sc-91269]