### PR TITLE
Fix x86 macos wheel build

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -25,7 +25,7 @@
 <h3>Bug fixes 🐛</h3>
 
 - Only download JAX version 0.5.3 for non-X86 MacOS. 
-  [(#1158)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1158)
+  [(#1163)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1163)
 
 - Fix Docker build for Lighting-Kokkos with ROCM library for AMD GPUs.
   Updating ROCM from 5.7 to 6.2.4. 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -24,6 +24,9 @@
 
 <h3>Bug fixes 🐛</h3>
 
+- Only download JAX version 0.5.3 for non-X86 MacOS. 
+  [(#1158)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1158)
+
 - Fix Docker build for Lighting-Kokkos with ROCM library for AMD GPUs.
   Updating ROCM from 5.7 to 6.2.4. 
   [(#1158)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1158)

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.42.0-dev19"
+__version__ = "0.42.0-dev20"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,7 +15,7 @@ clang-format~=16.0
 isort==5.13.2
 click==8.0.4
 cmake
-jax[cpu]==0.5.3; python_version <= "3.12"
+jax[cpu]==0.5.3; python_version <= "3.12" and (platform_machine != "x86_64" or platform_system != "Darwin")
 custatevec-cu12; sys_platform == "linux"
 cutensornet-cu12>=2.6.0; sys_platform == "linux"
 pylint==2.7.4

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -5,5 +5,5 @@ pytest-mock>=3.7.0
 pytest-xdist>=2.5.0
 pytest-split
 flaky>=3.7.0
-jax[cpu]==0.5.3; python_version <= "3.12"
+jax[cpu]==0.5.3; python_version <= "3.12" and not (platform_machine == "x86_64" and platform_system == "Darwin")
 git+https://github.com/PennyLaneAI/pennylane.git@master

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -5,5 +5,5 @@ pytest-mock>=3.7.0
 pytest-xdist>=2.5.0
 pytest-split
 flaky>=3.7.0
-jax[cpu]==0.5.3; python_version <= "3.12" and not (platform_machine == "x86_64" and platform_system == "Darwin")
+jax[cpu]==0.5.3; python_version <= "3.12" and (platform_machine != "x86_64" or platform_system != "Darwin")
 git+https://github.com/PennyLaneAI/pennylane.git@master


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [ ] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [ ] Ensure that the test suite passes, by running `make test`.

- [ ] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [ ] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**
Since adding jax==0.5.3 to requirements-tests.txt, macos wheel builds for x86 has been [failing](https://github.com/PennyLaneAI/pennylane-lightning/actions/runs/15030269152/job/42242462590). This is because after building the wheel we install requirements-tests.txt to test the wheel, and jaxlib 0.5.3 no longer has wheels for x86 MacOS.

**Description of the Change:**
Update requirements-tests.txt to only install jax==0.5.3 for mac that are not x86. requirements-dev.txt is updated as well.

**Benefits:**
[Wheels now build again](https://github.com/PennyLaneAI/pennylane-lightning/actions/runs/15053788416/job/42314776574?pr=1163).

**Possible Drawbacks:**

**Related GitHub Issues:**

[sc-91413]