### PR TITLE
chore: fix test now that `config.device_options` is immutable

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -14,7 +14,7 @@
 - Skipped Identity operation in Lightning Qubit and removed assert for applying Identity gate not equal to 1 wire.
   [(#1212)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1212)
 
-- Update `test_device.py` to no longer delete entries in an execution config's `device_options`.
+- Update `test_device.py` to no longer mutate an execution configuration for testing.
   [(#1242)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1242)
 
 <h3>Breaking changes 💔</h3>

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -14,6 +14,9 @@
 - Skipped Identity operation in Lightning Qubit and removed assert for applying Identity gate not equal to 1 wire.
   [(#1212)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1212)
 
+- Update `test_device.py` to no longer delete entries in an execution config's `device_options`.
+  [(#1242)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1242)
+
 <h3>Breaking changes 💔</h3>
 
 - No longer squeezes out singleton dimensions from samples in accordance with a breaking change in

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.43.0-dev20"
+__version__ = "0.43.0-dev21"

--- a/tests/lightning_base/test_device.py
+++ b/tests/lightning_base/test_device.py
@@ -659,6 +659,7 @@ class TestExecution:
         device = LightningDevice(wires=2)
         _, new_config = device.preprocess(config)
 
+        # Update the device options to be able to compare
         device_options = new_config.device_options.copy()
         device_options.update(
             {

--- a/tests/lightning_base/test_device.py
+++ b/tests/lightning_base/test_device.py
@@ -16,8 +16,8 @@ This module contains unit tests for new device API Lightning classes.
 """
 # pylint: disable=too-many-arguments, unused-argument
 
-from dataclasses import replace
 import itertools
+from dataclasses import replace
 
 import numpy as np
 import pennylane as qml

--- a/tests/lightning_base/test_device.py
+++ b/tests/lightning_base/test_device.py
@@ -661,11 +661,7 @@ class TestExecution:
 
         # Update the device options to be able to compare
         device_options = new_config.device_options.copy()
-        device_options.update(
-            {
-                "rng": 0,
-            }
-        )
+        device_options.pop("rng", None)
         new_config = replace(new_config, device_options=device_options)
 
         assert new_config == expected_config

--- a/tests/lightning_base/test_device.py
+++ b/tests/lightning_base/test_device.py
@@ -16,6 +16,7 @@ This module contains unit tests for new device API Lightning classes.
 """
 # pylint: disable=too-many-arguments, unused-argument
 
+from dataclasses import replace
 import itertools
 
 import numpy as np
@@ -657,7 +658,14 @@ class TestExecution:
         """Test that the execution config is set up correctly in preprocess"""
         device = LightningDevice(wires=2)
         _, new_config = device.preprocess(config)
-        del new_config.device_options["rng"]
+
+        device_options = new_config.device_options.copy()
+        device_options.update(
+            {
+                "rng": 0,
+            }
+        )
+        new_config = replace(new_config, device_options=device_options)
 
         assert new_config == expected_config
 


### PR DESCRIPTION
**Context:**

https://github.com/PennyLaneAI/pennylane/pull/8046 froze the dictionary fields of the execution config. You can't just delete things now.

[sc-96529]
