### PR TITLE
Update AmplitudeEmbedding tests for LK and LGPU

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -53,6 +53,9 @@
 
 <h3>Internal changes ⚙️</h3>
   
+- Enable `AmplitudeEmbedding` Python tests for `lightning.kokkos` and `lightning.gpu` devices.
+  [(#XX)](https://github.com/PennyLaneAI/pennylane-lightning/pull/XX)
+  
 - Update docker build CI for stable version to use v0.41.1.
   [(#1188)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1188)
 

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -113,12 +113,6 @@ class TestAmplitudeEmbedding:
     @pytest.mark.parametrize("first_op", [False, True])
     @pytest.mark.parametrize("n_qubits", range(2, 10, 2))
     def test_amplitudeembedding(self, first_op, n_qubits):
-        if not first_op:
-            if device_name != "lightning.qubit":
-                pytest.xfail(
-                    f"Operation StatePrep cannot be used after other Operations have already been applied on a {device_name} device."
-                )
-
         dev = qml.device(device_name, wires=n_qubits)
         dq = qml.device("default.qubit")
 


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [ ] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [ ] Ensure that the test suite passes, by running `make test`.

- [ ] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [ ] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**
Previously LK and LGPU does not support AmplitudeEmbedding after operations. Since support has been added, the test should no longer xfail.

**Description of the Change:**
Remove xfail for LK and LGPU for AmplitudeEmbedding test.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**

[sc-76161]