### PR TITLE
PR to RC branch do not upload to TestPyPI

### DIFF
--- a/.github/workflows/wheel_linux_aarch64.yml
+++ b/.github/workflows/wheel_linux_aarch64.yml
@@ -201,13 +201,14 @@ jobs:
         id: rc_build
         with:
           text: ${{ github.event.pull_request.head.ref }}
-          regex: '.*[0-9]+.[0-9]+.[0-9]+[-_]?rc[0-9]+'
+          regex: '.*[0-9]+.[0-9]+.[0-9]+[-_]?rc[0-9]*'
 
       - uses: actions/upload-artifact@v4
         if: |
-          github.event_name == 'pull_request' ||
+          github.event_name == 'release' ||
           github.event_name == 'workflow_dispatch' ||
-          github.ref == 'refs/heads/master'
+          github.ref == 'refs/heads/master' ||
+          steps.rc_build.outputs.match != ''
         with:
           name: ${{ runner.os }}-wheels-${{ matrix.pl_backend }}-${{ fromJson('{ "cp311-*":"py311","cp312-*":"py312", "cp313-*":"py313" }')[matrix.cibw_build] }}-${{ matrix.arch }}.zip
           path: ./wheelhouse/*.whl
@@ -224,18 +225,29 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       id-token: write
-    if: |
-      github.event_name == 'pull_request' ||
-      github.ref == 'refs/heads/master'
 
     steps:
+      - uses: actions-ecosystem/action-regex-match@main
+        id: rc_build
+        with:
+          text: ${{ github.event.pull_request.head.ref }}
+          regex: '.*[0-9]+.[0-9]+.[0-9]+[-_]?rc[0-9]*'
+
       - uses: actions/download-artifact@v4
+        if: |
+          github.event_name == 'release' ||
+          github.ref == 'refs/heads/master' || 
+          steps.rc_build.outputs.match != ''
         with:
           name: ${{ runner.os }}-wheels-${{ matrix.pl_backend }}-${{ fromJson('{ "cp311-*":"py311","cp312-*":"py312", "cp313-*":"py313" }')[matrix.cibw_build] }}-${{ matrix.arch }}.zip
           path: dist
 
       - name: Upload wheels to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        if: |
+          github.event_name == 'release' ||
+          github.ref == 'refs/heads/master' || 
+          steps.rc_build.outputs.match != ''
         with:
           verbose: true
           repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/wheel_linux_aarch64.yml
+++ b/.github/workflows/wheel_linux_aarch64.yml
@@ -201,7 +201,7 @@ jobs:
         id: rc_build
         with:
           text: ${{ github.event.pull_request.head.ref }}
-          regex: '.*[0-9]+.[0-9]+.[0-9]+[-_]?rc[0-9]*'
+          regex: '^v[0-9]+\.[0-9]+\.[0-9]+[-_]rc$'
 
       - uses: actions/upload-artifact@v4
         if: |
@@ -231,7 +231,7 @@ jobs:
         id: rc_build
         with:
           text: ${{ github.event.pull_request.head.ref }}
-          regex: '.*[0-9]+.[0-9]+.[0-9]+[-_]?rc[0-9]*'
+          regex: '^v[0-9]+\.[0-9]+\.[0-9]+[-_]rc$'
 
       - uses: actions/download-artifact@v4
         if: |

--- a/.github/workflows/wheel_linux_aarch64_cuda.yml
+++ b/.github/workflows/wheel_linux_aarch64_cuda.yml
@@ -160,7 +160,7 @@ jobs:
         id: rc_build
         with:
           text: ${{ github.event.pull_request.head.ref }}
-          regex: '.*[0-9]+.[0-9]+.[0-9]+[-_]?rc[0-9]*'
+          regex: '^v[0-9]+\.[0-9]+\.[0-9]+[-_]rc$'
 
       - uses: actions/upload-artifact@v4
         if: |
@@ -194,6 +194,12 @@ jobs:
       id-token: write
 
     steps:
+      - uses: actions-ecosystem/action-regex-match@main
+        id: rc_build
+        with:
+          text: ${{ github.event.pull_request.head.ref }}
+          regex: '^v[0-9]+\.[0-9]+\.[0-9]+[-_]rc$'
+
       - uses: actions/download-artifact@v4
         if: |
           github.event_name == 'release' ||

--- a/.github/workflows/wheel_linux_aarch64_cuda.yml
+++ b/.github/workflows/wheel_linux_aarch64_cuda.yml
@@ -160,13 +160,14 @@ jobs:
         id: rc_build
         with:
           text: ${{ github.event.pull_request.head.ref }}
-          regex: '.*[0-9]+.[0-9]+.[0-9]+[-_]?rc[0-9]+'
+          regex: '.*[0-9]+.[0-9]+.[0-9]+[-_]?rc[0-9]*'
 
       - uses: actions/upload-artifact@v4
         if: |
-          github.event_name == 'pull_request' ||
+          github.event_name == 'release' ||
           github.event_name == 'workflow_dispatch' ||
-          github.ref == 'refs/heads/master'
+          github.ref == 'refs/heads/master' ||
+          steps.rc_build.outputs.match != ''
         with:
           name: ${{ runner.os }}-wheels-${{ matrix.pl_backend }}-${{ fromJson('{ "cp311-*":"py311","cp312-*":"py312", "cp313-*":"py313" }')[matrix.cibw_build] }}-${{ matrix.arch }}-cu${{ matrix.cuda_version }}.zip
           path: ./wheelhouse/*.whl
@@ -191,17 +192,22 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       id-token: write
-    if: |
-      github.event_name == 'pull_request' ||
-      github.ref == 'refs/heads/master'
 
     steps:
       - uses: actions/download-artifact@v4
+        if: |
+          github.event_name == 'release' ||
+          github.ref == 'refs/heads/master' || 
+          steps.rc_build.outputs.match != ''
         with:
           name:  ${{ runner.os }}-wheels-${{ matrix.pl_backend }}-${{ fromJson('{ "cp311-*":"py311","cp312-*":"py312", "cp313-*":"py313" }')[matrix.cibw_build] }}-${{ matrix.arch }}-cu${{ matrix.cuda_version }}.zip
           path: dist
 
       - name: Upload wheels to TestPyPI
+        if: |
+          github.event_name == 'release' ||
+          github.ref == 'refs/heads/master' || 
+          steps.rc_build.outputs.match != ''
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           verbose: true

--- a/.github/workflows/wheel_linux_x86_64.yml
+++ b/.github/workflows/wheel_linux_x86_64.yml
@@ -187,11 +187,11 @@ jobs:
         id: rc_build
         with:
           text: ${{ github.event.pull_request.head.ref }}
-          regex: '.*[0-9]+.[0-9]+.[0-9]+[-_]?rc[0-9]+'
+          regex: '.*[0-9]+.[0-9]+.[0-9]+[-_]?rc[0-9]*'
 
       - uses: actions/upload-artifact@v4
         if: |
-          github.event_name == 'pull_request' ||
+          github.event_name == 'release' ||
           github.event_name == 'workflow_dispatch' ||
           github.ref == 'refs/heads/master' ||
           steps.rc_build.outputs.match != ''
@@ -211,18 +211,29 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       id-token: write
-    if: |
-      github.event_name == 'pull_request' ||
-      github.ref == 'refs/heads/master'
 
     steps:
+      - uses: actions-ecosystem/action-regex-match@main
+        id: rc_build
+        with:
+          text: ${{ github.event.pull_request.head.ref }}
+          regex: '.*[0-9]+.[0-9]+.[0-9]+[-_]?rc[0-9]*'
+
       - uses: actions/download-artifact@v4
+        if: |
+          github.event_name == 'release' ||
+          github.ref == 'refs/heads/master' || 
+          steps.rc_build.outputs.match != ''
         with:
           name: ${{ runner.os }}-wheels-${{ matrix.pl_backend }}-${{ fromJson('{ "cp311-*":"py311","cp312-*":"py312", "cp313-*":"py313" }')[matrix.cibw_build] }}-${{ matrix.arch }}.zip
           path: dist
 
       - name: Upload wheels to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        if: |
+          github.event_name == 'release' ||
+          github.ref == 'refs/heads/master' || 
+          steps.rc_build.outputs.match != ''
         with:
           verbose: true
           repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/wheel_linux_x86_64.yml
+++ b/.github/workflows/wheel_linux_x86_64.yml
@@ -187,7 +187,7 @@ jobs:
         id: rc_build
         with:
           text: ${{ github.event.pull_request.head.ref }}
-          regex: '.*[0-9]+.[0-9]+.[0-9]+[-_]?rc[0-9]*'
+          regex: '^v[0-9]+\.[0-9]+\.[0-9]+[-_]rc$'
 
       - uses: actions/upload-artifact@v4
         if: |
@@ -217,7 +217,7 @@ jobs:
         id: rc_build
         with:
           text: ${{ github.event.pull_request.head.ref }}
-          regex: '.*[0-9]+.[0-9]+.[0-9]+[-_]?rc[0-9]*'
+          regex: '^v[0-9]+\.[0-9]+\.[0-9]+[-_]rc$'
 
       - uses: actions/download-artifact@v4
         if: |

--- a/.github/workflows/wheel_linux_x86_64_cuda.yml
+++ b/.github/workflows/wheel_linux_x86_64_cuda.yml
@@ -107,7 +107,7 @@ jobs:
         id: rc_build
         with:
           text: ${{ github.event.pull_request.head.ref }}
-          regex: '.*[0-9]+.[0-9]+.[0-9]+[-_]?rc[0-9]*'
+          regex: '^v[0-9]+\.[0-9]+\.[0-9]+[-_]rc$'
 
       - uses: actions/upload-artifact@v4
         if: |
@@ -138,7 +138,7 @@ jobs:
         id: rc_build
         with:
           text: ${{ github.event.pull_request.head.ref }}
-          regex: '.*[0-9]+.[0-9]+.[0-9]+[-_]?rc[0-9]*'
+          regex: '^v[0-9]+\.[0-9]+\.[0-9]+[-_]rc$'
 
       - uses: actions/download-artifact@v4
         if: |

--- a/.github/workflows/wheel_linux_x86_64_cuda.yml
+++ b/.github/workflows/wheel_linux_x86_64_cuda.yml
@@ -107,11 +107,11 @@ jobs:
         id: rc_build
         with:
           text: ${{ github.event.pull_request.head.ref }}
-          regex: '.*[0-9]+.[0-9]+.[0-9]+[-_]?rc[0-9]+'
+          regex: '.*[0-9]+.[0-9]+.[0-9]+[-_]?rc[0-9]*'
 
       - uses: actions/upload-artifact@v4
         if: |
-          github.event_name == 'pull_request' ||
+          github.event_name == 'release' ||
           github.event_name == 'workflow_dispatch' ||
           github.ref == 'refs/heads/master' ||
           steps.rc_build.outputs.match != ''
@@ -132,18 +132,29 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       id-token: write
-    if: |
-      github.event_name == 'pull_request' ||
-      github.ref == 'refs/heads/master'
 
     steps:
+      - uses: actions-ecosystem/action-regex-match@main
+        id: rc_build
+        with:
+          text: ${{ github.event.pull_request.head.ref }}
+          regex: '.*[0-9]+.[0-9]+.[0-9]+[-_]?rc[0-9]*'
+
       - uses: actions/download-artifact@v4
+        if: |
+          github.event_name == 'release' ||
+          github.ref == 'refs/heads/master' || 
+          steps.rc_build.outputs.match != ''
         with:
           name:  ${{ runner.os }}-wheels-${{ matrix.pl_backend }}-${{ fromJson('{ "cp311-*":"py311","cp312-*":"py312","cp313-*":"py313" }')[matrix.cibw_build] }}-${{ matrix.arch }}-cu${{ matrix.cuda_version }}.zip
           path: dist
 
       - name: Upload wheels to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        if: |
+          github.event_name == 'release' ||
+          github.ref == 'refs/heads/master' || 
+          steps.rc_build.outputs.match != ''
         with:
           verbose: true
           repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/wheel_macos_arm64.yml
+++ b/.github/workflows/wheel_macos_arm64.yml
@@ -106,7 +106,7 @@ jobs:
         id: rc_build
         with:
           text: ${{ github.event.pull_request.head.ref }}
-          regex: '.*[0-9]+.[0-9]+.[0-9]+[-_]?rc[0-9]*'
+          regex: '^v[0-9]+\.[0-9]+\.[0-9]+[-_]rc$'
 
       - uses: actions/upload-artifact@v4
         if: |
@@ -136,7 +136,7 @@ jobs:
         id: rc_build
         with:
           text: ${{ github.event.pull_request.head.ref }}
-          regex: '.*[0-9]+.[0-9]+.[0-9]+[-_]?rc[0-9]*'
+          regex: '^v[0-9]+\.[0-9]+\.[0-9]+[-_]rc$'
 
       - uses: actions/download-artifact@v4
         if: |

--- a/.github/workflows/wheel_macos_arm64.yml
+++ b/.github/workflows/wheel_macos_arm64.yml
@@ -101,12 +101,19 @@ jobs:
         run: |
           python -m pip install twine
           python -m twine check ./wheelhouse/*.whl
+      
+      - uses: actions-ecosystem/action-regex-match@main
+        id: rc_build
+        with:
+          text: ${{ github.event.pull_request.head.ref }}
+          regex: '.*[0-9]+.[0-9]+.[0-9]+[-_]?rc[0-9]*'
 
       - uses: actions/upload-artifact@v4
         if: |
-          github.event_name == 'pull_request' ||
+          github.event_name == 'release' ||
           github.event_name == 'workflow_dispatch' ||
-          github.ref == 'refs/heads/master'
+          github.ref == 'refs/heads/master' || 
+          steps.rc_build.outputs.match != ''
         with:
           name: ${{ runner.os }}-wheels-${{ matrix.pl_backend }}-${{ fromJson('{ "cp311-*":"py311","cp312-*":"py312", "cp313-*":"py313" }')[matrix.cibw_build] }}-${{ matrix.arch }}.zip
           path: ./wheelhouse/*.whl
@@ -123,18 +130,29 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       id-token: write
-    if: |
-      github.event_name == 'pull_request' ||
-      github.ref == 'refs/heads/master'
 
     steps:
+      - uses: actions-ecosystem/action-regex-match@main
+        id: rc_build
+        with:
+          text: ${{ github.event.pull_request.head.ref }}
+          regex: '.*[0-9]+.[0-9]+.[0-9]+[-_]?rc[0-9]*'
+
       - uses: actions/download-artifact@v4
+        if: |
+          github.event_name == 'release' ||
+          github.ref == 'refs/heads/master' || 
+          steps.rc_build.outputs.match != ''
         with:
           name: macOS-wheels-${{ matrix.pl_backend }}-${{ fromJson('{ "cp311-*":"py311","cp312-*":"py312", "cp313-*":"py313" }')[matrix.cibw_build] }}-${{ matrix.arch }}.zip
           path: dist
 
       - name: Upload wheels to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        if: |
+          github.event_name == 'release' ||
+          github.ref == 'refs/heads/master' || 
+          steps.rc_build.outputs.match != ''
         with:
           verbose: true
           repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/wheel_macos_x86_64.yml
+++ b/.github/workflows/wheel_macos_x86_64.yml
@@ -180,11 +180,11 @@ jobs:
         id: rc_build
         with:
           text: ${{ github.event.pull_request.head.ref }}
-          regex: '.*[0-9]+.[0-9]+.[0-9]+[-_]?rc[0-9]+'
+          regex: '.*[0-9]+.[0-9]+.[0-9]+[-_]?rc[0-9]*'
 
       - uses: actions/upload-artifact@v4
         if: |
-          github.event_name == 'pull_request' ||
+          github.event_name == 'release' ||
           github.event_name == 'workflow_dispatch' ||
           github.ref == 'refs/heads/master' ||
           steps.rc_build.outputs.match != ''
@@ -204,18 +204,29 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       id-token: write
-    if: |
-      github.event_name == 'pull_request' ||
-      github.ref == 'refs/heads/master'
-
+    
     steps:
+      - uses: actions-ecosystem/action-regex-match@main
+        id: rc_build
+        with:
+          text: ${{ github.event.pull_request.head.ref }}
+          regex: '.*[0-9]+.[0-9]+.[0-9]+[-_]?rc[0-9]*'
+          
       - uses: actions/download-artifact@v4
+        if: |
+          github.event_name == 'release' ||
+          github.ref == 'refs/heads/master' || 
+          steps.rc_build.outputs.match != ''
         with:
           name: macOS-wheels-${{ matrix.pl_backend }}-${{ fromJson('{ "cp311-*":"py311","cp312-*":"py312","cp313-*":"py313"  }')[matrix.cibw_build] }}-${{ matrix.arch }}.zip
           path: dist
 
       - name: Upload wheels to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        if: |
+          github.event_name == 'release' ||
+          github.ref == 'refs/heads/master' || 
+          steps.rc_build.outputs.match != ''
         with:
           verbose: true
           repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/wheel_macos_x86_64.yml
+++ b/.github/workflows/wheel_macos_x86_64.yml
@@ -180,7 +180,7 @@ jobs:
         id: rc_build
         with:
           text: ${{ github.event.pull_request.head.ref }}
-          regex: '.*[0-9]+.[0-9]+.[0-9]+[-_]?rc[0-9]*'
+          regex: '^v[0-9]+\.[0-9]+\.[0-9]+[-_]rc$'
 
       - uses: actions/upload-artifact@v4
         if: |
@@ -210,7 +210,7 @@ jobs:
         id: rc_build
         with:
           text: ${{ github.event.pull_request.head.ref }}
-          regex: '.*[0-9]+.[0-9]+.[0-9]+[-_]?rc[0-9]*'
+          regex: '^v[0-9]+\.[0-9]+\.[0-9]+[-_]rc$'
           
       - uses: actions/download-artifact@v4
         if: |

--- a/.github/workflows/wheel_noarch.yml
+++ b/.github/workflows/wheel_noarch.yml
@@ -101,8 +101,10 @@ jobs:
 
       - uses: actions/download-artifact@v4
         if: |
-          ${{ github.event_name == 'release' }} ||
-          steps.rc_build.outputs.match != null
+            ${{
+              github.event_name == 'release' ||
+              steps.rc_build.outputs.match != ''
+            }}
         with:
           name: pure-python-wheels-${{ matrix.pl_backend }}.zip
           path: dist
@@ -110,7 +112,7 @@ jobs:
       - name: Upload wheels to PyPI
         if: |
           ${{ github.event_name == 'release' }} ||
-          steps.rc_build.outputs.match != ''
+          steps.rc_build.outputs.match != null
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__

--- a/.github/workflows/wheel_noarch.yml
+++ b/.github/workflows/wheel_noarch.yml
@@ -102,7 +102,7 @@ jobs:
       - uses: actions/download-artifact@v4
         if: |
           github.event_name == 'release' || 
-          steps.rc_build.outputs.match
+          steps.rc_build.outputs.match != ''
         with:
           name: pure-python-wheels-${{ matrix.pl_backend }}.zip
           path: dist
@@ -110,7 +110,7 @@ jobs:
       - name: Upload wheels to PyPI
         if: |
           github.event_name == 'release' || 
-          steps.rc_build.outputs.match
+          steps.rc_build.outputs.match != ''
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__

--- a/.github/workflows/wheel_noarch.yml
+++ b/.github/workflows/wheel_noarch.yml
@@ -67,9 +67,18 @@ jobs:
           python -m pip install twine
           python -m twine check dist/*.whl
 
+      - uses: actions-ecosystem/action-regex-match@main
+        id: rc_build
+        with:
+          text: ${{ github.event.pull_request.head.ref }}
+          regex: '.*[0-9]+.[0-9]+.[0-9]+[-_]?rc[0-9]*'
+
       - uses: actions/upload-artifact@v4
         if: |
-          (github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/master')
+          github.event_name == 'release' || 
+          github.event_name == 'workflow_dispatch' || 
+          github.ref == 'refs/heads/master' ||
+          steps.rc_build.outputs.match != ''
         with:
           name: pure-python-wheels-${{ matrix.pl_backend }}.zip
           path: dist/*.whl
@@ -84,14 +93,24 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
+      - uses: actions-ecosystem/action-regex-match@main
+        id: rc_build
+        with:
+          text: ${{ github.event.pull_request.head.ref }}
+          regex: '.*[0-9]+.[0-9]+.[0-9]+[-_]?rc[0-9]*'
+
       - uses: actions/download-artifact@v4
-        if: ${{ github.event_name == 'pull_request' }}
+        if: |
+          ${{ github.event_name == 'release' }} ||
+          steps.rc_build.outputs.match != ''
         with:
           name: pure-python-wheels-${{ matrix.pl_backend }}.zip
           path: dist
 
       - name: Upload wheels to PyPI
-        if: ${{ github.event_name == 'pull_request' }}
+        if: |
+          ${{ github.event_name == 'release' }} ||
+          steps.rc_build.outputs.match != ''
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__

--- a/.github/workflows/wheel_noarch.yml
+++ b/.github/workflows/wheel_noarch.yml
@@ -100,13 +100,17 @@ jobs:
           regex: '.*[0-9]+.[0-9]+.[0-9]+[-_]?rc[0-9]*'
 
       - uses: actions/download-artifact@v4
-        if: ${{ github.event_name == 'release' || steps.rc_build.outputs.match }}
+        if: |
+          github.event_name == 'release' || 
+          steps.rc_build.outputs.match
         with:
           name: pure-python-wheels-${{ matrix.pl_backend }}.zip
           path: dist
 
       - name: Upload wheels to PyPI
-        if: ${{ github.event_name == 'release' || steps.rc_build.outputs.match }}
+        if: |
+          github.event_name == 'release' || 
+          steps.rc_build.outputs.match
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__

--- a/.github/workflows/wheel_noarch.yml
+++ b/.github/workflows/wheel_noarch.yml
@@ -111,8 +111,10 @@ jobs:
 
       - name: Upload wheels to PyPI
         if: |
-          ${{ github.event_name == 'release' }} ||
-          steps.rc_build.outputs.match != null
+            ${{
+              github.event_name == 'release' ||
+              steps.rc_build.outputs.match
+            }}
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__

--- a/.github/workflows/wheel_noarch.yml
+++ b/.github/workflows/wheel_noarch.yml
@@ -102,7 +102,7 @@ jobs:
       - uses: actions/download-artifact@v4
         if: |
           ${{ github.event_name == 'release' }} ||
-          steps.rc_build.outputs.match != ''
+          steps.rc_build.outputs.match != null
         with:
           name: pure-python-wheels-${{ matrix.pl_backend }}.zip
           path: dist

--- a/.github/workflows/wheel_noarch.yml
+++ b/.github/workflows/wheel_noarch.yml
@@ -103,7 +103,7 @@ jobs:
         if: |
             ${{
               github.event_name == 'release' ||
-              steps.rc_build.outputs.match != ''
+              steps.rc_build.outputs.match
             }}
         with:
           name: pure-python-wheels-${{ matrix.pl_backend }}.zip

--- a/.github/workflows/wheel_noarch.yml
+++ b/.github/workflows/wheel_noarch.yml
@@ -100,21 +100,13 @@ jobs:
           regex: '.*[0-9]+.[0-9]+.[0-9]+[-_]?rc[0-9]*'
 
       - uses: actions/download-artifact@v4
-        if: |
-            ${{
-              github.event_name == 'release' ||
-              steps.rc_build.outputs.match
-            }}
+        if: ${{ github.event_name == 'release' || steps.rc_build.outputs.match }}
         with:
           name: pure-python-wheels-${{ matrix.pl_backend }}.zip
           path: dist
 
       - name: Upload wheels to PyPI
-        if: |
-            ${{
-              github.event_name == 'release' ||
-              steps.rc_build.outputs.match
-            }}
+        if: ${{ github.event_name == 'release' || steps.rc_build.outputs.match }}
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__

--- a/.github/workflows/wheel_noarch.yml
+++ b/.github/workflows/wheel_noarch.yml
@@ -71,7 +71,7 @@ jobs:
         id: rc_build
         with:
           text: ${{ github.event.pull_request.head.ref }}
-          regex: '.*[0-9]+.[0-9]+.[0-9]+[-_]?rc[0-9]*'
+          regex: '^v[0-9]+\.[0-9]+\.[0-9]+[-_]rc$'
 
       - uses: actions/upload-artifact@v4
         if: |
@@ -97,7 +97,7 @@ jobs:
         id: rc_build
         with:
           text: ${{ github.event.pull_request.head.ref }}
-          regex: '.*[0-9]+.[0-9]+.[0-9]+[-_]?rc[0-9]*'
+          regex: '^v[0-9]+\.[0-9]+\.[0-9]+[-_]rc$'
 
       - uses: actions/download-artifact@v4
         if: |

--- a/.github/workflows/wheel_win_x86_64.yml
+++ b/.github/workflows/wheel_win_x86_64.yml
@@ -201,11 +201,11 @@ jobs:
         id: rc_build
         with:
           text: ${{ github.event.pull_request.head.ref }}
-          regex: '.*[0-9]+.[0-9]+.[0-9]+[-_]?rc[0-9]+'
+          regex: '.*[0-9]+.[0-9]+.[0-9]+[-_]?rc[0-9]*'
 
       - uses: actions/upload-artifact@v4
         if: |
-          github.event_name == 'pull_request' ||
+          github.event_name == 'release' ||
           github.event_name == 'workflow_dispatch' ||
           github.ref == 'refs/heads/master' ||
           steps.rc_build.outputs.match != ''
@@ -223,18 +223,29 @@ jobs:
         pl_backend: ["lightning_qubit"]
         cibw_build: ${{ fromJson(needs.set_wheel_build_matrix.outputs.python_version) }}
     runs-on: ubuntu-24.04
-    if: |
-      github.event_name == 'pull_request' ||
-      github.ref == 'refs/heads/master'
 
     steps:
+      - uses: actions-ecosystem/action-regex-match@main
+        id: rc_build
+        with:
+          text: ${{ github.event.pull_request.head.ref }}
+          regex: '.*[0-9]+.[0-9]+.[0-9]+[-_]?rc[0-9]*'
+
       - uses: actions/download-artifact@v4
+        if: |
+          github.event_name == 'release' ||
+          github.ref == 'refs/heads/master' || 
+          steps.rc_build.outputs.match != ''
         with:
           name: Windows-wheels-${{ matrix.pl_backend }}-${{ fromJson('{ "cp311-*":"py311","cp312-*":"py312","cp313-*":"py313" }')[matrix.cibw_build] }}-${{ matrix.arch }}.zip
           path: dist
 
       - name: Upload wheels to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        if: |
+          github.event_name == 'release' ||
+          github.ref == 'refs/heads/master' || 
+          steps.rc_build.outputs.match != ''
         with:
           user: __token__
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}

--- a/.github/workflows/wheel_win_x86_64.yml
+++ b/.github/workflows/wheel_win_x86_64.yml
@@ -201,7 +201,7 @@ jobs:
         id: rc_build
         with:
           text: ${{ github.event.pull_request.head.ref }}
-          regex: '.*[0-9]+.[0-9]+.[0-9]+[-_]?rc[0-9]*'
+          regex: '^v[0-9]+\.[0-9]+\.[0-9]+[-_]rc$'
 
       - uses: actions/upload-artifact@v4
         if: |
@@ -229,7 +229,7 @@ jobs:
         id: rc_build
         with:
           text: ${{ github.event.pull_request.head.ref }}
-          regex: '.*[0-9]+.[0-9]+.[0-9]+[-_]?rc[0-9]*'
+          regex: '^v[0-9]+\.[0-9]+\.[0-9]+[-_]rc$'
 
       - uses: actions/download-artifact@v4
         if: |

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.43.0-rc3"
+__version__ = "0.43.0-rc4"

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
 markers =
     local_salt(salt): adds a salt to the seed provided by the pytest-rng fixture
-rng_salt = v0.43.0
+rng_salt = v0.42.0


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [ ] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [ ] Ensure that the test suite passes, by running `make test`.

- [ ] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [ ] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**
Previously when we have a PR basing on the rc branch, when we use `ci:build_wheel`, it automatically uploads to TestPyPI. We do not want this behaviour, and only the PR of the rc branch itself to upload to PyPI.

**Description of the Change:**
Fixed the above behaviour. 

Also revert change of updating test seed, which should be done in the master branch.

Both of these changes are reverting/updating previous commits.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
