### PR TITLE
Deprecate tests that have `QNode` call with shots kwarg

### DIFF
--- a/tests/test_native_mcm.py
+++ b/tests/test_native_mcm.py
@@ -397,7 +397,7 @@ class TestExecutionMCM:
             )
 
         res1 = qml.QNode(circuit_op, dq)()
-        res2 = qml.QNode(circuit_op, dev, mcm_method=mcm_method)(shots=10)
+        res2 = qml.set_shots(qml.QNode(circuit_op, dev, mcm_method=mcm_method), shots=10)()
         for r1, r2 in zip(res1, res2):
             if isinstance(r1, Sequence):
                 assert len(r1) == len(r2)
@@ -410,7 +410,7 @@ class TestExecutionMCM:
             return qml.expval(op=m), qml.probs(op=m), qml.var(op=m)
 
         res1 = qml.QNode(circuit_mcm, dq)()
-        res2 = qml.QNode(circuit_mcm, dev, mcm_method=mcm_method)(shots=10)
+        res2 = qml.set_shots(qml.QNode(circuit_mcm, dev, mcm_method=mcm_method), shots=10)()
         for r1, r2 in zip(res1, res2):
             if isinstance(r1, Sequence):
                 assert len(r1) == len(r2)


### PR DESCRIPTION
**Context:**
See https://github.com/PennyLaneAI/pennylane/pull/7906 for on-going deprecation of the `shots=` kwarg of `QNode` calls. Now we can use `set_shots` to assign the shots value to a qnode.

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
[[sc-95617](https://app.shortcut.com/xanaduai/story/95617)]