### PR TITLE
remove pennylane from docs group

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,8 +7,6 @@ python:
   install:
     - method: pip
       path: .
-      extra_requirements:
-        - 'docs'
 
 build:
   os: ubuntu-24.04
@@ -18,6 +16,7 @@ build:
     - graphviz
   jobs:
     post_install:
+      - pip install --group docs
       - PL_BACKEND="lightning_qubit" python scripts/configure_pyproject_toml.py && SKIP_COMPILATION=True python -m build
       - rm -rf ./build && PL_BACKEND="lightning_gpu" python scripts/configure_pyproject_toml.py && SKIP_COMPILATION=True python -m build
       - rm -rf ./build && PL_BACKEND="lightning_amdgpu" python scripts/configure_pyproject_toml.py && SKIP_COMPILATION=True python -m build

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.45.0-dev13"
+__version__ = "0.45.0-dev14"

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.45.0-dev12"
+__version__ = "0.45.0-dev13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,18 +82,13 @@ base = [
     "isort~=7.0.0",
     "pylint~=4.0.0"
 ]
-
-[project.optional-dependencies]
-kokkos = [ "pennylane-lightning-kokkos",]
-amdgpu = [ "pennylane-lightning-amdgpu",]
-gpu = [ "pennylane-lightning-gpu",]
-tensor = [ "pennylane-lightning-tensor",]
 docs = [
     "build",
     "wheel",
     "tomlkit",
     "custatevec-cu12; sys_platform == 'linux'",
     "cutensornet-cu12; sys_platform == 'linux'",
+    "pennylane @ git+https://github.com/PennyLaneAI/pennylane.git@master",
     "breathe",
     "docutils==0.21.2",
     "exhale>=0.3.3",
@@ -110,6 +105,12 @@ docs = [
     "sphinx-sitemap",
     "matplotlib"
 ]
+
+[project.optional-dependencies]
+kokkos = [ "pennylane-lightning-kokkos",]
+amdgpu = [ "pennylane-lightning-amdgpu",]
+gpu = [ "pennylane-lightning-gpu",]
+tensor = [ "pennylane-lightning-tensor",]
 
 [project.urls]
 Homepage = "https://github.com/PennyLaneAI/pennylane-lightning"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,6 @@ docs = [
     "tomlkit",
     "custatevec-cu12; sys_platform == 'linux'",
     "cutensornet-cu12; sys_platform == 'linux'",
-    "pennylane @ git+https://github.com/PennyLaneAI/pennylane.git@master",
     "breathe",
     "docutils==0.21.2",
     "exhale>=0.3.3",


### PR DESCRIPTION
**Context:**
Push to TestPyPI [failed on master](https://github.com/PennyLaneAI/pennylane-lightning/actions/runs/21483986213/job/61888856259) for version 0.45.0-dev12

**Description of the Change:**
Removing `pennylane @master ` from docs dependency group.

**Benefits:**
Upload to TestPyPi will work

**Possible Drawbacks:**
None
**Related GitHub Issues:**
