### PR TITLE
Update the release script for bumping the minimum PL version

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -75,6 +75,9 @@
 
 <h3>Internal changes ⚙️</h3>
 
+- Update Release script for bumping the minimum version for PennyLane.
+  [(#1253)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1253)
+
 - Update Python to 3.12 and CIBuildWheel to 3.1.4 for CI.
   [(#1248)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1248)
 

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.43.0-dev29"
+__version__ = "0.43.0-dev30"

--- a/scripts/create_lightning_rc.sh
+++ b/scripts/create_lightning_rc.sh
@@ -337,6 +337,16 @@ create_version_bump_PR(){
     git add $CHANGELOG_FILE
     git commit -m "Update CHANGELOG.md with new version entry."
 
+    # Update minimum PennLane version in requirements.txt and configure_pyproject_toml.py
+    sed -i "s/pennylane>=0.[0-9]\{2\}/pennylane>=${RELEASE_VERSION%??}/" ${ROOT_DIR}/requirements.txt
+    sed -i "s/pennylane>=0.[0-9]\{2\}/pennylane>=${RELEASE_VERSION%??}/" ${ROOT_DIR}/scripts/configure_pyproject_toml.py
+
+    git add ${ROOT_DIR}/requirements.txt ${ROOT_DIR}/scripts/configure_pyproject_toml.py
+    git commit -m "Update minimum PennyLane version to ${RELEASE_VERSION%??}"
+    
+    if [ "$LOCAL_TEST" == "false" ]; then
+    git push origin $(branch_name ${RELEASE_VERSION} bump)
+    fi
 }
 
 test_install_lightning(){

--- a/scripts/create_lightning_rc.sh
+++ b/scripts/create_lightning_rc.sh
@@ -338,8 +338,8 @@ create_version_bump_PR(){
     git commit -m "Update CHANGELOG.md with new version entry."
 
     # Update minimum PennLane version in requirements.txt and configure_pyproject_toml.py
-    sed -i "s/pennylane>=0.[0-9]\{2\}/pennylane>=${RELEASE_VERSION%??}/" ${ROOT_DIR}/requirements.txt
-    sed -i "s/pennylane>=0.[0-9]\{2\}/pennylane>=${RELEASE_VERSION%??}/" ${ROOT_DIR}/scripts/configure_pyproject_toml.py
+    sed -i "s/pennylane>=v\?[0-9\.]\+/pennylane>=${RELEASE_VERSION%??}/" ${ROOT_DIR}/requirements.txt
+    sed -i "s/pennylane>=v\?[0-9\.]\+/pennylane>=${RELEASE_VERSION%??}/" ${ROOT_DIR}/scripts/configure_pyproject_toml.py
 
     git add ${ROOT_DIR}/requirements.txt ${ROOT_DIR}/scripts/configure_pyproject_toml.py
     git commit -m "Update minimum PennyLane version to ${RELEASE_VERSION%??}"

--- a/scripts/validate_attrs.py
+++ b/scripts/validate_attrs.py
@@ -49,6 +49,7 @@ for path in Path().glob("*.whl"):
                 )
                 or re.match(r"pennylane_lightning/lightning_.*_ops.cpython-3.?.?-darwin\.so", name)
                 or re.match(r"pennylane_lightning/lightning_.*_ops.pdb", name)
+                or re.match(r"pennylane_lightning/lightning_.*_ops.*-win_amd64.pyd", name)
             ):
                 continue
 


### PR DESCRIPTION
**Context:**

* Update the release script for bumping the minimum PL version on the general bump PR 
* Update the allowed packages in the wheels inspection for the Windows version after Nanobind merge. 

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**

[sc-98910]
[sc-98305]
