### PR TITLE
Change CATALYST_GIT_TAG to 'main' for build

### DIFF
--- a/cmake/support_catalyst.cmake
+++ b/cmake/support_catalyst.cmake
@@ -26,9 +26,7 @@ macro(FindCatalyst target_name)
 
     else()
         if(NOT CATALYST_GIT_TAG)
-            # TODO: Revert to main after merging PR 2348
-            # https://github.com/PennyLaneAI/catalyst/pull/2348
-            set(CATALYST_GIT_TAG "rt_pprm" CACHE STRING "GIT_TAG value to build Catalyst")
+            set(CATALYST_GIT_TAG "main" CACHE STRING "GIT_TAG value to build Catalyst")
         endif()
         message(INFO " Building against Catalyst GIT TAG ${CATALYST_GIT_TAG}")
 

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.45.0-dev10"
+__version__ = "0.45.0-dev11"


### PR DESCRIPTION
**Context:**
Change CATALYST_GIT_TAG to 'main' for build. Follow up to #1330 

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
