### PR TITLE
Clean up preprocess and pass correct gate set

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -50,12 +50,16 @@
 - Updated `pyproject.toml` with project dependencies to replace the requirements files. Updated workflows to use installations from `pyproject.toml`.
   [(1334)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1334)
 
+- Cleaned up the preprocess transforms of the lightning devices, updating the calls to `decompose` with the correct gate set.
+  [(#1341)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1341)
+
 <h3>Contributors ✍️</h3>
 
 This release contains contributions from (in alphabetical order):
 
 Runor Agbaire,
 Ali Asadi,
+Astral Cai,
 Ashish Kanwar Singh,
 Jeffrey Kam,
 Joseph Lee,

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -32,6 +32,9 @@
 
 <h3>Internal changes ⚙️</h3>
 
+- Cleaned up the preprocess transforms of the lightning devices, updating the calls to `decompose` with the correct gate set.
+  [(#1341)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1341)
+
 - Remove MPICH checks from CI pipelines for Lightning devices with MPI distributed support.
   [(#1342)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1342)
 
@@ -55,9 +58,6 @@
 
 - Updated `pyproject.toml` with project dependencies to replace the requirements files. Updated workflows to use installations from `pyproject.toml`.
   [(1334)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1334)
-
-- Cleaned up the preprocess transforms of the lightning devices, updating the calls to `decompose` with the correct gate set.
-  [(#1341)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1341)
 
 <h3>Contributors ✍️</h3>
 

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.45.0-dev15"
+__version__ = "0.45.0-dev16"

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.45.0-dev17"
+__version__ = "0.45.0-dev18"

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.45.0-dev14"
+__version__ = "0.45.0-dev15"

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.45.0-dev16"
+__version__ = "0.45.0-dev17"

--- a/pennylane_lightning/lightning_base/lightning_base.py
+++ b/pennylane_lightning/lightning_base/lightning_base.py
@@ -879,7 +879,7 @@ def adjoint_transforms(device: LightningBase, allow_mcms: bool = False) -> qml.C
 
 
 def supports_adjoint(device, circuit) -> bool:
-    """Returns True iff the device supports adjoint differentiation of the given circuit."""
+    """Returns True if the device supports adjoint differentiation of the given circuit."""
 
     if circuit is None:
         return True

--- a/pennylane_lightning/lightning_base/lightning_base.py
+++ b/pennylane_lightning/lightning_base/lightning_base.py
@@ -846,8 +846,6 @@ def _adjoint_measurement(mp: MeasurementProcess) -> bool:
 
 def adjoint_observables(obs: Operator, capabilities: DeviceCapabilities) -> bool:
     """Returns True for observables supported in the adjoint differentiation method."""
-    if isinstance(obs, qml.Projector):
-        return False
     if isinstance(obs, qml.ops.SProd):
         return adjoint_observables(obs.base, capabilities)
     if isinstance(obs, (qml.ops.Sum, qml.ops.Prod)):

--- a/pennylane_lightning/lightning_gpu/lightning_gpu.py
+++ b/pennylane_lightning/lightning_gpu/lightning_gpu.py
@@ -19,9 +19,9 @@ interfaces with the NVIDIA cuQuantum cuStateVec simulator library for GPU-enable
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from ctypes.util import find_library
 from dataclasses import replace
-from functools import partial
 from importlib import util as imp_util
 from pathlib import Path
 from typing import List, Optional, Union
@@ -31,29 +31,28 @@ import numpy as np
 import pennylane as qml
 from numpy.random import BitGenerator, Generator, SeedSequence
 from numpy.typing import ArrayLike
+from pennylane.decomposition.gate_set import GateSet
 from pennylane.devices import ExecutionConfig
 from pennylane.devices.capabilities import OperatorProperties
 from pennylane.devices.modifiers import simulator_tracking, single_tape_support
 from pennylane.devices.preprocess import (
     decompose,
     device_resolve_dynamic_wires,
-    no_sampling,
-    validate_adjoint_trainable_params,
     validate_device_wires,
     validate_measurements,
     validate_observables,
 )
-from pennylane.exceptions import DecompositionUndefinedError, DeviceError
-from pennylane.measurements import MidMeasureMP
+from pennylane.exceptions import DeviceError
 from pennylane.operation import Operator
-from pennylane.ops import Conditional, PauliRot, Prod, SProd, Sum
 from pennylane.transforms import defer_measurements, dynamic_one_shot
 
 from pennylane_lightning.lightning_base.lightning_base import (
     LightningBase,
     QuantumTape_or_Batch,
     Result_or_ResultBatch,
+    adjoint_transforms,
     resolve_mcm_method,
+    supports_adjoint,
 )
 
 try:
@@ -90,96 +89,13 @@ _to_matrix_ops = {
 }
 
 
-def stopping_condition(op: Operator, allow_mcms: bool = True) -> bool:
-    """A function that determines whether or not an operation is supported by ``lightning.gpu``."""
-    if isinstance(op, MidMeasureMP):
-        # Conditional and MidMeasureMP should not be decomposed
-        return allow_mcms
+def make_stopping_condition(gate_set: GateSet) -> Callable[[Operator], bool]:
+    """Turn a gate set into a stopping condition."""
 
-    return _supports_operation(op.name)
+    def _stopping_condition(op: Operator):
+        return op in gate_set
 
-
-# need to create these once so we can compare in tests
-allow_mcms_stopping_condition = partial(stopping_condition, allow_mcms=True)
-no_mcms_stopping_condition = partial(stopping_condition, allow_mcms=False)
-
-
-def accepted_observables(obs: Operator) -> bool:
-    """A function that determines whether or not an observable is supported by ``lightning.gpu``."""
-    return _supports_observable(obs.name)
-
-
-def adjoint_observables(obs: Operator) -> bool:
-    """A function that determines whether or not an observable is supported by ``lightning.gpu``
-    when using the adjoint differentiation method."""
-    if isinstance(obs, qml.Projector):
-        return False
-
-    if isinstance(obs, SProd):
-        return adjoint_observables(obs.base)
-
-    if isinstance(obs, (Sum, Prod)):
-        return all(adjoint_observables(o) for o in obs)
-
-    return _supports_observable(obs.name)
-
-
-def adjoint_measurements(mp: qml.measurements.MeasurementProcess) -> bool:
-    """Specifies whether or not an observable is compatible with adjoint differentiation on DefaultQubit."""
-    return isinstance(mp, qml.measurements.ExpectationMP)
-
-
-def _supports_adjoint(circuit, device_wires=None):
-    if circuit is None:
-        return True
-
-    prog = qml.CompilePipeline()
-    _add_adjoint_transforms(prog, device_wires=device_wires)
-
-    try:
-        prog((circuit,))
-    except (DecompositionUndefinedError, DeviceError, AttributeError):
-        return False
-    return True
-
-
-def _adjoint_ops(op: qml.operation.Operator) -> bool:
-    """Specify whether or not an Operator is supported by adjoint differentiation."""
-
-    return not isinstance(op, (Conditional, MidMeasureMP, PauliRot)) and (
-        not any(qml.math.requires_grad(d) for d in op.data)
-        or (op.num_params == 1 and op.has_generator)
-    )
-
-
-def _add_adjoint_transforms(pipeline: qml.CompilePipeline, device_wires=None) -> None:
-    """Private helper function for ``preprocess`` that adds the transforms specific
-    for adjoint differentiation.
-
-    Args:
-        pipeline (qml.CompilePipeline): where we will add the adjoint differentiation transforms
-
-    Side Effects:
-        Adds transforms to the input program.
-
-    """
-
-    name = "adjoint + lightning.gpu"
-    pipeline.add_transform(no_sampling, name=name)
-    pipeline.add_transform(qml.transforms.broadcast_expand)
-    pipeline.add_transform(
-        decompose,
-        stopping_condition=_adjoint_ops,
-        name=name,
-        skip_initial_state_prep=False,
-        device_wires=device_wires,
-        target_gates=LightningGPU.capabilities.gate_set(differentiable=True),
-    )
-    pipeline.add_transform(validate_observables, accepted_observables, name=name)
-    pipeline.add_transform(
-        validate_measurements, analytic_measurements=adjoint_measurements, name=name
-    )
-    pipeline.add_transform(validate_adjoint_trainable_params)
+    return _stopping_condition
 
 
 # LightningGPU specific methods
@@ -376,28 +292,35 @@ class LightningGPU(LightningBase):
         """
         if execution_config is None:
             execution_config = ExecutionConfig()
-        exec_config = execution_config
 
+        exec_config = execution_config
         pipeline = qml.CompilePipeline()
+
+        gate_set = self.capabilities.gate_set()
+        allow_mcms = False
+        if exec_config.mcm_config.mcm_method != "deferred":
+            gate_set |= {"MidMeasureMP"}
+            allow_mcms = True
+        _stopping_condition = make_stopping_condition(gate_set)
 
         if qml.capture.enabled():
             if exec_config.mcm_config.mcm_method == "deferred":
                 pipeline.add_transform(qml.defer_measurements, num_wires=len(self.wires))
-            # Using stopping_condition_shots because we don't want to decompose Conditionals or MCMs
             pipeline.add_transform(
                 qml.transforms.decompose,
-                gate_set=self.capabilities.gate_set(),
-                stopping_condition=no_mcms_stopping_condition,
+                gate_set=gate_set,
+                stopping_condition=_stopping_condition,
             )
             return pipeline
 
         pipeline.add_transform(validate_measurements, name=self.name)
-        pipeline.add_transform(validate_observables, accepted_observables, name=self.name)
+        pipeline.add_transform(
+            validate_observables,
+            self.capabilities.supports_observable,
+            name=self.name,
+        )
         if exec_config.mcm_config.mcm_method == "deferred":
             pipeline.add_transform(defer_measurements, allow_postselect=False)
-            _stopping_condition = no_mcms_stopping_condition
-        else:
-            _stopping_condition = allow_mcms_stopping_condition
 
         pipeline.add_transform(
             decompose,
@@ -405,7 +328,7 @@ class LightningGPU(LightningBase):
             skip_initial_state_prep=True,
             name=self.name,
             device_wires=self.wires,
-            target_gates=self.capabilities.gate_set(),
+            target_gates=gate_set,
         )
         _allow_resets = exec_config.mcm_config.mcm_method != "deferred"
         pipeline.add_transform(
@@ -419,7 +342,8 @@ class LightningGPU(LightningBase):
         pipeline.add_transform(qml.transforms.broadcast_expand)
 
         if exec_config.gradient_method == "adjoint":
-            _add_adjoint_transforms(pipeline, device_wires=self.wires)
+            adjoint_transforms(self, allow_mcms)
+
         return pipeline
 
     # pylint: disable=unused-argument
@@ -476,9 +400,7 @@ class LightningGPU(LightningBase):
             return True
 
         if execution_config and execution_config.gradient_method in {"adjoint", "best"}:
-            if circuit is None:
-                return True
-            return _supports_adjoint(circuit=circuit, device_wires=self.wires)
+            return supports_adjoint(self, circuit)
 
         return False
 
@@ -489,7 +411,3 @@ class LightningGPU(LightningBase):
         """
 
         return LightningBase.get_c_interface_impl("LightningGPUSimulator", "lightning_gpu")
-
-
-_supports_operation = LightningGPU.capabilities.supports_operation
-_supports_observable = LightningGPU.capabilities.supports_observable

--- a/pennylane_lightning/lightning_gpu/lightning_gpu.py
+++ b/pennylane_lightning/lightning_gpu/lightning_gpu.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 from ctypes.util import find_library
 from dataclasses import replace
+from functools import partial
 from importlib import util as imp_util
 from pathlib import Path
 from typing import List, Optional, Union
@@ -49,6 +50,7 @@ from pennylane_lightning.lightning_base.lightning_base import (
     LightningBase,
     QuantumTape_or_Batch,
     Result_or_ResultBatch,
+    adjoint_transforms,
     resolve_mcm_method,
     supports_adjoint,
 )

--- a/pennylane_lightning/lightning_gpu/lightning_gpu.py
+++ b/pennylane_lightning/lightning_gpu/lightning_gpu.py
@@ -92,6 +92,9 @@ _to_matrix_ops = {
 def make_stopping_condition(gate_set: GateSet) -> Callable[[Operator], bool]:
     """Turn a gate set into a stopping condition."""
 
+    if not isinstance(gate_set, GateSet):
+        gate_set = GateSet(gate_set)
+
     def _stopping_condition(op: Operator):
         return op in gate_set
 

--- a/pennylane_lightning/lightning_gpu/lightning_gpu.py
+++ b/pennylane_lightning/lightning_gpu/lightning_gpu.py
@@ -342,7 +342,7 @@ class LightningGPU(LightningBase):
         pipeline.add_transform(qml.transforms.broadcast_expand)
 
         if exec_config.gradient_method == "adjoint":
-            adjoint_transforms(self, allow_mcms)
+            pipeline += adjoint_transforms(self, allow_mcms)
 
         return pipeline
 

--- a/pennylane_lightning/lightning_kokkos/lightning_kokkos.py
+++ b/pennylane_lightning/lightning_kokkos/lightning_kokkos.py
@@ -39,16 +39,17 @@ from pennylane.devices.preprocess import (
     validate_observables,
 )
 from pennylane.exceptions import DecompositionUndefinedError, DeviceError
-from pennylane.measurements import MidMeasureMP
 from pennylane.operation import Operator
-from pennylane.ops import Conditional, PauliRot, Prod, SProd, Sum
+from pennylane.ops import Conditional, MidMeasure, PauliRot, Prod, SProd, Sum
 from pennylane.transforms import defer_measurements, dynamic_one_shot
 
 from pennylane_lightning.lightning_base.lightning_base import (
     LightningBase,
     QuantumTape_or_Batch,
     Result_or_ResultBatch,
+    adjoint_transforms,
     resolve_mcm_method,
+    supports_adjoint,
 )
 
 try:
@@ -79,12 +80,13 @@ _to_matrix_ops = {
 
 def stopping_condition(op: Operator, allow_mcms: bool = True) -> bool:
     """A function that determines whether or not an operation is supported by ``lightning.kokkos``."""
+
     if isinstance(op, qml.PauliRot):
         word = op._hyperparameters["pauli_word"]  # pylint: disable=protected-access
         # decomposes to IsingXX, etc. for n <= 2
         return reduce(lambda x, y: x + (y != "I"), word, 0) > 2
 
-    if isinstance(op, MidMeasureMP):
+    if isinstance(op, MidMeasure):
         return allow_mcms
 
     return _supports_operation(op.name)
@@ -93,84 +95,6 @@ def stopping_condition(op: Operator, allow_mcms: bool = True) -> bool:
 # need to create these once so we can compare in tests
 allow_mcms_stopping_condition = partial(stopping_condition, allow_mcms=True)
 no_mcms_stopping_condition = partial(stopping_condition, allow_mcms=False)
-
-
-def accepted_observables(obs: Operator) -> bool:
-    """A function that determines whether or not an observable is supported by ``lightning.kokkos``."""
-    return _supports_observable(obs.name)
-
-
-def adjoint_observables(obs: Operator) -> bool:
-    """A function that determines whether or not an observable is supported by ``lightning.kokkos``
-    when using the adjoint differentiation method."""
-    if isinstance(obs, qml.Projector):
-        return False
-
-    if isinstance(obs, SProd):
-        return adjoint_observables(obs.base)
-
-    if isinstance(obs, (Sum, Prod)):
-        return all(adjoint_observables(o) for o in obs)
-
-    return _supports_observable(obs.name)
-
-
-def adjoint_measurements(mp: qml.measurements.MeasurementProcess) -> bool:
-    """Specifies whether or not an observable is compatible with adjoint differentiation on DefaultQubit."""
-    return isinstance(mp, qml.measurements.ExpectationMP)
-
-
-def _supports_adjoint(circuit, device_wires=None):
-    if circuit is None:
-        return True
-
-    prog = qml.CompilePipeline()
-    _add_adjoint_transforms(prog, device_wires=device_wires)
-
-    try:
-        prog((circuit,))
-    except (DecompositionUndefinedError, DeviceError, AttributeError):
-        return False
-    return True
-
-
-def _adjoint_ops(op: qml.operation.Operator) -> bool:
-    """Specify whether or not an Operator is supported by adjoint differentiation."""
-
-    return not isinstance(op, (Conditional, MidMeasureMP, PauliRot)) and (
-        not any(qml.math.requires_grad(d) for d in op.data)
-        or (op.num_params == 1 and op.has_generator)
-    )
-
-
-def _add_adjoint_transforms(pipeline: qml.CompilePipeline, device_wires=None) -> None:
-    """Private helper function for ``preprocess`` that adds the transforms specific
-    for adjoint differentiation.
-
-    Args:
-        pipeline (qml.CompilePipeline): where we will add the adjoint differentiation transforms
-
-    Side Effects:
-        Adds transforms to the input program.
-
-    """
-
-    name = "adjoint + lightning.kokkos"
-    pipeline.add_transform(no_sampling, name=name)
-    pipeline.add_transform(qml.transforms.broadcast_expand)
-    pipeline.add_transform(
-        decompose,
-        stopping_condition=_adjoint_ops,
-        name=name,
-        skip_initial_state_prep=False,
-        device_wires=device_wires,
-        target_gates=LightningKokkos.capabilities.gate_set(differentiable=True),
-    )
-    pipeline.add_transform(validate_observables, accepted_observables, name=name)
-    pipeline.add_transform(
-        validate_measurements, analytic_measurements=adjoint_measurements, name=name
-    )
-    pipeline.add_transform(validate_adjoint_trainable_params)
 
 
 @simulator_tracking
@@ -340,26 +264,36 @@ class LightningKokkos(LightningBase):
         """
         if execution_config is None:
             execution_config = ExecutionConfig()
+
         exec_config = execution_config
         pipeline = qml.CompilePipeline()
+
+        gate_set = self.capabilities.gate_set()
+        allow_mcms = False
+        _stopping_condition = no_mcms_stopping_condition
+        if exec_config.mcm_config.mcm_method != "deferred":
+            gate_set |= {"MidMeasureMP"}
+            allow_mcms = True
+            _stopping_condition = allow_mcms_stopping_condition
 
         if qml.capture.enabled():
             if exec_config.mcm_config.mcm_method == "deferred":
                 pipeline.add_transform(qml.defer_measurements, num_wires=len(self.wires))
             pipeline.add_transform(
                 qml.transforms.decompose,
-                gate_set=self.capabilities.gate_set(),
-                stopping_condition=no_mcms_stopping_condition,
+                gate_set=gate_set,
+                stopping_condition=_stopping_condition,
             )
             return pipeline
 
         pipeline.add_transform(validate_measurements, name=self.name)
-        pipeline.add_transform(validate_observables, accepted_observables, name=self.name)
+        pipeline.add_transform(
+            validate_observables,
+            self.capabilities.supports_observable,
+            name=self.name,
+        )
         if exec_config.mcm_config.mcm_method == "deferred":
             pipeline.add_transform(defer_measurements, allow_postselect=False)
-            _stopping_condition = no_mcms_stopping_condition
-        else:
-            _stopping_condition = allow_mcms_stopping_condition
 
         pipeline.add_transform(
             decompose,
@@ -367,7 +301,7 @@ class LightningKokkos(LightningBase):
             skip_initial_state_prep=True,
             name=self.name,
             device_wires=self.wires,
-            target_gates=self.capabilities.gate_set(),
+            target_gates=gate_set,
         )
 
         _allow_resets = exec_config.mcm_config.mcm_method != "deferred"
@@ -383,7 +317,8 @@ class LightningKokkos(LightningBase):
         pipeline.add_transform(qml.transforms.broadcast_expand)
 
         if exec_config.gradient_method == "adjoint":
-            _add_adjoint_transforms(pipeline, device_wires=self.wires)
+            pipeline += adjoint_transforms(self, allow_mcms)
+
         return pipeline
 
     # pylint: disable=unused-argument
@@ -439,9 +374,7 @@ class LightningKokkos(LightningBase):
             return True
 
         if execution_config and execution_config.gradient_method in {"adjoint", "best"}:
-            if circuit is None:
-                return True
-            return _supports_adjoint(circuit=circuit, device_wires=self.wires)
+            return supports_adjoint(self, circuit)
 
         return False
 
@@ -455,4 +388,3 @@ class LightningKokkos(LightningBase):
 
 
 _supports_operation = LightningKokkos.capabilities.supports_operation
-_supports_observable = LightningKokkos.capabilities.supports_observable

--- a/pennylane_lightning/lightning_kokkos/lightning_kokkos.py
+++ b/pennylane_lightning/lightning_kokkos/lightning_kokkos.py
@@ -32,15 +32,13 @@ from pennylane.devices.modifiers import simulator_tracking, single_tape_support
 from pennylane.devices.preprocess import (
     decompose,
     device_resolve_dynamic_wires,
-    no_sampling,
-    validate_adjoint_trainable_params,
     validate_device_wires,
     validate_measurements,
     validate_observables,
 )
-from pennylane.exceptions import DecompositionUndefinedError, DeviceError
+from pennylane.exceptions import DeviceError
 from pennylane.operation import Operator
-from pennylane.ops import Conditional, MidMeasure, PauliRot, Prod, SProd, Sum
+from pennylane.ops import MidMeasure
 from pennylane.transforms import defer_measurements, dynamic_one_shot
 
 from pennylane_lightning.lightning_base.lightning_base import (

--- a/pennylane_lightning/lightning_qubit/lightning_qubit.py
+++ b/pennylane_lightning/lightning_qubit/lightning_qubit.py
@@ -32,23 +32,23 @@ from pennylane.devices.modifiers import simulator_tracking, single_tape_support
 from pennylane.devices.preprocess import (
     decompose,
     device_resolve_dynamic_wires,
-    no_sampling,
-    validate_adjoint_trainable_params,
     validate_device_wires,
     validate_measurements,
     validate_observables,
 )
-from pennylane.exceptions import DecompositionUndefinedError, DeviceError
-from pennylane.measurements import MidMeasureMP, ShotsLike
+from pennylane.exceptions import DeviceError
+from pennylane.measurements import ShotsLike
 from pennylane.operation import Operator
-from pennylane.ops import Conditional, PauliRot, Prod, SProd, Sum
+from pennylane.ops import MidMeasure
 from pennylane.transforms import defer_measurements, dynamic_one_shot
 
 from pennylane_lightning.lightning_base.lightning_base import (
     LightningBase,
     QuantumTape_or_Batch,
     Result_or_ResultBatch,
+    adjoint_transforms,
     resolve_mcm_method,
+    supports_adjoint,
 )
 
 try:
@@ -87,7 +87,7 @@ def stopping_condition(op: Operator, allow_mcms=True) -> bool:
         word = op._hyperparameters["pauli_word"]  # pylint: disable=protected-access
         # decomposes to IsingXX, etc. for n <= 2
         return reduce(lambda x, y: x + (y != "I"), word, 0) > 2
-    if isinstance(op, MidMeasureMP):
+    if isinstance(op, MidMeasure):
         return allow_mcms
     return _supports_operation(op.name)
 
@@ -95,84 +95,6 @@ def stopping_condition(op: Operator, allow_mcms=True) -> bool:
 # need to create these once so we can compare in tests
 allow_mcms_stopping_condition = partial(stopping_condition, allow_mcms=True)
 no_mcms_stopping_condition = partial(stopping_condition, allow_mcms=False)
-
-
-def accepted_observables(obs: Operator) -> bool:
-    """A function that determines whether or not an observable is supported by ``lightning.qubit``."""
-    return _supports_observable(obs.name)
-
-
-def adjoint_observables(obs: Operator) -> bool:
-    """A function that determines whether or not an observable is supported by ``lightning.qubit``
-    when using the adjoint differentiation method."""
-    if isinstance(obs, qml.Projector):
-        return False
-
-    if isinstance(obs, SProd):
-        return adjoint_observables(obs.base)
-
-    if isinstance(obs, (Sum, Prod)):
-        return all(adjoint_observables(o) for o in obs)
-
-    return _supports_observable(obs.name)
-
-
-def adjoint_measurements(mp: qml.measurements.MeasurementProcess) -> bool:
-    """Specifies whether or not an observable is compatible with adjoint differentiation on DefaultQubit."""
-    return isinstance(mp, qml.measurements.ExpectationMP)
-
-
-def _supports_adjoint(circuit, device_wires=None):
-    if circuit is None:
-        return True
-
-    prog = qml.CompilePipeline()
-    _add_adjoint_transforms(prog, device_wires=device_wires)
-
-    try:
-        prog((circuit,))
-    except (DecompositionUndefinedError, DeviceError, AttributeError):
-        return False
-    return True
-
-
-def _adjoint_ops(op: qml.operation.Operator) -> bool:
-    """Specify whether or not an Operator is supported by adjoint differentiation."""
-
-    return not isinstance(op, (Conditional, MidMeasureMP, PauliRot)) and (
-        not any(qml.math.requires_grad(d) for d in op.data)
-        or (op.num_params == 1 and op.has_generator)
-    )
-
-
-def _add_adjoint_transforms(pipeline: qml.CompilePipeline, device_wires=None) -> None:
-    """Private helper function for ``preprocess`` that adds the transforms specific
-    for adjoint differentiation.
-
-    Args:
-        pipeline (qml.CompilePipeline): where we will add the adjoint differentiation transforms
-
-    Side Effects:
-        Adds transforms to the input program.
-
-    """
-
-    name = "adjoint + lightning.qubit"
-    pipeline.add_transform(no_sampling, name=name)
-    pipeline.add_transform(qml.transforms.broadcast_expand)
-    pipeline.add_transform(
-        decompose,
-        stopping_condition=_adjoint_ops,
-        name=name,
-        skip_initial_state_prep=False,
-        device_wires=device_wires,
-        target_gates=LightningQubit.capabilities.gate_set(differentiable=True),
-    )
-    pipeline.add_transform(validate_observables, accepted_observables, name=name)
-    pipeline.add_transform(
-        validate_measurements, analytic_measurements=adjoint_measurements, name=name
-    )
-    pipeline.add_transform(validate_adjoint_trainable_params)
 
 
 @simulator_tracking
@@ -368,24 +290,32 @@ class LightningQubit(LightningBase):
         exec_config = execution_config
         pipeline = qml.CompilePipeline()
 
+        gate_set = self.capabilities.gate_set()
+        allow_mcms = False
+        _stopping_condition = no_mcms_stopping_condition
+        if exec_config.mcm_config.mcm_method != "deferred":
+            gate_set |= {"MidMeasureMP"}
+            allow_mcms = True
+            _stopping_condition = allow_mcms_stopping_condition
+
         if qml.capture.enabled():
             if exec_config.mcm_config.mcm_method == "deferred":
                 pipeline.add_transform(qml.defer_measurements, num_wires=len(self.wires))
-            # Using stopping_condition_shots because we don't want to decompose Conditionals or MCMs
             pipeline.add_transform(
                 qml.transforms.decompose,
-                gate_set=self.capabilities.gate_set(),
-                stopping_condition=no_mcms_stopping_condition,
+                gate_set=gate_set,
+                stopping_condition=_stopping_condition,
             )
             return pipeline
 
         pipeline.add_transform(validate_measurements, name=self.name)
-        pipeline.add_transform(validate_observables, accepted_observables, name=self.name)
+        pipeline.add_transform(
+            validate_observables,
+            self.capabilities.supports_observable,
+            name=self.name,
+        )
         if exec_config.mcm_config.mcm_method == "deferred":
             pipeline.add_transform(defer_measurements, allow_postselect=False)
-            _stopping_condition = no_mcms_stopping_condition
-        else:
-            _stopping_condition = allow_mcms_stopping_condition
 
         pipeline.add_transform(
             decompose,
@@ -393,7 +323,7 @@ class LightningQubit(LightningBase):
             skip_initial_state_prep=True,
             name=self.name,
             device_wires=self.wires,
-            target_gates=self.capabilities.gate_set(),  # let's temporarily read the toml file to get the gate set
+            target_gates=gate_set,
         )
         _allow_resets = exec_config.mcm_config.mcm_method != "deferred"
         pipeline.add_transform(
@@ -407,7 +337,8 @@ class LightningQubit(LightningBase):
         pipeline.add_transform(qml.transforms.broadcast_expand)
 
         if exec_config.gradient_method == "adjoint":
-            _add_adjoint_transforms(pipeline, device_wires=self.wires)
+            pipeline += adjoint_transforms(self, allow_mcms)
+
         return pipeline
 
     # pylint: disable=unused-argument
@@ -474,9 +405,7 @@ class LightningQubit(LightningBase):
             return True
 
         if execution_config and execution_config.gradient_method in {"adjoint", "best"}:
-            if circuit is None:
-                return True
-            return _supports_adjoint(circuit=circuit, device_wires=self.wires)
+            return supports_adjoint(self, circuit)
 
         return False
 
@@ -528,4 +457,3 @@ def _validate_mcmc_options(
 
 
 _supports_operation = LightningQubit.capabilities.supports_operation
-_supports_observable = LightningQubit.capabilities.supports_observable

--- a/tests/lightning_base/test_device.py
+++ b/tests/lightning_base/test_device.py
@@ -226,8 +226,6 @@ class TestHelpers:
         actual_program = adjoint_transforms(dev, allow_mcms)
         for transform, expected_transform in zip(actual_program, expected_program, strict=True):
             assert transform.tape_transform == expected_transform.tape_transform
-            assert transform.args == expected_transform.args
-            assert transform.kwargs == expected_transform.kwargs
 
     @pytest.mark.skipif(
         device_name == "lightning.tensor",
@@ -908,8 +906,6 @@ class TestExecution:
         actual_program = device.preprocess_transforms(config)
         for transform, expected_transform in zip(actual_program, expected_program, strict=True):
             assert transform.tape_transform == expected_transform.tape_transform
-            assert transform.args == expected_transform.args
-            assert transform.kwargs == expected_transform.kwargs
 
     @pytest.mark.usefixtures("enable_and_disable_graph_decomp")
     @pytest.mark.parametrize(

--- a/tests/lightning_base/test_device.py
+++ b/tests/lightning_base/test_device.py
@@ -164,11 +164,11 @@ class TestHelpers:
     @pytest.mark.parametrize(
         "obs, expected",
         [
-            (qml.prod(qml.Projector([0], 0), qml.PauliZ(1)), False),
-            (qml.prod(qml.Projector([0], 0), qml.PauliZ(1)), False),
-            (qml.s_prod(1.5, qml.Projector([0], 0)), False),
-            (qml.sum(qml.Projector([0], 0), qml.Hadamard(1)), False),
-            (qml.sum(qml.prod(qml.Projector([0], 0), qml.Y(1)), qml.PauliX(1)), False),
+            (qml.prod(qml.Projector([0], 0), qml.PauliZ(1)), True),
+            (qml.prod(qml.Projector([0], 0), qml.PauliZ(1)), True),
+            (qml.s_prod(1.5, qml.Projector([0], 0)), True),
+            (qml.sum(qml.Projector([0], 0), qml.Hadamard(1)), True),
+            (qml.sum(qml.prod(qml.Projector([0], 0), qml.Y(1)), qml.PauliX(1)), True),
             (qml.prod(qml.Y(0), qml.Z(1)), True),
             (qml.prod(qml.Y(0), qml.PauliZ(1)), True),
             (qml.s_prod(1.5, qml.Y(1)), True),

--- a/tests/lightning_base/test_device.py
+++ b/tests/lightning_base/test_device.py
@@ -196,11 +196,10 @@ class TestHelpers:
         if device_name == "lightning.amdgpu":
             name = "adjoint + lightning.kokkos"
 
-        capabilities = LightningDevice.capabilities
-        gate_set = capabilities.gate_set(differentiable=True)
+        dev = LightningDevice(wires=2)
+        gate_set = dev.capabilities.gate_set(differentiable=True)
         if allow_mcms:
             gate_set |= {"MidMeasureMP"}
-        dev = LightningDevice(wires=2)
 
         expected_program.add_transform(no_sampling, name=name)
         expected_program.add_transform(qml.transforms.broadcast_expand)
@@ -209,12 +208,12 @@ class TestHelpers:
             stopping_condition=_adjoint_stopping_condition,
             name=name,
             skip_initial_state_prep=False,
-            device_wires=2,
+            device_wires=dev.wires,
             target_gates=gate_set,
         )
         expected_program.add_transform(
             validate_observables,
-            partial(adjoint_observables, capabilities=capabilities),
+            partial(adjoint_observables, capabilities=dev.capabilities),
             name=name,
         )
         expected_program.add_transform(

--- a/tests/lightning_base/test_device.py
+++ b/tests/lightning_base/test_device.py
@@ -212,7 +212,11 @@ class TestHelpers:
             device_wires=2,
             target_gates=gate_set,
         )
-        expected_program.add_transform(validate_observables, accepted_observables, name=name)
+        expected_program.add_transform(
+            validate_observables,
+            partial(adjoint_observables, capabilities=capabilities),
+            name=name,
+        )
         expected_program.add_transform(
             validate_measurements,
             analytic_measurements=_adjoint_measurement,

--- a/tests/lightning_base/test_device.py
+++ b/tests/lightning_base/test_device.py
@@ -33,7 +33,6 @@ from conftest import (
     LightningStateVector,
     device_name,
 )
-from pennylane.decomposition.gate_set import GateSet
 from pennylane.devices import DefaultQubit, ExecutionConfig, MCMConfig
 from pennylane.devices.preprocess import (
     decompose,
@@ -75,13 +74,13 @@ elif device_name in ("lightning.kokkos", "lightning.amdgpu"):
     accepted_observables = LightningDevice.capabilities.supports_observable
 
 elif device_name == "lightning.gpu":
-    from pennylane_lightning.lightning_gpu.lightning_gpu import make_stopping_condition
+    from pennylane_lightning.lightning_gpu.lightning_gpu import (
+        allow_mcms_stopping_condition,
+        no_mcms_stopping_condition,
+        stopping_condition,
+    )
 
     accepted_observables = LightningDevice.capabilities.supports_observable
-    _gate_set = LightningDevice.capabilities.gate_set()
-    stopping_condition = make_stopping_condition(GateSet(_gate_set))
-    no_mcms_stopping_condition = stopping_condition
-    allow_mcms_stopping_condition = make_stopping_condition(GateSet(_gate_set | {"MidMeasureMP"}))
 
 elif device_name == "lightning.tensor":
     from pennylane_lightning.lightning_tensor.lightning_tensor import (

--- a/tests/lightning_base/test_device.py
+++ b/tests/lightning_base/test_device.py
@@ -213,7 +213,7 @@ class TestHelpers:
         )
         expected_program.add_transform(
             validate_observables,
-            partial(adjoint_observables, capabilities=dev.capabilities),
+            stopping_condition=partial(adjoint_observables, capabilities=dev.capabilities),
             name=name,
         )
         expected_program.add_transform(
@@ -891,7 +891,7 @@ class TestExecution:
             )
             expected_program.add_transform(
                 validate_observables,
-                partial(adjoint_observables, capabilities=device.capabilities),
+                stopping_condition=partial(adjoint_observables, capabilities=device.capabilities),
                 name=name,
             )
             expected_program.add_transform(

--- a/tests/lightning_base/test_device.py
+++ b/tests/lightning_base/test_device.py
@@ -224,7 +224,10 @@ class TestHelpers:
         expected_program.add_transform(validate_adjoint_trainable_params)
 
         actual_program = adjoint_transforms(dev, allow_mcms)
-        assert actual_program == expected_program
+        for transform, expected_transform in zip(actual_program, expected_program, strict=True):
+            assert transform.tape_transform == expected_transform.tape_transform
+            assert transform.args == expected_transform.args
+            assert transform.kwargs == expected_transform.kwargs
 
     @pytest.mark.skipif(
         device_name == "lightning.tensor",
@@ -903,7 +906,10 @@ class TestExecution:
             gradient_method=gradient_method, mcm_config=MCMConfig(mcm_method=mcm_method)
         )
         actual_program = device.preprocess_transforms(config)
-        assert actual_program == expected_program
+        for transform, expected_transform in zip(actual_program, expected_program, strict=True):
+            assert transform.tape_transform == expected_transform.tape_transform
+            assert transform.args == expected_transform.args
+            assert transform.kwargs == expected_transform.kwargs
 
     @pytest.mark.usefixtures("enable_and_disable_graph_decomp")
     @pytest.mark.parametrize(


### PR DESCRIPTION
**Context:**
- Update the preprocess transforms to pass the correct gate set to `decompose`.
- Clean up duplicate code in the preprocess transforms.

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-110772]