### PR TITLE
Add "device" as a supported MCM method that resolves to "tree-traversal"

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 <h3>Improvements 🛠</h3>
 
+- Using `mcm_method="device"` on `lightning.qubit`, `lightning.kokkos` and `lightning.gpu`
+  now resolves to the tree-traversal method.
+  [(#1210)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1210)
+
 <h3>Breaking changes 💔</h3>
 
 <h3>Deprecations 👋</h3>

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.43.0-dev2"
+__version__ = "0.43.0-dev3"

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.43.0-dev5"
+__version__ = "0.43.0-dev6"

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.43.0-dev4"
+__version__ = "0.43.0-dev5"

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.43.0-dev1"
+__version__ = "0.43.0-dev2"

--- a/pennylane_lightning/lightning_gpu/lightning_gpu.py
+++ b/pennylane_lightning/lightning_gpu/lightning_gpu.py
@@ -350,7 +350,7 @@ class LightningGPU(LightningBase):
         new_device_options.update(mcmc_default)
 
         mcm_supported_methods = (
-            ("deferred", "tree-traversal", "one-shot", None)
+            ("device", "deferred", "tree-traversal", "one-shot", None)
             if not qml.capture.enabled()
             else ("deferred", "single-branch-statistics", None)
         )
@@ -359,6 +359,9 @@ class LightningGPU(LightningBase):
 
         if (mcm_method := mcm_config.mcm_method) not in mcm_supported_methods:
             raise DeviceError(f"mcm_method='{mcm_method}' is not supported with lightning.gpu.")
+
+        if mcm_config.mcm_method == "device":
+            mcm_config = replace(mcm_config, mcm_method="tree-traversal")
 
         if qml.capture.enabled():
 
@@ -374,8 +377,9 @@ class LightningGPU(LightningBase):
             elif mcm_method is None:
                 mcm_updated_values["mcm_method"] = "deferred"
 
-            updated_values["mcm_config"] = replace(mcm_config, **mcm_updated_values)
+            mcm_config = replace(mcm_config, **mcm_updated_values)
 
+        updated_values["mcm_config"] = mcm_config
         return replace(config, **updated_values, device_options=new_device_options)
 
     def preprocess(self, execution_config: ExecutionConfig = DefaultExecutionConfig):

--- a/pennylane_lightning/lightning_gpu/lightning_gpu.py
+++ b/pennylane_lightning/lightning_gpu/lightning_gpu.py
@@ -29,7 +29,7 @@ import numpy as np
 import pennylane as qml
 from numpy.random import BitGenerator, Generator, SeedSequence
 from numpy.typing import ArrayLike
-from pennylane.devices import DefaultExecutionConfig, ExecutionConfig
+from pennylane.devices import DefaultExecutionConfig, ExecutionConfig, MCMConfig
 from pennylane.devices.capabilities import OperatorProperties
 from pennylane.devices.modifiers import simulator_tracking, single_tape_support
 from pennylane.devices.preprocess import (
@@ -349,37 +349,7 @@ class LightningGPU(LightningBase):
 
         new_device_options.update(mcmc_default)
 
-        mcm_supported_methods = (
-            ("device", "deferred", "tree-traversal", "one-shot", None)
-            if not qml.capture.enabled()
-            else ("deferred", "single-branch-statistics", None)
-        )
-
-        mcm_config = config.mcm_config
-
-        if (mcm_method := mcm_config.mcm_method) not in mcm_supported_methods:
-            raise DeviceError(f"mcm_method='{mcm_method}' is not supported with lightning.gpu.")
-
-        if mcm_config.mcm_method == "device":
-            mcm_config = replace(mcm_config, mcm_method="tree-traversal")
-
-        if qml.capture.enabled():
-
-            mcm_updated_values = {}
-
-            if mcm_method == "single-branch-statistics" and mcm_config.postselect_mode is not None:
-                warn(
-                    "Setting 'postselect_mode' is not supported with mcm_method='single-branch-"
-                    "statistics'. 'postselect_mode' will be ignored.",
-                    UserWarning,
-                )
-                mcm_updated_values["postselect_mode"] = None
-            elif mcm_method is None:
-                mcm_updated_values["mcm_method"] = "deferred"
-
-            mcm_config = replace(mcm_config, **mcm_updated_values)
-
-        updated_values["mcm_config"] = mcm_config
+        updated_values["mcm_config"] = _resolve_mcm_method(config.mcm_config)
         return replace(config, **updated_values, device_options=new_device_options)
 
     def preprocess(self, execution_config: ExecutionConfig = DefaultExecutionConfig):
@@ -494,6 +464,40 @@ class LightningGPU(LightningBase):
         """
 
         return LightningBase.get_c_interface_impl("LightningGPUSimulator", "lightning_gpu")
+
+
+def _resolve_mcm_method(mcm_config: MCMConfig):
+    """Resolve the mcm config for the LightningGPU device."""
+
+    mcm_supported_methods = (
+        ("device", "deferred", "tree-traversal", "one-shot", None)
+        if not qml.capture.enabled()
+        else ("deferred", "single-branch-statistics", None)
+    )
+
+    if (mcm_method := mcm_config.mcm_method) not in mcm_supported_methods:
+        raise DeviceError(f"mcm_method='{mcm_method}' is not supported with lightning.gpu.")
+
+    if mcm_config.mcm_method == "device":
+        mcm_config = replace(mcm_config, mcm_method="tree-traversal")
+
+    if qml.capture.enabled():
+
+        mcm_updated_values = {}
+
+        if mcm_method == "single-branch-statistics" and mcm_config.postselect_mode is not None:
+            warn(
+                "Setting 'postselect_mode' is not supported with mcm_method='single-branch-"
+                "statistics'. 'postselect_mode' will be ignored.",
+                UserWarning,
+            )
+            mcm_updated_values["postselect_mode"] = None
+        elif mcm_method is None:
+            mcm_updated_values["mcm_method"] = "deferred"
+
+        mcm_config = replace(mcm_config, **mcm_updated_values)
+
+    return mcm_config
 
 
 _supports_operation = LightningGPU.capabilities.supports_operation

--- a/pennylane_lightning/lightning_gpu/lightning_gpu.toml
+++ b/pennylane_lightning/lightning_gpu/lightning_gpu.toml
@@ -119,7 +119,7 @@ runtime_code_generation = false
 # The methods of handling mid-circuit measurements that the device supports, e.g.,
 # "one-shot", "device", "tree-traversal", etc. An empty list indicates that the device
 # does not support mid-circuit measurements.
-supported_mcm_methods = [ "one-shot", "tree-traversal" ]
+supported_mcm_methods = [ "device", "one-shot", "tree-traversal" ]
 
 # Whether the device supports dynamic qubit allocation/deallocation.
 dynamic_qubit_management = false

--- a/pennylane_lightning/lightning_kokkos/lightning_kokkos.py
+++ b/pennylane_lightning/lightning_kokkos/lightning_kokkos.py
@@ -313,7 +313,7 @@ class LightningKokkos(LightningBase):
         new_device_options.update(mcmc_default)
 
         mcm_supported_methods = (
-            ("deferred", "tree-traversal", "one-shot", None)
+            ("deferred", "device", "tree-traversal", "one-shot", None)
             if not qml.capture.enabled()
             else ("deferred", "single-branch-statistics", None)
         )
@@ -322,6 +322,9 @@ class LightningKokkos(LightningBase):
 
         if (mcm_method := mcm_config.mcm_method) not in mcm_supported_methods:
             raise DeviceError(f"mcm_method='{mcm_method}' is not supported with lightning.kokkos.")
+
+        if mcm_config.mcm_method == "device":
+            mcm_config = replace(mcm_config, mcm_method="tree-traversal")
 
         if qml.capture.enabled():
 
@@ -337,8 +340,9 @@ class LightningKokkos(LightningBase):
             elif mcm_method is None:
                 mcm_updated_values["mcm_method"] = "deferred"
 
-            updated_values["mcm_config"] = replace(mcm_config, **mcm_updated_values)
+            mcm_config = replace(mcm_config, **mcm_updated_values)
 
+        updated_values["mcm_config"] = mcm_config
         return replace(config, **updated_values, device_options=new_device_options)
 
     def preprocess(self, execution_config: ExecutionConfig = DefaultExecutionConfig):

--- a/pennylane_lightning/lightning_kokkos/lightning_kokkos.py
+++ b/pennylane_lightning/lightning_kokkos/lightning_kokkos.py
@@ -25,7 +25,7 @@ import numpy as np
 import pennylane as qml
 from numpy.random import BitGenerator, Generator, SeedSequence
 from numpy.typing import ArrayLike
-from pennylane.devices import DefaultExecutionConfig, ExecutionConfig
+from pennylane.devices import DefaultExecutionConfig, ExecutionConfig, MCMConfig
 from pennylane.devices.capabilities import OperatorProperties
 from pennylane.devices.modifiers import simulator_tracking, single_tape_support
 from pennylane.devices.preprocess import (
@@ -312,37 +312,7 @@ class LightningKokkos(LightningBase):
 
         new_device_options.update(mcmc_default)
 
-        mcm_supported_methods = (
-            ("deferred", "device", "tree-traversal", "one-shot", None)
-            if not qml.capture.enabled()
-            else ("deferred", "single-branch-statistics", None)
-        )
-
-        mcm_config = config.mcm_config
-
-        if (mcm_method := mcm_config.mcm_method) not in mcm_supported_methods:
-            raise DeviceError(f"mcm_method='{mcm_method}' is not supported with lightning.kokkos.")
-
-        if mcm_config.mcm_method == "device":
-            mcm_config = replace(mcm_config, mcm_method="tree-traversal")
-
-        if qml.capture.enabled():
-
-            mcm_updated_values = {}
-
-            if mcm_method == "single-branch-statistics" and mcm_config.postselect_mode is not None:
-                warn(
-                    "Setting 'postselect_mode' is not supported with mcm_method='single-branch-"
-                    "statistics'. 'postselect_mode' will be ignored.",
-                    UserWarning,
-                )
-                mcm_updated_values["postselect_mode"] = None
-            elif mcm_method is None:
-                mcm_updated_values["mcm_method"] = "deferred"
-
-            mcm_config = replace(mcm_config, **mcm_updated_values)
-
-        updated_values["mcm_config"] = mcm_config
+        updated_values["mcm_config"] = _resolve_mcm_method(config.mcm_config)
         return replace(config, **updated_values, device_options=new_device_options)
 
     def preprocess(self, execution_config: ExecutionConfig = DefaultExecutionConfig):
@@ -457,6 +427,40 @@ class LightningKokkos(LightningBase):
         """
 
         return LightningBase.get_c_interface_impl("LightningKokkosSimulator", "lightning_kokkos")
+
+
+def _resolve_mcm_method(mcm_config: MCMConfig):
+    """Resolve the mcm method for the LightningKokkos device"""
+
+    mcm_supported_methods = (
+        ("deferred", "device", "tree-traversal", "one-shot", None)
+        if not qml.capture.enabled()
+        else ("deferred", "single-branch-statistics", None)
+    )
+
+    if (mcm_method := mcm_config.mcm_method) not in mcm_supported_methods:
+        raise DeviceError(f"mcm_method='{mcm_method}' is not supported with lightning.kokkos.")
+
+    if mcm_config.mcm_method == "device":
+        mcm_config = replace(mcm_config, mcm_method="tree-traversal")
+
+    if qml.capture.enabled():
+
+        mcm_updated_values = {}
+
+        if mcm_method == "single-branch-statistics" and mcm_config.postselect_mode is not None:
+            warn(
+                "Setting 'postselect_mode' is not supported with mcm_method='single-branch-"
+                "statistics'. 'postselect_mode' will be ignored.",
+                UserWarning,
+            )
+            mcm_updated_values["postselect_mode"] = None
+        elif mcm_method is None:
+            mcm_updated_values["mcm_method"] = "deferred"
+
+        mcm_config = replace(mcm_config, **mcm_updated_values)
+
+    return mcm_config
 
 
 _supports_operation = LightningKokkos.capabilities.supports_operation

--- a/pennylane_lightning/lightning_kokkos/lightning_kokkos.toml
+++ b/pennylane_lightning/lightning_kokkos/lightning_kokkos.toml
@@ -119,7 +119,7 @@ runtime_code_generation = false
 # The methods of handling mid-circuit measurements that the device supports, e.g.,
 # "one-shot", "device", "tree-traversal", etc. An empty list indicates that the device
 # does not support mid-circuit measurements.
-supported_mcm_methods = [ "one-shot", "tree-traversal" ]
+supported_mcm_methods = [ "device", "one-shot", "tree-traversal" ]
 
 # Whether the device supports dynamic qubit allocation/deallocation.
 dynamic_qubit_management = false

--- a/pennylane_lightning/lightning_qubit/lightning_qubit.py
+++ b/pennylane_lightning/lightning_qubit/lightning_qubit.py
@@ -25,7 +25,7 @@ import numpy as np
 import pennylane as qml
 from numpy.random import BitGenerator, Generator, SeedSequence
 from numpy.typing import ArrayLike
-from pennylane.devices import DefaultExecutionConfig, ExecutionConfig
+from pennylane.devices import DefaultExecutionConfig, ExecutionConfig, MCMConfig
 from pennylane.devices.capabilities import OperatorProperties
 from pennylane.devices.modifiers import simulator_tracking, single_tape_support
 from pennylane.devices.preprocess import (
@@ -335,37 +335,7 @@ class LightningQubit(LightningBase):
             if option not in new_device_options:
                 new_device_options[option] = getattr(self, f"_{option}", None)
 
-        mcm_supported_methods = (
-            ("device", "deferred", "tree-traversal", "one-shot", None)
-            if not qml.capture.enabled()
-            else ("deferred", "single-branch-statistics", None)
-        )
-
-        mcm_config = config.mcm_config
-
-        if (mcm_method := mcm_config.mcm_method) not in mcm_supported_methods:
-            raise DeviceError(f"mcm_method='{mcm_method}' is not supported with lightning.qubit")
-
-        if mcm_config.mcm_method == "device":
-            mcm_config = replace(mcm_config, mcm_method="tree-traversal")
-
-        if qml.capture.enabled():
-
-            mcm_updated_values = {}
-
-            if mcm_method == "single-branch-statistics" and mcm_config.postselect_mode is not None:
-                warn(
-                    "Setting 'postselect_mode' is not supported with mcm_method='single-branch-"
-                    "statistics'. 'postselect_mode' will be ignored.",
-                    UserWarning,
-                )
-                mcm_updated_values["postselect_mode"] = None
-            elif mcm_method is None:
-                mcm_updated_values["mcm_method"] = "deferred"
-
-            mcm_config = replace(mcm_config, **mcm_updated_values)
-
-        updated_values["mcm_config"] = mcm_config
+        updated_values["mcm_config"] = _resolve_mcm_method(config.mcm_config)
         return replace(config, **updated_values, device_options=new_device_options)
 
     def preprocess(self, execution_config: ExecutionConfig = DefaultExecutionConfig):
@@ -487,6 +457,40 @@ class LightningQubit(LightningBase):
         """
 
         return LightningBase.get_c_interface_impl("LightningSimulator", "lightning_qubit")
+
+
+def _resolve_mcm_method(mcm_config: MCMConfig):
+    """Resolve the mcm method for the LightningQubit device."""
+
+    mcm_supported_methods = (
+        ("device", "deferred", "tree-traversal", "one-shot", None)
+        if not qml.capture.enabled()
+        else ("deferred", "single-branch-statistics", None)
+    )
+
+    if (mcm_method := mcm_config.mcm_method) not in mcm_supported_methods:
+        raise DeviceError(f"mcm_method='{mcm_method}' is not supported with lightning.qubit")
+
+    if mcm_config.mcm_method == "device":
+        mcm_config = replace(mcm_config, mcm_method="tree-traversal")
+
+    if qml.capture.enabled():
+
+        mcm_updated_values = {}
+
+        if mcm_method == "single-branch-statistics" and mcm_config.postselect_mode is not None:
+            warn(
+                "Setting 'postselect_mode' is not supported with mcm_method='single-branch-"
+                "statistics'. 'postselect_mode' will be ignored.",
+                UserWarning,
+            )
+            mcm_updated_values["postselect_mode"] = None
+        elif mcm_method is None:
+            mcm_updated_values["mcm_method"] = "deferred"
+
+        mcm_config = replace(mcm_config, **mcm_updated_values)
+
+    return mcm_config
 
 
 _supports_operation = LightningQubit.capabilities.supports_operation

--- a/pennylane_lightning/lightning_qubit/lightning_qubit.py
+++ b/pennylane_lightning/lightning_qubit/lightning_qubit.py
@@ -336,7 +336,7 @@ class LightningQubit(LightningBase):
                 new_device_options[option] = getattr(self, f"_{option}", None)
 
         mcm_supported_methods = (
-            ("deferred", "tree-traversal", "one-shot", None)
+            ("device", "deferred", "tree-traversal", "one-shot", None)
             if not qml.capture.enabled()
             else ("deferred", "single-branch-statistics", None)
         )
@@ -345,6 +345,9 @@ class LightningQubit(LightningBase):
 
         if (mcm_method := mcm_config.mcm_method) not in mcm_supported_methods:
             raise DeviceError(f"mcm_method='{mcm_method}' is not supported with lightning.qubit")
+
+        if mcm_config.mcm_method == "device":
+            mcm_config = replace(mcm_config, mcm_method="tree-traversal")
 
         if qml.capture.enabled():
 
@@ -360,8 +363,9 @@ class LightningQubit(LightningBase):
             elif mcm_method is None:
                 mcm_updated_values["mcm_method"] = "deferred"
 
-            updated_values["mcm_config"] = replace(mcm_config, **mcm_updated_values)
+            mcm_config = replace(mcm_config, **mcm_updated_values)
 
+        updated_values["mcm_config"] = mcm_config
         return replace(config, **updated_values, device_options=new_device_options)
 
     def preprocess(self, execution_config: ExecutionConfig = DefaultExecutionConfig):

--- a/pennylane_lightning/lightning_qubit/lightning_qubit.toml
+++ b/pennylane_lightning/lightning_qubit/lightning_qubit.toml
@@ -119,7 +119,7 @@ runtime_code_generation = false
 # The methods of handling mid-circuit measurements that the device supports, e.g.,
 # "one-shot", "device", "tree-traversal", etc. An empty list indicates that the device
 # does not support mid-circuit measurements.
-supported_mcm_methods = [ "one-shot", "tree-traversal" ]
+supported_mcm_methods = [ "device", "one-shot", "tree-traversal" ]
 
 # Whether the device supports dynamic qubit allocation/deallocation.
 dynamic_qubit_management = false

--- a/tests/test_native_mcm.py
+++ b/tests/test_native_mcm.py
@@ -263,7 +263,7 @@ class TestSupportedConfigurationsMCM:
             spy_one_shot.assert_not_called()
 
     @pytest.mark.parametrize("shots", [None, 10])
-    def test_qnode_default_mcm_method_device(self, mocker):
+    def test_qnode_default_mcm_method_device(self, shots, mocker):
         """Test the default mcm method is used for analytical simulation"""
         spy_deferred = mocker.spy(qml.defer_measurements, "_transform")
         spy_dynamic_one_shot = mocker.spy(qml.dynamic_one_shot, "_transform")

--- a/tests/test_native_mcm.py
+++ b/tests/test_native_mcm.py
@@ -262,9 +262,8 @@ class TestSupportedConfigurationsMCM:
             spy_deffered.assert_not_called()
             spy_one_shot.assert_not_called()
 
-
-@pytest.mark.parametrize("shots", [None, 10])
-def test_qnode_default_mcm_method_device(self, mocker):
+    @pytest.mark.parametrize("shots", [None, 10])
+    def test_qnode_default_mcm_method_device(self, mocker):
         """Test the default mcm method is used for analytical simulation"""
         spy_deferred = mocker.spy(qml.defer_measurements, "_transform")
         spy_dynamic_one_shot = mocker.spy(qml.dynamic_one_shot, "_transform")
@@ -283,6 +282,7 @@ def test_qnode_default_mcm_method_device(self, mocker):
         spy_deferred.assert_not_called()
         spy_dynamic_one_shot.assert_not_called()
         spy_tree_traversal.assert_called_once()
+
     def test_qnode_default_mcm_method_analytical(self, mocker):
         """Test the default mcm method is used for analytical simulation"""
         spy_deferred = mocker.spy(qml.defer_measurements, "_transform")

--- a/tests/test_native_mcm.py
+++ b/tests/test_native_mcm.py
@@ -43,6 +43,7 @@ def get_device(wires, **kwargs):
 @pytest.fixture(
     scope="function",
     params=[
+        "device",
         "deferred",
         "one-shot",
         "tree-traversal",
@@ -257,7 +258,7 @@ class TestSupportedConfigurationsMCM:
             spy_one_shot.assert_called_once()
             spy_deffered.assert_not_called()
             spy_tree_traversal.assert_not_called()
-        elif mcm_method == "tree-traversal":
+        elif mcm_method in ("device", "tree-traversal"):
             spy_tree_traversal.assert_called_once()
             spy_deffered.assert_not_called()
             spy_one_shot.assert_not_called()

--- a/tests/test_native_mcm.py
+++ b/tests/test_native_mcm.py
@@ -258,7 +258,11 @@ class TestSupportedConfigurationsMCM:
             spy_one_shot.assert_called_once()
             spy_deffered.assert_not_called()
             spy_tree_traversal.assert_not_called()
-        elif mcm_method in ("device", "tree-traversal"):
+        elif mcm_method == "tree-traversal":
+            spy_tree_traversal.assert_called_once()
+            spy_deffered.assert_not_called()
+            spy_one_shot.assert_not_called()
+        elif mcm_method == "device":
             spy_tree_traversal.assert_called_once()
             spy_deffered.assert_not_called()
             spy_one_shot.assert_not_called()


### PR DESCRIPTION
**Context:**
It was previously determined that `mcm_method="device"` is the convention for using the device-native mcm method, one that does not require any transforms on the PL side. Now that tree-traversal is supported on the lightning devices, it can be considered a device native MCM method.

**Description of the Change:**
Update the Lightning devices that support tree-traversal to treat `mcm_method="device"` as tree-traversal.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-95418]