### PR TITLE
Add mcmc validator as transform

### DIFF
--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.43.0-dev13"
+__version__ = "0.43.0-dev14"

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -17,4 +17,4 @@ Version number (major.minor.patch[-label])
 """
 
 
-__version__ = "0.43.0-dev15"
+__version__ = "0.43.0-dev16"

--- a/pennylane_lightning/lightning_qubit/lightning_qubit.py
+++ b/pennylane_lightning/lightning_qubit/lightning_qubit.py
@@ -510,7 +510,7 @@ def _resolve_mcm_method(mcm_config: MCMConfig):
 
 
 def null_postprocess(results):
-    """ do nothing """
+    """do nothing"""
     return results[0]
 
 

--- a/pennylane_lightning/lightning_qubit/lightning_qubit.py
+++ b/pennylane_lightning/lightning_qubit/lightning_qubit.py
@@ -510,6 +510,7 @@ def _resolve_mcm_method(mcm_config: MCMConfig):
 
 
 def null_postprocess(results):
+    """ do nothing """
     return results[0]
 
 


### PR DESCRIPTION
**Context:**
As we have already implemented the `_validate_mcmc_options` helper to directly check mcmc options in execution config constructor, it is also important to have it actually added to the `preprocess` pipeline since with the decoupling between `shots` and `device` the only scenario when a device can get and validate the shots information will be the `preprocess`.
Given that, we would like to add the validator as a transform as well as keeping the original helper, before we entirely remove `shots` from `Device` on the PennyLane side (which should take a very long time).

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-103749]