### PR TITLE
Upload Lightning RC wheels for several versions of Python

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -30,6 +30,7 @@
     [(#1184)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1184)
   - **Lightning Tensor bindings** for tensor network simulations
     [(#1206)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1206)
+
 - Added support for `GlobalPhase` with zero-qubit Lightning devices. Currently, only the `lightning.qubit` and `lightning.kokkos` backends support zero-qubit initialization.
   [(#1205)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1205)
 
@@ -86,6 +87,9 @@
   [(#1237)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1237)
 
 <h3>Internal changes ⚙️</h3>
+
+- Update GitHubActions to produce the RC wheels for all Python versions. 
+  [(#1264)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1264)
 
 - Remove unnecessary `std::move` in `cuGates_host`.
   [(#1263)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1263)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -87,6 +87,9 @@
 
 <h3>Internal changes ⚙️</h3>
 
+- Remove unnecessary `std::move` in `cuGates_host`.
+  [(#1263)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1263)
+
 - Pin GitHub CI temporarily to the stable version to use Catalyst release v0.12.0.
   [(#1259)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1259)
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -88,7 +88,7 @@
 
 <h3>Internal changes ⚙️</h3>
 
-- Update GitHubActions to produce the RC wheels for all Python versions. 
+- Update GitHub Actions to produce the release candidate wheels for all supported Python versions. 
   [(#1264)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1264)
 
 - Remove unnecessary `std::move` in `cuGates_host`.

--- a/.github/workflows/set_wheel_build_matrix.yml
+++ b/.github/workflows/set_wheel_build_matrix.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           event_name="${{ inputs.event_name }}"
 
-          branch_name="${{ github.ref_name }}"
+          branch_name="${{ github.head_ref }}"
 
           is_release_candidate="false"
 

--- a/.github/workflows/set_wheel_build_matrix.yml
+++ b/.github/workflows/set_wheel_build_matrix.yml
@@ -36,35 +36,17 @@ jobs:
       - name: Checkout PennyLane-Lightning
         uses: actions/checkout@v4
 
-      - name: Update event name if release candidates
-        id: update_event_name
-        run: |
-          event_name="${{ inputs.event_name }}"
-
-          branch_name="${{ github.head_ref }}"
-
-          is_release_candidate="false"
-
-          # Check if the branch name matches the release candidate pattern v0.X.Y_rc
-          if [[ $branch_name =~ ^v0\.\d+\.\d+_rc$ ]]; then
-            echo "This is a release candidate branch: $branch_name"
-            is_release_candidate="true"
-          else
-            echo "This is NOT a release candidate branch: $branch_name"
-          fi
-
-          if [[ "$is_release_candidate" == "true" && "$event_name" == "pull_request" ]]; then
-            event_name="${event_name}-with_release_candidate"
-            echo "Updated event name to: $event_name"
-          else
-            echo "Event name remains: $event_name"
-          fi
-          echo "final_event_name=$event_name" >> $GITHUB_OUTPUT
-
       - name: Python version
         id: pyver
         run: |
-          if [[ ${{ steps.update_event_name.outputs.final_event_name }} == 'pull_request' ]]; then
+          # Check if the branch name matches the release candidate pattern v0.X.Y_rc
+          branch_name="${{ github.head_ref }}"
+          is_rc="false"
+          if [[ $branch_name == ^v0\.\d+\.\d+_rc$ ]]; then
+            is_rc="true"
+          fi
+
+          if [[ ${{ inputs.event_name }} == 'pull_request' ]] && [[ "$is_rc" == "true" ]]; then
             echo "python_version=$(python3 scripts/gen_pyver_matrix.py \
               --min-version=3.${{ env.PYTHON3_MIN_VERSION }} \
               --max-version=3.${{ env.PYTHON3_MAX_VERSION }})" >> $GITHUB_OUTPUT
@@ -73,10 +55,18 @@ jobs:
               --min-version=3.${{ env.PYTHON3_MIN_VERSION }} \
               --max-version=3.${{ env.PYTHON3_MAX_VERSION }} --range)" >> $GITHUB_OUTPUT
           fi
+
       - name: Python version for GPU runners
         id: pyvergpu
         run: |
-          if [[ ${{ steps.update_event_name.outputs.final_event_name }} == 'pull_request' ]]; then
+          # Check if the branch name matches the release candidate pattern v0.X.Y_rc
+          branch_name="${{ github.head_ref }}"
+          is_rc="false"
+          if [[ $branch_name == ^v0\.\d+\.\d+_rc$ ]]; then
+            is_rc="true"
+          fi
+
+          if [[ ${{ inputs.event_name }} == 'pull_request' ]] && [[ "$is_rc" == "true" ]]; then
             echo "python_version_gpu=$(python3 scripts/gen_pyver_matrix.py \
               --min-version=3.${{ env.PYTHON3_MIN_VERSION }} \
               --max-version=3.${{ env.PYTHON3_MAX_VERSION }})" >> $GITHUB_OUTPUT

--- a/.github/workflows/set_wheel_build_matrix.yml
+++ b/.github/workflows/set_wheel_build_matrix.yml
@@ -36,10 +36,35 @@ jobs:
       - name: Checkout PennyLane-Lightning
         uses: actions/checkout@v4
 
+      - name: Update event name if release candidates
+        id: update_event_name
+        run: |
+          event_name="${{ inputs.event_name }}"
+
+          branch_name="${{ github.ref_name }}"
+
+          is_release_candidate="false"
+
+          # Check if the branch name matches the release candidate pattern v0.X.Y_rc
+          if [[ $branch_name =~ ^v0\.\d+\.\d+_rc$ ]]; then
+            echo "This is a release candidate branch: $branch_name"
+            is_release_candidate="true"
+          else
+            echo "This is NOT a release candidate branch: $branch_name"
+          fi
+
+          if [[ "$is_release_candidate" == "true" && "$event_name" == "pull_request" ]]; then
+            event_name="${event_name}-with_release_candidate"
+            echo "Updated event name to: $event_name"
+          else
+            echo "Event name remains: $event_name"
+          fi
+          echo "final_event_name=$event_name" >> $GITHUB_OUTPUT
+
       - name: Python version
         id: pyver
         run: |
-          if [[ ${{ inputs.event_name }} == 'pull_request' ]]; then
+          if [[ ${{ steps.update_event_name.outputs.final_event_name }} == 'pull_request' ]]; then
             echo "python_version=$(python3 scripts/gen_pyver_matrix.py \
               --min-version=3.${{ env.PYTHON3_MIN_VERSION }} \
               --max-version=3.${{ env.PYTHON3_MAX_VERSION }})" >> $GITHUB_OUTPUT
@@ -51,7 +76,7 @@ jobs:
       - name: Python version for GPU runners
         id: pyvergpu
         run: |
-          if [[ ${{ inputs.event_name }} == 'pull_request' ]]; then
+          if [[ ${{ steps.update_event_name.outputs.final_event_name }} == 'pull_request' ]]; then
             echo "python_version_gpu=$(python3 scripts/gen_pyver_matrix.py \
               --min-version=3.${{ env.PYTHON3_MIN_VERSION }} \
               --max-version=3.${{ env.PYTHON3_MAX_VERSION }})" >> $GITHUB_OUTPUT

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.43.0-dev40"
+__version__ = "0.43.0-dev41"

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.43.0-dev37"
+__version__ = "0.43.0-dev38"

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.43.0-dev41"
+__version__ = "0.43.0-rc1"

--- a/pennylane_lightning/core/utils/cuda_utils/cuGates_host.hpp
+++ b/pennylane_lightning/core/utils/cuda_utils/cuGates_host.hpp
@@ -601,7 +601,7 @@ row-major format.
  */
 template <class CFP_t, class U = double>
 static auto getCRot(U phi, U theta, U omega) -> std::vector<CFP_t> {
-    const auto rot{std::move(getRot<CFP_t>(phi, theta, omega))};
+    const auto rot{getRot<CFP_t>(phi, theta, omega)};
     return {cuUtil::ONE<CFP_t>(),
             cuUtil::ZERO<CFP_t>(),
             cuUtil::ZERO<CFP_t>(),


### PR DESCRIPTION
**Context:**
In the release process, the wheels that are pushed to TestPiPy are only Min and Max Python versions

**Description of the Change:**
Now, for the release process, we push all the Python versions to TestPiPy 

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**


[sc-99745]