### PR TITLE
Remove GCC-11 dependency for L-AMDGPU build

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -33,7 +33,7 @@
 <h3>Internal changes ⚙️</h3>
 
 - Remove dependency for GCC-11 when building `lightning.amdgpu`.
-  [(#XXXX)](https://github.com/PennyLaneAI/pennylane-lightning/pull/XXXX)
+  [(#1343)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1343)
 
 - Remove MPICH checks from CI pipelines for Lightning devices with MPI distributed support.
   [(#1342)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1342)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -32,6 +32,9 @@
 
 <h3>Internal changes ⚙️</h3>
 
+- Remove dependency for GCC-11 when building `lightning.amdgpu`.
+  [(#XXXX)](https://github.com/PennyLaneAI/pennylane-lightning/pull/XXXX)
+
 - Remove MPICH checks from CI pipelines for Lightning devices with MPI distributed support.
   [(#1342)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1342)
 

--- a/doc/lightning_amdgpu/installation.rst
+++ b/doc/lightning_amdgpu/installation.rst
@@ -33,7 +33,7 @@ Install Lightning-AMDGPU
 
     # Install Lightning-AMDGPU
     PL_BACKEND="lightning_amdgpu" python scripts/configure_pyproject_toml.py
-    export CMAKE_ARGS="-DCMAKE_CXX_COMPILER=hipcc -DKokkos_ENABLE_HIP=ON -DKokkos_ARCH_AMD_GFX942=ON"
+    export CMAKE_ARGS="-DCMAKE_CXX_COMPILER=hipcc -DKokkos_ENABLE_HIP=ON -DKokkos_ARCH_AMD_GFX942=ON -DCMAKE_PREFIX_PATH=/opt/rocm"
     python -m pip install . -vv
 
 

--- a/doc/lightning_amdgpu/installation.rst
+++ b/doc/lightning_amdgpu/installation.rst
@@ -33,7 +33,10 @@ Install Lightning-AMDGPU
 
     # Install Lightning-AMDGPU
     PL_BACKEND="lightning_amdgpu" python scripts/configure_pyproject_toml.py
-    export CMAKE_ARGS="-DCMAKE_CXX_COMPILER=hipcc -DKokkos_ENABLE_HIP=ON -DKokkos_ARCH_AMD_GFX942=ON -DCMAKE_PREFIX_PATH=/opt/rocm"
+    export CMAKE_ARGS="-DCMAKE_CXX_COMPILER=hipcc \
+                                           -DKokkos_ENABLE_HIP=ON \
+                                           -DKokkos_ARCH_AMD_GFX942=ON \
+                                           -DCMAKE_PREFIX_PATH=/opt/rocm"
     python -m pip install . -vv
 
 

--- a/doc/lightning_amdgpu/installation.rst
+++ b/doc/lightning_amdgpu/installation.rst
@@ -34,9 +34,9 @@ Install Lightning-AMDGPU
     # Install Lightning-AMDGPU
     PL_BACKEND="lightning_amdgpu" python scripts/configure_pyproject_toml.py
     export CMAKE_ARGS="-DCMAKE_CXX_COMPILER=hipcc \
-                                           -DKokkos_ENABLE_HIP=ON \
-                                           -DKokkos_ARCH_AMD_GFX942=ON \
-                                           -DCMAKE_PREFIX_PATH=/opt/rocm"
+                       -DKokkos_ENABLE_HIP=ON \
+                       -DKokkos_ARCH_AMD_GFX942=ON \
+                       -DCMAKE_PREFIX_PATH=/opt/rocm"
     python -m pip install . -vv
 
 

--- a/doc/lightning_amdgpu/installation.rst
+++ b/doc/lightning_amdgpu/installation.rst
@@ -6,62 +6,19 @@ Install Lightning-AMDGPU from source
 
 Lightning-AMDGPU is an instantiation of the Lighting-Kokkos device, specifically for AMD GPUs using the HIP backend. For building Lightning-Kokkos for targets other than AMD GPUs, please refer to the :doc:`/lightning_kokkos/installation` page.
 
-Install Kokkos (Recommended)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+The installation instruction here is specifically for AMD MI300 GPU (GFX942); for other architecture, please refer to the `Kokkos wiki <https://kokkos.org/kokkos-core-wiki/get-started/configuration-guide.html>`_ for the correct flag.
 
 .. note::
 
-    Lightning-Kokkos is tested with Kokkos version 4.5.00
-
-We recommend first installing Kokkos with your desired configuration by following the instructions in the Kokkos documentation at <https://kokkos.github.io/kokkos-core-wiki/building.html>.
-For example, the following will build Kokkos for AMD MI300 GPU:
-
-Download the `Kokkos code <https://github.com/kokkos/kokkos/releases>`_.
-
-.. code-block:: bash
-
-    # Replace x, y, and z by the correct version
-    wget https://github.com/kokkos/kokkos/archive/refs/tags/4.x.yz.tar.gz
-    tar -xvf 4.x.y.z.tar.gz
-    cd kokkos-4.x.y.z
-
-Build Kokkos for AMD MI300 GPU (``GFX942`` architecture), and append the install location to ``CMAKE_PREFIX_PATH``.
-
-.. code-block:: bash
-
-    # Replace <install-path> with the path to install Kokkos
-    # e.g. $HOME/kokkos-install/4.5.0/GFX942
-    export KOKKOS_INSTALL_PATH=<install-path>
-    mkdir -p ${KOKKOS_INSTALL_PATH}
-
-    cmake -S . -B build -G Ninja \
-        -DCMAKE_BUILD_TYPE=Release \
-        -DCMAKE_INSTALL_PREFIX=${KOKKOS_INSTALL_PATH} \
-        -DCMAKE_CXX_STANDARD=20 \
-        -DCMAKE_CXX_COMPILER=hipcc \
-        -DCMAKE_PREFIX_PATH="/opt/rocm" \
-        -DBUILD_SHARED_LIBS:BOOL=ON \
-        -DBUILD_TESTING:BOOL=OFF \
-        -DKokkos_ENABLE_SERIAL:BOOL=ON \
-        -DKokkos_ENABLE_HIP:BOOL=ON \
-        -DKokkos_ARCH_AMD_GFX942:BOOL=ON \
-        -DKokkos_ENABLE_COMPLEX_ALIGN:BOOL=OFF \
-        -DKokkos_ENABLE_EXAMPLES:BOOL=OFF \
-        -DKokkos_ENABLE_TESTS:BOOL=OFF \
-        -DKokkos_ENABLE_LIBDL:BOOL=OFF
-    cmake --build build && cmake --install build
-    export CMAKE_PREFIX_PATH=:"${KOKKOS_INSTALL_PATH}":/opt/rocm:$CMAKE_PREFIX_PATH
-
-
-.. note::
-
-    - Requires AMD compiler ``hipcc`` or ``amdclang`` from the ROCm software stack.
-    - ``-DCMAKE_PREFIX_PATH="/opt/rocm"`` enables CMake to properly discover the ``rocthrust`` library
-    - For information on choosing the correct architecture flag for your AMD GPU, please refer to the `Kokkos wiki <https://kokkos.org/kokkos-core-wiki/get-started/configuration-guide.html>`_.
+    Lightning-Kokkos and Lightning-AMDGPU is tested with Kokkos version 4.5.00
 
 
 Install Lightning-AMDGPU
 ^^^^^^^^^^^^^^^^^^^^^^^^
+.. note::
+
+    - An AMD compiler ``hipcc`` or ``amdclang`` from the ROCm software stack is required.
+    - ``-DCMAKE_PREFIX_PATH="/opt/rocm"`` enables CMake to properly discover the ``rocthrust`` library
 
 .. code-block:: bash
 
@@ -69,20 +26,16 @@ Install Lightning-AMDGPU
     cd pennylane-lightning
     python -m pip install --group base
     pip install git+https://github.com/PennyLaneAI/pennylane.git@master
-    
+
     # First Install Lightning-Qubit
     PL_BACKEND="lightning_qubit" python scripts/configure_pyproject_toml.py
     python -m pip install . -vv
 
     # Install Lightning-AMDGPU
     PL_BACKEND="lightning_amdgpu" python scripts/configure_pyproject_toml.py
-    export CMAKE_ARGS="-DCMAKE_CXX_COMPILER=hipcc \
-                       -DCMAKE_CXX_FLAGS='--gcc-install-dir=/usr/lib/gcc/x86_64-linux-gnu/11/'"
+    export CMAKE_ARGS="-DCMAKE_CXX_COMPILER=hipcc -DKokkos_ENABLE_HIP=ON -DKokkos_ARCH_AMD_GFX942=ON"
     python -m pip install . -vv
 
-.. note::
-
-    Make sure that ``gcc-11`` is installed and accessible on your system, since it is required to compile the Lightning-AMDGPU device. This can be done on Ubuntu via ``sudo apt install gcc-11 g++-11``.
 
 
 .. _install-lightning-AMDGPU-with-mpi:

--- a/doc/lightning_amdgpu/installation.rst
+++ b/doc/lightning_amdgpu/installation.rst
@@ -10,7 +10,7 @@ The installation instruction here is specifically for AMD MI300 GPU (GFX942); fo
 
 .. note::
 
-    Lightning-Kokkos and Lightning-AMDGPU is tested with Kokkos version 4.5.00
+    Lightning-Kokkos and Lightning-AMDGPU are tested with Kokkos version 4.5.00
 
 
 Install Lightning-AMDGPU

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -216,8 +216,7 @@ RUN pip uninstall -y pennylane-lightning
 RUN python scripts/configure_pyproject_toml.py || true
 RUN CMAKE_ARGS="-DKokkos_ENABLE_SERIAL:BOOL=ON \
     -DKokkos_ENABLE_HIP:BOOL=ON \
-    -DKokkos_ARCH_${AMD_ARCH}=ON \
-    -DCMAKE_CXX_FLAGS='--gcc-install-dir=/usr/lib/gcc/x86_64-linux-gnu/11/'" \
+    -DKokkos_ARCH_${AMD_ARCH}=ON" \
     python -m build --wheel
 
 # Install lightning-amdgpu HIP backend

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.45.0-dev18"
+__version__ = "0.45.0-dev19"

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.45.0-dev16"
+__version__ = "0.45.0-dev17"

--- a/pennylane_lightning/core/simulators/lightning_kokkos/algorithms/AlgorithmsKokkos.cpp
+++ b/pennylane_lightning/core/simulators/lightning_kokkos/algorithms/AlgorithmsKokkos.cpp
@@ -23,6 +23,7 @@ using Pennylane::LightningKokkos::StateVectorKokkos;
 using namespace Pennylane::LightningKokkos::Algorithms;
 
 // explicit instantiation
+#ifndef __HIP_DEVICE_COMPILE__
 template class Pennylane::Algorithms::OpsData<StateVectorKokkos<float>>;
 template class Pennylane::Algorithms::OpsData<StateVectorKokkos<double>>;
 
@@ -31,3 +32,4 @@ template class Pennylane::Algorithms::JacobianData<StateVectorKokkos<double>>;
 
 template class Algorithms::AdjointJacobian<StateVectorKokkos<float>>;
 template class Algorithms::AdjointJacobian<StateVectorKokkos<double>>;
+#endif

--- a/pennylane_lightning/core/simulators/lightning_kokkos/algorithms/AlgorithmsKokkosMPI.cpp
+++ b/pennylane_lightning/core/simulators/lightning_kokkos/algorithms/AlgorithmsKokkosMPI.cpp
@@ -21,6 +21,7 @@ using namespace Pennylane::LightningKokkos;
 using Pennylane::LightningKokkos::StateVectorKokkosMPI;
 
 // explicit instantiation
+#ifndef __HIP_DEVICE_COMPILE__
 template class Pennylane::Algorithms::OpsData<StateVectorKokkosMPI<float>>;
 template class Pennylane::Algorithms::OpsData<StateVectorKokkosMPI<double>>;
 
@@ -30,3 +31,4 @@ template class Pennylane::Algorithms::JacobianData<
 
 template class Algorithms::AdjointJacobianMPI<StateVectorKokkosMPI<float>>;
 template class Algorithms::AdjointJacobianMPI<StateVectorKokkosMPI<double>>;
+#endif

--- a/pennylane_lightning/core/simulators/lightning_kokkos/measurements/MeasuresFunctors.hpp
+++ b/pennylane_lightning/core/simulators/lightning_kokkos/measurements/MeasuresFunctors.hpp
@@ -442,18 +442,46 @@ auto probs_bitshift_generic(
             d_probabilities);
         break;
     case 7UL:
-        Kokkos::parallel_reduce(
-            exp2(num_qubits - n_wires),
-            getProbsNQubitOpFunctor<PrecisionT, DeviceType, 7>(arr, num_qubits,
-                                                               wires),
-            d_probabilities);
+        // Following conditions are here to prevent error for HIP out of shared
+        // memory error
+#ifdef KOKKOS_ENABLE_HIP
+        if constexpr (std::is_same_v<DeviceType, Kokkos::HIP> &&
+                      sizeof(PrecisionT) == 8) {
+            Kokkos::parallel_reduce(
+                Kokkos::RangePolicy<DeviceType, Kokkos::LaunchBounds<32>>(
+                    0, exp2(num_qubits - n_wires)),
+                getProbsNQubitOpFunctor<PrecisionT, DeviceType, 7>(
+                    arr, num_qubits, wires),
+                d_probabilities);
+        } else
+#endif
+        {
+            Kokkos::parallel_reduce(
+                exp2(num_qubits - n_wires),
+                getProbsNQubitOpFunctor<PrecisionT, DeviceType, 7>(
+                    arr, num_qubits, wires),
+                d_probabilities);
+        }
         break;
     case 8UL:
-        Kokkos::parallel_reduce(
-            exp2(num_qubits - n_wires),
-            getProbsNQubitOpFunctor<PrecisionT, DeviceType, 8>(arr, num_qubits,
-                                                               wires),
-            d_probabilities);
+#ifdef KOKKOS_ENABLE_HIP
+        if constexpr (std::is_same_v<DeviceType, Kokkos::HIP> &&
+                      sizeof(PrecisionT) == 8) {
+            Kokkos::parallel_reduce(
+                Kokkos::RangePolicy<DeviceType, Kokkos::LaunchBounds<16>>(
+                    0, exp2(num_qubits - n_wires)),
+                getProbsNQubitOpFunctor<PrecisionT, DeviceType, 8>(
+                    arr, num_qubits, wires),
+                d_probabilities);
+        } else
+#endif
+        {
+            Kokkos::parallel_reduce(
+                exp2(num_qubits - n_wires),
+                getProbsNQubitOpFunctor<PrecisionT, DeviceType, 8>(
+                    arr, num_qubits, wires),
+                d_probabilities);
+        }
         break;
     default:
         Kokkos::parallel_reduce(


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [ ] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [ ] Ensure that the test suite passes, by running `make test`.

- [ ] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [ ] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**
Currently we need GCC-11 to build L-AMDGPU, because of some host/device code generation error otherwise. This dependency is bad for building on certain systems.

**Description of the Change:**
By specifying with a macro to build only the problematic sections for host, we can avoid this and allows us to use a more up to date GCC version, and not require GCC-11 specifically. This simplifies the installation instructions as well.

**Benefits:**
Simplify installation of L-AMDGPU

[Docker build](https://github.com/PennyLaneAI/pennylane-lightning/actions/runs/21873806062)
[latest/latest](https://github.com/PennyLaneAI/pennylane-lightning/actions/runs/22203266276)
[stable/stable](https://github.com/PennyLaneAI/pennylane-lightning/actions/runs/22203269090)

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-109268]