### PR TITLE
Stop creating wheels if the PR is draft

### DIFF
--- a/.github/workflows/wheel_linux_aarch64_cuda.yml
+++ b/.github/workflows/wheel_linux_aarch64_cuda.yml
@@ -22,7 +22,7 @@ jobs:
   set_wheel_build_matrix:
     if: |
       github.event_name != 'pull_request' ||
-      contains(github.event.pull_request.labels.*.name, 'ci:build_wheels') ||
+      (github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'ci:build_wheels')) ||
       github.event_name == 'workflow_dispatch'
     name: "Set wheel build matrix"
     uses: ./.github/workflows/set_wheel_build_matrix.yml

--- a/.github/workflows/wheel_noarch.yml
+++ b/.github/workflows/wheel_noarch.yml
@@ -27,7 +27,7 @@ jobs:
   build-pure-python-wheel:
     if: |
       github.event_name != 'pull_request' ||
-      (github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'ci:build_wheels') ||
+      (github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'ci:build_wheels')) ||
       github.event_name == 'workflow_dispatch'
     strategy:
       matrix:

--- a/.github/workflows/wheel_noarch.yml
+++ b/.github/workflows/wheel_noarch.yml
@@ -27,41 +27,35 @@ jobs:
   build-pure-python-wheel:
     if: |
       github.event_name != 'pull_request' ||
-      contains(github.event.pull_request.labels.*.name, 'ci:build_wheels') ||
+      (github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'ci:build_wheels') ||
       github.event_name == 'workflow_dispatch'
     strategy:
       matrix:
-        pl_backend: ["lightning_gpu", "lightning_kokkos", "lightning_qubit"]
+        pl_backend: ["lightning_qubit"]
     timeout-minutes: 30
     name: Linux - Pure Python wheels - ${{ matrix.pl_backend }} (Python 3.11)
     runs-on: pl-4-core-large-runner
 
     steps:
       - name: Checkout PennyLane-Lightning
-        if: ${{ matrix.pl_backend == 'lightning_qubit'}}
         uses: actions/checkout@v4
 
       - uses: actions/setup-python@v5
-        if: ${{ matrix.pl_backend == 'lightning_qubit'}}
         with:
           python-version: '3.11'
 
       - name: Upgrade pip
-        if: ${{ matrix.pl_backend == 'lightning_qubit'}}
         run: |
           python -m pip install --upgrade pip
 
       - name: Install dependencies
-        if: ${{ matrix.pl_backend == 'lightning_qubit'}}
         run: |
           python -m pip install tomlkit
 
       - name: Configure pyproject.toml file
-        if: ${{ matrix.pl_backend == 'lightning_qubit'}}
         run: PL_BACKEND="${{ matrix.pl_backend }}" python scripts/configure_pyproject_toml.py
 
       - name: Build wheels and source dist
-        if: ${{ matrix.pl_backend == 'lightning_qubit'}}
         env:
           SKIP_COMPILATION: True
         run: |
@@ -69,14 +63,12 @@ jobs:
           python -m build
 
       - name: Validate wheels
-        if: ${{ matrix.pl_backend == 'lightning_qubit'}}
         run: |
           python -m pip install twine
           python -m twine check dist/*.whl
 
       - uses: actions/upload-artifact@v4
         if: |
-          matrix.pl_backend == 'lightning_qubit' &&
           (github.event_name == 'release' || github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/master')
         with:
           name: pure-python-wheels-${{ matrix.pl_backend }}.zip
@@ -88,18 +80,18 @@ jobs:
     needs: build-pure-python-wheel
     strategy:
       matrix:
-        pl_backend: ["lightning_gpu", "lightning_kokkos", "lightning_qubit"]
+        pl_backend: ["lightning_qubit"]
     runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/download-artifact@v4
-        if: ${{ matrix.pl_backend == 'lightning_qubit' && github.event_name == 'release' }}
+        if: ${{ github.event_name == 'release' }}
         with:
           name: pure-python-wheels-${{ matrix.pl_backend }}.zip
           path: dist
 
       - name: Upload wheels to PyPI
-        if: ${{ matrix.pl_backend == 'lightning_qubit' && github.event_name == 'release' }}
+        if: ${{ github.event_name == 'release' }}
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__


### PR DESCRIPTION
**Context:**
The action to create the wheels for `no_arch` and `aarch64_cuda` triggers even if the PR is a draft. 

**Description of the Change:**
Avoid triggering the actions if the PR is in draft.
Remove conditions for each step in the action `no_arch`

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
