### PR TITLE
Remove MPICH checks from CI

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -33,7 +33,7 @@
 <h3>Internal changes ⚙️</h3>
 
 - Remove MPICH checks from CI pipelines for Lightning devices with MPI distributed support.
-  [(#)](https://github.com/PennyLaneAI/pennylane-lightning/pull/)
+  [(#1342)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1342)
 
 - Temporarily updated CI for stable versions to install from `requirements-tests.txt`, and fixed tests to work with pytest 9.0 and updated `queue_category` in PennyLane.
   [(#1340)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1340)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -32,6 +32,9 @@
 
 <h3>Internal changes ⚙️</h3>
 
+- Remove MPICH checks from CI pipelines for Lightning devices with MPI distributed support.
+  [(#)](https://github.com/PennyLaneAI/pennylane-lightning/pull/)
+
 - Temporarily updated CI for stable versions to install from `requirements-tests.txt`, and fixed tests to work with pytest 9.0 and updated `queue_category` in PennyLane.
   [(#1340)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1340)
 

--- a/.github/workflows/tests_lgpumpi_cpp.yml
+++ b/.github/workflows/tests_lgpumpi_cpp.yml
@@ -45,7 +45,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        mpilib: ["mpich", "openmpi"]
+        mpilib: ["openmpi"]
         cuda_version_maj: ["12"]
         cuda_version_min: ["4"]
     timeout-minutes: 60

--- a/.github/workflows/tests_lgpumpi_python.yml
+++ b/.github/workflows/tests_lgpumpi_python.yml
@@ -47,7 +47,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        mpilib: ["mpich", "openmpi"]
+        mpilib: ["openmpi"]
         cuda_version_maj: ["12"]
         cuda_version_min: ["2"]
     timeout-minutes: 30

--- a/.github/workflows/tests_lkmpi_cuda_cpp.yml
+++ b/.github/workflows/tests_lkmpi_cuda_cpp.yml
@@ -45,7 +45,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        mpilib: ["mpich", "openmpi"]
+        mpilib: ["openmpi"]
         kokkos_version: ["4.5.00"]
         exec_model: ["CUDA"]
         cuda_version_maj: ["12"]

--- a/.github/workflows/tests_lkmpi_cuda_python.yml
+++ b/.github/workflows/tests_lkmpi_cuda_python.yml
@@ -47,7 +47,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        mpilib: ["mpich", "openmpi"]
+        mpilib: ["openmpi"]
         kokkos_version: ["4.5.00"]
         exec_model: ["CUDA"]
         cuda_version_maj: ["12"]

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.45.0-dev15"
+__version__ = "0.45.0-dev16"


### PR DESCRIPTION
**Context:**
Remove MPICH checks from CIs for Lightning devices with MPI distributed support. We will continue testing these devices exclusively with OpenMPI to optimize CI runtime. OpenMPI remains a reliable source of truth for our validation on CIs, mostly because it offers robust support for the latest MPI standards, consistent behavior across our target hardware abstractions, and detailed error reporting that simplifies debugging during distributed execution.

[sc-111259]