### PR TITLE
[WIP] Deprecate device shots setting at init

### DIFF
--- a/pennylane_lightning/lightning_qubit/lightning_qubit.py
+++ b/pennylane_lightning/lightning_qubit/lightning_qubit.py
@@ -276,9 +276,10 @@ class LightningQubit(LightningBase):
                     f"The {kernel_name} is not supported and currently "
                     "only 'Local' and 'NonZeroRandom' kernels are supported."
                 )
-            shots = shots if isinstance(shots, Sequence) else [shots]
-            if any(num_burnin >= s for s in shots):
-                raise ValueError("Shots should be greater than num_burnin.")
+            if shots is not None:
+                shots_list = shots if isinstance(shots, Sequence) else [shots]
+                if any(num_burnin >= s for s in shots_list):
+                    raise ValueError("Shots should be greater than num_burnin.")
             self._kernel_name = kernel_name
             self._num_burnin = num_burnin
         else:

--- a/tests/test_measurements.py
+++ b/tests/test_measurements.py
@@ -454,7 +454,7 @@ class TestSample:
         """Tests if the samples returned by the sample function have
         the correct dimensions
         """
-        dev = qubit_device(wires=2, shots=shots)
+        dev = qubit_device(wires=2)
         ops = [qml.RX(1.5708, wires=[0]), qml.RX(1.5708, wires=[1])]
         obs = qml.PauliZ(wires=[0])
         tape = qml.tape.QuantumScript(ops, [qml.sample(op=obs)], shots=shots)
@@ -466,7 +466,7 @@ class TestSample:
         the correct values
         """
         shots = 1000
-        dev = qubit_device(wires=2, shots=shots)
+        dev = qubit_device(wires=2)
         ops = [qml.RX(1.5708, wires=[0])]
         obs = qml.PauliZ(0)
         tape = qml.tape.QuantumScript(ops, [qml.sample(op=obs)], shots=shots)
@@ -495,7 +495,7 @@ class TestSample:
         def reshape_samples(samples):
             return np.atleast_3d(samples) if len(wires) == 1 else np.atleast_2d(samples)
 
-        dev = qubit_device(wires=n_qubits, shots=shots)
+        dev = qubit_device(wires=n_qubits)
         samples = dev.execute(tape)
         probs = qml.measurements.ProbabilityMP(wires=wires).process_samples(
             reshape_samples(samples), wire_order=wires
@@ -546,9 +546,7 @@ def test_shots_single_measure_obs(shots, measure_f, obs, n_wires, mcmc, kernel_n
     if device_name in ("lightning.gpu", "lightning.kokkos"):
         dev = qml.device(device_name, wires=n_wires, seed=seed)
     elif device_name == "lightning.qubit":
-        dev = qml.device(
-            device_name, wires=n_wires, shots=shots, mcmc=mcmc, kernel_name=kernel_name, seed=seed
-        )
+        dev = qml.device(device_name, wires=n_wires, mcmc=mcmc, kernel_name=kernel_name, seed=seed)
     else:
         dev = qml.device(device_name, wires=n_wires)
 
@@ -589,13 +587,13 @@ def test_shots_single_measure_obs(shots, measure_f, obs, n_wires, mcmc, kernel_n
 def test_shots_bins(shots, qubit_device, seed):
     """Tests that Lightning handles multiple shots."""
 
-    dev = qubit_device(wires=1, shots=shots, seed=seed)
+    dev = qubit_device(wires=1, seed=seed)
 
+    @qml.set_shots(shots)
     @qml.qnode(dev)
     def circuit():
         return qml.expval(qml.PauliZ(wires=0))
 
-    if dev.name == "lightning.qubit":
-        assert np.sum(shots) == circuit.device.shots.total_shots
+    assert np.sum(shots) == circuit._shots.total_shots
 
     assert np.allclose(circuit(), 1.0)


### PR DESCRIPTION
**Context:**
As the [deprecation](https://github.com/PennyLaneAI/pennylane/pull/7979) on PennyLane side goes on, we might need to adjust some tests in Lightning as well.
However, note that there are some special usages in lightning devices that involve things e.g. validation against device.shots, this PR might be blocked by some other adjustments.

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
