### PR TITLE
Update pytest version

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 <h3>New features since last release</h3>
 
+- The distributed simulation using MPI in the `lightning.kokkos` device is added,
+  enabling larger quantum circuits by distributing workloads across multiple CPUs or GPUs.
+  [(#1114)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1114)
+
+- Mid-circuit measurements using the tree-traversal algorithm are now supported
+  in the `lightning.qubit`, `lightning.kokkos` and `lightning.gpu` devices,
+  providing both significant memory savings and sampling efficiency!
+  [(#1166)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1166)
+
 <h3>Improvements 🛠</h3>
 
 - Lightning devices accept a `seed` argument to enable deterministic shots measurements.
@@ -10,24 +19,32 @@
 - `MultiControlledX` gates are now natively supported in Lightning-Tensor.
   [(#1169)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1169)
 
-- Remove `MultiControlledX` gates native support in Lightning-Tensor.
-  [(#1183)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1183)
-
 - PennyLane-Lightning is compatible with JAX version 0.5.3+.
   [(#1152)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1152)
   [(#1161)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1161)
 
-- Improve performance of computing expectation values of Pauli Sentences for `lightning.kokkos`.
-  [(#1126)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1126)
-
-- Mid-circuit measurements using the tree-traversal algorithm are now supported
-  in the `lightning.qubit`, `lightning.kokkos` and `lightning.gpu` devices,
-  providing both significant memory savings and sampling efficiency!
-  [(#1166)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1166)
+- Refactor `MPIManager` class from `lightning.gpu` to base class.
+  [(#1162)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1162)
 
 <h3>Breaking changes 💔</h3>
 
+- The `LightningBaseStateVector`, `LightningBaseAdjointJacobian`, `LightningBaseMeasurements`, `LightningInterpreter` and `QuantumScriptSerializer` base classes now can be found at `pennylane_lightning.lightning_base`.
+
+  The new `lightning_base` module further enables the relocation of core files from `pennylane_lightning/core/src/*` to `pennylane_lightning/core/*`.
+
+  The license classifier and `project.license` as a TOML table are deprecated in favor of a SPDX license expression and removed in `pyproject.toml`.
+
+  To speedup the recompilation of C++ source code, `ccache` is also added to `Makefile`.
+
+  [(#1098)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1098)
+
+- Adhere to PyPA binary distribution format for built wheels.
+  [(#1193)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1193)
+
 <h3>Deprecations 👋</h3>
+
+- Remove `MultiControlledX` gates native support in `lightning.tensor`.
+  [(#1183)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1183)
 
 <h3>Documentation 📝</h3>
 
@@ -36,16 +53,18 @@
   [(#1141)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1141)
   [(#1142)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1142)
 
+- Fix typo in `lightning.gpu` documentation adjoint-jacobian section.
+  [(#1179)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1179)
+
 <h3>Bug fixes 🐛</h3>
 
-- Fixed the implementation of multi-controlled gates with a single target wire for arbitrary control values in Lightning-Tensor.
+- Fixed the implementation of multi-controlled gates with a single target wire for arbitrary control values in `lightning.tensor`.
   [(#1169)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1169)
 
 - Only download JAX version 0.5.3 for non-X86 MacOS. 
   [(#1163)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1163)
 
-- Fix Docker build for Lighting-Kokkos with ROCM library for AMD GPUs.
-  Updating ROCM from 5.7 to 6.2.4. 
+- Fix Docker build for `lighting.kokkos` with ROCM library for AMD GPUs. Updating ROCM from 5.7 to 6.2.4. 
   [(#1158)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1158)
 
 - Fix using Torch with `AmplitudeEmbedding` by applying `qml.broadcast_expand` before decomposition in the preprocessing stage. 
@@ -84,33 +103,6 @@
 - Bump `readthedocs` Github action runner to use Ubuntu-24.04.
   [(#1151)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1151)
 
-- The `LightningBaseStateVector`, `LightningBaseAdjointJacobian`, `LightningBaseMeasurements`, `LightningInterpreter` and `QuantumScriptSerializer` base classes now can be found at `pennylane_lightning.lightning_base`.
-
-  The new `lightning_base` module further enables the relocation of core files from `pennylane_lightning/core/src/*` to `pennylane_lightning/core/*`.
-
-  The license classifier and `project.license` as a TOML table are deprecated in favor of a SPDX license expression and removed in `pyproject.toml`.
-
-  To speedup the recompilation of C++ source code, `ccache` is also added to `Makefile`.
-
-  [(#1098)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1098)
-
-- All Catalyst plugins have been updated to be compatible with the next version of Catalyst (v0.12) with changes to the `QuantumDevice` interface.
-  [(#1143)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1143)
-  [(#1147)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1147)
-
-- Updates for depending deprecations to `Observable`, `is_trainable`, and `AnyWires` in pennylane.
-  [(#1138)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1138)
-  [(#1146)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1146)
-
-- Import custom PennyLane errors from `pennylane.exceptions` rather than top-level.
-  [(#1122)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1122)
-
-- Merge the `v0.41.0-rc` branch to the master and bump version.
-  [(#1132)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1132)
-
-- Added flags to all Codecov reports and a default carryforward flag for all flags.
-  [(1144)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1144)
-
 - Updated the `clang-format` and `clang-tidy` versions to v20 for compatibility with Catalyst.
   [(#1153)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1153)
 
@@ -123,8 +115,11 @@
 - Bump Github action runner to use `Ubuntu-24.04` or `Ubuntu-latest`. Fixing all `ubuntu-latest` action runners to `ubuntu-24.04`.
   [(#1167)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1167)
 
-- Adhere to PyPA binary distribution format for built wheels.
-  [(#1193)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1193)
+- Edit and prepare `CHANGELOG.md` for the release `v0.42.0`.
+  [(#1199)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1199)
+
+- Merge the `v0.41.0-rc` branch to the `master` and bump version.
+  [(#1132)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1132)
 
 <h3>Contributors ✍️</h3>
 
@@ -132,16 +127,16 @@ This release contains contributions from (in alphabetical order):
 
 Runor Agbaire,
 Ali Asadi,
-David Ittah,
+Yushao Chen,
 Christina Lee,
 Joseph Lee,
 Mehrdad Malekmohammadi,
 Anton Naim Ibrahim,
 Luis Alfredo Nuñez Meneses,
 Mudit Pandey,
-Andrija Paurevic,
 Shuli Shu,
-Marc Vandelle
+Marc Vandelle,
+Jake Zaia 
 
 ---
 
@@ -163,6 +158,25 @@ Marc Vandelle
 - Move the installation sections from `README.rst` to dedicated pages.
   [(#1131)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1131)
 
+<h3>Internal changes ⚙️</h3>
+
+- Updates for depending deprecations to `Observable`, `is_trainable`, and `AnyWires` in pennylane.
+  [(#1138)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1138)
+  [(#1146)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1146)
+
+- Improve performance of computing expectation values of Pauli Sentences for `lightning.kokkos`.
+  [(#1126)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1126)
+
+- Import custom PennyLane errors from `pennylane.exceptions` rather than top-level.
+  [(#1122)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1122)
+
+- Added flags to all Codecov reports and a default carryforward flag for all flags.
+  [(1144)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1144)
+
+- All Catalyst plugins have been updated to be compatible with the next version of Catalyst (v0.12) with changes to the `QuantumDevice` interface.
+  [(#1143)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1143)
+  [(#1147)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1147)
+
 <h3>Contributors ✍️</h3>
 
 This release contains contributions from (in alphabetical order):
@@ -170,9 +184,11 @@ This release contains contributions from (in alphabetical order):
 Ali Asadi,
 Amintor Dusko,
 Andrew Gardhouse,
+David Ittah,
 Joseph Lee,
 Anton Naim Ibrahim,
-Luis Alfredo Nuñez Meneses
+Luis Alfredo Nuñez Meneses,
+Andrija Paurevic,
 
 ---
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -14,6 +14,9 @@
 
 <h3>Internal changes ⚙️</h3>
 
+- Increased minimum version of `pytest` within requirements files to `8.4.1`.
+  [(#1207)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1207)
+
 - Merged the `v0.42.0_rc_merge` branch to the `master` and bumped the version.
   [(#1209)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1209)
 
@@ -21,7 +24,8 @@
 
 This release contains contributions from (in alphabetical order):
 
-Luis Alfredo Nuñez Meneses
+Luis Alfredo Nuñez Meneses,
+Jake Zaia
 
 ---
 

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.42.0-dev45"
+__version__ = "0.42.0-dev46"

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.42.0-dev44"
+__version__ = "0.42.0-dev45"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,7 +9,7 @@ cutensornet-cu12; sys_platform == "linux"
 git+https://github.com/PennyLaneAI/pennylane.git@master
 
 # Testing Dependencies
-pytest>=7.1.2
+pytest>=8.4.1
 pytest-benchmark
 pytest-cov>=3.0.0
 pytest-mock>=3.7.0

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,5 +1,5 @@
 # Testing Dependencies
-pytest>=7.1.2
+pytest>=8.4.1
 pytest-benchmark
 pytest-cov>=3.0.0
 pytest-mock>=3.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ pybind11>=2.12.0
 scipy-openblas32>=0.3.26
 
 # Testing Dependencies
-pytest>=7.1.2
+pytest>=8.4.1
 pytest-cov>=3.0.0
 pytest-mock>=3.7.0
 pytest-rng

--- a/scripts/compare_changelog_commits.sh
+++ b/scripts/compare_changelog_commits.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+
+# This script compares the list of merged PRs in Git with the list of PRs in the CHANGELOG.
+# It prints the authors of the merged PRs and the PRs in the CHANGELOG, and highlights any discrepancies.
+
+# Usage:
+# Edit the variable LAST_RELEASE_DATE with the date from https://github.com/PennyLaneAI/pennylane-lightning/releases
+# Run the script with 
+# bash compare_changelog_commits.sh 
+
+# Last release date
+LAST_RELEASE_DATE="2025-05-05"
+
+# Path to ChangeLog
+CHANGELOG_FILE="../.github/CHANGELOG.md"
+
+# -------------------------------------------------------------------------------------------------
+# Script body
+# -------------------------------------------------------------------------------------------------
+
+# Test if CHANGELOG file exists
+if [ ! -f "$CHANGELOG_FILE" ]; then
+    echo "CHANGELOG file not found at $CHANGELOG_FILE"
+    exit 1
+fi
+
+# Check if gh CLI is installed
+if ! command -v gh &> /dev/null; then
+    echo "gh CLI is not installed. Please install it to run this script."
+    exit 1
+fi
+
+# Find the end of the current version section in the CHANGELOG
+changelog_lower_bound=$(grep -n -- "---" "${CHANGELOG_FILE}" | head -n 1 | cut -d: -f1)
+
+# Find the beginning of the Contributors section
+contributors_begin=$(grep -n "<h3>Contributors ✍️</h3>" "${CHANGELOG_FILE}" | head -n 1 | cut -d: -f1)
+
+# Print list of Authors from Changelog and Git
+echo "Authors in CHANGELOG       /  Authors in Git"
+echo "---------------------------|---------------------------"
+paste <(sed -n "$((contributors_begin + 4)),$((changelog_lower_bound - 2))p" "${CHANGELOG_FILE}" | sort | sed 's/,//; s/$/,/') <(git log master --since=$LAST_RELEASE_DATE | grep "Author:" | sort | uniq | sed 's|<.*|| ; s|Author: ||' ) | column -t -s ','
+
+echo "--------------------------------------------------------------------------------"
+
+# Create the list of merged PR
+gh pr list --state merged --base master --search "merged:>=$LAST_RELEASE_DATE" -L 1000  | sort -h | awk -F 'MERGED' '{print $1}' > release_list_merged_PR.txt
+
+# Create the list of PRs in the CHANGELOG
+sed -n "1,${changelog_lower_bound}p" "${CHANGELOG_FILE}" | grep -B 1 'pull/'  | tr -d "\n" | sed 's/--/\n/g; s|pull/|pull/_ |g ; s/)//g'| awk '{print $NF, "  ", $0}' | sed 's|\[(.*||' |   sort -h -k1 > release_list_PR_in_changelog.txt
+
+
+interleave_rows(){
+    file1="$1"
+    file2="$2"
+
+    spliter="---------------------------------------------------------------------"
+
+    while IFS= read -r line1; do
+    # Extract the first column from each line
+    col1=$(echo "$line1" | awk '{print $1}')
+
+    #  Check if col1 is in file2
+    line2=$(grep "^$col1" "$file2")
+    # If line2 is empty, it means col1 is not in file2
+    if [ -z "$line2" ]; then
+        # Print the line from file1 with an empty line for file2
+        echo "MERGED | $line1"
+        echo " "
+        echo $spliter
+        continue
+    fi
+    # Extract the first column from line2
+    col2=$(echo "$line2" | awk '{print $1}')
+
+        # Print the line from file1 and the corresponding line from file2
+
+        echo "MERGED | $line1"
+        echo "CHGLOG | $line2"
+        echo $spliter
+    done < "$file1"
+
+    while IFS= read -r line2; do
+    # Extract the first column from each line
+    col2=$(echo "$line2" | awk '{print $1}')
+
+    # Check if col2 is in file1
+    line1=$(grep "^$col2" "$file1")
+    # If line1 is empty, it means col2 is not in file1
+    if [ -z "$line1" ]; then
+        # Print the line from file2 with an empty line for file1
+        echo " "
+        echo "CHGLOG | $line2"
+        echo $spliter
+        continue
+    fi
+    done < "$file2"
+
+}
+
+# Compare the two lists
+echo "--------------------------------------------------------------------------------"
+echo "Merged PRs in Git / PRs in CHANGELOG"
+interleave_rows release_list_merged_PR.txt release_list_PR_in_changelog.txt


### PR DESCRIPTION
**Context:**
Old pytest versions cause unit test failures in PennyLane and Lightning.

**Description of the Change:**
Updates the requirements files to only use versions of pytest which are properly supported.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-95292]