### PR TITLE
Remove `--no-deps` for PL installation for LQ stable test

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -50,6 +50,9 @@
 
 <h3>Internal changes ⚙️</h3>
 
+- Remove `--no-deps` for Lightning Qubit CI tests for stable version.
+  [(#XXXX)](https://github.com/PennyLaneAI/pennylane-lightning/pull/XXXX)
+
 - Ported Linux based GitHub Actions workflows from using the GitHub 4vcpu large runner to blacksmith 4vcpu runner.
   [(#1241)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1241)
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -51,7 +51,7 @@
 <h3>Internal changes ⚙️</h3>
 
 - Remove `--no-deps` for Lightning Qubit CI tests for stable version.
-  [(#XXXX)](https://github.com/PennyLaneAI/pennylane-lightning/pull/XXXX)
+  [(#1245)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1245)
 
 - Ported Linux based GitHub Actions workflows from using the GitHub 4vcpu large runner to blacksmith 4vcpu runner.
   [(#1241)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1241)

--- a/.github/workflows/tests_lqcpu_python.yml
+++ b/.github/workflows/tests_lqcpu_python.yml
@@ -187,7 +187,7 @@ jobs:
       - name: Install Stable PennyLane
         if: inputs.pennylane-version == 'stable'
         run: |
-          python -m pip uninstall -y pennylane && python -m pip install -U pennylane --no-deps
+          python -m pip uninstall -y pennylane && python -m pip install -U pennylane
 
       - name: Install ML libraries for interfaces
         run: |

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.43.0-dev22"
+__version__ = "0.43.0-dev23"


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [ ] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [ ] Ensure that the test suite passes, by running `make test`.

- [ ] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [ ] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**
Stable/Stable CI tests should use the dependencies from stable version of Pennylane. Currently for LQ tests, when using stable, we install stable Pennylane with `--no-deps` which does not reflect the old requirements. When PL updates their requirements, this breaks stable/stable tests, e.g. autoray in this case.

**Description of the Change:**
Remove `--no-deps` when installing PL for LQ stable tests. This is already the case for other device tests.

**Benefits:**
Restore balance to stable/stable CI.

**Possible Drawbacks:**

**Related GitHub Issues:**

[Stable/Stable](https://github.com/PennyLaneAI/pennylane-lightning/actions/runs/17328371451)
[Latest/Latest ](https://github.com/PennyLaneAI/pennylane-lightning/actions/runs/17328373930)(LG & LT fail expected) 

[sc-98480]