### PR TITLE
Remove native support to CX

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -10,6 +10,9 @@
 - `MultiControlledX` gates are now natively supported in Lightning-Tensor.
   [(#1169)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1169)
 
+- Remove `MultiControlledX` gates native support in Lightning-Tensor.
+  [(#1183)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1183)
+
 - PennyLane-Lightning is compatible with JAX version 0.5.3+.
   [(#1152)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1152)
   [(#1161)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1161)

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.42.0-dev36"
+__version__ = "0.42.0-dev37"

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.42.0-dev35"
+__version__ = "0.42.0-dev36"

--- a/pennylane_lightning/lightning_tensor/lightning_tensor.py
+++ b/pennylane_lightning/lightning_tensor/lightning_tensor.py
@@ -122,8 +122,6 @@ _operations = frozenset(
         "C(DoubleExcitationPlus)",
         "C(GlobalPhase)",
         "C(MultiRZ)",
-        "C(X)",
-        "MultiControlledX",
         "RX",
         "RY",
         "RZ",


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [ ] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [x] Ensure that the test suite passes, by running `make test`.

- [x] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [x] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**
[sc-93454]

Recent native support for `MultiControlledX` gate in LT, leads to performance regression for XAS applications. This PR is to revert the native support for `MultiControlledX` gate [PR#1169].  

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
