### PR TITLE
Revert change to plxpr primitives

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -55,9 +55,6 @@
   
 - Update docker build CI for stable version to use v0.41.1.
   [(#1188)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1188)
-  
-- Updates `LightningInterpreter` to adjust to a change in `adjoint_transform_prim` and `ctrl_transform_prim`.
-  [(#1177)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1177)
 
 - Remove flaky tests and add random seed to measurement tests.
   [(#1172)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1172)

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.42.0-dev37"
+__version__ = "0.42.0-dev38"


### PR DESCRIPTION
**Context:**

This PR reverts #1177  as that change was found to move the constants from being staticly known concrete arrays to dynamic tracers. 

**Description of the Change:**

Reverts #1177 

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
