### PR TITLE
[WIP] Move MCMC validation to preprocess in `lightning.qubit`

### DIFF
--- a/tests/lightning_base/test_measurements_samples_MCMC.py
+++ b/tests/lightning_base/test_measurements_samples_MCMC.py
@@ -74,19 +74,27 @@ class TestMCMCSample:
         """Tests if the samples returned by sample have
         the correct values
         """
+        # Create device (should not fail at initialization)
+        dev = qml.device(
+            device_name,
+            wires=2,
+            shots=1000,
+            mcmc=True,
+            kernel_name=kernel,
+            num_burnin=100,
+        )
+
+        # Error should be raised during preprocess when validation runs
         with pytest.raises(
             NotImplementedError,
             match=f"The {kernel} is not supported and currently only 'Local' and 'NonZeroRandom' kernels are supported.",
         ):
-            dev = qml.device(
-                device_name,
-                wires=2,
-                shots=1000,
-                mcmc=True,
-                kernel_name=kernel,
-                num_burnin=100,
-            )
+            dev.preprocess()
 
     def test_wrong_num_burnin(self):
+        # Create device (should not fail at initialization)
+        dev = qml.device(device_name, wires=2, shots=1000, mcmc=True, num_burnin=1000)
+
+        # Error should be raised during preprocess when validation runs
         with pytest.raises(ValueError, match="Shots should be greater than num_burnin."):
-            dev = qml.device(device_name, wires=2, shots=1000, mcmc=True, num_burnin=1000)
+            dev.preprocess()

--- a/tests/test_measurements.py
+++ b/tests/test_measurements.py
@@ -546,9 +546,7 @@ def test_shots_single_measure_obs(shots, measure_f, obs, n_wires, mcmc, kernel_n
     if device_name in ("lightning.gpu", "lightning.kokkos"):
         dev = qml.device(device_name, wires=n_wires, seed=seed)
     elif device_name == "lightning.qubit":
-        dev = qml.device(
-            device_name, wires=n_wires, shots=shots, mcmc=mcmc, kernel_name=kernel_name, seed=seed
-        )
+        dev = qml.device(device_name, wires=n_wires, mcmc=mcmc, kernel_name=kernel_name, seed=seed)
     else:
         dev = qml.device(device_name, wires=n_wires)
 


### PR DESCRIPTION
**Context:**
This should be considered as a bug; and the motivation for fixing it is the change made in `test_measurements`

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
