### PR TITLE
Disable fill-shots for one-shot and tree-traversal

### DIFF
--- a/pennylane_lightning/lightning_qubit/lightning_qubit.py
+++ b/pennylane_lightning/lightning_qubit/lightning_qubit.py
@@ -15,6 +15,7 @@ r"""
 This module contains the LightningQubit class, a PennyLane simulator device that
 interfaces with C++ for fast linear algebra calculations.
 """
+
 from dataclasses import replace
 from functools import partial, reduce
 from pathlib import Path
@@ -367,7 +368,6 @@ class LightningQubit(LightningBase):
         program = TransformProgram()
 
         if qml.capture.enabled():
-
             if exec_config.mcm_config.mcm_method == "deferred":
                 program.add_transform(qml.defer_measurements, num_wires=len(self.wires))
             # Using stopping_condition_shots because we don't want to decompose Conditionals or MCMs
@@ -497,10 +497,15 @@ def _resolve_mcm_method(mcm_config: MCMConfig, tape):
         final_mcm_method = "one-shot" if getattr(tape, "shots", None) else "deferred"
     elif mcm_config.mcm_method == "device":
         final_mcm_method = "tree-traversal"
+
+    if mcm_config.postselect_mode == "fill-shots" and final_mcm_method != "deferred":
+        raise DeviceError(
+            "Using postselect_mode='fill-shots' is only supported with mcm_method='deferred'."
+        )
+
     mcm_config = replace(mcm_config, mcm_method=final_mcm_method)
 
     if qml.capture.enabled():
-
         mcm_updated_values = {}
 
         if mcm_method == "single-branch-statistics" and mcm_config.postselect_mode is not None:


### PR DESCRIPTION
**Context:**

When using `mcm_method="one-shot"` or `"tree-traversal"`,  combined with `postselect_mode="fill-shots"`,  the postselection breaks the correlation between correlated measurements completely, producing incorrect results. The only way to fix that is by continuously running the simulation until we have enough valid shots, which fundamentally goes against the philosophy of treating shots as a budget constraint. Therefore, we have opted to disallow `"fill-shots"` for anything but `"deferred"`

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-100562]
[sc-99992]
Fixes https://github.com/PennyLaneAI/pennylane/issues/8366
https://github.com/PennyLaneAI/pennylane/issues/8332