### PR TITLE
fix stable and latest CI

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -33,7 +33,7 @@
 <h3>Internal changes ⚙️</h3>
 
 - Temporarily updated CI for stable versions to install from `requirements-tests.txt`.
-  [(#XXXX)](https://github.com/PennyLaneAI/pennylane-lightning/pull/XXXX)
+  [(#1340)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1340)
 
 - Cleaned up vector-matrix methods used by Lightning devices at `LinearAlgebra.hpp`.
   [(#1314)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1314)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -32,7 +32,7 @@
 
 <h3>Internal changes ⚙️</h3>
 
-- Temporarily updated CI for stable versions to install from `requirements-tests.txt`.
+- Temporarily updated CI for stable versions to install from `requirements-tests.txt`, and fixed tests to work with pytest 9.0 and updated `queue_category` in PennyLane.
   [(#1340)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1340)
 
 - Cleaned up vector-matrix methods used by Lightning devices at `LinearAlgebra.hpp`.

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -32,6 +32,9 @@
 
 <h3>Internal changes ⚙️</h3>
 
+- Temporarily updated CI for stable versions to install from `requirements-tests.txt`.
+  [(#XXXX)](https://github.com/PennyLaneAI/pennylane-lightning/pull/XXXX)
+
 - Cleaned up vector-matrix methods used by Lightning devices at `LinearAlgebra.hpp`.
   [(#1314)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1314)
 

--- a/.github/workflows/tests_gpu_python.yml
+++ b/.github/workflows/tests_gpu_python.yml
@@ -153,7 +153,11 @@ jobs:
 
       - name: Install required packages
         run: |
-          python -m pip install --group tests
+          if [[ "${{ inputs.lightning-version }}" == "stable" ]]; then # FIXME: remove after v0.45 release
+            python -m pip install -r requirements-tests.txt
+          else
+            python -m pip install --group tests
+          fi
           # pyscf is not compatible with numpy 2.4 yet
           python -m pip install cmake openfermionpyscf "numpy<2.4"
 

--- a/.github/workflows/tests_lgpumpi_python.yml
+++ b/.github/workflows/tests_lgpumpi_python.yml
@@ -134,7 +134,11 @@ jobs:
           PL_BACKEND: lightning_qubit
         run: |
           source /etc/profile.d/modules.sh && module use /opt/modules/ && module load ${{ matrix.mpilib }}
-          python -m pip install --group tests
+          if [[ "${{ inputs.lightning-version }}" == "stable" ]]; then # FIXME: remove after v0.45 release
+            python -m pip install -r requirements-tests.txt
+          else
+            python -m pip install --group tests
+          fi
           python -m pip install custatevec-cu12 # required for CUQUANTUM_SDK path
           # pyscf is not compatible with numpy 2.4 yet
           python -m pip install mpi4py openfermionpyscf "numpy<2.4"

--- a/.github/workflows/tests_lgpumpi_python.yml
+++ b/.github/workflows/tests_lgpumpi_python.yml
@@ -136,6 +136,7 @@ jobs:
           source /etc/profile.d/modules.sh && module use /opt/modules/ && module load ${{ matrix.mpilib }}
           if [[ "${{ inputs.lightning-version }}" == "stable" ]]; then # FIXME: remove after v0.45 release
             python -m pip install -r requirements-tests.txt
+            python -m pip install pytest==8.4.2
           else
             python -m pip install --group tests
           fi

--- a/.github/workflows/tests_lkcpu_python.yml
+++ b/.github/workflows/tests_lkcpu_python.yml
@@ -234,7 +234,11 @@ jobs:
         run: |
           WHEEL_NAME=$(cat ${{ github.workspace }}/${{ matrix.pl_backend }}-${{ matrix.exec_model }}_name.txt)
           mv ${{ github.workspace }}/wheel_${{ matrix.pl_backend }}-${{ matrix.exec_model }}.whl ${{ github.workspace }}/$WHEEL_NAME
-          python -m pip install --group tests
+          if [[ "${{ inputs.lightning-version }}" == "stable" ]]; then # FIXME: remove after v0.45 release
+            python -m pip install -r requirements-tests.txt
+          else
+            python -m pip install --group tests
+          fi
           # pyscf is not compatible with numpy 2.4 yet
           python -m pip install openfermionpyscf "numpy<2.4"
           if [ '${{ inputs.lightning-version }}' != 'stable' ]; then

--- a/.github/workflows/tests_lkcpu_python.yml
+++ b/.github/workflows/tests_lkcpu_python.yml
@@ -121,12 +121,16 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update && sudo apt-get -y -q install cmake gcc-$GCC_VERSION  g++-$GCC_VERSION
-          python -m pip install --upgrade pip          
+          python -m pip install --upgrade pip
           python -m pip install scipy-openblas32 wheel
 
       - name: Get required Python packages
         run: |
-          python -m pip install --group tests
+          if [[ "${{ inputs.lightning-version }}" == "stable" ]]; then # FIXME: remove after v0.45 release
+            python -m pip install -r requirements-tests.txt
+          else
+            python -m pip install --group tests
+          fi
           python -m pip install build
 
       - name: Create device wheel ${{ inputs.lightning-version }}

--- a/.github/workflows/tests_lkcuda_python.yml
+++ b/.github/workflows/tests_lkcuda_python.yml
@@ -190,7 +190,7 @@ jobs:
 
           # Upgrade pip
           python -m pip install --upgrade pip
-          
+
           # Create new venv for this workflow_run
           python --version
           python -m venv ${{ env.VENV_NAME }}
@@ -214,7 +214,11 @@ jobs:
         run: |
           cd main
           python -m pip install --upgrade pip
-          python -m pip install --group tests
+          if [[ "${{ inputs.lightning-version }}" == "stable" ]]; then # FIXME: remove after v0.45 release
+            python -m pip install -r requirements-tests.txt
+          else
+            python -m pip install --group tests
+          fi
           # pyscf is not compatible with numpy 2.4 yet
           python -m pip install openfermionpyscf "numpy<2.4"
 

--- a/.github/workflows/tests_lkmpi_cuda_python.yml
+++ b/.github/workflows/tests_lkmpi_cuda_python.yml
@@ -137,7 +137,11 @@ jobs:
           PL_BACKEND: lightning_qubit
         run: |
           source /etc/profile.d/modules.sh && module use /opt/modules/ && module load ${{ matrix.mpilib }}
-          python -m pip install --group tests
+          if [[ "${{ inputs.lightning-version }}" == "stable" ]]; then # FIXME: remove after v0.45 release
+            python -m pip install -r requirements-tests.txt
+          else
+            python -m pip install --group tests
+          fi
           # pyscf is not compatible with numpy 2.4 yet
           python -m pip install mpi4py openfermionpyscf "numpy<2.4"
           python scripts/configure_pyproject_toml.py || true

--- a/.github/workflows/tests_lqcpu_python.yml
+++ b/.github/workflows/tests_lqcpu_python.yml
@@ -101,7 +101,11 @@ jobs:
 
       - name: Get required Python packages
         run: |
-          python -m pip install --group tests
+          if [[ "${{ inputs.lightning-version }}" == "stable" ]]; then # FIXME: remove after v0.45 release
+            python -m pip install -r requirements-tests.txt
+          else
+            python -m pip install --group tests
+          fi
           python -m pip install build wheel
 
       - name: Create device wheel ${{ inputs.lightning-version }}
@@ -176,7 +180,11 @@ jobs:
         run: |
           WHEEL_NAME=$(cat ${{ github.workspace }}/${{ matrix.pl_backend }}-${{ matrix.blas }}_name.txt)
           mv ${{ github.workspace }}/wheel_${{ matrix.pl_backend }}-${{ matrix.blas }}.whl ${{ github.workspace }}/$WHEEL_NAME
-          python -m pip install --group tests
+          if [[ "${{ inputs.lightning-version }}" == "stable" ]]; then # FIXME: remove after v0.45 release
+            python -m pip install -r requirements-tests.txt
+          else
+            python -m pip install --group tests
+          fi
           # pyscf is not compatible with numpy 2.4 yet
           python -m pip install openfermionpyscf "numpy<2.4" semantic-version
           python -m pip install ${{ github.workspace }}/$WHEEL_NAME --no-deps --force-reinstall

--- a/.github/workflows/tests_lqcpu_python.yml
+++ b/.github/workflows/tests_lqcpu_python.yml
@@ -101,11 +101,7 @@ jobs:
 
       - name: Get required Python packages
         run: |
-          if [[ "${{ inputs.lightning-version }}" == "stable" ]]; then # FIXME: remove after v0.45 release
-            python -m pip install -r requirements-tests.txt
-          else
-            python -m pip install --group tests
-          fi
+          python -m pip install --group tests
           python -m pip install build wheel
 
       - name: Create device wheel ${{ inputs.lightning-version }}

--- a/.github/workflows/tests_lqcpu_python.yml
+++ b/.github/workflows/tests_lqcpu_python.yml
@@ -101,7 +101,11 @@ jobs:
 
       - name: Get required Python packages
         run: |
-          python -m pip install --group tests
+          if [[ "${{ inputs.lightning-version }}" == "stable" ]]; then # FIXME: remove after v0.45 release
+            python -m pip install -r requirements-tests.txt
+          else
+            python -m pip install --group tests
+          fi
           python -m pip install build wheel
 
       - name: Create device wheel ${{ inputs.lightning-version }}
@@ -176,11 +180,7 @@ jobs:
         run: |
           WHEEL_NAME=$(cat ${{ github.workspace }}/${{ matrix.pl_backend }}-${{ matrix.blas }}_name.txt)
           mv ${{ github.workspace }}/wheel_${{ matrix.pl_backend }}-${{ matrix.blas }}.whl ${{ github.workspace }}/$WHEEL_NAME
-          if [[ "${{ inputs.lightning-version }}" == "stable" ]]; then # FIXME: remove after v0.45 release
-            python -m pip install -r requirements-tests.txt
-          else
-            python -m pip install --group tests
-          fi
+          python -m pip install --group tests
           # pyscf is not compatible with numpy 2.4 yet
           python -m pip install openfermionpyscf "numpy<2.4" semantic-version
           python -m pip install ${{ github.workspace }}/$WHEEL_NAME --no-deps --force-reinstall

--- a/.github/workflows/tests_without_binary.yml
+++ b/.github/workflows/tests_without_binary.yml
@@ -74,7 +74,11 @@ jobs:
       - name: Get required Python packages
         run: |
           rm -fr $(python -m pip cache dir)/selfcheck/
-          python -m pip install --group tests
+          if [[ "${{ inputs.lightning-version }}" == "stable" ]]; then # FIXME: remove after v0.45 release
+            python -m pip install -r requirements-tests.txt
+          else
+            python -m pip install --group tests
+          fi
 
       - name: Checkout PennyLane for release or latest build
         if: inputs.pennylane-version == 'release' || inputs.pennylane-version == 'latest'

--- a/mpitests/test_measurements_sparse.py
+++ b/mpitests/test_measurements_sparse.py
@@ -76,15 +76,15 @@ class TestSparseExpval:
     def test_sparse_Pauli_words(self, cases, tol, dev):
         """Test expval of some simple sparse Hamiltonian"""
 
+        # Compute the sparse matrix of the input operator
+        # This is done outside of the QNode to avoid queuing the `Hamiltonian`
+        matrix = qml.Hamiltonian([1], [cases[0]]).sparse_matrix()
+
         @qml.qnode(dev, diff_method="parameter-shift")
         def circuit_expval():
             qml.RX(0.4, wires=[0])
             qml.RY(-0.2, wires=[1])
-            return qml.expval(
-                qml.SparseHamiltonian(
-                    qml.Hamiltonian([1], [cases[0]]).sparse_matrix(), wires=[0, 1]
-                )
-            )
+            return qml.expval(qml.SparseHamiltonian(matrix, wires=[0, 1]))
 
         assert np.allclose(circuit_expval(), cases[1], atol=tol, rtol=0)
 
@@ -92,11 +92,7 @@ class TestSparseExpval:
         def circuit_var():
             qml.RX(0.4, wires=[0])
             qml.RY(-0.2, wires=[1])
-            return qml.var(
-                qml.SparseHamiltonian(
-                    qml.Hamiltonian([1], [cases[0]]).sparse_matrix(), wires=[0, 1]
-                )
-            )
+            return qml.var(qml.SparseHamiltonian(matrix, wires=[0, 1]))
 
         assert np.allclose(circuit_var(), cases[2], atol=tol, rtol=0)
 
@@ -126,7 +122,7 @@ class TestSparseExpvalQChem:
             [qubits, range(qubits), H, hf_state, excitations],
             [
                 qubits,
-                np.random.permutation(np.arange(qubits)),
+                list(np.random.permutation(np.arange(qubits))),
                 H,
                 hf_state,
                 excitations,

--- a/mpitests/test_measurements_sparse.py
+++ b/mpitests/test_measurements_sparse.py
@@ -122,7 +122,7 @@ class TestSparseExpvalQChem:
             [qubits, range(qubits), H, hf_state, excitations],
             [
                 qubits,
-                list(np.random.permutation(np.arange(qubits))),
+                [2, 10, 5, 6, 9, 3, 4, 1, 0, 8, 11, 7],
                 H,
                 hf_state,
                 excitations,

--- a/mpitests/test_measurements_sparse.py
+++ b/mpitests/test_measurements_sparse.py
@@ -14,7 +14,7 @@
 """
 Unit tests for sparse measurements on :mod:`pennylane_lightning` MPI-enabled devices.
 """
-# pylint: disable=protected-access,too-few-public-methods,unused-import,missing-function-docstring,too-many-arguments
+# pylint: disable=protected-access,too-few-public-methods,unused-import,missing-function-docstring,too-many-arguments,too-many-positional-arguments
 
 import numpy as np
 import pennylane as qml

--- a/mpitests/test_measurements_sparse.py
+++ b/mpitests/test_measurements_sparse.py
@@ -119,9 +119,7 @@ class TestSparseExpvalQChem:
     singles, doubles = qchem.excitations(active_electrons, qubits)
     excitations = singles + doubles
 
-    _dtypes = [np.complex64, np.complex128] if device_name != "lightning.gpu" else [np.complex128]
-
-    @pytest.mark.parametrize("dtype", _dtypes)
+    @pytest.mark.parametrize("dtype", [np.complex128])
     @pytest.mark.parametrize(
         "qubits, wires, H, hf_state, excitations",
         [

--- a/mpitests/test_measurements_sparse.py
+++ b/mpitests/test_measurements_sparse.py
@@ -119,7 +119,7 @@ class TestSparseExpvalQChem:
     singles, doubles = qchem.excitations(active_electrons, qubits)
     excitations = singles + doubles
 
-    _dtypes = [np.complex64, np.complex128] if device_name != "lightning.gpu" else [np.complex64]
+    _dtypes = [np.complex64, np.complex128] if device_name != "lightning.gpu" else [np.complex128]
 
     @pytest.mark.parametrize("dtype", _dtypes)
     @pytest.mark.parametrize(

--- a/mpitests/test_measurements_sparse.py
+++ b/mpitests/test_measurements_sparse.py
@@ -115,7 +115,7 @@ class TestSparseExpvalQChem:
     singles, doubles = qchem.excitations(active_electrons, qubits)
     excitations = singles + doubles
 
-    @pytest.mark.parametrize("dtype", [np.complex128])
+    @pytest.mark.parametrize("dtype", [np.complex64, np.complex128])
     @pytest.mark.parametrize(
         "qubits, wires, H, hf_state, excitations",
         [

--- a/mpitests/test_measurements_sparse.py
+++ b/mpitests/test_measurements_sparse.py
@@ -73,7 +73,7 @@ class TestSparseExpval:
             ],
         ],
     )
-    def test_sparse_Pauli_words(self, cases, tol, dev):
+    def test_sparse_pauli_words(self, cases, tol, dev):
         """Test expval of some simple sparse Hamiltonian"""
 
         # Compute the sparse matrix of the input operator
@@ -129,7 +129,7 @@ class TestSparseExpvalQChem:
             ],
         ],
     )
-    def test_sparse_Pauli_words(self, qubits, wires, H, hf_state, excitations, tol, dtype):
+    def test_sparse_pauli_words(self, qubits, wires, H, hf_state, excitations, tol, dtype):
         """Test expval of some simple sparse Hamiltonian"""
 
         H_sparse = H.sparse_matrix(wires)

--- a/mpitests/test_measurements_sparse.py
+++ b/mpitests/test_measurements_sparse.py
@@ -119,9 +119,9 @@ class TestSparseExpvalQChem:
     singles, doubles = qchem.excitations(active_electrons, qubits)
     excitations = singles + doubles
 
-    @pytest.fixture(
-        params=[np.complex64, np.complex128] if device_name != "lightning.gpu" else [np.complex128]
-    )
+    _dtypes = [np.complex64, np.complex128] if device_name != "lightning.gpu" else [np.complex64]
+
+    @pytest.mark.parametrize("dtype", _dtypes)
     @pytest.mark.parametrize(
         "qubits, wires, H, hf_state, excitations",
         [
@@ -135,12 +135,12 @@ class TestSparseExpvalQChem:
             ],
         ],
     )
-    def test_sparse_Pauli_words(self, qubits, wires, H, hf_state, excitations, tol, request):
+    def test_sparse_Pauli_words(self, qubits, wires, H, hf_state, excitations, tol, dtype):
         """Test expval of some simple sparse Hamiltonian"""
 
         H_sparse = H.sparse_matrix(wires)
 
-        dev = qml.device(device_name, mpi=True, wires=wires, c_dtype=request.param)
+        dev = qml.device(device_name, mpi=True, wires=wires, c_dtype=dtype)
 
         @qml.qnode(dev, diff_method="parameter-shift")
         def circuit():

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.45.0-dev14"
+__version__ = "0.45.0-dev15"

--- a/tests/lightning_base/test_measurements_class.py
+++ b/tests/lightning_base/test_measurements_class.py
@@ -466,7 +466,7 @@ class TestSparseExpval:
             qml.SparseHamiltonian,
         ],
     )
-    def test_sparse_Pauli_words(self, obs, ham_terms, expected, tol, lightning_sv):
+    def test_sparse_pauli_words(self, obs, ham_terms, expected, tol, lightning_sv):
         """Test expval of some simple sparse observables"""
 
         ops = [qml.RX(0.4, wires=[0]), qml.RY(-0.2, wires=[1])]

--- a/tests/lightning_tensor/test_gates_and_expval.py
+++ b/tests/lightning_tensor/test_gates_and_expval.py
@@ -219,7 +219,7 @@ class TestSparseHExpval:
             [qml.Identity(0) @ qml.PauliZ(1), 0.980066577, 0.039469480],
         ],
     )
-    def test_sparse_Pauli_words(self, cases, qubit_device, method):
+    def test_sparse_pauli_words(self, cases, qubit_device, method):
         """Test expval of some simple sparse Hamiltonian"""
         dev = qml.device(device_name, wires=4, **method)
 

--- a/tests/test_measurements_sparse.py
+++ b/tests/test_measurements_sparse.py
@@ -47,7 +47,7 @@ class TestSparseExpval:
             [qml.Identity(0) @ qml.PauliZ(1), 0.98006657784124170, 0.039469480514526367],
         ],
     )
-    def test_sparse_Pauli_words(self, cases, tol, dev):
+    def test_sparse_pauli_words(self, cases, tol, dev):
         """Test expval of some simple sparse Hamiltonian"""
 
         # Compute the sparse matrix of the input operator
@@ -103,7 +103,7 @@ class TestSparseExpvalQChem:
             ],
         ],
     )
-    def test_sparse_Pauli_words(self, qubits, wires, H, hf_state, excitations, tol, dtype):
+    def test_sparse_pauli_words(self, qubits, wires, H, hf_state, excitations, tol, dtype):
         """Test expval of some simple sparse Hamiltonian"""
 
         H_sparse = H.sparse_matrix(wires)

--- a/tests/test_measurements_sparse.py
+++ b/tests/test_measurements_sparse.py
@@ -24,11 +24,10 @@ from pennylane import qchem
 if not ld._CPP_BINARY_AVAILABLE:
     pytest.skip("No binary module found. Skipping.", allow_module_level=True)
 
+if device_name == "lightning.tensor":
+    pytest.skip("Lightning.tensor does not support Sparse Hamiltonians.", allow_module_level=True)
 
-@pytest.mark.skipif(
-    device_name == "lightning.tensor",
-    reason="lightning.tensor does not support Sparse Hamiltonians",
-)
+
 class TestSparseExpval:
     """Tests for the expval function"""
 

--- a/tests/test_measurements_sparse.py
+++ b/tests/test_measurements_sparse.py
@@ -89,7 +89,7 @@ class TestSparseExpvalQChem:
     singles, doubles = qchem.excitations(active_electrons, qubits)
     excitations = singles + doubles
 
-    @pytest.fixture(params=[np.complex64, np.complex128])
+    @pytest.mark.parametrize("dtype", [np.complex64, np.complex128])
     @pytest.mark.parametrize(
         "qubits, wires, H, hf_state, excitations",
         [
@@ -103,12 +103,12 @@ class TestSparseExpvalQChem:
             ],
         ],
     )
-    def test_sparse_Pauli_words(self, qubits, wires, H, hf_state, excitations, tol, request):
+    def test_sparse_Pauli_words(self, qubits, wires, H, hf_state, excitations, tol, dtype):
         """Test expval of some simple sparse Hamiltonian"""
 
         H_sparse = H.sparse_matrix(wires)
 
-        dev = qml.device(device_name, wires=wires, c_dtype=request.param)
+        dev = qml.device(device_name, wires=wires, c_dtype=dtype)
 
         @qml.qnode(dev, diff_method="parameter-shift")
         def circuit():

--- a/tests/test_measurements_sparse.py
+++ b/tests/test_measurements_sparse.py
@@ -96,7 +96,7 @@ class TestSparseExpvalQChem:
             [qubits, range(qubits), H, hf_state, excitations],
             [
                 qubits,
-                np.random.permutation(np.arange(qubits)),
+                list(np.random.permutation(np.arange(qubits))),
                 H,
                 hf_state,
                 excitations,


### PR DESCRIPTION
**Context:**
There are several issues causing our CIs to fail:
- Since we removed our requirements.txt files and have all dependencies specified in pyproject.toml, our stable CI tests have failed, as it cannot install the test dependencies with the same command. 
- Since pytest 9.0 is introduced, one of test fixtures is deprecated and caused an error
- This uncovered one [issue](https://xanaduhq.slack.com/archives/C0271MF2M50/p1770241318650249) with PennyLane's queueing of matrix decomposition in a test
- This uncovered another [issue](https://xanaduhq.slack.com/archives/C0271MF2M50/p1770304537657249) with PennyLane's handling of wire_order in Composite Op

**Description of the Change:**
1. We introduce a temporary patch (which needs to be removed in the next release cycle) to install test dependencies with `pip install -r requirements-tests.txt` (the old way) for stable CI runs.

2. We updated the fixture to be compliant with pytest 9.0.For stable test, this is not reflected, so we pull the older version of pytest, which will also be removed in the next release cycle.

3. We apply the same fix [applied before ](https://github.com/PennyLaneAI/pennylane-lightning/pull/1292) to an offending test in the mpitests

4. We update the argument type of `wire_order` in a test

**Benefits:**
[stable/stable](https://github.com/PennyLaneAI/pennylane-lightning/actions/runs/21721347342) and [latest/latest](https://github.com/PennyLaneAI/pennylane-lightning/actions/runs/21721343991) CIs both pass again.

**Possible Drawbacks:**

**Related GitHub Issues:**



[sc-110620]