### PR TITLE
[DO NOT MERGE] Add lightning.amdgpu alias device for v0.43.0

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,6 +14,7 @@ build:
       - python -m pip install --exists-action=w --no-cache-dir -r doc/requirements.txt
       - PL_BACKEND="lightning_qubit" python scripts/configure_pyproject_toml.py && SKIP_COMPILATION=True python -m build
       - rm -rf ./build && PL_BACKEND="lightning_gpu" python scripts/configure_pyproject_toml.py && SKIP_COMPILATION=True python -m build
+      - rm -rf ./build && PL_BACKEND="lightning_amdgpu" python scripts/configure_pyproject_toml.py && SKIP_COMPILATION=True python -m build
       - rm -rf ./build && PL_BACKEND="lightning_kokkos" python scripts/configure_pyproject_toml.py && SKIP_COMPILATION=True python -m build
       - rm -rf ./build && PL_BACKEND="lightning_tensor" python scripts/configure_pyproject_toml.py && SKIP_COMPILATION=True python -m build
       - python -m pip install ./dist/*.whl

--- a/cmake/support_simulators.cmake
+++ b/cmake/support_simulators.cmake
@@ -27,7 +27,10 @@ MACRO(FIND_AND_ADD_SIMULATOR)
     FIND_SIMULATORS_LIST(SIMULATORS_LIST)
 
     FOREACH(BACKEND ${PL_BACKEND})
-        if (${BACKEND} IN_LIST SIMULATORS_LIST)
+        if ("${BACKEND}" STREQUAL "lightning_amdgpu")
+            # Reuse the lightning_kokkos source code for this backend
+            add_subdirectory(lightning_kokkos)
+        elseif (${BACKEND} IN_LIST SIMULATORS_LIST)
             add_subdirectory(${BACKEND})
         else()
             message("Could not find the requested backend. Options found are:")

--- a/doc/dev/installation.rst
+++ b/doc/dev/installation.rst
@@ -20,9 +20,14 @@ Select the device below for detailed source-installation instructions:
    :link: ../lightning_qubit/installation.html
 
 .. title-card::
-   :name: Lightning GPU
-   :description: Detailed guidelines to installing and testing the Lightning GPU device
+   :name: Lightning Nvidia GPU
+   :description: Detailed guidelines to installing and testing the Lightning GPU device for NVIDIA GPUs.
    :link: ../lightning_gpu/installation.html
+
+.. title-card::
+   :name: Lightning AMD GPU
+   :description: Detailed guidelines to installing and testing the Lightning AMD GPU device.
+   :link: ../lightning_amdgpu/installation.html
 
 .. title-card::
    :name: Lightning Kokkos

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -25,7 +25,7 @@ PennyLane-Lightning high performance simulators include the following backends:
     It can exploit the inherent parallelism of modern processing units supporting the `OpenMP <https://www.openmp.org/>`_,
     `CUDA <https://developer.nvidia.com/cuda-toolkit>`_ or `HIP <https://rocm.docs.amd.com/projects/HIP/en/latest>`_ programming models.
     It also offers distributed state-vector simulation via `MPI <https://www.mpi-forum.org/docs/>`_.
-*   ``lightning.amdgpu``: a state-vector simulator based on the ``lightning-kokkos``, specifically built with AMD GPU (HIP) support.
+*   ``lightning.amdgpu``: a state-vector simulator based on the ``lightning.kokkos``, specifically built for AMD GPU (HIP) support.
 *   ``lightning.gpu``: a state-vector simulator based on
     the `NVIDIA cuQuantum SDK <https://developer.nvidia.com/cuquantum-sdk>`_.
     It notably implements a distributed state-vector simulator based on `MPI <https://www.mpi-forum.org/docs/>`_.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -21,13 +21,14 @@ PennyLane-Lightning high performance simulators include the following backends:
 
 *   ``lightning.qubit``: a fast state-vector simulator written in C++
     with optional `OpenMP <https://www.openmp.org/>`_ additions and parallelized gate-level SIMD kernels.
-*   ``lightning.gpu``: a state-vector simulator based on
-    the `NVIDIA cuQuantum SDK <https://developer.nvidia.com/cuquantum-sdk>`_.
-    It notably implements a distributed state-vector simulator based on `MPI <https://www.mpi-forum.org/docs/>`_.
 *   ``lightning.kokkos``: a state-vector simulator written with `Kokkos <https://kokkos.github.io/kokkos-core-wiki/index.html>`_.
     It can exploit the inherent parallelism of modern processing units supporting the `OpenMP <https://www.openmp.org/>`_,
     `CUDA <https://developer.nvidia.com/cuda-toolkit>`_ or `HIP <https://rocm.docs.amd.com/projects/HIP/en/latest>`_ programming models.
     It also offers distributed state-vector simulation via `MPI <https://www.mpi-forum.org/docs/>`_.
+*   ``lightning.amdgpu``: a state-vector simulator based on the ``lightning-kokkos``, specifically built with AMD GPU (HIP) support.
+*   ``lightning.gpu``: a state-vector simulator based on
+    the `NVIDIA cuQuantum SDK <https://developer.nvidia.com/cuquantum-sdk>`_.
+    It notably implements a distributed state-vector simulator based on `MPI <https://www.mpi-forum.org/docs/>`_.
 *   ``lightning.tensor``: a tensor-network simulator based on the `NVIDIA cuQuantum SDK <https://developer.nvidia.com/cuquantum-sdk>`_.
     The supported methods are Matrix Product State (MPS) and Exact Tensor Network (TN).
 
@@ -44,14 +45,19 @@ The Lightning ecosystem provides the following devices:
     :link: lightning_qubit/device.html
 
 .. title-card::
-    :name: 'lightning.gpu'
-    :description: A heterogeneous backend state-vector simulator with NVIDIA cuQuantum library support.
-    :link: lightning_gpu/device.html
-
-.. title-card::
     :name: 'lightning.kokkos'
     :description: A heterogeneous backend state-vector simulator with Kokkos library support.
     :link: lightning_kokkos/device.html
+    
+.. title-card::
+    :name: 'lightning.amdgpu'
+    :description: A heterogeneous backend state-vector simulator based on Lightning-Kokkos specifically for AMD GPUs.
+    :link: lightning_gpu/device.html
+    
+.. title-card::
+    :name: 'lightning.gpu'
+    :description: A heterogeneous backend state-vector simulator with NVIDIA cuQuantum library support.
+    :link: lightning_gpu/device.html
 
 .. title-card::
     :name: 'lightning.tensor'
@@ -103,8 +109,9 @@ If you are using Lightning for research, please cite:
    :hidden:
 
    lightning_qubit/device
-   lightning_gpu/device
    lightning_kokkos/device
+   lightning_amdgpu/device
+   lightning_gpu/device
    lightning_tensor/device
 
 .. toctree::

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -52,7 +52,7 @@ The Lightning ecosystem provides the following devices:
 .. title-card::
     :name: 'lightning.amdgpu'
     :description: A heterogeneous backend state-vector simulator based on Lightning-Kokkos specifically for AMD GPUs.
-    :link: lightning_gpu/device.html
+    :link: lightning_amdgpu/device.html
     
 .. title-card::
     :name: 'lightning.gpu'

--- a/doc/lightning_amdgpu/device.rst
+++ b/doc/lightning_amdgpu/device.rst
@@ -1,0 +1,16 @@
+Lightning GPU device
+====================
+
+The ``lightning.amdgpu`` device is an extension of PennyLane's built-in ``lightning.qubit`` device.
+It extends the CPU-focused Lightning simulator to enable GPU-accelerated simulation of quantum state-vector evolution specifically on AMD GPUs.
+
+A ``lightning.amdgpu`` device can be loaded using:
+
+.. code-block:: python
+
+    import pennylane as qml
+    dev = qml.device("lightning.amdgpu", wires=2)
+
+The pre-built ``lightning.amdgpu`` device wheels are available for ROCm 7.0+ and MI300 series GPUs. For other versions of ROCm or AMD GPUs series, please refer to the :doc:`/lightning_amdgpu/installation` guide for instructions on building from source.
+
+The ``lightning.amdgpu`` device is an instantiation of the ``lightning.kokkos`` device specifically for AMD GPUs. It inherits all features from the ``lightning.kokkos`` device, including support for a wide range of quantum operations and observables, as well as compatibility with PennyLane's quantum functions and QNodes. For a comprehensive list of supported operations and observables, please refer to the :doc:`/lightning_kokkos/device` documentation.

--- a/doc/lightning_amdgpu/device.rst
+++ b/doc/lightning_amdgpu/device.rst
@@ -14,3 +14,7 @@ A ``lightning.amdgpu`` device can be loaded using:
 The pre-built ``lightning.amdgpu`` device wheels are available for ROCm 7.0+ and MI300 series GPUs. For other versions of ROCm or AMD GPUs series, please refer to the :doc:`/lightning_amdgpu/installation` guide for instructions on building from source.
 
 The ``lightning.amdgpu`` device is an instantiation of the ``lightning.kokkos`` device specifically for AMD GPUs. It inherits all features from the ``lightning.kokkos`` device, including support for a wide range of quantum operations and observables, as well as compatibility with PennyLane's quantum functions and QNodes. For a comprehensive list of supported operations and observables, please refer to the :doc:`/lightning_kokkos/device` documentation.
+
+.. note ::
+
+    It is not recommended to install both ``lightning.amdgpu`` and ``lightning.kokkos`` devices in the same environment, as this may lead to conflicts. Choose the device that best fits your hardware and simulation needs.

--- a/doc/lightning_amdgpu/device.rst
+++ b/doc/lightning_amdgpu/device.rst
@@ -1,4 +1,4 @@
-Lightning GPU device
+Lightning AMD GPU device
 ====================
 
 The ``lightning.amdgpu`` device is an extension of PennyLane's built-in ``lightning.qubit`` device.

--- a/doc/lightning_amdgpu/installation.rst
+++ b/doc/lightning_amdgpu/installation.rst
@@ -4,11 +4,7 @@ Lightning-AMDGPU installation
 Install Lightning-AMDGPU from source
 ====================================
 
-.. note::
-
-    The section below contains instructions for installing Lightning-Kokkos **from source**. For most cases, one can install Lightning-Kokkos via Spack or Docker by the installation instructions at `pennylane.ai/install <https://pennylane.ai/install/#high-performance-computing-and-gpus>`__. If those instructions do not work for you, or you have a more complex build environment that requires building from source, then consider reading on.
-
-As Kokkos enables support for many different HPC-targeted hardware platforms, ``lightning.kokkos`` can be built to support any of these platforms when building from source.
+Lightning-AMDGPU is an instantiation of the Lighting-Kokkos device, specifically for AMD GPUs using the HIP backend. For building Lightning-Kokkos for targets other than AMD GPUs, please refer to the :doc:`/lightning_kokkos/installation` page.
 
 Install Kokkos (Optional)
 ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -18,7 +14,7 @@ Install Kokkos (Optional)
     Lightning-Kokkos is tested with Kokkos version <= 4.5.00
 
 We suggest first installing Kokkos with the wanted configuration following the instructions found in the `Kokkos documentation <https://kokkos.github.io/kokkos-core-wiki/building.html>`_.
-For example, the following will build Kokkos for NVIDIA A100 cards:
+For example, the following will build Kokkos for AMD MI300 GPU:
 
 Download the `Kokkos code <https://github.com/kokkos/kokkos/releases>`_.
 
@@ -29,24 +25,26 @@ Download the `Kokkos code <https://github.com/kokkos/kokkos/releases>`_.
     tar -xvf 4.x.y.z.tar.gz
     cd kokkos-4.x.y.z
 
-Build Kokkos for NVIDIA A100 cards (``SM80`` architecture), and append the install location to ``CMAKE_PREFIX_PATH``.
+Build Kokkos for AMD MI300 GPU (``GFX942`` architecture), and append the install location to ``CMAKE_PREFIX_PATH``.
 
 .. code-block:: bash
 
     # Replace <install-path> with the path to install Kokkos
-    # e.g. $HOME/kokkos-install/4.5.0/AMPERE80
+    # e.g. $HOME/kokkos-install/4.5.0/GFX942
     export KOKKOS_INSTALL_PATH=<install-path>
     mkdir -p ${KOKKOS_INSTALL_PATH}
 
     cmake -S . -B build -G Ninja \
-        -DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+        -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_INSTALL_PREFIX=${KOKKOS_INSTALL_PATH} \
         -DCMAKE_CXX_STANDARD=20 \
+        -DCMAKE_CXX_COMPILER=hipcc \
+        -DCMAKE_PREFIX_PATH="/opt/rocm" \
         -DBUILD_SHARED_LIBS:BOOL=ON \
         -DBUILD_TESTING:BOOL=OFF \
         -DKokkos_ENABLE_SERIAL:BOOL=ON \
-        -DKokkos_ENABLE_CUDA:BOOL=ON \
-        -DKokkos_ARCH_AMPERE80:BOOL=ON \
+        -DKokkos_ENABLE_HIP:BOOL=ON \
+        -DKokkos_ARCH_AMD_GFX942:BOOL=ON \
         -DKokkos_ENABLE_COMPLEX_ALIGN:BOOL=OFF \
         -DKokkos_ENABLE_EXAMPLES:BOOL=OFF \
         -DKokkos_ENABLE_TESTS:BOOL=OFF \
@@ -55,14 +53,15 @@ Build Kokkos for NVIDIA A100 cards (``SM80`` architecture), and append the insta
     export CMAKE_PREFIX_PATH=:"${KOKKOS_INSTALL_PATH}":$CMAKE_PREFIX_PATH
 
 
-Note that the C++20 standard is required (enabled via the ``-DCMAKE_CXX_STANDARD=20`` option), hence CUDA 12 is required for the CUDA backend.
+.. note::
 
-Install Lightning-Kokkos
+    - Requires AMD compiler ``hipcc`` or ``amdclang`` from the ROCm software stack.
+    - `-DCMAKE_PREFIX_PATH="/opt/rocm"` enables CMake to properly discover the `rocthrust` library
+    - For information on choosing the correct architecture flag for your AMD GPU, please refer to the `Kokkos wiki <https://kokkos.org/kokkos-core-wiki/get-started/configuration-guide.html>`_.
+
+
+Install Lightning-AMDGPU
 ^^^^^^^^^^^^^^^^^^^^^^^^
-
-If an installation of Kokkos is not found, then our builder will automatically clone and install it during the build process. Lightning-Qubit needs to be 'installed' by ``pip`` before Lightning-Kokkos (compilation is not necessary).
-
-The simplest way to install Lightning-Kokkos (OpenMP backend) through ``pip``.
 
 .. code-block:: bash
 
@@ -71,93 +70,22 @@ The simplest way to install Lightning-Kokkos (OpenMP backend) through ``pip``.
     pip install -r requirements.txt
     pip install git+https://github.com/PennyLaneAI/pennylane.git@master
     
-    # Lightning-Qubit needs to be 'installed' by pip before Lightning-Kokkos 
-    # (compilation is not necessary)
+    # First Install Lightning-Qubit
     PL_BACKEND="lightning_qubit" python scripts/configure_pyproject_toml.py
-    SKIP_COMPILATION=True pip install -e . --config-settings editable_mode=compat
+    ip install . -vv
 
-    # Install Lightning-Kokkos with OpenMP backend
-    PL_BACKEND="lightning_kokkos" python scripts/configure_pyproject_toml.py
-    CMAKE_ARGS="-DKokkos_ENABLE_OPENMP=ON" python -m pip install -e . --config-settings editable_mode=compat -vv
+    # Install Lightning-AMDGPU
+    PL_BACKEND="lightning_amdgpu" python scripts/configure_pyproject_toml.py
+    export CMAKE_ARGS="-DCMAKE_CXX_COMPILER=hipcc \
+                       -DCMAKE_CXX_FLAGS='--gcc-install-dir=/usr/lib/gcc/x86_64-linux-gnu/11/' \
+                       -DCMAKE_PREFIX_PATH=/opt/rocm"
+    python -m pip install -e . --config-settings editable_mode=compat -vv
 
-The supported backend options are
+.. _install-lightning-AMDGPU-with-mpi:
 
-.. list-table::
-    :align: center
-    :width: 100 %
-    :widths: 20 20 20 20 20
-    :header-rows: 0
-
-    * - ``SERIAL``
-      - ``OPENMP``
-      - ``THREADS``
-      - ``HIP``
-      - ``CUDA``
-
-and the corresponding build options are ``-DKokkos_ENABLE_XYZ=ON``, where ``XYZ`` needs be replaced by the backend name, for instance ``OPENMP``.
-
-One can simutaneously activate one serial, one parallel CPU host (e.g. ``OPENMP``, ``THREADS``) and one parallel GPU device backend (e.g. ``HIP``, ``CUDA``), but not two of any category at the same time.
-For ``HIP`` and ``CUDA``, the appropriate software stacks are required to enable compilation and subsequent use.
-Similarly, the CMake option ``-DKokkos_ARCH_{...}=ON`` must also be specified to target a given architecture.
-A list of the architectures is found on the `Kokkos wiki <https://kokkos.org/kokkos-core-wiki/API/core/Macros.html#architectures>`_.
-Note that ``THREADS`` backend is not recommended since `Kokkos does not guarantee its safety <https://github.com/kokkos/kokkos-core-wiki/blob/17f08a6483937c26e14ec3c93a2aa40e4ce081ce/docs/source/ProgrammingGuide/Initialization.md?plain=1#L67>`_.
-
-.. _install-lightning-kokkos-with-mpi:
-
-Install Lightning-Kokkos with MPI
+Install Lightning-AMDGPU with MPI
 =================================
 
 .. note::
 
-    Building Lightning-Kokkos with MPI requires an MPI library and ``mpi4py``. 
-    If building for GPU, please ensure that MPI is built with GPU support - for example, see the guide to
-    build OpenMPI with `CUDA <https://docs.open-mpi.org/en/v5.0.x/tuning-apps/networking/cuda.html>`_
-    and `ROCm <https://docs.open-mpi.org/en/v5.0.x/tuning-apps/networking/rocm.html>`_ support.
-
-
-To install Lightning-Kokkos with MPI support, we recommend first installing Kokkos for your specific architecture such as CPU (``SERIAL``, ``OPENMP``),  Nvidia GPU (``CUDA``), or AMD GPU (``HIP``)
-and exporting the install location to ``CMAKE_PREFIX_PATH`` as described above.
-Then Lightning-Kokkos with MPI support can be installed in the *editable* mode by adding the ``ENABLE_MPI=ON`` option to the CMake arguments:
-
-.. code-block:: bash
-
-    git clone https://github.com/PennyLaneAI/pennylane-lightning.git
-    cd pennylane-lightning
-    pip install -r requirements.txt
-    pip install git+https://github.com/PennyLaneAI/pennylane.git@master
-
-    # Lightning-Qubit needs to be 'installed' by pip before Lightning-Kokkos 
-    # (compilation is not necessary)
-    PL_BACKEND="lightning_qubit" python scripts/configure_pyproject_toml.py
-    SKIP_COMPILATION=True pip install -e . --config-settings editable_mode=compat
-
-    # Install Lightning-Kokkos with MPI support
-    PL_BACKEND="lightning_kokkos" python scripts/configure_pyproject_toml.py
-    CMAKE_ARGS="-DENABLE_MPI=ON" python -m pip install -e . --config-settings editable_mode=compat -vv
-
-If required, extra linker flags for MPI (e.g. for GPU Transport Layer) can be added using the ``MPI_EXTRA_LINKER_FLAGS`` environment variable, for example:
-
-.. code-block:: bash
-
-    # Optional and system dependent
-    export MPI_EXTRA_LINKER_FLAGS="-lxpmem -L/opt/cray/pe/mpich/8.1.31/gtl/lib -lmpi_gtl_hsa"
-
-For an example of how to install Lightning-Kokkos with MPI on an HPC system, check out the :doc:`/lightning_kokkos/installation_hpc` page
-
-Test Lightning-Kokkos with MPI
-===========================
-
-After installing Lightning-Kokkos with MPI, you can test the Python layer of the MPI enabled plugin as follows (Lightning-Qubit must be installed as well):
-
-.. code-block:: bash
-
-    pip install -r requirements-tests.txt
-    PL_DEVICE="lightning_kokkos" mpirun -np 2 python -m pytest mpitests --tb=short
-
-To compile and test the C++ code, you can use the following command:
-
-.. code-block:: bash
-
-    PL_BACKEND="lightning_kokkos" make test-cpp-mpi
-
-By default this will compile Kokkos with ``SERIAL`` backend. If using a different pre-compiled Kokkos backend, you can export the environment variable ``CMAKE_PREFIX_PATH`` with the Kokkos install location.
+    To build Lightning-AMDGPU with MPI support, please consult the lightning-kokkos installation guide at :doc:`/lightning_kokkos/installation` and :doc:`/lightning_kokkos/insstallation_hpc`.

--- a/doc/lightning_amdgpu/installation.rst
+++ b/doc/lightning_amdgpu/installation.rst
@@ -6,7 +6,7 @@ Install Lightning-AMDGPU from source
 
 Lightning-AMDGPU is an instantiation of the Lighting-Kokkos device, specifically for AMD GPUs using the HIP backend. For building Lightning-Kokkos for targets other than AMD GPUs, please refer to the :doc:`/lightning_kokkos/installation` page.
 
-Install Kokkos (Optional)
+Install Kokkos (Recommended)
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. note::
@@ -56,7 +56,7 @@ Build Kokkos for AMD MI300 GPU (``GFX942`` architecture), and append the install
 .. note::
 
     - Requires AMD compiler ``hipcc`` or ``amdclang`` from the ROCm software stack.
-    - `-DCMAKE_PREFIX_PATH="/opt/rocm"` enables CMake to properly discover the `rocthrust` library
+    - ``-DCMAKE_PREFIX_PATH="/opt/rocm"`` enables CMake to properly discover the ``rocthrust`` library
     - For information on choosing the correct architecture flag for your AMD GPU, please refer to the `Kokkos wiki <https://kokkos.org/kokkos-core-wiki/get-started/configuration-guide.html>`_.
 
 
@@ -82,7 +82,7 @@ Install Lightning-AMDGPU
 
 .. note ::
 
-    - Make sure that gcc-11 is installed and accessible on your system, since it is required to compile the Lightning-AMDGPU device. This can be done on Ubuntu via ``sudo apt install gcc-11 g++-11``.
+    - Make sure that ``gcc-11`` is installed and accessible on your system, since it is required to compile the Lightning-AMDGPU device. This can be done on Ubuntu via ``sudo apt install gcc-11 g++-11``.
 
 
 .. _install-lightning-AMDGPU-with-mpi:

--- a/doc/lightning_amdgpu/installation.rst
+++ b/doc/lightning_amdgpu/installation.rst
@@ -92,4 +92,4 @@ Install Lightning-AMDGPU with MPI
 
 .. note::
 
-    To build Lightning-AMDGPU with MPI support, please consult the lightning-kokkos installation guide at :doc:`/lightning_kokkos/installation` and :doc:`/lightning_kokkos/insstallation_hpc`.
+    To build Lightning-AMDGPU with MPI support, please consult the Lightning-Kokkos installation guide at :doc:`/lightning_kokkos/installation` and :doc:`/lightning_kokkos/installation_hpc`.

--- a/doc/lightning_amdgpu/installation.rst
+++ b/doc/lightning_amdgpu/installation.rst
@@ -1,0 +1,163 @@
+Lightning-AMDGPU installation
+*****************************
+
+Install Lightning-AMDGPU from source
+====================================
+
+.. note::
+
+    The section below contains instructions for installing Lightning-Kokkos **from source**. For most cases, one can install Lightning-Kokkos via Spack or Docker by the installation instructions at `pennylane.ai/install <https://pennylane.ai/install/#high-performance-computing-and-gpus>`__. If those instructions do not work for you, or you have a more complex build environment that requires building from source, then consider reading on.
+
+As Kokkos enables support for many different HPC-targeted hardware platforms, ``lightning.kokkos`` can be built to support any of these platforms when building from source.
+
+Install Kokkos (Optional)
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. note::
+
+    Lightning-Kokkos is tested with Kokkos version <= 4.5.00
+
+We suggest first installing Kokkos with the wanted configuration following the instructions found in the `Kokkos documentation <https://kokkos.github.io/kokkos-core-wiki/building.html>`_.
+For example, the following will build Kokkos for NVIDIA A100 cards:
+
+Download the `Kokkos code <https://github.com/kokkos/kokkos/releases>`_.
+
+.. code-block:: bash
+
+    # Replace x, y, and z by the correct version
+    wget https://github.com/kokkos/kokkos/archive/refs/tags/4.x.yz.tar.gz
+    tar -xvf 4.x.y.z.tar.gz
+    cd kokkos-4.x.y.z
+
+Build Kokkos for NVIDIA A100 cards (``SM80`` architecture), and append the install location to ``CMAKE_PREFIX_PATH``.
+
+.. code-block:: bash
+
+    # Replace <install-path> with the path to install Kokkos
+    # e.g. $HOME/kokkos-install/4.5.0/AMPERE80
+    export KOKKOS_INSTALL_PATH=<install-path>
+    mkdir -p ${KOKKOS_INSTALL_PATH}
+
+    cmake -S . -B build -G Ninja \
+        -DCMAKE_BUILD_TYPE=RelWithDebugInfo \
+        -DCMAKE_INSTALL_PREFIX=${KOKKOS_INSTALL_PATH} \
+        -DCMAKE_CXX_STANDARD=20 \
+        -DBUILD_SHARED_LIBS:BOOL=ON \
+        -DBUILD_TESTING:BOOL=OFF \
+        -DKokkos_ENABLE_SERIAL:BOOL=ON \
+        -DKokkos_ENABLE_CUDA:BOOL=ON \
+        -DKokkos_ARCH_AMPERE80:BOOL=ON \
+        -DKokkos_ENABLE_COMPLEX_ALIGN:BOOL=OFF \
+        -DKokkos_ENABLE_EXAMPLES:BOOL=OFF \
+        -DKokkos_ENABLE_TESTS:BOOL=OFF \
+        -DKokkos_ENABLE_LIBDL:BOOL=OFF
+    cmake --build build && cmake --install build
+    export CMAKE_PREFIX_PATH=:"${KOKKOS_INSTALL_PATH}":$CMAKE_PREFIX_PATH
+
+
+Note that the C++20 standard is required (enabled via the ``-DCMAKE_CXX_STANDARD=20`` option), hence CUDA 12 is required for the CUDA backend.
+
+Install Lightning-Kokkos
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+If an installation of Kokkos is not found, then our builder will automatically clone and install it during the build process. Lightning-Qubit needs to be 'installed' by ``pip`` before Lightning-Kokkos (compilation is not necessary).
+
+The simplest way to install Lightning-Kokkos (OpenMP backend) through ``pip``.
+
+.. code-block:: bash
+
+    git clone https://github.com/PennyLaneAI/pennylane-lightning.git
+    cd pennylane-lightning
+    pip install -r requirements.txt
+    pip install git+https://github.com/PennyLaneAI/pennylane.git@master
+    
+    # Lightning-Qubit needs to be 'installed' by pip before Lightning-Kokkos 
+    # (compilation is not necessary)
+    PL_BACKEND="lightning_qubit" python scripts/configure_pyproject_toml.py
+    SKIP_COMPILATION=True pip install -e . --config-settings editable_mode=compat
+
+    # Install Lightning-Kokkos with OpenMP backend
+    PL_BACKEND="lightning_kokkos" python scripts/configure_pyproject_toml.py
+    CMAKE_ARGS="-DKokkos_ENABLE_OPENMP=ON" python -m pip install -e . --config-settings editable_mode=compat -vv
+
+The supported backend options are
+
+.. list-table::
+    :align: center
+    :width: 100 %
+    :widths: 20 20 20 20 20
+    :header-rows: 0
+
+    * - ``SERIAL``
+      - ``OPENMP``
+      - ``THREADS``
+      - ``HIP``
+      - ``CUDA``
+
+and the corresponding build options are ``-DKokkos_ENABLE_XYZ=ON``, where ``XYZ`` needs be replaced by the backend name, for instance ``OPENMP``.
+
+One can simutaneously activate one serial, one parallel CPU host (e.g. ``OPENMP``, ``THREADS``) and one parallel GPU device backend (e.g. ``HIP``, ``CUDA``), but not two of any category at the same time.
+For ``HIP`` and ``CUDA``, the appropriate software stacks are required to enable compilation and subsequent use.
+Similarly, the CMake option ``-DKokkos_ARCH_{...}=ON`` must also be specified to target a given architecture.
+A list of the architectures is found on the `Kokkos wiki <https://kokkos.org/kokkos-core-wiki/API/core/Macros.html#architectures>`_.
+Note that ``THREADS`` backend is not recommended since `Kokkos does not guarantee its safety <https://github.com/kokkos/kokkos-core-wiki/blob/17f08a6483937c26e14ec3c93a2aa40e4ce081ce/docs/source/ProgrammingGuide/Initialization.md?plain=1#L67>`_.
+
+.. _install-lightning-kokkos-with-mpi:
+
+Install Lightning-Kokkos with MPI
+=================================
+
+.. note::
+
+    Building Lightning-Kokkos with MPI requires an MPI library and ``mpi4py``. 
+    If building for GPU, please ensure that MPI is built with GPU support - for example, see the guide to
+    build OpenMPI with `CUDA <https://docs.open-mpi.org/en/v5.0.x/tuning-apps/networking/cuda.html>`_
+    and `ROCm <https://docs.open-mpi.org/en/v5.0.x/tuning-apps/networking/rocm.html>`_ support.
+
+
+To install Lightning-Kokkos with MPI support, we recommend first installing Kokkos for your specific architecture such as CPU (``SERIAL``, ``OPENMP``),  Nvidia GPU (``CUDA``), or AMD GPU (``HIP``)
+and exporting the install location to ``CMAKE_PREFIX_PATH`` as described above.
+Then Lightning-Kokkos with MPI support can be installed in the *editable* mode by adding the ``ENABLE_MPI=ON`` option to the CMake arguments:
+
+.. code-block:: bash
+
+    git clone https://github.com/PennyLaneAI/pennylane-lightning.git
+    cd pennylane-lightning
+    pip install -r requirements.txt
+    pip install git+https://github.com/PennyLaneAI/pennylane.git@master
+
+    # Lightning-Qubit needs to be 'installed' by pip before Lightning-Kokkos 
+    # (compilation is not necessary)
+    PL_BACKEND="lightning_qubit" python scripts/configure_pyproject_toml.py
+    SKIP_COMPILATION=True pip install -e . --config-settings editable_mode=compat
+
+    # Install Lightning-Kokkos with MPI support
+    PL_BACKEND="lightning_kokkos" python scripts/configure_pyproject_toml.py
+    CMAKE_ARGS="-DENABLE_MPI=ON" python -m pip install -e . --config-settings editable_mode=compat -vv
+
+If required, extra linker flags for MPI (e.g. for GPU Transport Layer) can be added using the ``MPI_EXTRA_LINKER_FLAGS`` environment variable, for example:
+
+.. code-block:: bash
+
+    # Optional and system dependent
+    export MPI_EXTRA_LINKER_FLAGS="-lxpmem -L/opt/cray/pe/mpich/8.1.31/gtl/lib -lmpi_gtl_hsa"
+
+For an example of how to install Lightning-Kokkos with MPI on an HPC system, check out the :doc:`/lightning_kokkos/installation_hpc` page
+
+Test Lightning-Kokkos with MPI
+===========================
+
+After installing Lightning-Kokkos with MPI, you can test the Python layer of the MPI enabled plugin as follows (Lightning-Qubit must be installed as well):
+
+.. code-block:: bash
+
+    pip install -r requirements-tests.txt
+    PL_DEVICE="lightning_kokkos" mpirun -np 2 python -m pytest mpitests --tb=short
+
+To compile and test the C++ code, you can use the following command:
+
+.. code-block:: bash
+
+    PL_BACKEND="lightning_kokkos" make test-cpp-mpi
+
+By default this will compile Kokkos with ``SERIAL`` backend. If using a different pre-compiled Kokkos backend, you can export the environment variable ``CMAKE_PREFIX_PATH`` with the Kokkos install location.

--- a/doc/lightning_amdgpu/installation.rst
+++ b/doc/lightning_amdgpu/installation.rst
@@ -72,7 +72,7 @@ Install Lightning-AMDGPU
     
     # First Install Lightning-Qubit
     PL_BACKEND="lightning_qubit" python scripts/configure_pyproject_toml.py
-    ip install . -vv
+    python -m pip install . -vv
 
     # Install Lightning-AMDGPU
     PL_BACKEND="lightning_amdgpu" python scripts/configure_pyproject_toml.py

--- a/doc/lightning_amdgpu/installation.rst
+++ b/doc/lightning_amdgpu/installation.rst
@@ -50,7 +50,7 @@ Build Kokkos for AMD MI300 GPU (``GFX942`` architecture), and append the install
         -DKokkos_ENABLE_TESTS:BOOL=OFF \
         -DKokkos_ENABLE_LIBDL:BOOL=OFF
     cmake --build build && cmake --install build
-    export CMAKE_PREFIX_PATH=:"${KOKKOS_INSTALL_PATH}":$CMAKE_PREFIX_PATH
+    export CMAKE_PREFIX_PATH=:"${KOKKOS_INSTALL_PATH}":/opt/rocm:$CMAKE_PREFIX_PATH
 
 
 .. note::
@@ -77,9 +77,13 @@ Install Lightning-AMDGPU
     # Install Lightning-AMDGPU
     PL_BACKEND="lightning_amdgpu" python scripts/configure_pyproject_toml.py
     export CMAKE_ARGS="-DCMAKE_CXX_COMPILER=hipcc \
-                       -DCMAKE_CXX_FLAGS='--gcc-install-dir=/usr/lib/gcc/x86_64-linux-gnu/11/' \
-                       -DCMAKE_PREFIX_PATH=/opt/rocm"
-    python -m pip install -e . --config-settings editable_mode=compat -vv
+                       -DCMAKE_CXX_FLAGS='--gcc-install-dir=/usr/lib/gcc/x86_64-linux-gnu/11/'"
+    python -m pip install . -vv
+
+.. note ::
+
+    - Make sure that gcc-11 is installed and accessible on your system, since it is required to compile the Lightning-AMDGPU device. This can be done on Ubuntu via ``sudo apt install gcc-11 g++-11``.
+
 
 .. _install-lightning-AMDGPU-with-mpi:
 

--- a/doc/lightning_amdgpu/package.rst
+++ b/doc/lightning_amdgpu/package.rst
@@ -1,0 +1,19 @@
+lightning_gpu
+=============
+
+.. automodapi:: pennylane_lightning.lightning_gpu
+    :no-heading:
+    :include-all-objects:
+
+.. raw:: html
+
+        <div style='clear:both'></div>
+        </br>
+
+Directly importing the device class:
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: python3
+
+    from pennylane_lightning.lightning_gpu import LightningGPU
+

--- a/doc/lightning_amdgpu/package.rst
+++ b/doc/lightning_amdgpu/package.rst
@@ -1,7 +1,7 @@
-lightning_gpu
+lightning_amdgpu
 =============
 
-.. automodapi:: pennylane_lightning.lightning_gpu
+.. automodapi:: pennylane_lightning.lightning_amdgpu
     :no-heading:
     :include-all-objects:
 
@@ -15,5 +15,5 @@ Directly importing the device class:
 
 .. code-block:: python3
 
-    from pennylane_lightning.lightning_gpu import LightningGPU
+    from pennylane_lightning.lightning_amdgpu import LightningAMDGPU
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -211,7 +211,7 @@ ENV CXX=hipcc
 ENV PL_BACKEND=lightning_amdgpu
 RUN pip uninstall -y pennylane-lightning
 RUN python scripts/configure_pyproject_toml.py || true
-RUN CMAKE_ARGS="-DKokkos_ENABLE_SERIAL:BOOL=ON -DKokkos_ENABLE_OPENMP:BOOL=ON -DKokkos_ENABLE_HIP:BOOL=ON -DKokkos_ARCH_${AMD_ARCH}=ON -DCMAKE_CXX_FLAGS='--gcc-install-dir=/usr/lib/gcc/x86_64-linux-gnu/11/'" python -m build --wheel
+RUN CMAKE_ARGS="-DKokkos_ENABLE_SERIAL:BOOL=ON -DKokkos_ENABLE_HIP:BOOL=ON -DKokkos_ARCH_${AMD_ARCH}=ON -DCMAKE_CXX_FLAGS='--gcc-install-dir=/usr/lib/gcc/x86_64-linux-gnu/11/'" python -m build --wheel
 
 # Install lightning-amdgpu HIP backend
 FROM rocm/dev-ubuntu-22.04:7.0.2 AS wheel-lightning-kokkos-rocm

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,14 +18,14 @@ ARG PENNYLANE_VERSION=master
 # Create basic runtime environment base on Ubuntu 22.04 (jammy)
 # Create and activate runtime virtual environment
 FROM ubuntu:jammy AS base-runtime
-ARG AMD_ARCH=AMD_GFX90A
+ARG AMD_ARCH=AMD_GFX942
 ARG CUDA_ARCH=AMPERE80
 ARG CUDA_INSTALLER=https://developer.download.nvidia.com/compute/cuda/12.2.2/local_installers/cuda_12.2.2_535.104.05_linux.run
 ARG DEBIAN_FRONTEND=noninteractive
 ARG GCC_VERSION=11
 ARG LIGHTNING_VERSION=master
 ARG PENNYLANE_VERSION
-ARG ROCM_INSTALLER=https://repo.radeon.com/amdgpu-install/6.2.4/ubuntu/jammy/amdgpu-install_6.2.60204-1_all.deb
+ARG ROCM_INSTALLER=https://repo.radeon.com/amdgpu-install/7.0.3/ubuntu/jammy/amdgpu-install_7.0.3.70003-1_all.deb
 RUN apt-get update \
     && apt-get install --no-install-recommends -y \
     apt-utils \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -200,6 +200,7 @@ RUN apt-get update \
     && apt-get install --no-install-recommends -y ./$(echo ${ROCM_INSTALLER} | xargs -I {} basename {}) \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
+RUN wget -q -O - https://repo.radeon.com/rocm/rocm.gpg.key | gpg --dearmor | tee /etc/apt/trusted.gpg.d/rocm.gpg > /dev/null
 RUN amdgpu-install -y --accept-eula --usecase=rocm,hiplibsdk --no-dkms
 
 # Download Lightning release and build lightning-kokkos backend with Kokkos-ROCm

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -214,7 +214,7 @@ RUN python scripts/configure_pyproject_toml.py || true
 RUN CMAKE_ARGS="-DKokkos_ENABLE_SERIAL:BOOL=ON -DKokkos_ENABLE_OPENMP:BOOL=ON -DKokkos_ENABLE_HIP:BOOL=ON -DKokkos_ARCH_${AMD_ARCH}=ON -DCMAKE_CXX_FLAGS='--gcc-install-dir=/usr/lib/gcc/x86_64-linux-gnu/11/'" python -m build --wheel
 
 # Install lightning-kokkos HIP backend
-FROM rocm/dev-ubuntu-22.04:6.2.4 AS wheel-lightning-kokkos-rocm
+FROM rocm/dev-ubuntu-22.04:7.0.2 AS wheel-lightning-kokkos-rocm
 ARG PENNYLANE_VERSION
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -208,7 +208,7 @@ FROM base-build-rocm AS build-wheel-lightning-kokkos-rocm
 WORKDIR /opt/pennylane-lightning
 ENV CMAKE_PREFIX_PATH=/opt/rocm:$CMAKE_PREFIX_PATH
 ENV CXX=hipcc
-ENV PL_BACKEND=lightning_kokkos
+ENV PL_BACKEND=lightning_amdgpu
 RUN pip uninstall -y pennylane-lightning
 RUN python scripts/configure_pyproject_toml.py || true
 RUN CMAKE_ARGS="-DKokkos_ENABLE_SERIAL:BOOL=ON -DKokkos_ENABLE_OPENMP:BOOL=ON -DKokkos_ENABLE_HIP:BOOL=ON -DKokkos_ARCH_${AMD_ARCH}=ON -DCMAKE_CXX_FLAGS='--gcc-install-dir=/usr/lib/gcc/x86_64-linux-gnu/11/'" python -m build --wheel

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -226,6 +226,7 @@ RUN apt-get update \
     && apt-get install --no-install-recommends -y \
     git \
     libgomp1 \
+    libomp-dev \
     python3.12 \
     python3-pip \
     python3.12-venv \
@@ -234,6 +235,7 @@ RUN apt-get update \
 ENV VIRTUAL_ENV=/opt/venv
 RUN python3.12 -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+ENV LD_LIBRARY_PATH="/usr/lib/llvm-14/lib:$LD_LIBRARY_PATH"
 COPY --from=build-wheel-lightning-kokkos-rocm /opt/pennylane-lightning/dist/ /
 COPY --from=build-wheel-lightning-qubit /opt/pennylane-lightning/dist/ /
 RUN pip install --force-reinstall --no-cache-dir pennylane_lightning*.whl && rm pennylane_lightning*.whl

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -213,7 +213,7 @@ RUN pip uninstall -y pennylane-lightning
 RUN python scripts/configure_pyproject_toml.py || true
 RUN CMAKE_ARGS="-DKokkos_ENABLE_SERIAL:BOOL=ON -DKokkos_ENABLE_OPENMP:BOOL=ON -DKokkos_ENABLE_HIP:BOOL=ON -DKokkos_ARCH_${AMD_ARCH}=ON -DCMAKE_CXX_FLAGS='--gcc-install-dir=/usr/lib/gcc/x86_64-linux-gnu/11/'" python -m build --wheel
 
-# Install lightning-kokkos HIP backend
+# Install lightning-amdgpu HIP backend
 FROM rocm/dev-ubuntu-22.04:7.0.2 AS wheel-lightning-kokkos-rocm
 ARG PENNYLANE_VERSION
 ENV DEBIAN_FRONTEND=noninteractive

--- a/pennylane_lightning/core/bindings/Bindings.hpp
+++ b/pennylane_lightning/core/bindings/Bindings.hpp
@@ -71,7 +71,11 @@ using namespace Pennylane::LightningQubit::NanoBindings;
 #include "MeasurementsKokkos.hpp"
 #include "ObservablesKokkos.hpp"
 
+#ifdef _ENABLE_PLAMDGPU
+#define LIGHTNING_MODULE_NAME lightning_amdgpu_ops
+#else
 #define LIGHTNING_MODULE_NAME lightning_kokkos_ops
+#endif
 
 /// @cond DEV
 namespace {

--- a/pennylane_lightning/core/simulators/lightning_kokkos/CMakeLists.txt
+++ b/pennylane_lightning/core/simulators/lightning_kokkos/CMakeLists.txt
@@ -48,6 +48,11 @@ endif()
 
 add_library(lightning_kokkos STATIC ${LKOKKOS_FILES})
 target_compile_options(lightning_compile_options INTERFACE "-D_ENABLE_PLKOKKOS=1")
+target_compile_definitions(lightning_kokkos PUBLIC "_ENABLE_PLKOKKOS=1")
+
+if("${PL_BACKEND}" STREQUAL "lightning_amdgpu")
+    target_compile_definitions(lightning_kokkos PUBLIC "_ENABLE_PLAMDGPU=1")
+endif()
 
 FindKokkos(lightning_external_libs)
 
@@ -91,6 +96,14 @@ set(COMPONENT_SUBDIRS   algorithms
 foreach(COMP ${COMPONENT_SUBDIRS})
     add_subdirectory(${COMP})
 endforeach()
+
+if("${PL_BACKEND}" STREQUAL "lightning_amdgpu")
+    add_library(lightning_amdgpu ALIAS lightning_kokkos)
+    add_library(lightning_amdgpu_algorithms ALIAS lightning_kokkos_algorithms)
+    add_library(lightning_amdgpu_observables ALIAS lightning_kokkos_observables)
+    add_library(lightning_amdgpu_bindings ALIAS lightning_kokkos_bindings)
+    add_library(lightning_amdgpu_measurements ALIAS lightning_kokkos_measurements)
+endif()
 
 if (BUILD_TESTS)
     enable_testing()

--- a/pennylane_lightning/core/simulators/lightning_kokkos/measurements/MeasurementsKokkos.hpp
+++ b/pennylane_lightning/core/simulators/lightning_kokkos/measurements/MeasurementsKokkos.hpp
@@ -639,7 +639,21 @@ class Measurements final
         // Reducing over `d_probabilities` requires too much L0 scratch memory
         // on GPUs. If n_wires >= 20, this also requires quite a bit of memory
         // on CPUs, so we fallback to the next implementation
-        if (n_wires < MDRANGE_NWIRES_MAX && !is_gpu_scratch_limited) {
+        //
+        // On HIP, MDRangePolicy with ParallelReduce can fail to find a valid
+        // tile size for small shapes (e.g. all_offsets.size() <= 2). We
+        // fallback to parallel_for in these cases.
+        bool use_mdrange =
+            n_wires < MDRANGE_NWIRES_MAX && !is_gpu_scratch_limited;
+#ifdef KOKKOS_ENABLE_HIP
+        if (std::is_same_v<KokkosExecSpace, Kokkos::HIP>) {
+            if (all_offsets.size() <= 2) {
+                use_mdrange = false;
+            }
+        }
+#endif
+
+        if (use_mdrange) {
             using MDPolicyType_2D =
                 Kokkos::MDRangePolicy<Kokkos::Rank<2, Kokkos::Iterate::Left>>;
             auto md_policy = MDPolicyType_2D(

--- a/pennylane_lightning/lightning_amdgpu/__init__.py
+++ b/pennylane_lightning/lightning_amdgpu/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2024 Xanadu Quantum Technologies Inc.
+# Copyright 2025 Xanadu Quantum Technologies Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pennylane_lightning/lightning_amdgpu/__init__.py
+++ b/pennylane_lightning/lightning_amdgpu/__init__.py
@@ -13,14 +13,20 @@
 # limitations under the License.
 """PennyLane lightning_amdgpu package."""
 
+import sys
+
 from pennylane_lightning.core import __version__
 
-import sys
 try:
     import pennylane_lightning.lightning_amdgpu_ops as lightning_amdgpu_ops
+
     sys.modules["pennylane_lightning.lightning_kokkos_ops"] = lightning_amdgpu_ops
-    sys.modules["pennylane_lightning.lightning_kokkos_ops.algorithms"] = lightning_amdgpu_ops.algorithms
-    sys.modules["pennylane_lightning.lightning_kokkos_ops.observables"] = lightning_amdgpu_ops.observables
+    sys.modules["pennylane_lightning.lightning_kokkos_ops.algorithms"] = (
+        lightning_amdgpu_ops.algorithms
+    )
+    sys.modules["pennylane_lightning.lightning_kokkos_ops.observables"] = (
+        lightning_amdgpu_ops.observables
+    )
 except ImportError:
     pass
 

--- a/pennylane_lightning/lightning_amdgpu/__init__.py
+++ b/pennylane_lightning/lightning_amdgpu/__init__.py
@@ -1,0 +1,27 @@
+# Copyright 2018-2024 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""PennyLane lightning_amdgpu package."""
+
+from pennylane_lightning.core import __version__
+
+import sys
+try:
+    import pennylane_lightning.lightning_amdgpu_ops as lightning_amdgpu_ops
+    sys.modules["pennylane_lightning.lightning_kokkos_ops"] = lightning_amdgpu_ops
+    sys.modules["pennylane_lightning.lightning_kokkos_ops.algorithms"] = lightning_amdgpu_ops.algorithms
+    sys.modules["pennylane_lightning.lightning_kokkos_ops.observables"] = lightning_amdgpu_ops.observables
+except ImportError:
+    pass
+
+from .lightning_amdgpu import LightningAmdgpu

--- a/pennylane_lightning/lightning_amdgpu/lightning_amdgpu.py
+++ b/pennylane_lightning/lightning_amdgpu/lightning_amdgpu.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2025 Xanadu Quantum Technologies Inc.
+# Copyright 2025 Xanadu Quantum Technologies Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pennylane_lightning/lightning_amdgpu/lightning_amdgpu.py
+++ b/pennylane_lightning/lightning_amdgpu/lightning_amdgpu.py
@@ -13,11 +13,13 @@
 # limitations under the License.
 from pennylane_lightning.lightning_kokkos import LightningKokkos
 
+
 class LightningAmdgpu(LightningKokkos):
     """PennyLane-Lightning AMDGPU device.
 
     A device alias for LightningKokkos targeting AMDGPU platforms.
     """
+
     name = "lightning.amdgpu"
     short_name = "lightning.amdgpu"
 

--- a/pennylane_lightning/lightning_amdgpu/lightning_amdgpu.py
+++ b/pennylane_lightning/lightning_amdgpu/lightning_amdgpu.py
@@ -138,7 +138,8 @@ class LightningAmdgpu(LightningKokkos):
             except ValueError:
                 print("Warning: Could not parse ROCm versions for integer comparison.")
 
-        if num_devices == 0:
-            raise RuntimeError(
-                "No supported AMD GPU devices found. Please ensure that an AMD GPU is available and accessible."
-            )
+        # TO FIX WITH GET C INTERFACE FOR EDITABLE
+        # if num_devices == 0:
+        #     raise RuntimeError(
+        #         "No supported AMD GPU devices found. Please ensure that an AMD GPU is available and accessible."
+        #     )

--- a/pennylane_lightning/lightning_amdgpu/lightning_amdgpu.py
+++ b/pennylane_lightning/lightning_amdgpu/lightning_amdgpu.py
@@ -23,6 +23,6 @@ class LightningAmdgpu(LightningKokkos):
     name = "lightning.amdgpu"
     short_name = "lightning.amdgpu"
 
-    def __init__(self, wires, *args, **kwargs):
+    def __init__(self, wires=None, *args, **kwargs):
         # Pass all arguments through to the parent Kokkos device
         super().__init__(wires, *args, **kwargs)

--- a/pennylane_lightning/lightning_amdgpu/lightning_amdgpu.py
+++ b/pennylane_lightning/lightning_amdgpu/lightning_amdgpu.py
@@ -1,0 +1,26 @@
+# Copyright 2018-2025 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from pennylane_lightning.lightning_kokkos import LightningKokkos
+
+class LightningAmdgpu(LightningKokkos):
+    """PennyLane-Lightning AMDGPU device.
+
+    A device alias for LightningKokkos targeting AMDGPU platforms.
+    """
+    name = "lightning.amdgpu"
+    short_name = "lightning.amdgpu"
+
+    def __init__(self, wires, *args, **kwargs):
+        # Pass all arguments through to the parent Kokkos device
+        super().__init__(wires, *args, **kwargs)

--- a/pennylane_lightning/lightning_amdgpu/lightning_amdgpu.py
+++ b/pennylane_lightning/lightning_amdgpu/lightning_amdgpu.py
@@ -20,9 +20,6 @@ class LightningAmdgpu(LightningKokkos):
     A device alias for LightningKokkos targeting AMDGPU platforms.
     """
 
-    name = "lightning.amdgpu"
-    short_name = "lightning.amdgpu"
-
     def __init__(self, wires=None, *args, **kwargs):
         # Pass all arguments through to the parent Kokkos device
         super().__init__(wires, *args, **kwargs)

--- a/pennylane_lightning/lightning_amdgpu/lightning_amdgpu.py
+++ b/pennylane_lightning/lightning_amdgpu/lightning_amdgpu.py
@@ -77,12 +77,11 @@ class LightningAmdgpu(LightningKokkos):
 
         if lib_path and os.path.exists(lib_path):
             try:
-                # --- CRITICAL STEP: ATTEMPT TO LOAD ---
                 # If dependencies (like libamdhip64.so.7) are missing,
                 # this line triggers OSError immediately.
                 hip_lib = ctypes.CDLL(lib_path)
 
-                # If we reached here, the library loaded! Now query the version.
+                # If we reached here, the library loaded. Now query the version.
                 version_val = ctypes.c_int()
                 status = hip_lib.hipRuntimeGetVersion(ctypes.byref(version_val))
 

--- a/pennylane_lightning/lightning_amdgpu/lightning_amdgpu.py
+++ b/pennylane_lightning/lightning_amdgpu/lightning_amdgpu.py
@@ -17,7 +17,7 @@ from pennylane_lightning.lightning_kokkos import LightningKokkos
 class LightningAmdgpu(LightningKokkos):
     """PennyLane-Lightning AMDGPU device.
 
-    A device alias for LightningKokkos targeting AMDGPU platforms.
+    A device alias for LightningKokkos targeting AMD GPU platforms.
     """
 
     def __init__(self, wires=None, *args, **kwargs):

--- a/pennylane_lightning/lightning_base/_serialize.py
+++ b/pennylane_lightning/lightning_base/_serialize.py
@@ -77,7 +77,7 @@ class QuantumScriptSerializer:
                 raise ImportError(
                     f"Pre-compiled binaries for {device_name} are not available."
                 ) from exception
-        elif device_name == "lightning.kokkos":
+        elif device_name in ("lightning.kokkos", "lightning.amdgpu"):
             try:
                 import pennylane_lightning.lightning_kokkos_ops as lightning_ops
             except ImportError as exception:
@@ -103,7 +103,12 @@ class QuantumScriptSerializer:
 
         self._use_mpi = use_mpi
 
-        if device_name in ["lightning.qubit", "lightning.kokkos", "lightning.gpu"]:
+        if device_name in [
+            "lightning.qubit",
+            "lightning.kokkos",
+            "lightning.amdgpu",
+            "lightning.gpu",
+        ]:
             assert tensor_backend == str()
             self._set_lightning_state_bindings(lightning_ops)
         else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,10 +32,10 @@ name = "Xanadu Quantum Technologies Inc."
 email = "software@xanadu.ai"
 
 [project.optional-dependencies]
-gpu = [ "pennylane-lightning-gpu",]
 kokkos = [ "pennylane-lightning-kokkos",]
-tensor = [ "pennylane-lightning-tensor",]
 amdgpu = [ "pennylane-lightning-amdgpu",]
+gpu = [ "pennylane-lightning-gpu",]
+tensor = [ "pennylane-lightning-tensor",]
 
 [project.urls]
 Homepage = "https://github.com/PennyLaneAI/pennylane-lightning"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ email = "software@xanadu.ai"
 gpu = [ "pennylane-lightning-gpu",]
 kokkos = [ "pennylane-lightning-kokkos",]
 tensor = [ "pennylane-lightning-tensor",]
+amdgpu = [ "pennylane-lightning-amdgpu",]
 
 [project.urls]
 Homepage = "https://github.com/PennyLaneAI/pennylane-lightning"

--- a/scripts/backend_support.py
+++ b/scripts/backend_support.py
@@ -17,7 +17,13 @@ Internal logic to check and set backend variables.
 import os
 
 default_backend = "lightning_qubit"
-supported_backends = {"lightning_kokkos", "lightning_qubit", "lightning_gpu", "lightning_tensor", "lightning_amdgpu"}
+supported_backends = {
+    "lightning_kokkos",
+    "lightning_qubit",
+    "lightning_gpu",
+    "lightning_tensor",
+    "lightning_amdgpu",
+}
 supported_backends.update({sb.replace("_", ".") for sb in supported_backends})
 
 

--- a/scripts/backend_support.py
+++ b/scripts/backend_support.py
@@ -17,7 +17,7 @@ Internal logic to check and set backend variables.
 import os
 
 default_backend = "lightning_qubit"
-supported_backends = {"lightning_kokkos", "lightning_qubit", "lightning_gpu", "lightning_tensor"}
+supported_backends = {"lightning_kokkos", "lightning_qubit", "lightning_gpu", "lightning_tensor", "lightning_amdgpu"}
 supported_backends.update({sb.replace("_", ".") for sb in supported_backends})
 
 

--- a/scripts/backend_support.py
+++ b/scripts/backend_support.py
@@ -18,11 +18,11 @@ import os
 
 default_backend = "lightning_qubit"
 supported_backends = {
-    "lightning_kokkos",
     "lightning_qubit",
+    "lightning_kokkos",
+    "lightning_amdgpu",
     "lightning_gpu",
     "lightning_tensor",
-    "lightning_amdgpu",
 }
 supported_backends.update({sb.replace("_", ".") for sb in supported_backends})
 

--- a/setup.py
+++ b/setup.py
@@ -164,10 +164,11 @@ class CMakeBuild(build_ext):
             destination = os.path.join(os.getcwd(), f"build_{backend}")
             shutil.copy(source, destination)
     
-        if backend in ("lightning_kokkos", "lightning_qubit"):
+        if backend in ("lightning_kokkos", "lightning_qubit", "lightning_amdgpu"):
             if platform.system() in ["Linux", "Darwin"]:
                 shared_lib_ext = {"Linux": ".so", "Darwin": ".dylib"}[platform.system()]
-                source = os.path.join(f"{extdir}", f"lib{backend}_catalyst{shared_lib_ext}")
+                lib_name = "lightning_kokkos" if backend == "lightning_amdgpu" else backend
+                source = os.path.join(f"{extdir}", f"lib{lib_name}_catalyst{shared_lib_ext}")
                 destination = os.path.join(os.getcwd(), self.build_temp)
                 shutil.copy(source, destination)
 

--- a/setup.py
+++ b/setup.py
@@ -179,6 +179,9 @@ packages_list = ["pennylane_lightning." + backend]
 if backend == "lightning_qubit":
     packages_list += ["pennylane_lightning.core", "pennylane_lightning.lightning_base"]
 
+if backend == "lightning_amdgpu":
+    packages_list += ["pennylane_lightning.lightning_kokkos"]
+
 info = {
     "version": version,
     "packages": find_namespace_packages(include=packages_list),

--- a/tests/bindings/test_backend_nb.py
+++ b/tests/bindings/test_backend_nb.py
@@ -435,6 +435,9 @@ class TestBackendInfoBindings:
         """Test getting backend info."""
         if hasattr(current_module, "backend_info"):
             info = current_module.backend_info()
-            assert info["NAME"] == device_name
+            if device_name == "lightning.amdgpu":
+                assert info["NAME"] == "lightning.kokkos"
+            else:
+                assert info["NAME"] == device_name
         else:
             pytest.skip("backend_info function not available in module")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -94,14 +94,14 @@ def n_subsystems(request):
 # Looking for the device for testing.
 default_device = "lightning.qubit"
 
-supported_devices = {"lightning.kokkos", "lightning.qubit", "lightning.gpu", "lightning.tensor"}
+supported_devices = {"lightning.qubit", "lightning.kokkos", "lightning.amdgpu", "lightning.gpu", "lightning.tensor"}
 
 
 def get_device():
     """Return the pennylane lightning device.
 
     The device is ``lightning.qubit`` by default. Allowed values are:
-    "lightning.kokkos", "lightning.qubit", "lightning.gpu", and "lightning.tensor".
+    "lightning.qubit", "lightning.kokkos", "lightning.amdgpu", "lightning.gpu", and "lightning.tensor".
     If the environment variable ``PL_DEVICE`` is defined, its value is used.
     """
     device = os.environ.get("PL_DEVICE", default_device)
@@ -153,25 +153,34 @@ else:
         backend_cap = "GPU"  # Special case for GPU (uppercase)
     if device_name == "lightning.qubit":
         backend_cap = ""  # Special case for LightningQubit (default)
+    if device_name == "lightning.amdgpu":
+        backend_cap = "Kokkos"
 
     # Import main device class
     module_path = f"pennylane_lightning.{device_module_name}"
-    device_class = (
-        f"LightningQubit" if device_name == "lightning.qubit" else f"Lightning{backend_cap}"
-    )  # Special case for LightningQubit (default)
+    
+    if device_name == "lightning.amdgpu":
+        device_class = "LightningAmdgpu"
+        helper_module_path = "pennylane_lightning.lightning_kokkos"
+    else:
+        device_class = (
+            f"LightningQubit" if device_name == "lightning.qubit" else f"Lightning{backend_cap}"
+        )  # Special case for LightningQubit (default)
+        helper_module_path = module_path
+
     module = importlib.import_module(module_path)
     LightningDevice = getattr(module, device_class)
 
     # Import adjoint jacobian class
-    adjoint_module = importlib.import_module(f"{module_path}._adjoint_jacobian")
+    adjoint_module = importlib.import_module(f"{helper_module_path}._adjoint_jacobian")
     LightningAdjointJacobian = getattr(adjoint_module, f"Lightning{backend_cap}AdjointJacobian")
 
     # Import measurements class
-    measurements_module = importlib.import_module(f"{module_path}._measurements")
+    measurements_module = importlib.import_module(f"{helper_module_path}._measurements")
     LightningMeasurements = getattr(measurements_module, f"Lightning{backend_cap}Measurements")
 
     # Import state vector class
-    state_vector_module = importlib.import_module(f"{module_path}._state_vector")
+    state_vector_module = importlib.import_module(f"{helper_module_path}._state_vector")
     LightningStateVector = getattr(state_vector_module, f"Lightning{backend_cap}StateVector")
 
     # Try to import ops module

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -94,7 +94,13 @@ def n_subsystems(request):
 # Looking for the device for testing.
 default_device = "lightning.qubit"
 
-supported_devices = {"lightning.qubit", "lightning.kokkos", "lightning.amdgpu", "lightning.gpu", "lightning.tensor"}
+supported_devices = {
+    "lightning.qubit",
+    "lightning.kokkos",
+    "lightning.amdgpu",
+    "lightning.gpu",
+    "lightning.tensor",
+}
 
 
 def get_device():
@@ -158,7 +164,7 @@ else:
 
     # Import main device class
     module_path = f"pennylane_lightning.{device_module_name}"
-    
+
     if device_name == "lightning.amdgpu":
         device_class = "LightningAmdgpu"
         helper_module_path = "pennylane_lightning.lightning_kokkos"

--- a/tests/lightning_base/test_device.py
+++ b/tests/lightning_base/test_device.py
@@ -58,25 +58,7 @@ if device_name == "lightning.qubit":
         validate_measurements,
         validate_observables,
     )
-elif device_name == "lightning.kokkos":
-    from pennylane_lightning.lightning_kokkos.lightning_kokkos import (
-        _add_adjoint_transforms,
-        _adjoint_ops,
-        _supports_adjoint,
-        accepted_observables,
-        adjoint_measurements,
-        adjoint_observables,
-        allow_mcms_stopping_condition,
-        decompose,
-        no_mcms_stopping_condition,
-        no_sampling,
-        stopping_condition,
-        validate_adjoint_trainable_params,
-        validate_device_wires,
-        validate_measurements,
-        validate_observables,
-    )
-elif device_name == "lightning.amdgpu":
+elif device_name in ("lightning.kokkos", "lightning.amdgpu"):
     from pennylane_lightning.lightning_kokkos.lightning_kokkos import (
         _add_adjoint_transforms,
         _adjoint_ops,

--- a/tests/lightning_base/test_device.py
+++ b/tests/lightning_base/test_device.py
@@ -76,6 +76,24 @@ elif device_name == "lightning.kokkos":
         validate_measurements,
         validate_observables,
     )
+elif device_name == "lightning.amdgpu":
+    from pennylane_lightning.lightning_kokkos.lightning_kokkos import (
+        _add_adjoint_transforms,
+        _adjoint_ops,
+        _supports_adjoint,
+        accepted_observables,
+        adjoint_measurements,
+        adjoint_observables,
+        allow_mcms_stopping_condition,
+        decompose,
+        no_mcms_stopping_condition,
+        no_sampling,
+        stopping_condition,
+        validate_adjoint_trainable_params,
+        validate_device_wires,
+        validate_measurements,
+        validate_observables,
+    )
 elif device_name == "lightning.gpu":
     from pennylane_lightning.lightning_gpu.lightning_gpu import (
         _add_adjoint_transforms,
@@ -223,6 +241,8 @@ class TestHelpers:
         expected_program = qml.transforms.core.TransformProgram()
 
         name = f"adjoint + {device_name}"
+        if device_name == "lightning.amdgpu":
+            name = "adjoint + lightning.kokkos"
         expected_program.add_transform(no_sampling, name=name)
         expected_program.add_transform(qml.transforms.broadcast_expand)
         expected_program.add_transform(
@@ -897,6 +917,8 @@ class TestExecution:
 
         if adjoint:
             name = f"adjoint + {device_name}"
+            if device_name == "lightning.amdgpu":
+                name = "adjoint + lightning.kokkos"
             expected_program.add_transform(no_sampling, name=name)
             expected_program.add_transform(qml.transforms.broadcast_expand)
             expected_program.add_transform(

--- a/tests/lightning_base/test_state_vector_class.py
+++ b/tests/lightning_base/test_state_vector_class.py
@@ -50,7 +50,10 @@ def test_device_name_and_init(num_wires, dtype):
     """Test the class initialization and returned properties."""
     state_vector = LightningStateVector(num_wires, dtype=dtype)
     assert state_vector.dtype == dtype
-    assert state_vector.device_name == device_name
+    if device_name == "lightning.amdgpu":
+        assert state_vector.device_name == "lightning.kokkos"
+    else:
+        assert state_vector.device_name == device_name
     assert state_vector.wires == Wires(range(num_wires))
 
     if device_name == "lightning.kokkos":

--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -462,7 +462,7 @@ def test_qubit_unitary(n_wires, theta, phi, tol):
 
 
 @pytest.mark.skipif(
-    device_name not in ("lightning.qubit", "lightning.kokkos"),
+    device_name not in ("lightning.qubit", "lightning.kokkos", "lightning.amdgpu"),
     reason="PennyLane-like StatePrep only implemented in lightning.qubit and lightning.kokkos.",
 )
 @pytest.mark.parametrize("n_targets", list(range(2, 8)))
@@ -685,7 +685,7 @@ def test_controlled_qubit_unitary_from_op(tol):
 
 @pytest.mark.local_salt(42)
 @pytest.mark.skipif(
-    device_name not in ("lightning.qubit", "lightning.kokkos"),
+    device_name not in ("lightning.qubit", "lightning.kokkos", "lightning.amdgpu"),
     reason="PauliRot operations only implemented in lightning.qubit and lightning.kokkos.",
 )
 @pytest.mark.parametrize("n_wires", [1, 2, 3, 4, 5, 10, 15])

--- a/tests/test_measurements.py
+++ b/tests/test_measurements.py
@@ -526,7 +526,9 @@ def test_shots_single_measure_obs(shots, measure_f, obs, n_wires, mcmc, kernel_n
     """Tests that Lightning handles shots in a circuit where a single measurement of a common observable is performed at the end."""
 
     if (
-        shots is None or device_name in ("lightning.gpu", "lightning.kokkos", "lightning.tensor")
+        shots is None
+        or device_name
+        in ("lightning.gpu", "lightning.amdgpu", "lightning.kokkos", "lightning.tensor")
     ) and (mcmc or kernel_name != "Local"):
         pytest.skip(f"Device {device_name} does not have an mcmc option.")
 
@@ -539,7 +541,7 @@ def test_shots_single_measure_obs(shots, measure_f, obs, n_wires, mcmc, kernel_n
     if measure_f in (qml.expval, qml.var) and obs is None:
         pytest.skip("qml.expval, qml.var requires observable.")
 
-    if device_name in ("lightning.gpu", "lightning.kokkos"):
+    if device_name in ("lightning.gpu", "lightning.amdgpu", "lightning.kokkos"):
         dev = qml.device(device_name, wires=n_wires, seed=seed)
     elif device_name == "lightning.qubit":
         dev = qml.device(

--- a/tests/test_measurements_sparse.py
+++ b/tests/test_measurements_sparse.py
@@ -100,7 +100,7 @@ class TestSparseExpvalQChem:
             [qubits, range(qubits), H, hf_state, excitations],
             [
                 qubits,
-                np.random.permutation(np.arange(qubits)),
+                list(np.random.permutation(np.arange(qubits))),
                 H,
                 hf_state,
                 excitations,

--- a/tests/test_measurements_sparse.py
+++ b/tests/test_measurements_sparse.py
@@ -93,7 +93,7 @@ class TestSparseExpvalQChem:
     singles, doubles = qchem.excitations(active_electrons, qubits)
     excitations = singles + doubles
 
-    @pytest.fixture(params=[np.complex64, np.complex128])
+    @pytest.mark.parametrize("c_dtype", [np.complex64, np.complex128])
     @pytest.mark.parametrize(
         "qubits, wires, H, hf_state, excitations",
         [
@@ -107,12 +107,12 @@ class TestSparseExpvalQChem:
             ],
         ],
     )
-    def test_sparse_Pauli_words(self, qubits, wires, H, hf_state, excitations, tol, request):
+    def test_sparse_Pauli_words(self, qubits, wires, H, hf_state, excitations, tol, c_dtype):
         """Test expval of some simple sparse Hamiltonian"""
 
         H_sparse = H.sparse_matrix(wires)
 
-        dev = qml.device(device_name, wires=wires, c_dtype=request.param)
+        dev = qml.device(device_name, wires=wires, c_dtype=c_dtype)
 
         @qml.qnode(dev, diff_method="parameter-shift")
         def circuit():

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -28,7 +28,7 @@ from pennylane_lightning.lightning_base._serialize import (
 if not LightningDevice._CPP_BINARY_AVAILABLE:
     pytest.skip("No binary module found. Skipping.", allow_module_level=True)
 
-if device_name == "lightning.kokkos":
+if device_name in ("lightning.kokkos", "lightning.amdgpu"):
     from pennylane_lightning.lightning_kokkos_ops.observables import (
         HamiltonianC64,
         HamiltonianC128,


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [ ] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [ ] Ensure that the test suite passes, by running `make test`.

- [ ] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [ ] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**
This PR introduces a new device `lightning.amdgpu` as an alias for `lightning.kokkos`

```
>>> qml.about()
Name: pennylane
Version: 0.43.1
...
Installed devices:
- lightning.qubit (pennylane_lightning-0.43.0)
- lightning.amdgpu (pennylane_lightning_amdgpu-0.43.0)
```

Users can instantiate this device with
```
qml.device('lightning.amdgpu')
```
This device also works with `qjit`.

Notes:
- This device is simply an alias of `lightning.kokkos`, there might be issues if both`lightning.amdgpu` and `lightning.kokkos` are installed, as there may be conflicts.
- The package name is `pennylane_lightning_amdgpu` (e.g. `pennylane_lightning_amdgpu-0.43.0-cp311-cp311-linux_x86_64.whl`)
- The shared lib name is updated (`lightning_amdgpu_ops.cpython-311-x86_64-linux-gnu.so`), but we do not change the catalyst shared lib name (`liblightning_kokkos_catalyst.so`), since Catalyst will continue to think this is the lightning-kokkos device.
- To test build this, you can do:
```
make python

# assuming Kokkos is built in KOKKOS_INSTALL_PATH
export CMAKE_PREFIX_PATH=:"${KOKKOS_INSTALL_PATH}":/opt/rocm:$CMAKE_PREFIX_PATH
PL_BACKEND="lightning_amdgpu" \
build_options="-DCMAKE_CXX_COMPILER=hipcc -DCMAKE_CXX_FLAGS='--gcc-install-dir=/usr/lib/gcc/x86_64-linux-gnu/11/'" \
make python

# run tests
PL_DEVICE="lightning.amdgpu" python -m pytest tests/
```

The instructions to build a wheel actually for AMD GPU is available [here](https://www.notion.so/xanaduai/Building-wheel-for-Lightning-x-AMD-2b5bc6bd1764805dbc52d077313b7b50). 


**Description of the Change:**

**Benefits:**


**Possible Drawbacks:**

**Related GitHub Issues:**

[sc-104098]