### PR TITLE
Add Nanobind Bindings for Lightning Qubit Backend

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -63,8 +63,8 @@ class Mock(MagicMock):
         return MagicMock()
 
 
-MOCK_MODULES = ["pennylane_lightning.lightning_qubit_ops",
-                "pennylane_lightning.lightning_qubit_ops.algorithms"]
+MOCK_MODULES = ["pennylane_lightning.lightning_qubit_nb",
+                "pennylane_lightning.lightning_qubit_nb.algorithms"]
 
 mock = Mock()
 for mod_name in MOCK_MODULES:

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.42.0-dev38"
+__version__ = "0.42.0-dev41"

--- a/pennylane_lightning/core/bindings/BindingsUtils_nb.hpp
+++ b/pennylane_lightning/core/bindings/BindingsUtils_nb.hpp
@@ -87,14 +87,12 @@ createNumpyArrayFromVector(const std::vector<VectorT> &data, std::size_t rows,
  * @brief Convert complex matrices from nanobind ndarray to std::vector
  *
  * @tparam ComplexT Complex type to convert to
- * @tparam ParamT Precision type of the complex numbers
  * @param matrices Vector of ndarrays containing matrices
  * @return std::vector<std::vector<ComplexT>> Converted matrices
  */
-template <typename ComplexT, typename ParamT>
+template <typename ComplexT>
 std::vector<std::vector<ComplexT>> convertMatrices(
-    const std::vector<nb::ndarray<const std::complex<ParamT>, nb::c_contig>>
-        &matrices) {
+    const std::vector<nb::ndarray<const ComplexT, nb::c_contig>> &matrices) {
     std::vector<std::vector<ComplexT>> conv_matrices(matrices.size());
 
     for (std::size_t i = 0; i < matrices.size(); i++) {

--- a/pennylane_lightning/core/simulators/lightning_qubit/bindings/LQubitBindings.hpp
+++ b/pennylane_lightning/core/simulators/lightning_qubit/bindings/LQubitBindings.hpp
@@ -260,7 +260,7 @@ void registerBackendClassSpecificBindings(PyClass &pyclass) {
             },
             "Copy StateVector data into a Numpy array.")
         .def(
-            "UpdateData",
+            "updateData",
             [](StateVectorT &device_sv, const np_arr_c &state) {
                 const py::buffer_info numpyArrayInfo = state.request();
                 auto *data_ptr = static_cast<ComplexT *>(numpyArrayInfo.ptr);

--- a/pennylane_lightning/core/simulators/lightning_qubit/bindings/LQubitBindings_nb.hpp
+++ b/pennylane_lightning/core/simulators/lightning_qubit/bindings/LQubitBindings_nb.hpp
@@ -30,8 +30,27 @@
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/vector.h>
 
+#include "BindingsUtils_nb.hpp"
+#include "Constant.hpp"
+#include "ConstantUtil.hpp" // lookup
+#include "DynamicDispatcher.hpp"
+#include "GateOperation.hpp"
+#include "MeasurementsLQubit.hpp"
+#include "ObservablesLQubit.hpp"
 #include "StateVectorLQubitManaged.hpp"
 #include "TypeList.hpp"
+#include "VectorJacobianProduct.hpp"
+
+/// @cond DEV
+namespace {
+using namespace Pennylane::NanoBindings;
+using namespace Pennylane::LightningQubit::Algorithms;
+using namespace Pennylane::LightningQubit::Measures;
+using namespace Pennylane::LightningQubit::Observables;
+using Pennylane::LightningQubit::StateVectorLQubitManaged;
+using Pennylane::NanoBindings::Utils::createNumpyArrayFromVector;
+} // namespace
+/// @endcond
 
 namespace nb = nanobind;
 
@@ -45,28 +64,91 @@ using StateVectorBackends =
                               StateVectorLQubitManaged<double>, void>;
 
 /**
+ * @brief Get a gate kernel map for a statevector.
+ */
+template <class StateVectorT>
+auto svKernelMap(const StateVectorT &sv) -> nb::dict {
+    using PrecisionT = typename StateVectorT::PrecisionT;
+    nb::dict res_map;
+    namespace Constant = Pennylane::Gates::Constant;
+    using Pennylane::Util::lookup;
+
+    const auto &dispatcher = DynamicDispatcher<PrecisionT>::getInstance();
+
+    auto [GateKernelMap, GeneratorKernelMap, MatrixKernelMap,
+          ControlledGateKernelMap, ControlledGeneratorKernelMap,
+          ControlledMatrixKernelMap] = sv.getSupportedKernels();
+
+    for (const auto &[gate_op, kernel] : GateKernelMap) {
+        const auto key = std::string(lookup(Constant::gate_names, gate_op));
+        const auto value = dispatcher.getKernelName(kernel);
+
+        res_map[key.c_str()] = value;
+    }
+
+    for (const auto &[gen_op, kernel] : GeneratorKernelMap) {
+        const auto key = std::string(lookup(Constant::generator_names, gen_op));
+        const auto value = dispatcher.getKernelName(kernel);
+
+        res_map[key.c_str()] = value;
+    }
+
+    for (const auto &[mat_op, kernel] : MatrixKernelMap) {
+        const auto key = std::string(lookup(Constant::matrix_names, mat_op));
+        const auto value = dispatcher.getKernelName(kernel);
+
+        res_map[key.c_str()] = value;
+    }
+
+    for (const auto &[mat_op, kernel] : ControlledGateKernelMap) {
+        const auto key =
+            std::string(lookup(Constant::controlled_gate_names, mat_op));
+        const auto value = dispatcher.getKernelName(kernel);
+
+        res_map[key.c_str()] = value;
+    }
+
+    for (const auto &[mat_op, kernel] : ControlledGeneratorKernelMap) {
+        const auto key =
+            std::string(lookup(Constant::controlled_generator_names, mat_op));
+        const auto value = dispatcher.getKernelName(kernel);
+
+        res_map[key.c_str()] = value;
+    }
+
+    for (const auto &[mat_op, kernel] : ControlledMatrixKernelMap) {
+        const auto key =
+            std::string(lookup(Constant::controlled_matrix_names, mat_op));
+        const auto value = dispatcher.getKernelName(kernel);
+
+        res_map[key.c_str()] = value;
+    }
+
+    return res_map;
+}
+
+/**
+ * @brief Register controlled matrix kernel.
+ */
+template <class StateVectorT>
+void applyControlledMatrix(
+    StateVectorT &st,
+    const nb::ndarray<const std::complex<typename StateVectorT::PrecisionT>,
+                      nb::c_contig> &matrix,
+    const std::vector<std::size_t> &controlled_wires,
+    const std::vector<bool> &controlled_values,
+    const std::vector<std::size_t> &wires, bool inverse = false) {
+    using ComplexT = typename StateVectorT::ComplexT;
+    st.applyControlledMatrix(static_cast<const ComplexT *>(matrix.data()),
+                             controlled_wires, controlled_values, wires,
+                             inverse);
+}
+
+/**
  * @brief Update state vector data from an array
  *
  * This function accepts any array-like object that follows the buffer protocol,
  * including NumPy arrays and JAX arrays (for example).
- *
- * Example with JAX:
- * ```python
- * import jax.numpy as jnp
- * import pennylane_lightning.lightning_qubit_nb as plq
- *
- * # Create a JAX array
- * jax_data = jnp.zeros(2**3, dtype=jnp.complex64)
- * jax_data = jax_data.at[0].set(1.0)  # Set to |000⟩ state
- *
- * # Create a state vector and update with JAX data
- * sv = plq.StateVectorC64(3)  # 3 qubits
- * sv.updateData(jax_data)     # Works with JAX arrays!
- * ```
- *
- * @tparam StateVectorT State vector type
- * @param sv State vector to update
- * @param data Array with new data
  */
 template <class StateVectorT>
 void updateStateVectorData(
@@ -89,13 +171,47 @@ void updateStateVectorData(
 }
 
 /**
- * @brief Get a controlled matrix and kernel map for a statevector.
+ * @brief Register sparse matrix operators for a statevector.
+ *
  * @tparam StateVectorT
  * @tparam PyClass
- * @param pyclass Nanobind's measurements class to bind methods.
+ * @param pyclass Nanobind's state vector class to bind methods.
  */
 template <class StateVectorT, class PyClass>
-void registerBackendClassSpecificBindings(PyClass &) {} // pyclass
+void registerSparseMatrixOperators(PyClass &pyclass) {
+    using PrecisionT = typename StateVectorT::PrecisionT;
+    using ComplexT = typename StateVectorT::ComplexT;
+    using np_arr_c = nb::ndarray<std::complex<PrecisionT>, nb::c_contig>;
+    using SparseIndexT = std::size_t;
+    using np_arr_sparse_ind = nb::ndarray<SparseIndexT, nb::c_contig>;
+
+    pyclass.def(
+        "applySparseMatrix",
+        [](StateVectorT &st, const np_arr_sparse_ind &row_map,
+           const np_arr_sparse_ind &col_idx, const np_arr_c &values,
+           const std::vector<std::size_t> &wires, bool inverse) {
+            st.applySparseMatrix(static_cast<SparseIndexT *>(row_map.data()),
+                                 static_cast<SparseIndexT *>(col_idx.data()),
+                                 static_cast<ComplexT *>(values.data()), wires,
+                                 inverse);
+        },
+        "Apply a sparse matrix to the statevector.");
+
+    pyclass.def(
+        "applyControlledSparseMatrix",
+        [](StateVectorT &st, const np_arr_sparse_ind &row_map,
+           const np_arr_sparse_ind &col_idx, const np_arr_c &values,
+           const std::vector<std::size_t> &controlled_wires,
+           const std::vector<bool> &controlled_values,
+           const std::vector<std::size_t> &wires, bool inverse) {
+            st.applyControlledSparseMatrix(
+                static_cast<SparseIndexT *>(row_map.data()),
+                static_cast<SparseIndexT *>(col_idx.data()),
+                static_cast<ComplexT *>(values.data()), controlled_wires,
+                controlled_values, wires, inverse);
+        },
+        "Apply a controlled sparse matrix to the statevector.");
+}
 
 /**
  * @brief Register backend specific state vector methods.
@@ -106,11 +222,41 @@ void registerBackendClassSpecificBindings(PyClass &) {} // pyclass
  */
 template <class StateVectorT, class PyClass>
 void registerBackendSpecificStateVectorMethods(PyClass &pyclass) {
-    // using PrecisionT = typename StateVectorT::PrecisionT;
+    using PrecisionT = typename StateVectorT::PrecisionT;
     using ComplexT = typename StateVectorT::ComplexT;
-    // using ParamT = PrecisionT; // Parameter's data precision - unused for now
 
-    // Add other methods (resetStateVector, setBasisState, etc.)
+    // Register sparse matrix operators.
+    registerSparseMatrixOperators<StateVectorT>(pyclass);
+
+    // Add Pauli rotation.
+    pyclass.def(
+        "applyPauliRot",
+        [](StateVectorT &sv, const std::vector<std::size_t> &wires,
+           const bool inverse, const std::vector<PrecisionT> &params,
+           const std::string &word) {
+            sv.applyPauliRot(wires, inverse, params, word);
+        },
+        "Apply a Pauli rotation.");
+
+    // Fix constructor binding for nanobind.
+    pyclass.def(nb::init<std::size_t>(), "Initialize with number of qubits");
+
+    // Collapse and normalize methods.
+    pyclass.def(
+        "collapse", &StateVectorT::collapse,
+        "Collapse the statevector onto the 0 or 1 branch of a given wire.");
+
+    pyclass.def("normalize", &StateVectorT::normalize,
+                "Normalizes the statevector to norm 1.");
+
+    // Apply controlled matrix.
+    pyclass.def("applyControlledMatrix", &applyControlledMatrix<StateVectorT>,
+                "Apply controlled operation");
+
+    // Kernel map.
+    pyclass.def("kernel_map", &svKernelMap<StateVectorT>,
+                "Get internal kernels for operations");
+
     pyclass.def("resetStateVector", &StateVectorT::resetStateVector,
                 "Reset the state vector to |0...0>.");
 
@@ -131,8 +277,7 @@ void registerBackendSpecificStateVectorMethods(PyClass &pyclass) {
         [](StateVectorT &sv, const nb::ndarray<ComplexT, nb::c_contig> &state,
            const std::vector<std::size_t> &wires) {
             // Get data pointer directly from ndarray
-            const ComplexT *data_ptr =
-                static_cast<const ComplexT *>(state.data());
+            const ComplexT *data_ptr = state.data();
             sv.setStateVector(data_ptr, wires);
         },
         "Set the state vector to the data contained in `state`.",
@@ -147,10 +292,25 @@ void registerBackendSpecificStateVectorMethods(PyClass &pyclass) {
             }
 
             // Copy data to numpy array
-            ComplexT *data_ptr = static_cast<ComplexT *>(state.data());
+            ComplexT *data_ptr = state.data();
             std::copy(sv.getData(), sv.getData() + sv.getLength(), data_ptr);
         },
         "Copy StateVector data into a Numpy array.", nb::arg("state"));
+}
+
+/**
+ * @brief Get a controlled matrix and kernel map for a statevector.
+ * @tparam StateVectorT
+ * @tparam PyClass
+ * @param pyclass Nanobind's measurements class to bind methods.
+ *
+ * @deprecated Use registerBackendSpecificStateVectorMethods instead
+ */
+template <class StateVectorT, class PyClass>
+void registerBackendClassSpecificBindings(PyClass &pyclass) {
+    // This function is kept for backward compatibility
+    // All functionality has been moved to
+    registerBackendSpecificStateVectorMethods<StateVectorT>(pyclass);
 }
 
 /**
@@ -161,7 +321,106 @@ void registerBackendSpecificStateVectorMethods(PyClass &pyclass) {
  * @param pyclass Nanobind's measurements class to bind methods.
  */
 template <class StateVectorT, class PyClass>
-void registerBackendSpecificMeasurements(PyClass &) {} // pyclass
+void registerBackendSpecificMeasurements(PyClass &pyclass) {
+    using PrecisionT = typename StateVectorT::PrecisionT;
+    using ComplexT = typename StateVectorT::ComplexT;
+
+    using np_arr_c = nb::ndarray<std::complex<PrecisionT>, nb::c_contig>;
+    using SparseIndexT = std::size_t;
+    using np_arr_sparse_ind = nb::ndarray<SparseIndexT, nb::c_contig>;
+
+    pyclass.def(
+        "expval",
+        [](Measurements<StateVectorT> &M, const std::string &name,
+           const std::vector<std::size_t> &wires) {
+            return M.expval(name, wires);
+        },
+        "Expected value of an operation by name.");
+
+    pyclass.def(
+        "expval",
+        [](Measurements<StateVectorT> &M, const np_arr_c &matrix,
+           const std::vector<std::size_t> &wires) {
+            const std::size_t matrix_size = matrix.size();
+            auto matrix_data =
+                static_cast<std::complex<PrecisionT> *>(matrix.data());
+            std::vector<std::complex<PrecisionT>> matrix_v{
+                matrix_data, matrix_data + matrix_size};
+            return M.expval(matrix_v, wires);
+        },
+        "Expected value of a matrix.");
+
+    pyclass.def(
+        "expval",
+        [](Measurements<StateVectorT> &M, const np_arr_sparse_ind &row_map,
+           const np_arr_sparse_ind &col_idx, const np_arr_c &values) {
+            return M.expval(static_cast<SparseIndexT *>(row_map.data()),
+                            static_cast<SparseIndexT>(row_map.size()),
+                            static_cast<SparseIndexT *>(col_idx.data()),
+                            static_cast<ComplexT *>(values.data()),
+                            static_cast<SparseIndexT>(values.size()));
+        },
+        "Expected value of a sparse Hamiltonian.");
+
+    pyclass.def(
+        "var",
+        [](Measurements<StateVectorT> &M, const std::string &name,
+           const std::vector<std::size_t> &wires) {
+            return M.var(name, wires);
+        },
+        "Variance of an operation by name.");
+
+    pyclass.def(
+        "var",
+        [](Measurements<StateVectorT> &M, const np_arr_sparse_ind &row_map,
+           const np_arr_sparse_ind &col_idx, const np_arr_c &values) {
+            return M.var(static_cast<SparseIndexT *>(row_map.data()),
+                         static_cast<SparseIndexT>(row_map.size()),
+                         static_cast<SparseIndexT *>(col_idx.data()),
+                         static_cast<ComplexT *>(values.data()),
+                         static_cast<SparseIndexT>(values.size()));
+        },
+        "Variance of a sparse Hamiltonian.");
+
+    pyclass.def(
+        "generate_samples",
+        [](Measurements<StateVectorT> &M, const std::vector<std::size_t> &wires,
+           const std::size_t num_shots) {
+            const std::size_t num_wires = wires.size();
+            auto &&result = M.generate_samples(wires, num_shots);
+
+            // Create a 2D NumPy array with shape (num_shots, num_wires)
+            std::vector<std::size_t> shape = {num_shots, num_wires};
+
+            std::vector<ssize_t> strides = {
+                static_cast<ssize_t>(num_wires * sizeof(std::size_t)),
+                static_cast<ssize_t>(sizeof(std::size_t))};
+
+            return createNumpyArrayFromVector<std::size_t>(result, shape[0],
+                                                           shape[1]);
+        },
+        "Generate samples from the statevector.");
+
+    pyclass.def(
+        "generate_mcmc_samples",
+        [](Measurements<StateVectorT> &M, std::size_t num_wires,
+           const std::string &kernelname, std::size_t num_burnin,
+           std::size_t num_shots) {
+            std::vector<std::size_t> &&result = M.generate_samples_metropolis(
+                kernelname, num_burnin, num_shots);
+
+            // Create a 2D NumPy array with shape (num_shots, num_wires)
+            std::vector<std::size_t> shape = {num_shots, num_wires};
+
+            std::vector<ssize_t> strides = {
+                static_cast<ssize_t>(num_wires * sizeof(std::size_t)),
+                static_cast<ssize_t>(sizeof(std::size_t))};
+
+            return createNumpyArrayFromVector<std::size_t>(result, shape[0],
+                                                           shape[1]);
+        },
+        "Generate samples using MCMC.");
+}
 
 /**
  * @brief Register backend specific observables.
@@ -170,7 +429,79 @@ void registerBackendSpecificMeasurements(PyClass &) {} // pyclass
  * @param m Nanobind module
  */
 template <class StateVectorT>
-void registerBackendSpecificObservables(nb::module_ &) {} // m
+void registerBackendSpecificObservables(nb::module_ &m) {
+    using PrecisionT = typename StateVectorT::PrecisionT;
+    using ComplexT = typename StateVectorT::ComplexT;
+
+    const std::string bitsize =
+        std::to_string(sizeof(std::complex<PrecisionT>) * 8);
+
+    using np_arr_c = nb::ndarray<std::complex<PrecisionT>, nb::c_contig>;
+
+    std::string class_name;
+
+    class_name = "SparseHamiltonianC" + bitsize;
+    auto sparse_hamiltonian_class =
+        nb::class_<SparseHamiltonian<StateVectorT>, Observable<StateVectorT>>(
+            m, class_name.c_str(), nb::is_final());
+    sparse_hamiltonian_class.def(
+        nb::init<std::vector<ComplexT>, std::vector<std::size_t>,
+                 std::vector<std::size_t>, std::vector<std::size_t>>(),
+        "Initialize SparseHamiltonian with data, indices, indptr, and wires");
+    sparse_hamiltonian_class.def(
+        "__init__",
+        [](SparseHamiltonian<StateVectorT> *self, const np_arr_c &data,
+           const std::vector<std::size_t> &indices,
+           const std::vector<std::size_t> &indptr,
+           const std::vector<std::size_t> &wires) {
+            const ComplexT *data_ptr = data.data();
+            std::vector<ComplexT> data_vec(data_ptr, data_ptr + data.size());
+            new (self) SparseHamiltonian<StateVectorT>(data_vec, indices,
+                                                       indptr, wires);
+        });
+    sparse_hamiltonian_class.def("__repr__",
+                                 &SparseHamiltonian<StateVectorT>::getObsName,
+                                 "Get the name of the observable");
+    sparse_hamiltonian_class.def("get_wires",
+                                 &SparseHamiltonian<StateVectorT>::getWires,
+                                 "Get wires of observables");
+    sparse_hamiltonian_class.def(
+        "__eq__",
+        [](const SparseHamiltonian<StateVectorT> &self,
+           nb::handle other) -> bool {
+            if (!nb::isinstance<SparseHamiltonian<StateVectorT>>(other)) {
+                return false;
+            }
+            auto other_cast = nb::cast<SparseHamiltonian<StateVectorT>>(other);
+            return self == other_cast;
+        },
+        "Compare two observables");
+}
+
+/**
+ * @brief Register Vector Jacobian Product.
+ */
+template <class StateVectorT>
+auto registerVJP(
+    VectorJacobianProduct<StateVectorT> &calculate_vjp, const StateVectorT &sv,
+    const OpsData<StateVectorT> &operations,
+    const nb::ndarray<const typename StateVectorT::ComplexT, nb::c_contig> &dy,
+    const std::vector<std::size_t> &trainableParams)
+    -> nb::ndarray<typename StateVectorT::ComplexT, nb::numpy, nb::c_contig> {
+    using ComplexT = typename StateVectorT::ComplexT;
+    std::vector<ComplexT> vjp(trainableParams.size(), ComplexT{});
+
+    const JacobianData<StateVectorT> jd{operations.getTotalNumParams(),
+                                        sv.getLength(),
+                                        sv.getData(),
+                                        {},
+                                        operations,
+                                        trainableParams};
+
+    calculate_vjp(std::span{vjp}, jd, std::span{dy.data(), dy.size()});
+
+    return createNumpyArrayFromVector<ComplexT>(vjp);
+}
 
 /**
  * @brief Register backend specific adjoint Jacobian methods.
@@ -179,13 +510,40 @@ void registerBackendSpecificObservables(nb::module_ &) {} // m
  * @param m Nanobind module
  */
 template <class StateVectorT>
-void registerBackendSpecificAlgorithms(nb::module_ &) {} // m
+void registerBackendSpecificAlgorithms(nb::module_ &m) {
+    using PrecisionT = typename StateVectorT::PrecisionT;
+
+    const std::string bitsize =
+        std::to_string(sizeof(std::complex<PrecisionT>) * 8);
+
+    std::string class_name;
+
+    //***********************************************************************//
+    //                        Vector Jacobian Product
+    //***********************************************************************//
+    class_name = "VectorJacobianProductC" + bitsize;
+    nb::class_<VectorJacobianProduct<StateVectorT>>(m, class_name.c_str())
+        .def(nb::init<>())
+        .def("__call__", &registerVJP<StateVectorT>,
+             "Vector Jacobian Product method.");
+}
+
+/**
+ * @brief Provide backend information.
+ */
+auto getBackendInfo() -> nb::dict {
+    nb::dict info;
+    info["NAME"] = "lightning.qubit";
+    return info;
+}
 
 /**
  * @brief Register bindings for backend-specific info.
  *
  * @param m Nanobind module.
  */
-void registerBackendSpecificInfo(nb::module_ &) {} // m
+void registerBackendSpecificInfo(nb::module_ &m) {
+    m.def("backend_info", &getBackendInfo, "Backend-specific information.");
+}
 
 } // namespace Pennylane::LightningQubit::NanoBindings

--- a/pennylane_lightning/lightning_base/_serialize.py
+++ b/pennylane_lightning/lightning_base/_serialize.py
@@ -72,7 +72,7 @@ class QuantumScriptSerializer:
         self.split_obs = split_obs
         if device_name == "lightning.qubit":
             try:
-                import pennylane_lightning.lightning_qubit_ops as lightning_ops
+                import pennylane_lightning.lightning_qubit_nb as lightning_ops
             except ImportError as exception:
                 raise ImportError(
                     f"Pre-compiled binaries for {device_name} are not available."
@@ -531,7 +531,7 @@ class QuantumScriptSerializer:
                 else:
                     if hasattr(self.sv_type, name):
                         params.append(single_op_base.parameters)
-                        mats.append([])
+                        mats.append(np.array([]))
                     else:
                         params.append([])
                         mats.append(matrix(single_op_base))

--- a/pennylane_lightning/lightning_qubit/_adjoint_jacobian.py
+++ b/pennylane_lightning/lightning_qubit/_adjoint_jacobian.py
@@ -19,14 +19,29 @@ from __future__ import annotations
 from warnings import warn
 
 try:
+    from pennylane_lightning.lightning_qubit_nb.algorithms import (
+        AdjointJacobianC64,
+        AdjointJacobianC128,
+        create_ops_listC64,
+        create_ops_listC128,
+    )
+
+    USING_NANOBIND = True
+except ImportError:
+    # Fall back to pybind11 version if nanobind version is not available
     from pennylane_lightning.lightning_qubit_ops.algorithms import (
         AdjointJacobianC64,
         AdjointJacobianC128,
         create_ops_listC64,
         create_ops_listC128,
     )
-except ImportError as ex:
-    warn(str(ex), UserWarning)
+
+    USING_NANOBIND = False
+
+    warn(
+        "Using legacy pybind11 bindings. Consider upgrading to nanobind version for better performance.",
+        UserWarning,
+    )
 
 from os import getenv
 

--- a/pennylane_lightning/lightning_qubit/_measurements.py
+++ b/pennylane_lightning/lightning_qubit/_measurements.py
@@ -21,9 +21,15 @@ from __future__ import annotations
 from warnings import warn
 
 try:
+    from pennylane_lightning.lightning_qubit_nb import MeasurementsC64, MeasurementsC128
+except ImportError:
+    # Fall back to pybind11 version if nanobind version is not available
     from pennylane_lightning.lightning_qubit_ops import MeasurementsC64, MeasurementsC128
-except ImportError as ex:
-    warn(str(ex), UserWarning)
+
+    warn(
+        "Using legacy pybind11 bindings. Consider upgrading to nanobind version for better performance.",
+        UserWarning,
+    )
 
 import numpy as np
 

--- a/pennylane_lightning/lightning_qubit/lightning_qubit.py
+++ b/pennylane_lightning/lightning_qubit/lightning_qubit.py
@@ -50,12 +50,22 @@ from pennylane_lightning.lightning_base.lightning_base import (
 )
 
 try:
-    from pennylane_lightning.lightning_qubit_ops import backend_info
+    from pennylane_lightning.lightning_qubit_nb import backend_info
 
     LQ_CPP_BINARY_AVAILABLE = True
 except ImportError as ex:
-    warn(str(ex), UserWarning)
-    LQ_CPP_BINARY_AVAILABLE = False
+    try:
+        # Fall back to pybind11 version if nanobind version is not available
+        from pennylane_lightning.lightning_qubit_ops import backend_info
+
+        warn(
+            "Using legacy pybind11 bindings. Consider upgrading to nanobind version for better performance.",
+            UserWarning,
+        )
+        LQ_CPP_BINARY_AVAILABLE = True
+    except ImportError:
+        warn(str(ex), UserWarning)
+        LQ_CPP_BINARY_AVAILABLE = False
 
 from ._adjoint_jacobian import LightningAdjointJacobian
 from ._measurements import LightningMeasurements

--- a/tests/bindings/test_lqubit_bindings_nb.py
+++ b/tests/bindings/test_lqubit_bindings_nb.py
@@ -1,0 +1,338 @@
+# Copyright 2025 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for LightningQubit-specific Nanobind bindings."""
+
+import numpy as np
+import pytest
+from conftest import backend
+
+# Skip all tests if not using lightning.qubit
+if backend != "qubit":
+    pytest.skip("Skipping tests for binaries other than lightning_qubit.", allow_module_level=True)
+
+
+class TestLQubitStateVectorBindings:
+    """Tests for LightningQubit-specific StateVector bindings."""
+
+    @pytest.fixture
+    def get_statevector_class(self):
+        """Get StateVector class based on precision."""
+
+        def _get_class(module, precision="64"):
+            class_name = f"StateVectorC{precision}"
+            if hasattr(module, class_name):
+                return getattr(module, class_name)
+            pytest.skip(f"Class {class_name} not available in module")
+
+        return _get_class
+
+    @pytest.mark.parametrize("precision", ["64", "128"])
+    def test_init(self, current_nanobind_module, precision, get_statevector_class):
+        """Test initialization of state vector."""
+        StateVectorClass = get_statevector_class(current_nanobind_module, precision)
+        num_qubits = 2
+        sv = StateVectorClass(num_qubits)
+        # Check that we can get the state
+        state = np.zeros(2**num_qubits, dtype=np.complex64 if precision == "64" else np.complex128)
+        sv.getState(state)
+        # Initial state should be |0...0>
+        expected = np.zeros(
+            2**num_qubits, dtype=np.complex64 if precision == "64" else np.complex128
+        )
+        expected[0] = 1.0
+        assert np.allclose(state, expected)
+
+    @pytest.mark.parametrize("precision", ["64", "128"])
+    def test_reset_state_vector(self, current_nanobind_module, precision, get_statevector_class):
+        """Test resetting state vector to |0...0>."""
+        StateVectorClass = get_statevector_class(current_nanobind_module, precision)
+        num_qubits = 2
+        sv = StateVectorClass(num_qubits)
+        # Apply X gate to first qubit to change state
+        sv.PauliX([0], False, [])
+        # Reset state vector
+        sv.resetStateVector()
+        # Check state is |0...0>
+        state = np.zeros(2**num_qubits, dtype=np.complex64 if precision == "64" else np.complex128)
+        sv.getState(state)
+        expected = np.zeros(
+            2**num_qubits, dtype=np.complex64 if precision == "64" else np.complex128
+        )
+        expected[0] = 1.0
+        assert np.allclose(state, expected)
+
+    @pytest.mark.parametrize("precision", ["64", "128"])
+    def test_set_basis_state(self, current_nanobind_module, precision, get_statevector_class):
+        """Test setting state vector to a basis state."""
+        StateVectorClass = get_statevector_class(current_nanobind_module, precision)
+        num_qubits = 2
+        sv = StateVectorClass(num_qubits)
+        # Set to |11>
+        basis_state = [1, 1]
+        sv.setBasisState(basis_state, [0, 1])
+        # Check state
+        state = np.zeros(2**num_qubits, dtype=np.complex64 if precision == "64" else np.complex128)
+        sv.getState(state)
+        expected = np.zeros(
+            2**num_qubits, dtype=np.complex64 if precision == "64" else np.complex128
+        )
+        expected[3] = 1.0
+        assert np.allclose(state, expected)
+
+    @pytest.mark.parametrize("precision", ["64", "128"])
+    def test_set_state_vector(self, current_nanobind_module, precision, get_statevector_class):
+        """Test setting state vector to a custom state."""
+        StateVectorClass = get_statevector_class(current_nanobind_module, precision)
+        num_qubits = 2
+        sv = StateVectorClass(num_qubits)
+        # Create a custom state (|00> + |11>)/sqrt(2)
+        custom_state = np.zeros(
+            2**num_qubits, dtype=np.complex64 if precision == "64" else np.complex128
+        )
+        custom_state[0] = 1.0 / np.sqrt(2)
+        custom_state[3] = 1.0 / np.sqrt(2)
+        sv.setStateVector(custom_state, [0, 1])
+        # Check state
+        state = np.zeros(2**num_qubits, dtype=np.complex64 if precision == "64" else np.complex128)
+        sv.getState(state)
+        assert np.allclose(state, custom_state)
+
+    @pytest.mark.parametrize("precision", ["64", "128"])
+    def test_update_data(self, current_nanobind_module, precision, get_statevector_class):
+        """Test updating state vector data."""
+        StateVectorClass = get_statevector_class(current_nanobind_module, precision)
+        num_qubits = 2
+        sv = StateVectorClass(num_qubits)
+        # Create a custom state (|01>)
+        custom_state = np.zeros(
+            2**num_qubits, dtype=np.complex64 if precision == "64" else np.complex128
+        )
+        custom_state[1] = 1.0
+        sv.updateData(custom_state)
+        # Check state
+        state = np.zeros(2**num_qubits, dtype=np.complex64 if precision == "64" else np.complex128)
+        sv.getState(state)
+        assert np.allclose(state, custom_state)
+
+    @pytest.mark.parametrize("precision", ["64", "128"])
+    def test_kernel_map(self, current_nanobind_module, precision, get_statevector_class):
+        """Test getting kernel map."""
+        StateVectorClass = get_statevector_class(current_nanobind_module, precision)
+        num_qubits = 2
+        sv = StateVectorClass(num_qubits)
+        kernel_map = sv.kernel_map()
+        # Check that kernel map contains expected keys
+        assert "PauliX" in kernel_map
+        assert "Hadamard" in kernel_map
+        assert "CNOT" in kernel_map
+
+    @pytest.mark.parametrize("precision", ["64", "128"])
+    def test_normalize(self, current_nanobind_module, precision, get_statevector_class):
+        """Test normalizing state vector."""
+        StateVectorClass = get_statevector_class(current_nanobind_module, precision)
+        num_qubits = 2
+        sv = StateVectorClass(num_qubits)
+        # Create a non-normalized state
+        custom_state = np.zeros(
+            2**num_qubits, dtype=np.complex64 if precision == "64" else np.complex128
+        )
+        custom_state[0] = 2.0
+        sv.updateData(custom_state)
+        # Normalize
+        sv.normalize()
+        # Check state
+        state = np.zeros(2**num_qubits, dtype=np.complex64 if precision == "64" else np.complex128)
+        sv.getState(state)
+        expected = np.zeros(
+            2**num_qubits, dtype=np.complex64 if precision == "64" else np.complex128
+        )
+        expected[0] = 1.0
+        assert np.allclose(state, expected)
+
+
+class TestLQubitMeasurementsBindings:
+    """Tests for LightningQubit-specific Measurements bindings."""
+
+    @pytest.fixture
+    def get_classes(self):
+        """Get StateVector and Measurements classes based on precision."""
+
+        def _get_classes(module, precision="64"):
+            # Get StateVector class
+            state_vector_class_name = f"StateVectorC{precision}"
+            if hasattr(module, state_vector_class_name):
+                state_vector_class = getattr(module, state_vector_class_name)
+            else:
+                pytest.skip(f"Class {state_vector_class_name} not available in module")
+
+            # Get Measurements class
+            measurements_class_name = f"MeasurementsC{precision}"
+            if hasattr(module, measurements_class_name):
+                measurements_class = getattr(module, measurements_class_name)
+            else:
+                pytest.skip(f"Class {measurements_class_name} not available in module")
+
+            return state_vector_class, measurements_class
+
+        return _get_classes
+
+    @pytest.mark.parametrize("precision", ["64", "128"])
+    def test_expval_named(self, current_nanobind_module, precision, get_classes):
+        """Test expected value calculation with named observable."""
+        StateVectorClass, MeasurementsClass = get_classes(current_nanobind_module, precision)
+        num_qubits = 1
+        sv = StateVectorClass(num_qubits)
+        # Apply Hadamard
+        sv.Hadamard([0], False, [])
+        # Create measurements object
+        meas = MeasurementsClass(sv)
+        # Calculate expected value of PauliZ
+        expval = meas.expval("PauliZ", [0])
+        assert np.isclose(expval, 0.0)
+
+    @pytest.mark.parametrize("precision", ["64", "128"])
+    def test_var_named(self, current_nanobind_module, precision, get_classes):
+        """Test variance calculation with named observable."""
+        StateVectorClass, MeasurementsClass = get_classes(current_nanobind_module, precision)
+        num_qubits = 1
+        sv = StateVectorClass(num_qubits)
+        # Apply Hadamard
+        sv.Hadamard([0], False, [])
+        # Create measurements object
+        meas = MeasurementsClass(sv)
+        # Calculate variance of PauliZ
+        var = meas.var("PauliZ", [0])
+        assert np.isclose(var, 1.0)
+
+    @pytest.mark.parametrize("precision", ["64", "128"])
+    def test_generate_samples(self, current_nanobind_module, precision, get_classes):
+        """Test generating samples."""
+        StateVectorClass, MeasurementsClass = get_classes(current_nanobind_module, precision)
+        num_qubits = 2
+        sv = StateVectorClass(num_qubits)
+        # Apply Hadamard to both qubits
+        sv.Hadamard([0], False, [])
+        sv.Hadamard([1], False, [])
+        # Create measurements object
+        meas = MeasurementsClass(sv)
+        # Generate samples
+        num_shots = 1000
+        samples = meas.generate_samples([0, 1], num_shots)
+        # Check shape
+        assert samples.shape == (num_shots, 2)
+        # Check distribution (should be roughly uniform)
+        counts = {
+            (0, 0): 0,
+            (0, 1): 0,
+            (1, 0): 0,
+            (1, 1): 0,
+        }
+        for sample in samples:
+            counts[(sample[0], sample[1])] += 1
+
+        # Each outcome should occur roughly 25% of the time
+        for outcome, count in counts.items():
+            assert 150 <= count <= 350, f"Outcome {outcome} occurred {count} times, expected ~250"
+
+    @pytest.mark.parametrize("precision", ["64", "128"])
+    def test_generate_mcmc_samples(self, current_nanobind_module, precision, get_classes):
+        """Test generating MCMC samples."""
+        StateVectorClass, MeasurementsClass = get_classes(current_nanobind_module, precision)
+        num_qubits = 2
+        sv = StateVectorClass(num_qubits)
+        # Apply Hadamard to both qubits
+        sv.Hadamard([0], False, [])
+        sv.Hadamard([1], False, [])
+        # Create measurements object
+        meas = MeasurementsClass(sv)
+        # Generate samples
+        num_shots = 1000
+        num_burnin = 100
+        samples = meas.generate_mcmc_samples(num_qubits, "local", num_burnin, num_shots)
+        # Check shape
+        assert samples.shape == (num_shots, num_qubits)
+
+
+class TestLQubitSparseHamiltonianBindings:
+    """Tests for LightningQubit-specific SparseHamiltonian bindings."""
+
+    @pytest.fixture
+    def get_sparse_hamiltonian_class(self):
+        """Get SparseHamiltonian class based on precision."""
+
+        def _get_class(module, precision="64"):
+            # SparseHamiltonian is in the observables submodule
+            if hasattr(module, "observables"):
+                observables_module = module.observables
+                class_name = f"SparseHamiltonianC{precision}"
+                if hasattr(observables_module, class_name):
+                    return getattr(observables_module, class_name)
+                else:
+                    pytest.skip(f"Class {class_name} not available in module.observables")
+            else:
+                pytest.skip("observables submodule not available")
+
+        return _get_class
+
+    @pytest.mark.parametrize("precision", ["64", "128"])
+    def test_init(self, current_nanobind_module, precision, get_sparse_hamiltonian_class):
+        """Test initialization of SparseHamiltonian."""
+        SparseHamiltonianClass = get_sparse_hamiltonian_class(current_nanobind_module, precision)
+
+        # Create a simple sparse matrix for the Pauli-Z operator
+        data = np.array([1.0, -1.0], dtype=np.complex64 if precision == "64" else np.complex128)
+        indices = np.array([0, 1], dtype=np.uint64)
+        indptr = np.array([0, 1, 2], dtype=np.uint64)
+        wires = [0]
+
+        # Create SparseHamiltonian
+        sparse_ham = SparseHamiltonianClass(data, indices, indptr, wires)
+
+        # Check wires
+        assert sparse_ham.get_wires() == wires
+
+        # Check string representation
+        assert "SparseHamiltonian" in sparse_ham.__repr__()
+
+
+class TestLQubitVJPBindings:
+    """Tests for LightningQubit-specific VectorJacobianProduct bindings."""
+
+    @pytest.mark.parametrize("precision", ["64", "128"])
+    def test_vjp_init(self, current_nanobind_module, precision):
+        """Test VectorJacobianProduct initialization."""
+        # VectorJacobianProduct is in the algorithms submodule
+        if hasattr(current_nanobind_module, "algorithms"):
+            algorithms_module = current_nanobind_module.algorithms
+            vjp_class_name = f"VectorJacobianProductC{precision}"
+            if hasattr(algorithms_module, vjp_class_name):
+                vjp_class = getattr(algorithms_module, vjp_class_name)
+                vjp = vjp_class()
+                assert vjp is not None
+            else:
+                pytest.skip(f"Class {vjp_class_name} not available in module.algorithms")
+        else:
+            pytest.skip("algorithms submodule not available")
+
+
+class TestLQubitBackendInfoBindings:
+    """Tests for LightningQubit-specific backend info bindings."""
+
+    def test_backend_info(self, current_nanobind_module):
+        """Test getting backend info."""
+        if hasattr(current_nanobind_module, "backend_info"):
+            info = current_nanobind_module.backend_info()
+            assert info["NAME"] == "lightning.qubit"
+        else:
+            pytest.skip("backend_info function not available in module")

--- a/tests/bindings/test_statevector_nb.py
+++ b/tests/bindings/test_statevector_nb.py
@@ -297,3 +297,38 @@ class TestStateVectorNB:
         sv.getState(result)
 
         assert np.allclose(result, state_data)
+
+    @pytest.mark.parametrize("precision", ["64", "128"])
+    def test_statevector_with_aligned_array(
+        self, current_nanobind_module, precision, get_statevector_class
+    ):
+        """Test StateVector with aligned array."""
+        StateVectorClass = get_statevector_class(current_nanobind_module, precision)
+
+        # Create a state vector
+        num_qubits = 2
+        sv = StateVectorClass(num_qubits)
+
+        # Create an aligned array
+        dtype_str = np.complex64 if precision == "64" else np.complex128
+        capsule = current_nanobind_module.allocate_aligned_array(
+            2**num_qubits, np.dtype(dtype_str), True
+        )
+
+        # Convert the capsule to a numpy array using numpy's array interface
+        # This approach works with both pybind11 and nanobind
+        arr = np.asarray(capsule, dtype=dtype_str)
+
+        # Set the first element to 1.0 to create a valid state
+        arr[0] = 1.0
+
+        # Update the state vector with the aligned array
+        sv.updateData(arr)
+
+        # Check that the state is correct
+        result = np.zeros(2**num_qubits, dtype=dtype_str)
+        sv.getState(result)
+
+        expected = np.zeros(2**num_qubits, dtype=dtype_str)
+        expected[0] = 1.0
+        assert np.allclose(result, expected)

--- a/tests/test_binary_info.py
+++ b/tests/test_binary_info.py
@@ -22,7 +22,7 @@ if platform.machine() != "x86_64":
     pytest.skip("Expected to fail on non x86 systems. Skipping.", allow_module_level=True)
 
 try:
-    from pennylane_lightning.lightning_qubit_ops import compile_info, runtime_info
+    from pennylane_lightning.lightning_qubit_nb import compile_info, runtime_info
 except (ImportError, ModuleNotFoundError):
     try:
         from pennylane_lightning.lightning_kokkos_ops import compile_info, runtime_info

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -60,7 +60,7 @@ elif device_name == "lightning.tensor":
         allow_module_level=True,
     )
 else:
-    from pennylane_lightning.lightning_qubit_ops.observables import (
+    from pennylane_lightning.lightning_qubit_nb.observables import (
         HamiltonianC64,
         HamiltonianC128,
         HermitianObsC64,


### PR DESCRIPTION
## Description
This PR adds Nanobind-based Python bindings for the Lightning Qubit backend, replacing the previous Pybind11 implementation. Nanobind offers improved performance and reduced binary size compared to Pybind11.

## Key changes:

Created LQubitBindings_nb.hpp with Nanobind-specific implementations
Added support for all existing Lightning Qubit functionality in the Nanobind interface
Maintained API compatibility with the existing Pybind11 bindings
Added tests to verify the Nanobind implementation works correctly
Implemented graceful fallback (in most of the cases) to Pybind11 when Nanobind is not available
The implementation follows the same pattern used for other Lightning backends, with backend-specific functionality registered through template functions. This ensures consistent behavior across all Lightning backends while allowing for backend-specific optimizations.

Performance testing shows improved import times and reduced memory usage with the Nanobind implementation.

[sc-92715]