### PR TITLE
Fix the slow down of the CI caused by the qml.concurrency update in Pennylane

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -79,6 +79,9 @@
 - Bump `readthedocs` Github action runner to use Ubuntu-24.04.
   [(#1151)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1151)
 
+- Removed `max_workers` argument for `default.qubit` device in Python tests to reduce CI testing time.
+  [(##1174)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1174)
+
 <h3>Contributors ✍️</h3>
 
 This release contains contributions from (in alphabetical order):
@@ -93,6 +96,7 @@ Anton Naim Ibrahim,
 Luis Alfredo Nuñez Meneses,
 Mudit Pandey,
 Andrija Paurevic,
+Marc Vandelle
 
 ---
 

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.42.0-dev23"
+__version__ = "0.42.0-dev24"

--- a/tests/lightning_base/test_device.py
+++ b/tests/lightning_base/test_device.py
@@ -502,7 +502,7 @@ class TestExecution:
 
     @staticmethod
     def calculate_reference(tape):
-        device = DefaultQubit(max_workers=1)
+        device = DefaultQubit()
         program, _ = device.preprocess()
         tapes, transf_fn = program([tape])
         results = device.execute(tapes)
@@ -907,7 +907,7 @@ class TestExecution:
         dev = LightningDevice(wires=None)
         result = dev.execute([qs0, qs1, qs2])
 
-        dev_ref = DefaultQubit(max_workers=1)
+        dev_ref = DefaultQubit()
         result_ref = dev_ref.execute([qs0, qs1, qs2])
 
         for r, e in zip(result, result_ref):
@@ -974,7 +974,7 @@ class TestDerivatives:
 
     @staticmethod
     def calculate_reference(tape, execute_and_derivatives=False):
-        device = DefaultQubit(max_workers=1)
+        device = DefaultQubit()
         program, config = device.preprocess(ExecutionConfig(gradient_method="adjoint"))
         tapes, transf_fn = program([tape])
 
@@ -1208,7 +1208,7 @@ class TestDerivatives:
                 dev.compute_derivatives(tapes, new_config),
             )
 
-        dev_ref = DefaultQubit(max_workers=1)
+        dev_ref = DefaultQubit()
         config = ExecutionConfig(gradient_method="adjoint")
         program, new_config = dev_ref.preprocess(config)
         tapes, fn = program([qs])
@@ -1351,7 +1351,7 @@ class TestVJP:
 
     @staticmethod
     def calculate_reference(tape, dy, execute_and_derivatives=False):
-        device = DefaultQubit(max_workers=1)
+        device = DefaultQubit()
         program, config = device.preprocess(ExecutionConfig(gradient_method="adjoint"))
         tapes, transf_fn = program([tape])
         dy = [dy]
@@ -1583,7 +1583,7 @@ class TestVJP:
                 dev.compute_vjp(tapes, dy, new_config),
             )
 
-        dev_ref = DefaultQubit(max_workers=1)
+        dev_ref = DefaultQubit()
         config = ExecutionConfig(gradient_method="adjoint")
         program, new_config = dev_ref.preprocess(config)
         tapes, fn = program([qs])

--- a/tests/lightning_base/test_expval.py
+++ b/tests/lightning_base/test_expval.py
@@ -33,7 +33,7 @@ def dev(request):
 
 
 def calculate_reference(tape):
-    dev = DefaultQubit(max_workers=1)
+    dev = DefaultQubit()
     program, _ = dev.preprocess()
     tapes, transf_fn = program([tape])
     results = dev.execute(tapes)

--- a/tests/lightning_base/test_jacobian_method.py
+++ b/tests/lightning_base/test_jacobian_method.py
@@ -32,7 +32,7 @@ class TestJacobian:
 
     @staticmethod
     def calculate_reference(tape, execute_and_derivatives=False):
-        device = DefaultQubit(max_workers=1)
+        device = DefaultQubit()
         program, config = device.preprocess(ExecutionConfig(gradient_method="adjoint"))
         tapes, transf_fn = program([tape])
 
@@ -106,7 +106,7 @@ class TestVJP:
 
     @staticmethod
     def calculate_reference(tape, dy, execute_and_derivatives=False):
-        device = DefaultQubit(max_workers=1)
+        device = DefaultQubit()
         program, config = device.preprocess(ExecutionConfig(gradient_method="adjoint"))
         tapes, transf_fn = program([tape])
         dy = [dy]

--- a/tests/lightning_base/test_measurements_class.py
+++ b/tests/lightning_base/test_measurements_class.py
@@ -606,7 +606,7 @@ class TestMeasurements:
                 continue
             new_meas.append(m)
         if use_default:
-            dev = DefaultQubit(max_workers=1)
+            dev = DefaultQubit()
             program, _ = dev.preprocess()
             tapes, transf_fn = program([tape])
             results = dev.execute(tapes)
@@ -853,7 +853,7 @@ class TestControlledOps:
 
     @staticmethod
     def calculate_reference(tape):
-        dev = DefaultQubit(max_workers=1)
+        dev = DefaultQubit()
         program, _ = dev.preprocess()
         tapes, transf_fn = program([tape])
         results = dev.execute(tapes)

--- a/tests/lightning_base/test_simulate_method.py
+++ b/tests/lightning_base/test_simulate_method.py
@@ -34,7 +34,7 @@ class TestSimulate:
 
     @staticmethod
     def calculate_reference(tape):
-        dev = DefaultQubit(max_workers=1)
+        dev = DefaultQubit()
         program, _ = dev.preprocess()
         tapes, transf_fn = program([tape])
         results = dev.execute(tapes)


### PR DESCRIPTION
# Addressing CI Timeouts 

This PR aims to tackle the recent and recurring CI job timeouts we've been seeing on the `latest/latest` branch. We've noticed a significant and unexplained slowdown in our continuous integration pipelines, causing many actions to fail.

Here are a few examples of the affected workflows:

* https://github.com/PennyLaneAI/pennylane-lightning/actions/runs/15381144467/job/43272216165
* https://github.com/PennyLaneAI/pennylane-lightning/actions/runs/15381144467/job/43272279979
* https://github.com/PennyLaneAI/pennylane-lightning/actions/runs/15381144467/job/43306798534

These are happening since the merge of the following PR in Pennylane:
* https://github.com/PennyLaneAI/pennylane/pull/7401
