### PR TITLE
 Remove FIXMEs for pinning jax & catalyst version for CI with stable

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -14,6 +14,9 @@
 
 <h3>Internal changes ⚙️</h3>
 
+- Remove FIXMEs for pinning jax & catalyst 0.11.0 for CI with stable.
+  [(#1211)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1211)
+
 - Increased minimum version of `pytest` within requirements files to `8.4.1`.
   [(#1207)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1207)
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 <h3>Internal changes ⚙️</h3>
 
-- Remove FIXMEs for pinning jax & catalyst 0.11.0 for CI with stable.
+- Remove FIXMEs for pinning jax & catalyst 0.11.0 for CI testing stable version.
   [(#1211)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1211)
 
 - Increased minimum version of `pytest` within requirements files to `8.4.1`.

--- a/.github/workflows/tests_gpu_cpp.yml
+++ b/.github/workflows/tests_gpu_cpp.yml
@@ -85,7 +85,6 @@ jobs:
         with:
           repository: PennyLaneAI/catalyst
           path: ${{ github.workspace}}/catalyst
-          ref: ${{ (inputs.pennylane-version == 'stable' && 'v0.11.0') || 'main' }} # FIXME: remove after v0.42 release
 
       - uses: actions/setup-python@v5
         id: setup_python

--- a/.github/workflows/tests_gpu_python.yml
+++ b/.github/workflows/tests_gpu_python.yml
@@ -96,7 +96,6 @@ jobs:
         with:
           repository: PennyLaneAI/catalyst
           path: ${{ github.workspace}}/catalyst
-          ref: ${{ (inputs.pennylane-version == 'stable' && 'v0.11.0') || 'main' }} # FIXME: remove after v0.42 release
 
       - uses: actions/setup-python@v5
         id: setup_python
@@ -144,12 +143,6 @@ jobs:
         run: |
           python -m pip install -r requirements-tests.txt
           python -m pip install cmake openfermionpyscf
-
-      - name: Revert to older JAX version for stable
-        if: inputs.pennylane-version == 'stable'
-        run: |
-          # FIXME: remove after v0.42 release
-          python -m pip install "jax[cpu]==0.4.28"
 
       - name: Install required lightning_gpu only packages
         if: matrix.pl_backend == 'lightning_gpu'

--- a/.github/workflows/tests_lgpumpi_cpp.yml
+++ b/.github/workflows/tests_lgpumpi_cpp.yml
@@ -61,7 +61,6 @@ jobs:
         with:
           repository: PennyLaneAI/catalyst
           path: ${{ github.workspace}}/catalyst
-          ref: ${{ (inputs.pennylane-version == 'stable' && 'v0.11.0') || 'main' }} # FIXME: remove after v0.42 release
 
       - name: Switch to stable build of Lightning-GPU
         if: inputs.lightning-version == 'stable'

--- a/.github/workflows/tests_lgpumpi_python.yml
+++ b/.github/workflows/tests_lgpumpi_python.yml
@@ -63,7 +63,6 @@ jobs:
         with:
           repository: PennyLaneAI/catalyst
           path: ${{ github.workspace}}/catalyst
-          ref: ${{ (inputs.pennylane-version == 'stable' && 'v0.11.0') || 'main' }} # FIXME: remove after v0.42 release
 
       - name: Switch to release build of Lightning
         if: inputs.lightning-version == 'release'
@@ -128,12 +127,6 @@ jobs:
           python -m pip install mpi4py openfermionpyscf
           python scripts/configure_pyproject_toml.py || true
           python -m pip install . -vv
-
-      - name: Revert to older JAX version for stable
-        if: inputs.pennylane-version == 'stable'
-        run: |
-          # FIXME: remove after v0.42 release
-          python -m pip install "jax[cpu]==0.4.28"
 
       - name: Checkout PennyLane for release or latest build
         if: inputs.pennylane-version == 'release' || inputs.pennylane-version == 'latest'

--- a/.github/workflows/tests_linux_cpp.yml
+++ b/.github/workflows/tests_linux_cpp.yml
@@ -65,7 +65,6 @@ jobs:
         with:
           repository: PennyLaneAI/catalyst
           path: ${{ github.workspace}}/catalyst
-          ref: ${{ (inputs.pennylane-version == 'stable' && 'v0.11.0') || 'main' }} # FIXME: remove after v0.42 release
 
       - name: Install dependencies
         run: |
@@ -144,7 +143,6 @@ jobs:
         with:
           repository: PennyLaneAI/catalyst
           path: ${{ github.workspace}}/catalyst
-          ref: ${{ (inputs.pennylane-version == 'stable' && 'v0.11.0') || 'main' }} # FIXME: remove after v0.42 release
 
       - name: Install dependencies
         run: |
@@ -231,7 +229,6 @@ jobs:
         with:
           repository: PennyLaneAI/catalyst
           path: ${{ github.workspace}}/catalyst
-          ref: ${{ (inputs.pennylane-version == 'stable' && 'v0.11.0') || 'main' }} # FIXME: remove after v0.42 release
 
       - name: Restoring cached dependencies
         id: kokkos-cache
@@ -348,7 +345,6 @@ jobs:
         with:
           repository: PennyLaneAI/catalyst
           path: ${{ github.workspace}}/catalyst
-          ref: ${{ (inputs.pennylane-version == 'stable' && 'v0.11.0') || 'main' }} # FIXME: remove after v0.42 release
 
       - name: Restoring cached dependencies
         id: kokkos-cache

--- a/.github/workflows/tests_lkcpu_python.yml
+++ b/.github/workflows/tests_lkcpu_python.yml
@@ -75,7 +75,6 @@ jobs:
         with:
           repository: PennyLaneAI/catalyst
           path: ${{ github.workspace}}/catalyst
-          ref: ${{ (inputs.pennylane-version == 'stable' && 'v0.11.0') || 'main' }} # FIXME: remove after v0.42 release
 
       - name: Switch to release build of Lightning
         if: inputs.lightning-version == 'release'
@@ -213,12 +212,6 @@ jobs:
             SKIP_COMPILATION=True python -m pip install . -vv
           fi
           python -m pip install ${{ github.workspace }}/$WHEEL_NAME --no-deps
-
-      - name: Revert to older JAX version for stable
-        if: inputs.pennylane-version == 'stable'
-        run: |
-          # FIXME: remove after v0.42 release
-          python -m pip install "jax[cpu]==0.4.28"
 
       - name: Checkout PennyLane for release or latest build
         if: inputs.pennylane-version == 'release' || inputs.pennylane-version == 'latest'

--- a/.github/workflows/tests_lkcuda_cpp.yml
+++ b/.github/workflows/tests_lkcuda_cpp.yml
@@ -152,7 +152,6 @@ jobs:
         with:
           repository: PennyLaneAI/catalyst
           path: ${{ github.workspace}}/catalyst
-          ref: ${{ (inputs.pennylane-version == 'stable' && 'v0.11.0') || 'main' }} # FIXME: remove after v0.42 release
 
       - uses: actions/setup-python@v5
         id: setup_python

--- a/.github/workflows/tests_lkcuda_python.yml
+++ b/.github/workflows/tests_lkcuda_python.yml
@@ -214,12 +214,6 @@ jobs:
           python -m pip install -r requirements-tests.txt
           python -m pip install openfermionpyscf
 
-      - name: Revert to older JAX version for stable
-        if: inputs.pennylane-version == 'stable'
-        run: |
-          # FIXME: remove after v0.42 release
-          python -m pip install "jax[cpu]==0.4.28"
-
       - name: Checkout PennyLane for release or latest build
         if: inputs.pennylane-version == 'release' || inputs.pennylane-version == 'latest'
         uses: actions/checkout@v4
@@ -253,7 +247,6 @@ jobs:
         with:
           repository: PennyLaneAI/catalyst
           path: ${{ github.workspace}}/catalyst
-          ref: ${{ (inputs.pennylane-version == 'stable' && 'v0.11.0') || 'main' }} # FIXME: remove after v0.42 release
 
       - name: Install ML libraries for interfaces
         run: |

--- a/.github/workflows/tests_lkmpi_cuda_cpp.yml
+++ b/.github/workflows/tests_lkmpi_cuda_cpp.yml
@@ -63,7 +63,6 @@ jobs:
         with:
           repository: PennyLaneAI/catalyst
           path: ${{ github.workspace}}/catalyst
-          ref: ${{ (inputs.pennylane-version == 'stable' && 'v0.11.0') || 'main' }} # FIXME: remove after v0.42 release
 
       - name: Switch to stable build of Lightning-Kokkos
         if: inputs.lightning-version == 'stable'

--- a/.github/workflows/tests_lkmpi_cuda_python.yml
+++ b/.github/workflows/tests_lkmpi_cuda_python.yml
@@ -65,7 +65,6 @@ jobs:
         with:
           repository: PennyLaneAI/catalyst
           path: ${{ github.workspace}}/catalyst
-          ref: ${{ (inputs.pennylane-version == 'stable' && 'v0.11.0') || 'main' }} # FIXME: remove after v0.42 release
 
       - name: Switch to release build of Lightning
         if: inputs.lightning-version == 'release'
@@ -129,12 +128,6 @@ jobs:
           python -m pip install mpi4py openfermionpyscf
           python scripts/configure_pyproject_toml.py || true
           python -m pip install . -vv
-
-      - name: Revert to older JAX version for stable
-        if: inputs.pennylane-version == 'stable'
-        run: |
-          # FIXME: remove after v0.42 release
-          python -m pip install "jax[cpu]==0.4.28"
 
       - name: Clone Kokkos repository
         run: |

--- a/.github/workflows/tests_lqcpu_python.yml
+++ b/.github/workflows/tests_lqcpu_python.yml
@@ -81,7 +81,6 @@ jobs:
         with:
           repository: PennyLaneAI/catalyst
           path: ${{ github.workspace}}/catalyst
-          ref: ${{ (inputs.pennylane-version == 'stable' && 'v0.11.0') || 'main' }} # FIXME: remove after v0.42 release
 
       - name: Install dependencies
         run: |
@@ -164,12 +163,6 @@ jobs:
           python -m pip install -r requirements-tests.txt
           python -m pip install openfermionpyscf semantic-version
           python -m pip install ${{ github.workspace }}/$WHEEL_NAME --no-deps --force-reinstall
-
-      - name: Revert to older JAX version for stable
-        if: inputs.pennylane-version == 'stable'
-        run: |
-          # FIXME: remove after v0.42 release
-          python -m pip install "jax[cpu]==0.4.28"
 
       - name: Checkout PennyLane for release or latest build
         if: inputs.pennylane-version == 'release' || inputs.pennylane-version == 'latest'

--- a/.github/workflows/tests_windows_cpp.yml
+++ b/.github/workflows/tests_windows_cpp.yml
@@ -43,7 +43,6 @@ jobs:
         with:
           repository: PennyLaneAI/catalyst
           path: ${{ github.workspace}}/catalyst
-          ref: ${{ (inputs.pennylane-version == 'stable' && 'v0.11.0') || 'main' }} # FIXME: remove after v0.42 release
 
       - name: Kokkos execution strategy
         id: exec_model

--- a/.github/workflows/tests_without_binary.yml
+++ b/.github/workflows/tests_without_binary.yml
@@ -108,7 +108,6 @@ jobs:
         with:
           repository: PennyLaneAI/catalyst
           path: ${{ github.workspace}}/catalyst
-          ref: ${{ (inputs.pennylane-version == 'stable' && 'v0.11.0') || 'main' }} # FIXME: remove after v0.42 release
 
       - name: Install the pennylane_lightning core package (lightning_qubit)
         env:

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.43.0-dev1"
+__version__ = "0.43.0-dev2"

--- a/pennylane_lightning/lightning_base/lightning_base.py
+++ b/pennylane_lightning/lightning_base/lightning_base.py
@@ -72,10 +72,6 @@ class LightningBase(Device):
             computing the jacobian.
     """
 
-    # pylint: disable=too-many-instance-attributes
-    pennylane_requires = ">=0.41"
-    version = __version__
-
     def __init__(  # pylint: disable=too-many-arguments
         self,
         wires: Union[int, List] = None,

--- a/pennylane_lightning/lightning_base/lightning_base.py
+++ b/pennylane_lightning/lightning_base/lightning_base.py
@@ -72,6 +72,8 @@ class LightningBase(Device):
             computing the jacobian.
     """
 
+    # pylint: disable=too-many-instance-attributes
+
     def __init__(  # pylint: disable=too-many-arguments
         self,
         wires: Union[int, List] = None,


### PR DESCRIPTION
**Context:**
Actions after release 0.42.0
[sc-91326]


Remove `pennylane_requires` and `version` from `lightning_base.py` because they were part of the OLD API.
[sc-95134]
**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
