### PR TITLE
Fix using Torch with `AmplitudeEmbedding` by applying `qml.broadcast_expand` before decomposition in the preprocessing stage. Issue 7325

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -32,6 +32,9 @@
   Updating ROCM from 5.7 to 6.2.4. 
   [(#1158)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1158)
 
+- Fix using Torch with `AmplitudeEmbedding` by applying `qml.broadcast_expand` before decomposition in the preprocessing stage. 
+  [(#)]()
+
 <h3>Internal changes ⚙️</h3>
 
 - Use local catalyst repository instead of fetching on Github CI.

--- a/pennylane_lightning/lightning_gpu/lightning_gpu.py
+++ b/pennylane_lightning/lightning_gpu/lightning_gpu.py
@@ -162,6 +162,7 @@ def _add_adjoint_transforms(program: TransformProgram) -> None:
 
     name = "adjoint + lightning.gpu"
     program.add_transform(no_sampling, name=name)
+    program.add_transform(qml.transforms.broadcast_expand)
     program.add_transform(
         decompose,
         stopping_condition=_adjoint_ops,
@@ -173,7 +174,6 @@ def _add_adjoint_transforms(program: TransformProgram) -> None:
     program.add_transform(
         validate_measurements, analytic_measurements=adjoint_measurements, name=name
     )
-    program.add_transform(qml.transforms.broadcast_expand)
     program.add_transform(validate_adjoint_trainable_params)
 
 

--- a/pennylane_lightning/lightning_kokkos/lightning_kokkos.py
+++ b/pennylane_lightning/lightning_kokkos/lightning_kokkos.py
@@ -152,6 +152,7 @@ def _add_adjoint_transforms(program: TransformProgram) -> None:
 
     name = "adjoint + lightning.kokkos"
     program.add_transform(no_sampling, name=name)
+    program.add_transform(qml.transforms.broadcast_expand)
     program.add_transform(
         decompose,
         stopping_condition=_adjoint_ops,
@@ -163,7 +164,6 @@ def _add_adjoint_transforms(program: TransformProgram) -> None:
     program.add_transform(
         validate_measurements, analytic_measurements=adjoint_measurements, name=name
     )
-    program.add_transform(qml.transforms.broadcast_expand)
     program.add_transform(validate_adjoint_trainable_params)
 
 

--- a/pennylane_lightning/lightning_qubit/lightning_qubit.py
+++ b/pennylane_lightning/lightning_qubit/lightning_qubit.py
@@ -156,6 +156,7 @@ def _add_adjoint_transforms(program: TransformProgram) -> None:
 
     name = "adjoint + lightning.qubit"
     program.add_transform(no_sampling, name=name)
+    program.add_transform(qml.transforms.broadcast_expand)
     program.add_transform(
         decompose,
         stopping_condition=_adjoint_ops,
@@ -167,7 +168,6 @@ def _add_adjoint_transforms(program: TransformProgram) -> None:
     program.add_transform(
         validate_measurements, analytic_measurements=adjoint_measurements, name=name
     )
-    program.add_transform(qml.transforms.broadcast_expand)
     program.add_transform(validate_adjoint_trainable_params)
 
 

--- a/tests/lightning_base/test_device.py
+++ b/tests/lightning_base/test_device.py
@@ -102,7 +102,7 @@ else:
 if not LightningDevice._CPP_BINARY_AVAILABLE:  # pylint: disable=protected-access
     pytest.skip("No binary module found. Skipping.", allow_module_level=True)
 
-fixture_params = itertools.product([3, None], [np.complex64, np.complex128])  # wires x c_dtype
+fixture_params = list(itertools.product([3, None], [np.complex64, np.complex128]))  # wires x c_dtype
 
 
 @pytest.fixture(params=fixture_params)
@@ -191,6 +191,7 @@ class TestHelpers:
 
         name = f"adjoint + {device_name}"
         expected_program.add_transform(no_sampling, name=name)
+        expected_program.add_transform(qml.transforms.broadcast_expand)
         expected_program.add_transform(
             decompose,
             stopping_condition=_adjoint_ops,
@@ -204,7 +205,6 @@ class TestHelpers:
             analytic_measurements=adjoint_measurements,
             name=name,
         )
-        expected_program.add_transform(qml.transforms.broadcast_expand)
         expected_program.add_transform(validate_adjoint_trainable_params)
 
         actual_program = qml.transforms.core.TransformProgram()
@@ -699,6 +699,7 @@ class TestExecution:
         if adjoint:
             name = f"adjoint + {device_name}"
             expected_program.add_transform(no_sampling, name=name)
+            expected_program.add_transform(qml.transforms.broadcast_expand)
             expected_program.add_transform(
                 decompose,
                 stopping_condition=_adjoint_ops,
@@ -712,7 +713,6 @@ class TestExecution:
                 analytic_measurements=adjoint_measurements,
                 name=name,
             )
-            expected_program.add_transform(qml.transforms.broadcast_expand)
             expected_program.add_transform(validate_adjoint_trainable_params)
 
         gradient_method = "adjoint" if adjoint else None


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [ ] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [ ] Ensure that the test suite passes, by running `make test`.

- [ ] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [ ] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**
https://github.com/PennyLaneAI/pennylane/issues/7325 

**Description of the Change:**
Move `qml.broadcast_expand` before `decomposition` in the preprocessing for Adjoint-Jacobian method for LQ, LK, LGPU

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
