### PR TITLE
Adding nightly RC builds

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -32,6 +32,9 @@
 
 <h3>Internal changes ⚙️</h3>
 
+- Added workflow to create and upload nightly builds of the RC branch and trigger Catalyst's nightly RC builds.
+  [(#1344)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1344)
+
 - Updated Github docker build action to use relevant lightning branch.
   [(#1346)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1346)
 

--- a/.github/workflows/set_nightly_version_rc.py
+++ b/.github/workflows/set_nightly_version_rc.py
@@ -1,0 +1,49 @@
+# Copyright 2025 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This module bumps the PennyLane development version by one unit.
+"""
+
+import os
+import re
+
+version_file_path = os.path.join(os.path.dirname(__file__), "../../../pennylane_lightning/core/_version.py")
+
+assert os.path.isfile(version_file_path)
+
+with open(version_file_path, "r+", encoding="UTF-8") as f:
+    lines = f.readlines()
+
+    version_line = lines[-1]
+    assert "__version__ = " in version_line
+    pattern = r"(\d+).(\d+).(\d+)-rc(\d+)"
+    match = re.search(pattern, version_line)
+    if match:
+        # Case 1: Version has RC suffix
+        major, minor, bug, rc = match.groups()
+        replacement = f'__version__ = "{major}.{minor}.{bug}-rc{int(rc)+1}"\n'
+    else:
+        # Case 2: Version has no RC suffix
+        base_pattern = r"(\d+).(\d+).(\d+)"
+        base_match = re.search(base_pattern, version_line)
+        assert base_match, "Version string must be in format X.Y.Z or X.Y.Z-rcN"
+        major, minor, bug = base_match.groups()
+        replacement = f'__version__ = "{major}.{minor}.{bug}-rc0"\n'
+
+    lines[-1] = replacement
+
+    f.seek(0)
+    f.writelines(lines)
+    f.truncate()

--- a/.github/workflows/set_nightly_version_rc.py
+++ b/.github/workflows/set_nightly_version_rc.py
@@ -19,7 +19,7 @@ This module bumps the PennyLane development version by one unit.
 import os
 import re
 
-version_file_path = os.path.join(os.path.dirname(__file__), "../../../pennylane_lightning/core/_version.py")
+version_file_path = os.path.join(os.path.dirname(__file__), "../../pennylane_lightning/core/_version.py")
 
 assert os.path.isfile(version_file_path)
 

--- a/.github/workflows/set_nightly_version_rc.py
+++ b/.github/workflows/set_nightly_version_rc.py
@@ -28,7 +28,7 @@ with open(version_file_path, "r+", encoding="UTF-8") as f:
 
     version_line = lines[-1]
     assert "__version__ = " in version_line
-    pattern = r"(\d+).(\d+).(\d+)_rc(\d+)"
+    pattern = r"(\d+)\.(\d+)\.(\d+)_rc(\d+)"
     match = re.search(pattern, version_line)
     if match:
         # Case 1: Version has RC suffix
@@ -36,7 +36,7 @@ with open(version_file_path, "r+", encoding="UTF-8") as f:
         replacement = f'__version__ = "{major}.{minor}.{bug}_rc{int(rc)+1}"\n'
     else:
         # Case 2: Version has no RC suffix
-        base_pattern = r"(\d+).(\d+).(\d+)"
+        base_pattern = r"(\d+)\.(\d+)\.(\d+)"
         base_match = re.search(base_pattern, version_line)
         assert base_match, "Version string must be in format X.Y.Z or X.Y.Z-rcN"
         major, minor, bug = base_match.groups()

--- a/.github/workflows/set_nightly_version_rc.py
+++ b/.github/workflows/set_nightly_version_rc.py
@@ -28,19 +28,19 @@ with open(version_file_path, "r+", encoding="UTF-8") as f:
 
     version_line = lines[-1]
     assert "__version__ = " in version_line
-    pattern = r"(\d+).(\d+).(\d+)-rc(\d+)"
+    pattern = r"(\d+).(\d+).(\d+)_rc(\d+)"
     match = re.search(pattern, version_line)
     if match:
         # Case 1: Version has RC suffix
         major, minor, bug, rc = match.groups()
-        replacement = f'__version__ = "{major}.{minor}.{bug}-rc{int(rc)+1}"\n'
+        replacement = f'__version__ = "{major}.{minor}.{bug}_rc{int(rc)+1}"\n'
     else:
         # Case 2: Version has no RC suffix
         base_pattern = r"(\d+).(\d+).(\d+)"
         base_match = re.search(base_pattern, version_line)
         assert base_match, "Version string must be in format X.Y.Z or X.Y.Z-rcN"
         major, minor, bug = base_match.groups()
-        replacement = f'__version__ = "{major}.{minor}.{bug}-rc0"\n'
+        replacement = f'__version__ = "{major}.{minor}.{bug}_rc0"\n'
 
     lines[-1] = replacement
 

--- a/.github/workflows/set_nightly_version_rc.py
+++ b/.github/workflows/set_nightly_version_rc.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Xanadu Quantum Technologies Inc.
+# Copyright 2026 Xanadu Quantum Technologies Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """
-This module bumps the PennyLane development version by one unit.
+This module bumps the PennyLane release-candidate version by one unit.
 """
 
 import os

--- a/.github/workflows/set_wheel_build_matrix.yml
+++ b/.github/workflows/set_wheel_build_matrix.yml
@@ -25,7 +25,7 @@ on:
         value: ${{ jobs.set-builder-matrix.outputs.kokkos_version }}
 
 concurrency:
-  group: set_wheel_build_matrix-${{ github.ref }}-${{ github.workflow }}-${{ github.run_id }}
+  group: set_wheel_build_matrix-${{ github.run_id }}-${{ github.job }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/set_wheel_build_matrix.yml
+++ b/.github/workflows/set_wheel_build_matrix.yml
@@ -10,6 +10,9 @@ on:
       event_name:
         required: true
         type: string
+      workflow_name:
+        required: false
+        type: string
     outputs:
       python_version:
         description: "Python versions."
@@ -25,7 +28,7 @@ on:
         value: ${{ jobs.set-builder-matrix.outputs.kokkos_version }}
 
 concurrency:
-  group: set_wheel_build_matrix-${{ github.run_id }}-${{ github.job }}
+  group: set_wheel_build_matrix-${{ inputs.workflow_name }}-${{ github.ref }}-${{ github.workflow }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/set_wheel_build_matrix.yml
+++ b/.github/workflows/set_wheel_build_matrix.yml
@@ -25,7 +25,7 @@ on:
         value: ${{ jobs.set-builder-matrix.outputs.kokkos_version }}
 
 concurrency:
-  group: set_wheel_build_matrix-${{ github.ref }}-${{ github.workflow }}
+  group: set_wheel_build_matrix-${{ github.ref }}-${{ github.workflow }}-${{ github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/upload-nightly-rc-release.yml
+++ b/.github/workflows/upload-nightly-rc-release.yml
@@ -125,7 +125,7 @@ jobs:
       branch: ${{ needs.setup-rc.outputs.rc_branch }}
 
   check-wheel-uploads:
-    needs: [build-linux-aarch64-cuda, build-linux-x86_64, build-linux-x86_64-cuda, build-linux-aarch64, build-macos-arm64, build-windows-x86_64, build-windows-x86_64_rocm, build-noarch]
+    # needs: [build-linux-aarch64-cuda, build-linux-x86_64, build-linux-x86_64-cuda, build-linux-aarch64, build-macos-arm64, build-windows-x86_64, build-windows-x86_64_rocm, build-noarch]
     name: Check wheel uploads
     runs-on: ubuntu-24.04
     

--- a/.github/workflows/upload-nightly-rc-release.yml
+++ b/.github/workflows/upload-nightly-rc-release.yml
@@ -64,51 +64,51 @@ jobs:
         git commit -m "[no ci] bump nightly version"
         git push
 
-    build-linux-aarch64-cuda:
-      needs: setup-rc
-      if: ${{ needs.setup-rc.outputs.branch_exists == 'true' }}
-      uses: ./.github/workflows/wheel_linux_aarch64_cuda.yml
-      with:
-        branch: ${{ needs.setup-rc.outputs.rc_branch }}
+  build-linux-aarch64-cuda:
+    needs: setup-rc
+    if: ${{ needs.setup-rc.outputs.branch_exists == 'true' }}
+    uses: ./.github/workflows/wheel_linux_aarch64_cuda.yml
+    with:
+      branch: ${{ needs.setup-rc.outputs.rc_branch }}
 
-    build-linux-x86_64:
-      needs: setup-rc
-      if: ${{ needs.setup-rc.outputs.branch_exists == 'true' }}
-      uses: ./.github/workflows/wheel_linux_x86_64.yml
-      with:
-        branch: ${{ needs.setup-rc.outputs.rc_branch }}
+  build-linux-x86_64:
+    needs: setup-rc
+    if: ${{ needs.setup-rc.outputs.branch_exists == 'true' }}
+    uses: ./.github/workflows/wheel_linux_x86_64.yml
+    with:
+      branch: ${{ needs.setup-rc.outputs.rc_branch }}
 
-    build-linux-x86_64-cuda:
-      needs: setup-rc
-      if: ${{ needs.setup-rc.outputs.branch_exists == 'true' }}
-      uses: ./.github/workflows/wheel_linux_x86_64_cuda.yml
-      with:
-        branch: ${{ needs.setup-rc.outputs.rc_branch }}
+  build-linux-x86_64-cuda:
+    needs: setup-rc
+    if: ${{ needs.setup-rc.outputs.branch_exists == 'true' }}
+    uses: ./.github/workflows/wheel_linux_x86_64_cuda.yml
+    with:
+      branch: ${{ needs.setup-rc.outputs.rc_branch }}
 
-    build-linux-aarch64:
-      needs: setup-rc
-      if: ${{ needs.setup-rc.outputs.branch_exists == 'true' }}
-      uses: ./.github/workflows/wheel_linux_aarch64.yml
-      with:
-        branch: ${{ needs.setup-rc.outputs.rc_branch }}
+  build-linux-aarch64:
+    needs: setup-rc
+    if: ${{ needs.setup-rc.outputs.branch_exists == 'true' }}
+    uses: ./.github/workflows/wheel_linux_aarch64.yml
+    with:
+      branch: ${{ needs.setup-rc.outputs.rc_branch }}
 
-    build-macos-x86_64:
-      needs: setup-rc
-      if: ${{ needs.setup-rc.outputs.branch_exists == 'true' }}
-      uses: ./.github/workflows/wheel_macos_x86_64.yml
-      with:
-        branch: ${{ needs.setup-rc.outputs.rc_branch }}
+  build-macos-x86_64:
+    needs: setup-rc
+    if: ${{ needs.setup-rc.outputs.branch_exists == 'true' }}
+    uses: ./.github/workflows/wheel_macos_x86_64.yml
+    with:
+      branch: ${{ needs.setup-rc.outputs.rc_branch }}
 
-    build-macos-arm64:
-      needs: setup-rc
-      if: ${{ needs.setup-rc.outputs.branch_exists == 'true' }}
-      uses: ./.github/workflows/wheel_macos_arm64.yml
-      with:
-        branch: ${{ needs.setup-rc.outputs.rc_branch }}
+  build-macos-arm64:
+    needs: setup-rc
+    if: ${{ needs.setup-rc.outputs.branch_exists == 'true' }}
+    uses: ./.github/workflows/wheel_macos_arm64.yml
+    with:
+      branch: ${{ needs.setup-rc.outputs.rc_branch }}
 
-    build-windows-x86_64:
-      needs: setup-rc
-      if: ${{ needs.setup-rc.outputs.branch_exists == 'true' }}
-      uses: ./.github/workflows/wheel_windows_x86_64.yml
-      with:
-        branch: ${{ needs.setup-rc.outputs.rc_branch }}
+  build-windows-x86_64:
+    needs: setup-rc
+    if: ${{ needs.setup-rc.outputs.branch_exists == 'true' }}
+    uses: ./.github/workflows/wheel_windows_x86_64.yml
+    with:
+      branch: ${{ needs.setup-rc.outputs.rc_branch }}

--- a/.github/workflows/upload-nightly-rc-release.yml
+++ b/.github/workflows/upload-nightly-rc-release.yml
@@ -7,6 +7,10 @@ on:
   workflow_dispatch:
   push:
 
+concurrency:
+  group: nightly-rc-release-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   setup-rc:
     name: Setup the release

--- a/.github/workflows/upload-nightly-rc-release.yml
+++ b/.github/workflows/upload-nightly-rc-release.yml
@@ -109,6 +109,6 @@ jobs:
   build-windows-x86_64:
     needs: setup-rc
     if: ${{ needs.setup-rc.outputs.branch_exists == 'true' }}
-    uses: ./.github/workflows/wheel_windows_x86_64.yml
+    uses: ./.github/workflows/wheel_win_x86_64.yml
     with:
       branch: ${{ needs.setup-rc.outputs.rc_branch }}

--- a/.github/workflows/upload-nightly-rc-release.yml
+++ b/.github/workflows/upload-nightly-rc-release.yml
@@ -58,11 +58,11 @@ jobs:
       run: |
         echo "rc_branch is ${{ steps.check_rc.outputs.rc_branch }}"
         python $GITHUB_WORKSPACE/.github/workflows/set_nightly_version_rc.py
-        git config --global user.email '${{ secrets.AUTO_UPDATE_VERSION_RINGO_EMAIL }}'
-        git config --global user.name "ringo-but-quantum"
-        git add $GITHUB_WORKSPACE/pennylane/_version.py
-        git commit -m "[no ci] bump nightly version"
-        git push
+        # git config --global user.email '${{ secrets.AUTO_UPDATE_VERSION_RINGO_EMAIL }}'
+        # git config --global user.name "ringo-but-quantum"
+        # git add $GITHUB_WORKSPACE/pennylane/_version.py
+        # git commit -m "[no ci] bump nightly version"
+        # git push
 
   build-linux-aarch64-cuda:
     needs: setup-rc
@@ -92,13 +92,6 @@ jobs:
     with:
       branch: ${{ needs.setup-rc.outputs.rc_branch }}
 
-  build-macos-x86_64:
-    needs: setup-rc
-    if: ${{ needs.setup-rc.outputs.branch_exists == 'true' }}
-    uses: ./.github/workflows/wheel_macos_x86_64.yml
-    with:
-      branch: ${{ needs.setup-rc.outputs.rc_branch }}
-
   build-macos-arm64:
     needs: setup-rc
     if: ${{ needs.setup-rc.outputs.branch_exists == 'true' }}
@@ -110,5 +103,19 @@ jobs:
     needs: setup-rc
     if: ${{ needs.setup-rc.outputs.branch_exists == 'true' }}
     uses: ./.github/workflows/wheel_win_x86_64.yml
+    with:
+      branch: ${{ needs.setup-rc.outputs.rc_branch }}
+
+  build-windows-x86_64:
+    needs: setup-rc
+    if: ${{ needs.setup-rc.outputs.branch_exists == 'true' }}
+    uses: ./.github/workflows/wheel_linux_x86_64_rocm.yml
+    with:
+      branch: ${{ needs.setup-rc.outputs.rc_branch }}
+  
+  build-noarch:
+    needs: setup-rc
+    if: ${{ needs.setup-rc.outputs.branch_exists == 'true' }}
+    uses: ./.github/workflows/wheel_noarch.yml
     with:
       branch: ${{ needs.setup-rc.outputs.rc_branch }}

--- a/.github/workflows/upload-nightly-rc-release.yml
+++ b/.github/workflows/upload-nightly-rc-release.yml
@@ -43,7 +43,7 @@ jobs:
           echo "rc_branch=$RC_BRANCH" >> $GITHUB_OUTPUT
           echo "Found rc branch: $RC_BRANCH"
         else
-          echo "branch_exists=false" >> $GITHUB_OUTPUT
+          echo "branch_exists=true" >> $GITHUB_OUTPUT
         fi
 
     - name: Checkout Lightning repo

--- a/.github/workflows/upload-nightly-rc-release.yml
+++ b/.github/workflows/upload-nightly-rc-release.yml
@@ -137,7 +137,7 @@ jobs:
 
       - name: Check for uploaded wheels
         env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          GITHUB_TOKEN: "${{ secrets.PENNYLANE_TRIGGER_RC_WORKFLOW }}"
         run: |
           # Check if any wheel artifacts were uploaded
           git config user.name "GitHub Actions Bot"

--- a/.github/workflows/upload-nightly-rc-release.yml
+++ b/.github/workflows/upload-nightly-rc-release.yml
@@ -1,0 +1,114 @@
+name: Build nightly Lightning RC releases for TestPyPI
+
+on:
+  schedule:
+    # Run every weekday at 5:50 EDT (cron is in UTC)
+    - cron: "50 9 * * 1-5"
+  workflow_dispatch:
+  push:
+
+jobs:
+  setup-rc:
+    name: Setup the release
+    runs-on: ubuntu-24.04
+    outputs:
+      rc_branch: ${{ steps.check_rc.outputs.rc_branch }}
+      branch_exists: ${{ steps.check_rc.outputs.branch_exists }}
+    steps:
+    - name: Checkout Lightning repo
+      uses: actions/checkout@v4
+      with:
+        ref: master
+
+    # Sets up Python environment
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.11"
+        
+    # Ensure setuptools is up-to-date for pyproject.toml processing
+    - name: Install latest setuptools 
+      run: |
+        python -m pip install --upgrade pip
+        pip install --upgrade setuptools        
+
+    - name: Check for rc branch
+      id: check_rc
+      run: |
+        VERSION=$(python setup.py --version)
+        IFS=. read MAJ MIN PAT <<< "${VERSION%-dev[0-9]*}"
+        RC_BRANCH="v${MAJ}.$((MIN-1)).${PAT}-rc0"
+        if git ls-remote --exit-code origin "refs/heads/$RC_BRANCH"; then
+          echo "branch_exists=true" >> $GITHUB_OUTPUT
+          echo "rc_branch=$RC_BRANCH" >> $GITHUB_OUTPUT
+          echo "Found rc branch: $RC_BRANCH"
+        else
+          echo "branch_exists=false" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Checkout Lightning repo
+      if: ${{ steps.check_rc.outputs.branch_exists == 'true' }}
+      uses: actions/checkout@v4
+      with:
+        ssh-key: ${{ secrets.NIGHTLY_VERSION_UPDATE_DEPLOY_KEY }}
+        ref: ${{ steps.check_rc.outputs.rc_branch }}
+
+    - name: Bump rc version
+      if: ${{ steps.check_rc.outputs.branch_exists == 'true' }}
+      run: |
+        echo "rc_branch is ${{ steps.check_rc.outputs.rc_branch }}"
+        python $GITHUB_WORKSPACE/.github/workflows/set_nightly_version_rc.py
+        git config --global user.email '${{ secrets.AUTO_UPDATE_VERSION_RINGO_EMAIL }}'
+        git config --global user.name "ringo-but-quantum"
+        git add $GITHUB_WORKSPACE/pennylane/_version.py
+        git commit -m "[no ci] bump nightly version"
+        git push
+
+    build-linux-aarch64-cuda:
+      needs: setup-rc
+      if: ${{ needs.setup-rc.outputs.branch_exists == 'true' }}
+      uses: ./.github/workflows/wheel_linux_aarch64_cuda.yml
+      with:
+        branch: ${{ needs.setup-rc.outputs.rc_branch }}
+
+    build-linux-x86_64:
+      needs: setup-rc
+      if: ${{ needs.setup-rc.outputs.branch_exists == 'true' }}
+      uses: ./.github/workflows/wheel_linux_x86_64.yml
+      with:
+        branch: ${{ needs.setup-rc.outputs.rc_branch }}
+
+    build-linux-x86_64-cuda:
+      needs: setup-rc
+      if: ${{ needs.setup-rc.outputs.branch_exists == 'true' }}
+      uses: ./.github/workflows/wheel_linux_x86_64_cuda.yml
+      with:
+        branch: ${{ needs.setup-rc.outputs.rc_branch }}
+
+    build-linux-aarch64:
+      needs: setup-rc
+      if: ${{ needs.setup-rc.outputs.branch_exists == 'true' }}
+      uses: ./.github/workflows/wheel_linux_aarch64.yml
+      with:
+        branch: ${{ needs.setup-rc.outputs.rc_branch }}
+
+    build-macos-x86_64:
+      needs: setup-rc
+      if: ${{ needs.setup-rc.outputs.branch_exists == 'true' }}
+      uses: ./.github/workflows/wheel_macos_x86_64.yml
+      with:
+        branch: ${{ needs.setup-rc.outputs.rc_branch }}
+
+    build-macos-arm64:
+      needs: setup-rc
+      if: ${{ needs.setup-rc.outputs.branch_exists == 'true' }}
+      uses: ./.github/workflows/wheel_macos_arm64.yml
+      with:
+        branch: ${{ needs.setup-rc.outputs.rc_branch }}
+
+    build-windows-x86_64:
+      needs: setup-rc
+      if: ${{ needs.setup-rc.outputs.branch_exists == 'true' }}
+      uses: ./.github/workflows/wheel_windows_x86_64.yml
+      with:
+        branch: ${{ needs.setup-rc.outputs.rc_branch }}

--- a/.github/workflows/upload-nightly-rc-release.yml
+++ b/.github/workflows/upload-nightly-rc-release.yml
@@ -119,3 +119,19 @@ jobs:
     uses: ./.github/workflows/wheel_noarch.yml
     with:
       branch: ${{ needs.setup-rc.outputs.rc_branch }}
+
+  check-wheel-uploads:
+    needs: [build-linux-aarch64-cuda, build-linux-x86_64, build-linux-x86_64-cuda, build-linux-aarch64, build-macos-arm64, build-windows-x86_64, build-windows-x86_64_rocm, build-noarch]
+    name: Check wheel uploads
+    runs-on: ubuntu-24.04
+    
+    steps:
+      - name: Check for uploaded wheels
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          # Check if any wheel artifacts were uploaded
+          git config user.name "GitHub Actions Bot"
+          git config user.email "<>"         
+          gh workflow run "Build Release Branch Nightly for TestPyPI" --repo PennyLaneAI/catalyst --ref sc-111637-sync-rc
+          

--- a/.github/workflows/upload-nightly-rc-release.yml
+++ b/.github/workflows/upload-nightly-rc-release.yml
@@ -130,6 +130,11 @@ jobs:
     runs-on: ubuntu-24.04
     
     steps:
+      - name: Checkout Lightning repo
+        uses: actions/checkout@v4
+        with:
+          ref: master
+
       - name: Check for uploaded wheels
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/upload-nightly-rc-release.yml
+++ b/.github/workflows/upload-nightly-rc-release.yml
@@ -106,7 +106,7 @@ jobs:
     with:
       branch: ${{ needs.setup-rc.outputs.rc_branch }}
 
-  build-windows-x86_64:
+  build-windows-x86_64_rocm:
     needs: setup-rc
     if: ${{ needs.setup-rc.outputs.branch_exists == 'true' }}
     uses: ./.github/workflows/wheel_linux_x86_64_rocm.yml

--- a/.github/workflows/upload-nightly-rc-release.yml
+++ b/.github/workflows/upload-nightly-rc-release.yml
@@ -42,7 +42,7 @@ jobs:
           echo "rc_branch=$RC_BRANCH" >> $GITHUB_OUTPUT
           echo "Found rc branch: $RC_BRANCH"
         else
-          echo "branch_exists=false" >> $GITHUB_OUTPUT
+          echo "branch_exists=true" >> $GITHUB_OUTPUT
         fi
 
     - name: Checkout Lightning repo
@@ -59,9 +59,9 @@ jobs:
         python $GITHUB_WORKSPACE/.github/workflows/set_nightly_version_rc.py
         git config --global user.email '${{ secrets.AUTO_UPDATE_VERSION_RINGO_EMAIL }}'
         git config --global user.name "ringo-but-quantum"
-        git add $GITHUB_WORKSPACE/pennylane/_version.py
+        git add $GITHUB_WORKSPACE/pennylane-lightning/_version.py
         git commit -m "[no ci] bump nightly version"
-        git push
+        # git push
 
   build-linux-aarch64-cuda:
     needs: setup-rc

--- a/.github/workflows/upload-nightly-rc-release.yml
+++ b/.github/workflows/upload-nightly-rc-release.yml
@@ -7,10 +7,6 @@ on:
   workflow_dispatch:
   push:
 
-# concurrency:
-#   group: nightly-rc-release-${{ github.ref }}
-#   cancel-in-progress: false
-
 jobs:
   setup-rc:
     name: Setup the release

--- a/.github/workflows/upload-nightly-rc-release.yml
+++ b/.github/workflows/upload-nightly-rc-release.yml
@@ -82,47 +82,47 @@ jobs:
     with:
       branch: ${{ needs.setup-rc.outputs.rc_branch }}
 
-  # build-linux-x86_64-cuda:
-  #   needs: setup-rc
-  #   if: ${{ needs.setup-rc.outputs.branch_exists == 'true' }}
-  #   uses: ./.github/workflows/wheel_linux_x86_64_cuda.yml
-  #   with:
-  #     branch: ${{ needs.setup-rc.outputs.rc_branch }}
+  build-linux-x86_64-cuda:
+    needs: setup-rc
+    if: ${{ needs.setup-rc.outputs.branch_exists == 'true' }}
+    uses: ./.github/workflows/wheel_linux_x86_64_cuda.yml
+    with:
+      branch: ${{ needs.setup-rc.outputs.rc_branch }}
 
-  # build-linux-aarch64:
-  #   needs: setup-rc
-  #   if: ${{ needs.setup-rc.outputs.branch_exists == 'true' }}
-  #   uses: ./.github/workflows/wheel_linux_aarch64.yml
-  #   with:
-  #     branch: ${{ needs.setup-rc.outputs.rc_branch }}
+  build-linux-aarch64:
+    needs: setup-rc
+    if: ${{ needs.setup-rc.outputs.branch_exists == 'true' }}
+    uses: ./.github/workflows/wheel_linux_aarch64.yml
+    with:
+      branch: ${{ needs.setup-rc.outputs.rc_branch }}
 
-  # build-macos-arm64:
-  #   needs: setup-rc
-  #   if: ${{ needs.setup-rc.outputs.branch_exists == 'true' }}
-  #   uses: ./.github/workflows/wheel_macos_arm64.yml
-  #   with:
-  #     branch: ${{ needs.setup-rc.outputs.rc_branch }}
+  build-macos-arm64:
+    needs: setup-rc
+    if: ${{ needs.setup-rc.outputs.branch_exists == 'true' }}
+    uses: ./.github/workflows/wheel_macos_arm64.yml
+    with:
+      branch: ${{ needs.setup-rc.outputs.rc_branch }}
 
-  # build-windows-x86_64:
-  #   needs: setup-rc
-  #   if: ${{ needs.setup-rc.outputs.branch_exists == 'true' }}
-  #   uses: ./.github/workflows/wheel_win_x86_64.yml
-  #   with:
-  #     branch: ${{ needs.setup-rc.outputs.rc_branch }}
+  build-windows-x86_64:
+    needs: setup-rc
+    if: ${{ needs.setup-rc.outputs.branch_exists == 'true' }}
+    uses: ./.github/workflows/wheel_win_x86_64.yml
+    with:
+      branch: ${{ needs.setup-rc.outputs.rc_branch }}
 
-  # build-windows-x86_64_rocm:
-  #   needs: setup-rc
-  #   if: ${{ needs.setup-rc.outputs.branch_exists == 'true' }}
-  #   uses: ./.github/workflows/wheel_linux_x86_64_rocm.yml
-  #   with:
-  #     branch: ${{ needs.setup-rc.outputs.rc_branch }}
+  build-windows-x86_64_rocm:
+    needs: setup-rc
+    if: ${{ needs.setup-rc.outputs.branch_exists == 'true' }}
+    uses: ./.github/workflows/wheel_linux_x86_64_rocm.yml
+    with:
+      branch: ${{ needs.setup-rc.outputs.rc_branch }}
   
-  # build-noarch:
-  #   needs: setup-rc
-  #   if: ${{ needs.setup-rc.outputs.branch_exists == 'true' }}
-  #   uses: ./.github/workflows/wheel_noarch.yml
-  #   with:
-  #     branch: ${{ needs.setup-rc.outputs.rc_branch }}
+  build-noarch:
+    needs: setup-rc
+    if: ${{ needs.setup-rc.outputs.branch_exists == 'true' }}
+    uses: ./.github/workflows/wheel_noarch.yml
+    with:
+      branch: ${{ needs.setup-rc.outputs.rc_branch }}
 
   check-wheel-uploads:
     # needs: [build-linux-aarch64-cuda, build-linux-x86_64, build-linux-x86_64-cuda, build-linux-aarch64, build-macos-arm64, build-windows-x86_64, build-windows-x86_64_rocm, build-noarch]

--- a/.github/workflows/upload-nightly-rc-release.yml
+++ b/.github/workflows/upload-nightly-rc-release.yml
@@ -36,7 +36,7 @@ jobs:
       run: |
         VERSION=$(python setup.py --version)
         IFS=. read MAJ MIN PAT <<< "${VERSION%-dev[0-9]*}"
-        RC_BRANCH="v${MAJ}.$((MIN-1)).${PAT}_rc0"
+        RC_BRANCH="v${MAJ}.$((MIN-1)).${PAT}_rc"
         if git ls-remote --exit-code origin "refs/heads/$RC_BRANCH"; then
           echo "branch_exists=true" >> $GITHUB_OUTPUT
           echo "rc_branch=$RC_BRANCH" >> $GITHUB_OUTPUT

--- a/.github/workflows/upload-nightly-rc-release.yml
+++ b/.github/workflows/upload-nightly-rc-release.yml
@@ -7,9 +7,9 @@ on:
   workflow_dispatch:
   push:
 
-concurrency:
-  group: nightly-rc-release-${{ github.ref }}
-  cancel-in-progress: false
+# concurrency:
+#   group: nightly-rc-release-${{ github.ref }}
+#   cancel-in-progress: false
 
 jobs:
   setup-rc:

--- a/.github/workflows/upload-nightly-rc-release.yml
+++ b/.github/workflows/upload-nightly-rc-release.yml
@@ -43,9 +43,8 @@ jobs:
           echo "rc_branch=$RC_BRANCH" >> $GITHUB_OUTPUT
           echo "Found rc branch: $RC_BRANCH"
         else
-          echo "branch_exists=true" >> $GITHUB_OUTPUT
+          echo "branch_exists=false" >> $GITHUB_OUTPUT
         fi
-        echo "Event name is ${{ github.event_name }}"
 
     - name: Checkout Lightning repo
       if: ${{ steps.check_rc.outputs.branch_exists == 'true' }}
@@ -138,5 +137,5 @@ jobs:
         run: |
           git config user.name "GitHub Actions Bot"
           git config user.email "<>"         
-          gh workflow run build-nightly-release-candidate.yaml --repo PennyLaneAI/catalyst --ref sc-111637-sync-rc #TODO remove ref
+          gh workflow run build-nightly-release-candidate.yaml --repo PennyLaneAI/catalyst
           

--- a/.github/workflows/upload-nightly-rc-release.yml
+++ b/.github/workflows/upload-nightly-rc-release.yml
@@ -82,47 +82,47 @@ jobs:
     with:
       branch: ${{ needs.setup-rc.outputs.rc_branch }}
 
-  build-linux-x86_64-cuda:
-    needs: setup-rc
-    if: ${{ needs.setup-rc.outputs.branch_exists == 'true' }}
-    uses: ./.github/workflows/wheel_linux_x86_64_cuda.yml
-    with:
-      branch: ${{ needs.setup-rc.outputs.rc_branch }}
+  # build-linux-x86_64-cuda:
+  #   needs: setup-rc
+  #   if: ${{ needs.setup-rc.outputs.branch_exists == 'true' }}
+  #   uses: ./.github/workflows/wheel_linux_x86_64_cuda.yml
+  #   with:
+  #     branch: ${{ needs.setup-rc.outputs.rc_branch }}
 
-  build-linux-aarch64:
-    needs: setup-rc
-    if: ${{ needs.setup-rc.outputs.branch_exists == 'true' }}
-    uses: ./.github/workflows/wheel_linux_aarch64.yml
-    with:
-      branch: ${{ needs.setup-rc.outputs.rc_branch }}
+  # build-linux-aarch64:
+  #   needs: setup-rc
+  #   if: ${{ needs.setup-rc.outputs.branch_exists == 'true' }}
+  #   uses: ./.github/workflows/wheel_linux_aarch64.yml
+  #   with:
+  #     branch: ${{ needs.setup-rc.outputs.rc_branch }}
 
-  build-macos-arm64:
-    needs: setup-rc
-    if: ${{ needs.setup-rc.outputs.branch_exists == 'true' }}
-    uses: ./.github/workflows/wheel_macos_arm64.yml
-    with:
-      branch: ${{ needs.setup-rc.outputs.rc_branch }}
+  # build-macos-arm64:
+  #   needs: setup-rc
+  #   if: ${{ needs.setup-rc.outputs.branch_exists == 'true' }}
+  #   uses: ./.github/workflows/wheel_macos_arm64.yml
+  #   with:
+  #     branch: ${{ needs.setup-rc.outputs.rc_branch }}
 
-  build-windows-x86_64:
-    needs: setup-rc
-    if: ${{ needs.setup-rc.outputs.branch_exists == 'true' }}
-    uses: ./.github/workflows/wheel_win_x86_64.yml
-    with:
-      branch: ${{ needs.setup-rc.outputs.rc_branch }}
+  # build-windows-x86_64:
+  #   needs: setup-rc
+  #   if: ${{ needs.setup-rc.outputs.branch_exists == 'true' }}
+  #   uses: ./.github/workflows/wheel_win_x86_64.yml
+  #   with:
+  #     branch: ${{ needs.setup-rc.outputs.rc_branch }}
 
-  build-windows-x86_64_rocm:
-    needs: setup-rc
-    if: ${{ needs.setup-rc.outputs.branch_exists == 'true' }}
-    uses: ./.github/workflows/wheel_linux_x86_64_rocm.yml
-    with:
-      branch: ${{ needs.setup-rc.outputs.rc_branch }}
+  # build-windows-x86_64_rocm:
+  #   needs: setup-rc
+  #   if: ${{ needs.setup-rc.outputs.branch_exists == 'true' }}
+  #   uses: ./.github/workflows/wheel_linux_x86_64_rocm.yml
+  #   with:
+  #     branch: ${{ needs.setup-rc.outputs.rc_branch }}
   
-  build-noarch:
-    needs: setup-rc
-    if: ${{ needs.setup-rc.outputs.branch_exists == 'true' }}
-    uses: ./.github/workflows/wheel_noarch.yml
-    with:
-      branch: ${{ needs.setup-rc.outputs.rc_branch }}
+  # build-noarch:
+  #   needs: setup-rc
+  #   if: ${{ needs.setup-rc.outputs.branch_exists == 'true' }}
+  #   uses: ./.github/workflows/wheel_noarch.yml
+  #   with:
+  #     branch: ${{ needs.setup-rc.outputs.rc_branch }}
 
   check-wheel-uploads:
     # needs: [build-linux-aarch64-cuda, build-linux-x86_64, build-linux-x86_64-cuda, build-linux-aarch64, build-macos-arm64, build-windows-x86_64, build-windows-x86_64_rocm, build-noarch]

--- a/.github/workflows/upload-nightly-rc-release.yml
+++ b/.github/workflows/upload-nightly-rc-release.yml
@@ -36,13 +36,13 @@ jobs:
       run: |
         VERSION=$(python setup.py --version)
         IFS=. read MAJ MIN PAT <<< "${VERSION%-dev[0-9]*}"
-        RC_BRANCH="v${MAJ}.$((MIN-1)).${PAT}-rc0"
+        RC_BRANCH="v${MAJ}.$((MIN-1)).${PAT}_rc0"
         if git ls-remote --exit-code origin "refs/heads/$RC_BRANCH"; then
           echo "branch_exists=true" >> $GITHUB_OUTPUT
           echo "rc_branch=$RC_BRANCH" >> $GITHUB_OUTPUT
           echo "Found rc branch: $RC_BRANCH"
         else
-          echo "branch_exists=true" >> $GITHUB_OUTPUT
+          echo "branch_exists=false" >> $GITHUB_OUTPUT
         fi
 
     - name: Checkout Lightning repo
@@ -61,7 +61,7 @@ jobs:
         git config --global user.name "ringo-but-quantum"
         git add $GITHUB_WORKSPACE/pennylane-lightning/_version.py
         git commit -m "[no ci] bump nightly version"
-        # git push
+        git push
 
   build-linux-aarch64-cuda:
     needs: setup-rc

--- a/.github/workflows/upload-nightly-rc-release.yml
+++ b/.github/workflows/upload-nightly-rc-release.yml
@@ -5,7 +5,7 @@ on:
     # Run every weekday at 5:50 EDT (cron is in UTC)
     - cron: "50 9 * * 1-5"
   workflow_dispatch:
-  push:
+  push: # TODO remove
 
 jobs:
   setup-rc:
@@ -43,7 +43,7 @@ jobs:
           echo "rc_branch=$RC_BRANCH" >> $GITHUB_OUTPUT
           echo "Found rc branch: $RC_BRANCH"
         else
-          echo "branch_exists=false" >> $GITHUB_OUTPUT
+          echo "branch_exists=true" >> $GITHUB_OUTPUT
         fi
 
     - name: Checkout Lightning repo

--- a/.github/workflows/upload-nightly-rc-release.yml
+++ b/.github/workflows/upload-nightly-rc-release.yml
@@ -135,12 +135,12 @@ jobs:
         with:
           ref: master
 
-      - name: Check for uploaded wheels
+      - name: Trigger Catalyst RC workflow
         env:
           GITHUB_TOKEN: "${{ secrets.PENNYLANE_TRIGGER_RC_WORKFLOW }}"
         run: |
           # Check if any wheel artifacts were uploaded
           git config user.name "GitHub Actions Bot"
           git config user.email "<>"         
-          gh workflow run "Build Release Branch Nightly for TestPyPI" --repo PennyLaneAI/catalyst --ref sc-111637-sync-rc
+          gh workflow run build-nightly-release-candidate.yaml --repo PennyLaneAI/catalyst --ref sc-111637-sync-rc
           

--- a/.github/workflows/upload-nightly-rc-release.yml
+++ b/.github/workflows/upload-nightly-rc-release.yml
@@ -120,7 +120,7 @@ jobs:
       branch: ${{ needs.setup-rc.outputs.rc_branch }}
 
   trigger-catalyst-rc:
-    needs: [build-linux-aarch64-cuda, build-linux-x86_64, build-linux-x86_64-cuda, build-linux-aarch64, build-macos-arm64, build-windows-x86_64, build-windows-x86_64_rocm, build-noarch]
+    needs: [build-linux-aarch64-cuda, build-linux-x86_64, build-linux-x86_64-cuda, build-linux-aarch64, build-macos-arm64, build-windows-x86_64, build-linux-x86_64_rocm, build-noarch]
     name: Trigger Catalyst RC workflow
     runs-on: ubuntu-24.04
     

--- a/.github/workflows/upload-nightly-rc-release.yml
+++ b/.github/workflows/upload-nightly-rc-release.yml
@@ -5,7 +5,6 @@ on:
     # Run every weekday at 3:30 AM EDT (cron is in UTC)
       - cron: "30 7 * * 1-5"
   workflow_dispatch:
-  push: # TODO remove
 
 jobs:
   setup-rc:
@@ -122,7 +121,7 @@ jobs:
 
   trigger-catalyst-rc:
     needs: [build-linux-aarch64-cuda, build-linux-x86_64, build-linux-x86_64-cuda, build-linux-aarch64, build-macos-arm64, build-windows-x86_64, build-windows-x86_64_rocm, build-noarch]
-    name: Check wheel uploads
+    name: Trigger Catalyst RC workflow
     runs-on: ubuntu-24.04
     
     steps:

--- a/.github/workflows/upload-nightly-rc-release.yml
+++ b/.github/workflows/upload-nightly-rc-release.yml
@@ -9,7 +9,7 @@ on:
 
 concurrency:
   group: nightly-rc-release-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   setup-rc:

--- a/.github/workflows/upload-nightly-rc-release.yml
+++ b/.github/workflows/upload-nightly-rc-release.yml
@@ -59,7 +59,7 @@ jobs:
         python $GITHUB_WORKSPACE/.github/workflows/set_nightly_version_rc.py
         git config --global user.email '${{ secrets.AUTO_UPDATE_VERSION_RINGO_EMAIL }}'
         git config --global user.name "ringo-but-quantum"
-        git add $GITHUB_WORKSPACE/pennylane-lightning/_version.py
+        git add $GITHUB_WORKSPACE/pennylane_lightning/core/_version.py
         git commit -m "[no ci] bump nightly version"
         git push
 

--- a/.github/workflows/upload-nightly-rc-release.yml
+++ b/.github/workflows/upload-nightly-rc-release.yml
@@ -2,8 +2,8 @@ name: Build nightly Lightning RC releases for TestPyPI
 
 on:
   schedule:
-    # Run every weekday at 5:50 EDT (cron is in UTC)
-    - cron: "50 9 * * 1-5"
+    # Run every weekday at 3:30 AM EDT (cron is in UTC)
+      - cron: "30 7 * * 1-5"
   workflow_dispatch:
   push: # TODO remove
 
@@ -45,6 +45,7 @@ jobs:
         else
           echo "branch_exists=true" >> $GITHUB_OUTPUT
         fi
+        echo "Event name is ${{ github.event_name }}"
 
     - name: Checkout Lightning repo
       if: ${{ steps.check_rc.outputs.branch_exists == 'true' }}

--- a/.github/workflows/upload-nightly-rc-release.yml
+++ b/.github/workflows/upload-nightly-rc-release.yml
@@ -43,7 +43,7 @@ jobs:
           echo "rc_branch=$RC_BRANCH" >> $GITHUB_OUTPUT
           echo "Found rc branch: $RC_BRANCH"
         else
-          echo "branch_exists=true" >> $GITHUB_OUTPUT
+          echo "branch_exists=false" >> $GITHUB_OUTPUT
         fi
 
     - name: Checkout Lightning repo
@@ -120,7 +120,7 @@ jobs:
     with:
       branch: ${{ needs.setup-rc.outputs.rc_branch }}
 
-  check-wheel-uploads:
+  trigger-catalyst-rc:
     needs: [build-linux-aarch64-cuda, build-linux-x86_64, build-linux-x86_64-cuda, build-linux-aarch64, build-macos-arm64, build-windows-x86_64, build-windows-x86_64_rocm, build-noarch]
     name: Check wheel uploads
     runs-on: ubuntu-24.04
@@ -135,8 +135,7 @@ jobs:
         env:
           GITHUB_TOKEN: "${{ secrets.PENNYLANE_TRIGGER_RC_WORKFLOW }}"
         run: |
-          # Check if any wheel artifacts were uploaded
           git config user.name "GitHub Actions Bot"
           git config user.email "<>"         
-          gh workflow run build-nightly-release-candidate.yaml --repo PennyLaneAI/catalyst --ref sc-111637-sync-rc
+          gh workflow run build-nightly-release-candidate.yaml --repo PennyLaneAI/catalyst --ref sc-111637-sync-rc #TODO remove ref
           

--- a/.github/workflows/upload-nightly-rc-release.yml
+++ b/.github/workflows/upload-nightly-rc-release.yml
@@ -121,7 +121,7 @@ jobs:
       branch: ${{ needs.setup-rc.outputs.rc_branch }}
 
   check-wheel-uploads:
-    # needs: [build-linux-aarch64-cuda, build-linux-x86_64, build-linux-x86_64-cuda, build-linux-aarch64, build-macos-arm64, build-windows-x86_64, build-windows-x86_64_rocm, build-noarch]
+    needs: [build-linux-aarch64-cuda, build-linux-x86_64, build-linux-x86_64-cuda, build-linux-aarch64, build-macos-arm64, build-windows-x86_64, build-windows-x86_64_rocm, build-noarch]
     name: Check wheel uploads
     runs-on: ubuntu-24.04
     

--- a/.github/workflows/upload-nightly-rc-release.yml
+++ b/.github/workflows/upload-nightly-rc-release.yml
@@ -57,11 +57,11 @@ jobs:
       run: |
         echo "rc_branch is ${{ steps.check_rc.outputs.rc_branch }}"
         python $GITHUB_WORKSPACE/.github/workflows/set_nightly_version_rc.py
-        # git config --global user.email '${{ secrets.AUTO_UPDATE_VERSION_RINGO_EMAIL }}'
-        # git config --global user.name "ringo-but-quantum"
-        # git add $GITHUB_WORKSPACE/pennylane/_version.py
-        # git commit -m "[no ci] bump nightly version"
-        # git push
+        git config --global user.email '${{ secrets.AUTO_UPDATE_VERSION_RINGO_EMAIL }}'
+        git config --global user.name "ringo-but-quantum"
+        git add $GITHUB_WORKSPACE/pennylane/_version.py
+        git commit -m "[no ci] bump nightly version"
+        git push
 
   build-linux-aarch64-cuda:
     needs: setup-rc

--- a/.github/workflows/upload-nightly-rc-release.yml
+++ b/.github/workflows/upload-nightly-rc-release.yml
@@ -105,7 +105,7 @@ jobs:
     with:
       branch: ${{ needs.setup-rc.outputs.rc_branch }}
 
-  build-windows-x86_64_rocm:
+  build-linux-x86_64_rocm:
     needs: setup-rc
     if: ${{ needs.setup-rc.outputs.branch_exists == 'true' }}
     uses: ./.github/workflows/wheel_linux_x86_64_rocm.yml

--- a/.github/workflows/wheel_linux_aarch64.yml
+++ b/.github/workflows/wheel_linux_aarch64.yml
@@ -18,6 +18,12 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      branch:
+        required: false
+        type: string  
+        default: master        
 
 concurrency:
   group: wheel_linux_aarch64-${{ github.ref }}

--- a/.github/workflows/wheel_linux_aarch64.yml
+++ b/.github/workflows/wheel_linux_aarch64.yml
@@ -114,6 +114,8 @@ jobs:
     steps:
       - name: Checkout PennyLane-Lightning
         uses: actions/checkout@v4
+        with:        
+          ref: ${{ inputs.branch }}        
 
       - name: Restoring cached dependencies
         id: kokkos-cache

--- a/.github/workflows/wheel_linux_aarch64.yml
+++ b/.github/workflows/wheel_linux_aarch64.yml
@@ -26,7 +26,7 @@ on:
         default: master        
 
 concurrency:
-  group: wheel_linux_aarch64-${{ github.ref }}
+  group: wheel_linux_aarch64-${{ github.ref }}-${{ inputs.branch }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/wheel_linux_aarch64.yml
+++ b/.github/workflows/wheel_linux_aarch64.yml
@@ -35,6 +35,7 @@ jobs:
   set_wheel_build_matrix:
     if: |
       github.event_name != 'pull_request' ||
+      github.event_name == 'schedule' ||
       (github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'ci:build_wheels')) ||
       github.event_name == 'workflow_dispatch'
     name: "Set wheel build matrix"
@@ -205,6 +206,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: |
           github.event_name == 'release' ||
+          github.event_name == 'schedule' ||
           github.event_name == 'workflow_dispatch' ||
           github.ref == 'refs/heads/master' ||
           steps.rc_build.outputs.match != ''
@@ -235,6 +237,7 @@ jobs:
       - uses: actions/download-artifact@v4
         if: |
           github.event_name == 'release' ||
+          github.event_name == 'schedule' ||
           github.ref == 'refs/heads/master' || 
           steps.rc_build.outputs.match != ''
         with:
@@ -245,6 +248,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         if: |
           github.event_name == 'release' ||
+          github.event_name == 'schedule' ||
           github.ref == 'refs/heads/master' || 
           steps.rc_build.outputs.match != ''
         with:

--- a/.github/workflows/wheel_linux_aarch64.yml
+++ b/.github/workflows/wheel_linux_aarch64.yml
@@ -23,10 +23,9 @@ on:
       branch:
         required: false
         type: string  
-        default: master        
 
 concurrency:
-  group: wheel_linux_aarch64-${{ inputs.branch || github.ref }}
+  group: wheel_linux_aarch64-${{ github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/wheel_linux_aarch64.yml
+++ b/.github/workflows/wheel_linux_aarch64.yml
@@ -35,7 +35,6 @@ jobs:
   set_wheel_build_matrix:
     if: |
       github.event_name != 'pull_request' ||
-      github.event_name == 'schedule' ||
       (github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'ci:build_wheels')) ||
       github.event_name == 'workflow_dispatch'
     name: "Set wheel build matrix"

--- a/.github/workflows/wheel_linux_aarch64.yml
+++ b/.github/workflows/wheel_linux_aarch64.yml
@@ -6,12 +6,12 @@ name: Wheel::Linux::ARM
 # **Who does it impact**: Wheels to be uploaded to PyPI.
 
 on:
-  pull_request:
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - ready_for_review
+  # pull_request:
+  #   types:
+  #     - opened
+  #     - reopened
+  #     - synchronize
+  #     - ready_for_review
   push:
     branches:
       - master

--- a/.github/workflows/wheel_linux_aarch64.yml
+++ b/.github/workflows/wheel_linux_aarch64.yml
@@ -26,7 +26,7 @@ on:
         default: master        
 
 concurrency:
-  group: wheel_linux_aarch64-${{ github.ref }}-${{ inputs.branch }}
+  group: wheel_linux_aarch64-${{ github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/wheel_linux_aarch64.yml
+++ b/.github/workflows/wheel_linux_aarch64.yml
@@ -35,8 +35,7 @@ jobs:
   set_wheel_build_matrix:
     if: |
       github.event_name != 'pull_request' ||
-      (github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'ci:build_wheels')) ||
-      github.event_name == 'workflow_dispatch'
+      (github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'ci:build_wheels')) 
     name: "Set wheel build matrix"
     uses: ./.github/workflows/set_wheel_build_matrix.yml
     with:

--- a/.github/workflows/wheel_linux_aarch64.yml
+++ b/.github/workflows/wheel_linux_aarch64.yml
@@ -6,12 +6,12 @@ name: Wheel::Linux::ARM
 # **Who does it impact**: Wheels to be uploaded to PyPI.
 
 on:
-  # pull_request:
-  #   types:
-  #     - opened
-  #     - reopened
-  #     - synchronize
-  #     - ready_for_review
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
   push:
     branches:
       - master

--- a/.github/workflows/wheel_linux_aarch64.yml
+++ b/.github/workflows/wheel_linux_aarch64.yml
@@ -117,7 +117,7 @@ jobs:
       - name: Checkout PennyLane-Lightning
         uses: actions/checkout@v4
         with:        
-          ref: ${{ inputs.branch }}        
+          ref: ${{ inputs.branch || github.ref }}        
 
       - name: Restoring cached dependencies
         id: kokkos-cache

--- a/.github/workflows/wheel_linux_aarch64.yml
+++ b/.github/workflows/wheel_linux_aarch64.yml
@@ -36,7 +36,8 @@ jobs:
   set_wheel_build_matrix:
     if: |
       github.event_name != 'pull_request' ||
-      (github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'ci:build_wheels'))
+      (github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'ci:build_wheels')) ||
+      github.event_name == 'workflow_dispatch'
     name: "Set wheel build matrix"
     uses: ./.github/workflows/set_wheel_build_matrix.yml
     with:

--- a/.github/workflows/wheel_linux_aarch64.yml
+++ b/.github/workflows/wheel_linux_aarch64.yml
@@ -26,7 +26,7 @@ on:
         default: master        
 
 concurrency:
-  group: wheel_linux_aarch64-${{ github.ref }}
+  group: wheel_linux_aarch64-${{ inputs.branch || github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/wheel_linux_aarch64.yml
+++ b/.github/workflows/wheel_linux_aarch64.yml
@@ -42,6 +42,7 @@ jobs:
     uses: ./.github/workflows/set_wheel_build_matrix.yml
     with:
       event_name: ${{ github.event_name }}
+      workflow_name: wheel_linux_aarch64
 
   build_dependencies:
     needs: [set_wheel_build_matrix]

--- a/.github/workflows/wheel_linux_aarch64_cuda.yml
+++ b/.github/workflows/wheel_linux_aarch64_cuda.yml
@@ -53,7 +53,8 @@ jobs:
     steps:
       - name: Checkout PennyLane-Lightning
         uses: actions/checkout@v4
-        ref: ${{ inputs.branch }}
+        with:        
+          ref: ${{ inputs.branch }}
 
       - name: Install Python 3.12
         uses: actions/setup-python@v5

--- a/.github/workflows/wheel_linux_aarch64_cuda.yml
+++ b/.github/workflows/wheel_linux_aarch64_cuda.yml
@@ -13,6 +13,12 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      branch:
+        required: false
+        type: string
+        default: master        
 
 concurrency:
   group: wheel_linux_aarch64_cu12-${{ github.ref }}
@@ -47,6 +53,7 @@ jobs:
     steps:
       - name: Checkout PennyLane-Lightning
         uses: actions/checkout@v4
+        ref: ${{ inputs.branch }}
 
       - name: Install Python 3.12
         uses: actions/setup-python@v5

--- a/.github/workflows/wheel_linux_aarch64_cuda.yml
+++ b/.github/workflows/wheel_linux_aarch64_cuda.yml
@@ -21,7 +21,7 @@ on:
         default: master        
 
 concurrency:
-  group: wheel_linux_aarch64_cu12-${{ github.ref }}
+  group: wheel_linux_aarch64_cu12-${{ github.ref }}-${{ inputs.branch }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/wheel_linux_aarch64_cuda.yml
+++ b/.github/workflows/wheel_linux_aarch64_cuda.yml
@@ -26,10 +26,10 @@ concurrency:
 
 jobs:
   set_wheel_build_matrix:
-    if: |
-      github.event_name != 'pull_request' ||
-      (github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'ci:build_wheels')) ||
-      github.event_name == 'workflow_dispatch'
+    # if: |
+    #   github.event_name != 'pull_request' ||
+    #   (github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'ci:build_wheels')) ||
+    #   github.event_name == 'workflow_dispatch'
     name: "Set wheel build matrix"
     uses: ./.github/workflows/set_wheel_build_matrix.yml
     with:

--- a/.github/workflows/wheel_linux_aarch64_cuda.yml
+++ b/.github/workflows/wheel_linux_aarch64_cuda.yml
@@ -6,7 +6,7 @@ name: Wheel::Linux::ARM::CUDA
 # **Who does it impact**: Wheels to be uploaded to PyPI.
 
 on:
-  pull_request:
+  # pull_request:
   push:
     branches:
       - master

--- a/.github/workflows/wheel_linux_aarch64_cuda.yml
+++ b/.github/workflows/wheel_linux_aarch64_cuda.yml
@@ -34,7 +34,7 @@ jobs:
     uses: ./.github/workflows/set_wheel_build_matrix.yml
     with:
       event_name: ${{ github.event_name }}
-      workflow_name: ${{ github.workflow }}
+      workflow_name: wheel_linux_aarch64_cuda
 
   linux-wheels-aarch64:
     needs: [set_wheel_build_matrix]

--- a/.github/workflows/wheel_linux_aarch64_cuda.yml
+++ b/.github/workflows/wheel_linux_aarch64_cuda.yml
@@ -18,10 +18,9 @@ on:
       branch:
         required: false
         type: string
-        default: master        
 
 concurrency:
-  group: wheel_linux_aarch64_cu12-${{ inputs.branch || github.ref }}-${{ github.workflow }}
+  group: wheel_linux_aarch64_cu12-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/wheel_linux_aarch64_cuda.yml
+++ b/.github/workflows/wheel_linux_aarch64_cuda.yml
@@ -21,7 +21,7 @@ on:
         default: master        
 
 concurrency:
-  group: wheel_linux_aarch64_cu12-${{ github.ref }}-${{ inputs.branch }}
+  group: wheel_linux_aarch64_cu12-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/wheel_linux_aarch64_cuda.yml
+++ b/.github/workflows/wheel_linux_aarch64_cuda.yml
@@ -26,10 +26,10 @@ concurrency:
 
 jobs:
   set_wheel_build_matrix:
-    # if: |
-    #   github.event_name != 'pull_request' ||
-    #   (github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'ci:build_wheels')) ||
-    #   github.event_name == 'workflow_dispatch'
+    if: |
+      github.event_name != 'pull_request' ||
+      (github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'ci:build_wheels')) ||
+      github.event_name == 'workflow_dispatch'
     name: "Set wheel build matrix"
     uses: ./.github/workflows/set_wheel_build_matrix.yml
     with:

--- a/.github/workflows/wheel_linux_aarch64_cuda.yml
+++ b/.github/workflows/wheel_linux_aarch64_cuda.yml
@@ -6,7 +6,7 @@ name: Wheel::Linux::ARM::CUDA
 # **Who does it impact**: Wheels to be uploaded to PyPI.
 
 on:
-  # pull_request:
+  pull_request:
   push:
     branches:
       - master

--- a/.github/workflows/wheel_linux_aarch64_cuda.yml
+++ b/.github/workflows/wheel_linux_aarch64_cuda.yml
@@ -106,6 +106,7 @@ jobs:
         shell: bash
         run: |
           echo "version=$(echo  ${{ matrix.cibw_build }} | tr -cd '[:digit:].' | sed 's/./&./1')" >> $GITHUB_OUTPUT
+          echo "Event name is ${{ github.event_name }}"
 
       - uses: actions/setup-python@v5
         id: setup_python

--- a/.github/workflows/wheel_linux_aarch64_cuda.yml
+++ b/.github/workflows/wheel_linux_aarch64_cuda.yml
@@ -27,6 +27,7 @@ jobs:
   set_wheel_build_matrix:
     if: |
       github.event_name != 'pull_request' ||
+      github.event_name == 'schedule' ||
       (github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'ci:build_wheels')) ||
       github.event_name == 'workflow_dispatch'
     name: "Set wheel build matrix"
@@ -178,6 +179,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: |
           github.event_name == 'release' ||
+          github.event_name == 'schedule' ||
           github.event_name == 'workflow_dispatch' ||
           github.ref == 'refs/heads/master' ||
           steps.rc_build.outputs.match != ''
@@ -216,6 +218,7 @@ jobs:
       - uses: actions/download-artifact@v4
         if: |
           github.event_name == 'release' ||
+          github.event_name == 'schedule' ||
           github.ref == 'refs/heads/master' || 
           steps.rc_build.outputs.match != ''
         with:
@@ -225,6 +228,7 @@ jobs:
       - name: Upload wheels to TestPyPI
         if: |
           github.event_name == 'release' ||
+          github.event_name == 'schedule' ||
           github.ref == 'refs/heads/master' || 
           steps.rc_build.outputs.match != ''
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/wheel_linux_aarch64_cuda.yml
+++ b/.github/workflows/wheel_linux_aarch64_cuda.yml
@@ -27,7 +27,6 @@ jobs:
   set_wheel_build_matrix:
     if: |
       github.event_name != 'pull_request' ||
-      github.event_name == 'schedule' ||
       (github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'ci:build_wheels')) ||
       github.event_name == 'workflow_dispatch'
     name: "Set wheel build matrix"

--- a/.github/workflows/wheel_linux_aarch64_cuda.yml
+++ b/.github/workflows/wheel_linux_aarch64_cuda.yml
@@ -21,7 +21,7 @@ on:
         default: master        
 
 concurrency:
-  group: wheel_linux_aarch64_cu12-${{ inputs.branch || github.ref }}
+  group: wheel_linux_aarch64_cu12-${{ inputs.branch || github.ref }}-${{ github.workflow }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/wheel_linux_aarch64_cuda.yml
+++ b/.github/workflows/wheel_linux_aarch64_cuda.yml
@@ -106,7 +106,6 @@ jobs:
         shell: bash
         run: |
           echo "version=$(echo  ${{ matrix.cibw_build }} | tr -cd '[:digit:].' | sed 's/./&./1')" >> $GITHUB_OUTPUT
-          echo "Event name is ${{ github.event_name }}"
 
       - uses: actions/setup-python@v5
         id: setup_python

--- a/.github/workflows/wheel_linux_aarch64_cuda.yml
+++ b/.github/workflows/wheel_linux_aarch64_cuda.yml
@@ -34,6 +34,7 @@ jobs:
     uses: ./.github/workflows/set_wheel_build_matrix.yml
     with:
       event_name: ${{ github.event_name }}
+      workflow_name: ${{ github.workflow }}
 
   linux-wheels-aarch64:
     needs: [set_wheel_build_matrix]

--- a/.github/workflows/wheel_linux_aarch64_cuda.yml
+++ b/.github/workflows/wheel_linux_aarch64_cuda.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Checkout PennyLane-Lightning
         uses: actions/checkout@v4
         with:        
-          ref: ${{ inputs.branch }}
+          ref: ${{ inputs.branch || github.ref }}
 
       - name: Install Python 3.12
         uses: actions/setup-python@v5

--- a/.github/workflows/wheel_linux_aarch64_cuda.yml
+++ b/.github/workflows/wheel_linux_aarch64_cuda.yml
@@ -21,7 +21,7 @@ on:
         default: master        
 
 concurrency:
-  group: wheel_linux_aarch64_cu12-${{ github.ref }}
+  group: wheel_linux_aarch64_cu12-${{ inputs.branch || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/wheel_linux_aarch64_cuda.yml
+++ b/.github/workflows/wheel_linux_aarch64_cuda.yml
@@ -27,8 +27,7 @@ jobs:
   set_wheel_build_matrix:
     if: |
       github.event_name != 'pull_request' ||
-      (github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'ci:build_wheels')) ||
-      github.event_name == 'workflow_dispatch'
+      (github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'ci:build_wheels')) 
     name: "Set wheel build matrix"
     uses: ./.github/workflows/set_wheel_build_matrix.yml
     with:

--- a/.github/workflows/wheel_linux_x86_64.yml
+++ b/.github/workflows/wheel_linux_x86_64.yml
@@ -29,7 +29,7 @@ on:
         default: master        
 
 concurrency:
-  group: wheel_linux_x86_64-${{ github.ref }}
+  group: wheel_linux_x86_64-${{ github.ref }}-${{ inputs.branch }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/wheel_linux_x86_64.yml
+++ b/.github/workflows/wheel_linux_x86_64.yml
@@ -126,6 +126,8 @@ jobs:
 
       - name: Checkout PennyLane-Lightning
         uses: actions/checkout@v4
+        with:        
+          ref: ${{ inputs.branch }}         
 
       - name: Copy cached libraries
         if: steps.kokkos-cache.outputs.cache-hit == 'true'

--- a/.github/workflows/wheel_linux_x86_64.yml
+++ b/.github/workflows/wheel_linux_x86_64.yml
@@ -21,6 +21,12 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      branch:
+        required: false
+        type: string  
+        default: master        
 
 concurrency:
   group: wheel_linux_x86_64-${{ github.ref }}

--- a/.github/workflows/wheel_linux_x86_64.yml
+++ b/.github/workflows/wheel_linux_x86_64.yml
@@ -42,7 +42,7 @@ jobs:
     uses: ./.github/workflows/set_wheel_build_matrix.yml
     with:
       event_name: ${{ github.event_name }}
-      workflow_name: ${{ github.workflow }}
+      workflow_name: wheel_linux_x86_64
 
   build_dependencies:
     needs: [set_wheel_build_matrix]

--- a/.github/workflows/wheel_linux_x86_64.yml
+++ b/.github/workflows/wheel_linux_x86_64.yml
@@ -42,6 +42,7 @@ jobs:
     uses: ./.github/workflows/set_wheel_build_matrix.yml
     with:
       event_name: ${{ github.event_name }}
+      workflow_name: ${{ github.workflow }}
 
   build_dependencies:
     needs: [set_wheel_build_matrix]

--- a/.github/workflows/wheel_linux_x86_64.yml
+++ b/.github/workflows/wheel_linux_x86_64.yml
@@ -35,7 +35,6 @@ jobs:
   set_wheel_build_matrix:
     if: |
       github.event_name != 'pull_request' ||
-      github.event_name == 'schedule' ||
       (github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'ci:build_wheels')) ||
       github.event_name == 'workflow_dispatch'
     name: "Set wheel build matrix"

--- a/.github/workflows/wheel_linux_x86_64.yml
+++ b/.github/workflows/wheel_linux_x86_64.yml
@@ -29,7 +29,7 @@ on:
         default: master        
 
 concurrency:
-  group: wheel_linux_x86_64-${{ inputs.branch || github.ref }}
+  group: wheel_linux_x86_64-${{ inputs.branch || github.ref }}-${{ github.workflow }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/wheel_linux_x86_64.yml
+++ b/.github/workflows/wheel_linux_x86_64.yml
@@ -9,12 +9,12 @@ env:
   GCC_VERSION: 13
 
 on:
-  # pull_request:
-  #   types:
-  #     - opened
-  #     - reopened
-  #     - synchronize
-  #     - ready_for_review
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
   push:
     branches:
       - master

--- a/.github/workflows/wheel_linux_x86_64.yml
+++ b/.github/workflows/wheel_linux_x86_64.yml
@@ -9,12 +9,12 @@ env:
   GCC_VERSION: 13
 
 on:
-  pull_request:
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - ready_for_review
+  # pull_request:
+  #   types:
+  #     - opened
+  #     - reopened
+  #     - synchronize
+  #     - ready_for_review
   push:
     branches:
       - master

--- a/.github/workflows/wheel_linux_x86_64.yml
+++ b/.github/workflows/wheel_linux_x86_64.yml
@@ -29,7 +29,7 @@ on:
         default: master        
 
 concurrency:
-  group: wheel_linux_x86_64-${{ inputs.branch || github.ref }}-${{ github.workflow }}
+  group: wheel_linux_x86_64-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/wheel_linux_x86_64.yml
+++ b/.github/workflows/wheel_linux_x86_64.yml
@@ -29,7 +29,7 @@ on:
         default: master        
 
 concurrency:
-  group: wheel_linux_x86_64-${{ github.ref }}-${{ inputs.branch }}
+  group: wheel_linux_x86_64-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/wheel_linux_x86_64.yml
+++ b/.github/workflows/wheel_linux_x86_64.yml
@@ -36,6 +36,7 @@ jobs:
   set_wheel_build_matrix:
     if: |
       github.event_name != 'pull_request' ||
+      github.event_name == 'schedule' ||
       (github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'ci:build_wheels')) ||
       github.event_name == 'workflow_dispatch'
     name: "Set wheel build matrix"
@@ -207,6 +208,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: |
           github.event_name == 'release' ||
+          github.event_name == 'schedule' ||
           github.event_name == 'workflow_dispatch' ||
           github.ref == 'refs/heads/master' ||
           steps.rc_build.outputs.match != ''
@@ -237,6 +239,7 @@ jobs:
       - uses: actions/download-artifact@v4
         if: |
           github.event_name == 'release' ||
+          github.event_name == 'schedule' ||
           github.ref == 'refs/heads/master' || 
           steps.rc_build.outputs.match != ''
         with:
@@ -247,6 +250,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         if: |
           github.event_name == 'release' ||
+          github.event_name == 'schedule' ||
           github.ref == 'refs/heads/master' || 
           steps.rc_build.outputs.match != ''
         with:

--- a/.github/workflows/wheel_linux_x86_64.yml
+++ b/.github/workflows/wheel_linux_x86_64.yml
@@ -35,8 +35,7 @@ jobs:
   set_wheel_build_matrix:
     if: |
       github.event_name != 'pull_request' ||
-      (github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'ci:build_wheels')) ||
-      github.event_name == 'workflow_dispatch'
+      (github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'ci:build_wheels')) 
     name: "Set wheel build matrix"
     uses: ./.github/workflows/set_wheel_build_matrix.yml
     with:

--- a/.github/workflows/wheel_linux_x86_64.yml
+++ b/.github/workflows/wheel_linux_x86_64.yml
@@ -130,7 +130,7 @@ jobs:
       - name: Checkout PennyLane-Lightning
         uses: actions/checkout@v4
         with:        
-          ref: ${{ inputs.branch }}         
+          ref: ${{ inputs.branch || github.ref }}         
 
       - name: Copy cached libraries
         if: steps.kokkos-cache.outputs.cache-hit == 'true'

--- a/.github/workflows/wheel_linux_x86_64.yml
+++ b/.github/workflows/wheel_linux_x86_64.yml
@@ -26,7 +26,6 @@ on:
       branch:
         required: false
         type: string  
-        default: master        
 
 concurrency:
   group: wheel_linux_x86_64-${{ github.ref }}

--- a/.github/workflows/wheel_linux_x86_64.yml
+++ b/.github/workflows/wheel_linux_x86_64.yml
@@ -36,7 +36,8 @@ jobs:
   set_wheel_build_matrix:
     if: |
       github.event_name != 'pull_request' ||
-      (github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'ci:build_wheels'))
+      (github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'ci:build_wheels')) ||
+      github.event_name == 'workflow_dispatch'
     name: "Set wheel build matrix"
     uses: ./.github/workflows/set_wheel_build_matrix.yml
     with:

--- a/.github/workflows/wheel_linux_x86_64.yml
+++ b/.github/workflows/wheel_linux_x86_64.yml
@@ -29,7 +29,7 @@ on:
         default: master        
 
 concurrency:
-  group: wheel_linux_x86_64-${{ github.ref }}
+  group: wheel_linux_x86_64-${{ inputs.branch || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/wheel_linux_x86_64_cuda.yml
+++ b/.github/workflows/wheel_linux_x86_64_cuda.yml
@@ -25,7 +25,7 @@ on:
         default: master        
 
 concurrency:
-  group: wheel_linux_x86_64_cu12-${{ github.ref }}
+  group: wheel_linux_x86_64_cu12-${{ github.ref }}-${{ inputs.branch }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/wheel_linux_x86_64_cuda.yml
+++ b/.github/workflows/wheel_linux_x86_64_cuda.yml
@@ -17,6 +17,12 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      branch:
+        required: false
+        type: string  
+        default: master        
 
 concurrency:
   group: wheel_linux_x86_64_cu12-${{ github.ref }}

--- a/.github/workflows/wheel_linux_x86_64_cuda.yml
+++ b/.github/workflows/wheel_linux_x86_64_cuda.yml
@@ -58,6 +58,8 @@ jobs:
     steps:
       - name: Checkout PennyLane-Lightning
         uses: actions/checkout@v4
+        with:        
+          ref: ${{ inputs.branch }}         
 
       - name: Install dependencies (AlmaLinux)
         if: ${{ (matrix.container_img == 'quay.io/pypa/manylinux_2_28_x86_64') }}

--- a/.github/workflows/wheel_linux_x86_64_cuda.yml
+++ b/.github/workflows/wheel_linux_x86_64_cuda.yml
@@ -31,8 +31,7 @@ jobs:
   set_wheel_build_matrix:
     if: |
         github.event_name != 'pull_request' ||
-        (github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'ci:build_wheels')) ||
-        github.event_name == 'workflow_dispatch'
+        (github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'ci:build_wheels')) 
     name: "Set wheel build matrix"
     uses: ./.github/workflows/set_wheel_build_matrix.yml
     with:

--- a/.github/workflows/wheel_linux_x86_64_cuda.yml
+++ b/.github/workflows/wheel_linux_x86_64_cuda.yml
@@ -32,6 +32,7 @@ jobs:
   set_wheel_build_matrix:
     if: |
         github.event_name != 'pull_request' ||
+        github.event_name == 'schedule' ||
         (github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'ci:build_wheels')) ||
         github.event_name == 'workflow_dispatch'
     name: "Set wheel build matrix"
@@ -122,6 +123,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: |
           github.event_name == 'release' ||
+          github.event_name == 'schedule' ||
           github.event_name == 'workflow_dispatch' ||
           github.ref == 'refs/heads/master' ||
           steps.rc_build.outputs.match != ''
@@ -153,6 +155,7 @@ jobs:
       - uses: actions/download-artifact@v4
         if: |
           github.event_name == 'release' ||
+          github.event_name == 'schedule' ||
           github.ref == 'refs/heads/master' || 
           steps.rc_build.outputs.match != ''
         with:
@@ -163,6 +166,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         if: |
           github.event_name == 'release' ||
+          github.event_name == 'schedule' ||
           github.ref == 'refs/heads/master' || 
           steps.rc_build.outputs.match != ''
         with:

--- a/.github/workflows/wheel_linux_x86_64_cuda.yml
+++ b/.github/workflows/wheel_linux_x86_64_cuda.yml
@@ -30,8 +30,8 @@ concurrency:
 jobs:
   set_wheel_build_matrix:
     if: |
-        github.event_name != 'pull_request' ||
-        (github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'ci:build_wheels')) 
+      github.event_name != 'pull_request' ||
+      (github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'ci:build_wheels')) 
     name: "Set wheel build matrix"
     uses: ./.github/workflows/set_wheel_build_matrix.yml
     with:

--- a/.github/workflows/wheel_linux_x86_64_cuda.yml
+++ b/.github/workflows/wheel_linux_x86_64_cuda.yml
@@ -32,7 +32,8 @@ jobs:
   set_wheel_build_matrix:
     if: |
         github.event_name != 'pull_request' ||
-        (github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'ci:build_wheels'))
+        (github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'ci:build_wheels')) ||
+        github.event_name == 'workflow_dispatch'
     name: "Set wheel build matrix"
     uses: ./.github/workflows/set_wheel_build_matrix.yml
     with:

--- a/.github/workflows/wheel_linux_x86_64_cuda.yml
+++ b/.github/workflows/wheel_linux_x86_64_cuda.yml
@@ -22,7 +22,6 @@ on:
       branch:
         required: false
         type: string  
-        default: master        
 
 concurrency:
   group: wheel_linux_x86_64_cu12-${{ github.ref }}

--- a/.github/workflows/wheel_linux_x86_64_cuda.yml
+++ b/.github/workflows/wheel_linux_x86_64_cuda.yml
@@ -5,12 +5,12 @@ name: Wheel::Linux::x86_64::CUDA
 # **Why we have it**: To build wheels for pennylane-lightning-gpu installation.
 # **Who does it impact**: Wheels to be uploaded to PyPI.
 on:
-  # pull_request:
-  #   types:
-  #     - opened
-  #     - reopened
-  #     - synchronize
-  #     - ready_for_review
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
   push:
     branches:
       - master

--- a/.github/workflows/wheel_linux_x86_64_cuda.yml
+++ b/.github/workflows/wheel_linux_x86_64_cuda.yml
@@ -25,7 +25,7 @@ on:
         default: master        
 
 concurrency:
-  group: wheel_linux_x86_64_cu12-${{ inputs.branch || github.ref }}
+  group: wheel_linux_x86_64_cu12-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/wheel_linux_x86_64_cuda.yml
+++ b/.github/workflows/wheel_linux_x86_64_cuda.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Checkout PennyLane-Lightning
         uses: actions/checkout@v4
         with:        
-          ref: ${{ inputs.branch }}         
+          ref: ${{ inputs.branch || github.ref }}         
 
       - name: Install dependencies (AlmaLinux)
         if: ${{ (matrix.container_img == 'quay.io/pypa/manylinux_2_28_x86_64') }}

--- a/.github/workflows/wheel_linux_x86_64_cuda.yml
+++ b/.github/workflows/wheel_linux_x86_64_cuda.yml
@@ -38,6 +38,7 @@ jobs:
     uses: ./.github/workflows/set_wheel_build_matrix.yml
     with:
       event_name: ${{ github.event_name }}
+      workflow_name: wheel_linux_x86_64_cuda
 
   linux-wheels-x86-64:
     needs: [set_wheel_build_matrix]

--- a/.github/workflows/wheel_linux_x86_64_cuda.yml
+++ b/.github/workflows/wheel_linux_x86_64_cuda.yml
@@ -31,7 +31,6 @@ jobs:
   set_wheel_build_matrix:
     if: |
         github.event_name != 'pull_request' ||
-        github.event_name == 'schedule' ||
         (github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'ci:build_wheels')) ||
         github.event_name == 'workflow_dispatch'
     name: "Set wheel build matrix"

--- a/.github/workflows/wheel_linux_x86_64_cuda.yml
+++ b/.github/workflows/wheel_linux_x86_64_cuda.yml
@@ -25,7 +25,7 @@ on:
         default: master        
 
 concurrency:
-  group: wheel_linux_x86_64_cu12-${{ github.ref }}-${{ inputs.branch }}
+  group: wheel_linux_x86_64_cu12-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/wheel_linux_x86_64_cuda.yml
+++ b/.github/workflows/wheel_linux_x86_64_cuda.yml
@@ -5,12 +5,12 @@ name: Wheel::Linux::x86_64::CUDA
 # **Why we have it**: To build wheels for pennylane-lightning-gpu installation.
 # **Who does it impact**: Wheels to be uploaded to PyPI.
 on:
-  pull_request:
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - ready_for_review
+  # pull_request:
+  #   types:
+  #     - opened
+  #     - reopened
+  #     - synchronize
+  #     - ready_for_review
   push:
     branches:
       - master

--- a/.github/workflows/wheel_linux_x86_64_cuda.yml
+++ b/.github/workflows/wheel_linux_x86_64_cuda.yml
@@ -25,7 +25,7 @@ on:
         default: master        
 
 concurrency:
-  group: wheel_linux_x86_64_cu12-${{ github.ref }}
+  group: wheel_linux_x86_64_cu12-${{ inputs.branch || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/wheel_linux_x86_64_rocm.yml
+++ b/.github/workflows/wheel_linux_x86_64_rocm.yml
@@ -129,7 +129,9 @@ jobs:
 
       - name: Checkout PennyLane-Lightning
         uses: actions/checkout@v4
-
+        with:        
+          ref: ${{ inputs.branch }} 
+          
       - name: Copy cached libraries
         if: steps.kokkos-cache.outputs.cache-hit == 'true'
         run: |

--- a/.github/workflows/wheel_linux_x86_64_rocm.yml
+++ b/.github/workflows/wheel_linux_x86_64_rocm.yml
@@ -28,7 +28,7 @@ on:
         default: master        
 
 concurrency:
-  group: wheel_linux_x86_64_rocm-${{ github.ref }}
+  group: wheel_linux_x86_64_rocm-${{ github.ref }}-${{ inputs.branch }}
   cancel-in-progress: true
 
 jobs:
@@ -131,7 +131,7 @@ jobs:
         uses: actions/checkout@v4
         with:        
           ref: ${{ inputs.branch }} 
-          
+
       - name: Copy cached libraries
         if: steps.kokkos-cache.outputs.cache-hit == 'true'
         run: |

--- a/.github/workflows/wheel_linux_x86_64_rocm.yml
+++ b/.github/workflows/wheel_linux_x86_64_rocm.yml
@@ -20,6 +20,12 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      branch:
+        required: false
+        type: string  
+        default: master        
 
 concurrency:
   group: wheel_linux_x86_64_rocm-${{ github.ref }}

--- a/.github/workflows/wheel_linux_x86_64_rocm.yml
+++ b/.github/workflows/wheel_linux_x86_64_rocm.yml
@@ -41,6 +41,7 @@ jobs:
     uses: ./.github/workflows/set_wheel_build_matrix.yml
     with:
       event_name: ${{ github.event_name }}
+      workflow_name: wheel_linux_x86_64_rocm
 
   build_dependencies:
     needs: [set_wheel_build_matrix]

--- a/.github/workflows/wheel_linux_x86_64_rocm.yml
+++ b/.github/workflows/wheel_linux_x86_64_rocm.yml
@@ -28,7 +28,7 @@ on:
         default: master        
 
 concurrency:
-  group: wheel_linux_x86_64_rocm-${{ inputs.branch || github.ref }}
+  group: wheel_linux_x86_64_rocm-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/wheel_linux_x86_64_rocm.yml
+++ b/.github/workflows/wheel_linux_x86_64_rocm.yml
@@ -25,7 +25,6 @@ on:
       branch:
         required: false
         type: string  
-        default: master        
 
 concurrency:
   group: wheel_linux_x86_64_rocm-${{ github.ref }}

--- a/.github/workflows/wheel_linux_x86_64_rocm.yml
+++ b/.github/workflows/wheel_linux_x86_64_rocm.yml
@@ -133,7 +133,7 @@ jobs:
       - name: Checkout PennyLane-Lightning
         uses: actions/checkout@v4
         with:        
-          ref: ${{ inputs.branch }} 
+          ref: ${{ inputs.branch || github.ref }} 
 
       - name: Copy cached libraries
         if: steps.kokkos-cache.outputs.cache-hit == 'true'

--- a/.github/workflows/wheel_linux_x86_64_rocm.yml
+++ b/.github/workflows/wheel_linux_x86_64_rocm.yml
@@ -8,12 +8,12 @@ permissions:
 # **Who does it impact**: Wheels to be uploaded to PyPI.
 
 on:
-  # pull_request:
-  #   types:
-  #     - opened
-  #     - reopened
-  #     - synchronize
-  #     - ready_for_review
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
   push:
     branches:
       - master

--- a/.github/workflows/wheel_linux_x86_64_rocm.yml
+++ b/.github/workflows/wheel_linux_x86_64_rocm.yml
@@ -28,7 +28,7 @@ on:
         default: master        
 
 concurrency:
-  group: wheel_linux_x86_64_rocm-${{ github.ref }}
+  group: wheel_linux_x86_64_rocm-${{ inputs.branch || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/wheel_linux_x86_64_rocm.yml
+++ b/.github/workflows/wheel_linux_x86_64_rocm.yml
@@ -35,6 +35,7 @@ jobs:
   set_wheel_build_matrix:
     if: |
       github.event_name != 'pull_request' ||
+      github.event_name == 'schedule' ||
       (github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'ci:build_wheels')) ||
       github.event_name == 'workflow_dispatch'
     name: "Set wheel build matrix"
@@ -192,6 +193,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: |
           github.event_name == 'release' ||
+          github.event_name == 'schedule' ||
           github.event_name == 'workflow_dispatch' ||
           github.ref == 'refs/heads/master' ||
           steps.rc_build.outputs.match != ''
@@ -223,6 +225,7 @@ jobs:
       - uses: actions/download-artifact@v4
         if: |
           github.event_name == 'release' ||
+          github.event_name == 'schedule' ||
           github.ref == 'refs/heads/master' || 
           steps.rc_build.outputs.match != ''
         with:
@@ -233,6 +236,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         if: |
           github.event_name == 'release' ||
+          github.event_name == 'schedule' ||
           github.ref == 'refs/heads/master' || 
           steps.rc_build.outputs.match != ''
         with:

--- a/.github/workflows/wheel_linux_x86_64_rocm.yml
+++ b/.github/workflows/wheel_linux_x86_64_rocm.yml
@@ -8,12 +8,12 @@ permissions:
 # **Who does it impact**: Wheels to be uploaded to PyPI.
 
 on:
-  pull_request:
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - ready_for_review
+  # pull_request:
+  #   types:
+  #     - opened
+  #     - reopened
+  #     - synchronize
+  #     - ready_for_review
   push:
     branches:
       - master

--- a/.github/workflows/wheel_linux_x86_64_rocm.yml
+++ b/.github/workflows/wheel_linux_x86_64_rocm.yml
@@ -34,7 +34,6 @@ jobs:
   set_wheel_build_matrix:
     if: |
       github.event_name != 'pull_request' ||
-      github.event_name == 'schedule' ||
       (github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'ci:build_wheels')) ||
       github.event_name == 'workflow_dispatch'
     name: "Set wheel build matrix"

--- a/.github/workflows/wheel_linux_x86_64_rocm.yml
+++ b/.github/workflows/wheel_linux_x86_64_rocm.yml
@@ -35,7 +35,8 @@ jobs:
   set_wheel_build_matrix:
     if: |
       github.event_name != 'pull_request' ||
-      (github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'ci:build_wheels'))
+      (github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'ci:build_wheels')) ||
+      github.event_name == 'workflow_dispatch'
     name: "Set wheel build matrix"
     uses: ./.github/workflows/set_wheel_build_matrix.yml
     with:

--- a/.github/workflows/wheel_linux_x86_64_rocm.yml
+++ b/.github/workflows/wheel_linux_x86_64_rocm.yml
@@ -34,8 +34,7 @@ jobs:
   set_wheel_build_matrix:
     if: |
       github.event_name != 'pull_request' ||
-      (github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'ci:build_wheels')) ||
-      github.event_name == 'workflow_dispatch'
+      (github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'ci:build_wheels')) 
     name: "Set wheel build matrix"
     uses: ./.github/workflows/set_wheel_build_matrix.yml
     with:

--- a/.github/workflows/wheel_linux_x86_64_rocm.yml
+++ b/.github/workflows/wheel_linux_x86_64_rocm.yml
@@ -28,7 +28,7 @@ on:
         default: master        
 
 concurrency:
-  group: wheel_linux_x86_64_rocm-${{ github.ref }}-${{ inputs.branch }}
+  group: wheel_linux_x86_64_rocm-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/wheel_macos_arm64.yml
+++ b/.github/workflows/wheel_macos_arm64.yml
@@ -58,6 +58,8 @@ jobs:
     steps:
       - name: Checkout PennyLane-Lightning
         uses: actions/checkout@v4
+        with:        
+          ref: ${{ inputs.branch }}
 
       - uses: actions/setup-python@v5
         name: Install Python

--- a/.github/workflows/wheel_macos_arm64.yml
+++ b/.github/workflows/wheel_macos_arm64.yml
@@ -29,7 +29,7 @@ env:
   MACOSX_DEPLOYMENT_TARGET: 13.0
 
 concurrency:
-  group: wheel_macos_arm64-${{ github.ref }}
+  group: wheel_macos_arm64-${{ github.ref }}-${{ inputs.branch }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/wheel_macos_arm64.yml
+++ b/.github/workflows/wheel_macos_arm64.yml
@@ -18,6 +18,12 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      branch:
+        required: false
+        type: string  
+        default: master        
 
 env:
   MACOSX_DEPLOYMENT_TARGET: 13.0

--- a/.github/workflows/wheel_macos_arm64.yml
+++ b/.github/workflows/wheel_macos_arm64.yml
@@ -6,12 +6,12 @@ name: Wheel::MacOS::ARM
 # **Who does it impact**: Wheels to be uploaded to PyPI.
 
 on:
-  pull_request:
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - ready_for_review
+  # pull_request:
+  #   types:
+  #     - opened
+  #     - reopened
+  #     - synchronize
+  #     - ready_for_review
   push:
     branches:
       - master

--- a/.github/workflows/wheel_macos_arm64.yml
+++ b/.github/workflows/wheel_macos_arm64.yml
@@ -42,6 +42,7 @@ jobs:
     uses: ./.github/workflows/set_wheel_build_matrix.yml
     with:
       event_name: ${{ github.event_name }}
+      workflow_name: wheel_macos_arm64
 
   mac-wheels-arm64:
     needs: [set_wheel_build_matrix]

--- a/.github/workflows/wheel_macos_arm64.yml
+++ b/.github/workflows/wheel_macos_arm64.yml
@@ -29,7 +29,7 @@ env:
   MACOSX_DEPLOYMENT_TARGET: 13.0
 
 concurrency:
-  group: wheel_macos_arm64-${{ github.ref }}-${{ inputs.branch }}
+  group: wheel_macos_arm64-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/wheel_macos_arm64.yml
+++ b/.github/workflows/wheel_macos_arm64.yml
@@ -29,7 +29,7 @@ env:
   MACOSX_DEPLOYMENT_TARGET: 13.0
 
 concurrency:
-  group: wheel_macos_arm64-${{ inputs.branch || github.ref }}
+  group: wheel_macos_arm64-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/wheel_macos_arm64.yml
+++ b/.github/workflows/wheel_macos_arm64.yml
@@ -23,7 +23,6 @@ on:
       branch:
         required: false
         type: string  
-        default: master        
 
 env:
   MACOSX_DEPLOYMENT_TARGET: 13.0

--- a/.github/workflows/wheel_macos_arm64.yml
+++ b/.github/workflows/wheel_macos_arm64.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Checkout PennyLane-Lightning
         uses: actions/checkout@v4
         with:        
-          ref: ${{ inputs.branch }}
+          ref: ${{ inputs.branch || github.ref }}
 
       - uses: actions/setup-python@v5
         name: Install Python

--- a/.github/workflows/wheel_macos_arm64.yml
+++ b/.github/workflows/wheel_macos_arm64.yml
@@ -125,6 +125,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: |
           github.event_name == 'release' ||
+          github.event_name == 'schedule' ||
           github.event_name == 'workflow_dispatch' ||
           github.ref == 'refs/heads/master' || 
           steps.rc_build.outputs.match != ''
@@ -155,6 +156,7 @@ jobs:
       - uses: actions/download-artifact@v4
         if: |
           github.event_name == 'release' ||
+          github.event_name == 'schedule' ||
           github.ref == 'refs/heads/master' || 
           steps.rc_build.outputs.match != ''
         with:
@@ -165,6 +167,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         if: |
           github.event_name == 'release' ||
+          github.event_name == 'schedule' ||
           github.ref == 'refs/heads/master' || 
           steps.rc_build.outputs.match != ''
         with:

--- a/.github/workflows/wheel_macos_arm64.yml
+++ b/.github/workflows/wheel_macos_arm64.yml
@@ -35,8 +35,7 @@ jobs:
   set_wheel_build_matrix:
     if: |
       github.event_name != 'pull_request' ||
-      (github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'ci:build_wheels')) ||
-      github.event_name == 'workflow_dispatch'
+      (github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'ci:build_wheels')) 
     name: "Set wheel build matrix"
     uses: ./.github/workflows/set_wheel_build_matrix.yml
     with:

--- a/.github/workflows/wheel_macos_arm64.yml
+++ b/.github/workflows/wheel_macos_arm64.yml
@@ -29,7 +29,7 @@ env:
   MACOSX_DEPLOYMENT_TARGET: 13.0
 
 concurrency:
-  group: wheel_macos_arm64-${{ github.ref }}
+  group: wheel_macos_arm64-${{ inputs.branch || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/wheel_macos_arm64.yml
+++ b/.github/workflows/wheel_macos_arm64.yml
@@ -36,7 +36,8 @@ jobs:
   set_wheel_build_matrix:
     if: |
       github.event_name != 'pull_request' ||
-      (github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'ci:build_wheels'))
+      (github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'ci:build_wheels')) ||
+      github.event_name == 'workflow_dispatch'
     name: "Set wheel build matrix"
     uses: ./.github/workflows/set_wheel_build_matrix.yml
     with:

--- a/.github/workflows/wheel_macos_arm64.yml
+++ b/.github/workflows/wheel_macos_arm64.yml
@@ -6,12 +6,12 @@ name: Wheel::MacOS::ARM
 # **Who does it impact**: Wheels to be uploaded to PyPI.
 
 on:
-  # pull_request:
-  #   types:
-  #     - opened
-  #     - reopened
-  #     - synchronize
-  #     - ready_for_review
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
   push:
     branches:
       - master

--- a/.github/workflows/wheel_noarch.yml
+++ b/.github/workflows/wheel_noarch.yml
@@ -26,7 +26,7 @@ on:
         default: master        
 
 concurrency:
-  group: wheel_noarch-${{ github.ref }}
+  group: wheel_noarch-${{ github.ref }}-${{ inputs.branch }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/wheel_noarch.yml
+++ b/.github/workflows/wheel_noarch.yml
@@ -18,6 +18,12 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      branch:
+        required: false
+        type: string  
+        default: master        
 
 concurrency:
   group: wheel_noarch-${{ github.ref }}

--- a/.github/workflows/wheel_noarch.yml
+++ b/.github/workflows/wheel_noarch.yml
@@ -45,6 +45,8 @@ jobs:
     steps:
       - name: Checkout PennyLane-Lightning
         uses: actions/checkout@v4
+        with:        
+          ref: ${{ inputs.branch }}
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/wheel_noarch.yml
+++ b/.github/workflows/wheel_noarch.yml
@@ -23,7 +23,6 @@ on:
       branch:
         required: false
         type: string  
-        default: master        
 
 concurrency:
   group: wheel_noarch-${{ github.ref }}

--- a/.github/workflows/wheel_noarch.yml
+++ b/.github/workflows/wheel_noarch.yml
@@ -33,6 +33,7 @@ jobs:
   build-pure-python-wheel:
     if: |
       github.event_name != 'pull_request' ||
+      github.event_name == 'schedule' ||
       (github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'ci:build_wheels')) ||
       github.event_name == 'workflow_dispatch'
     strategy:
@@ -84,6 +85,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: |
           github.event_name == 'release' || 
+          github.event_name == 'schedule' ||
           github.event_name == 'workflow_dispatch' || 
           github.ref == 'refs/heads/master' ||
           steps.rc_build.outputs.match != ''

--- a/.github/workflows/wheel_noarch.yml
+++ b/.github/workflows/wheel_noarch.yml
@@ -26,7 +26,7 @@ on:
         default: master        
 
 concurrency:
-  group: wheel_noarch-${{ inputs.branch || github.ref }}
+  group: wheel_noarch-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/wheel_noarch.yml
+++ b/.github/workflows/wheel_noarch.yml
@@ -26,7 +26,7 @@ on:
         default: master        
 
 concurrency:
-  group: wheel_noarch-${{ github.ref }}
+  group: wheel_noarch-${{ inputs.branch || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/wheel_noarch.yml
+++ b/.github/workflows/wheel_noarch.yml
@@ -6,12 +6,12 @@ name: Wheel::Any::None
 # **Who does it impact**: Wheels to be uploaded to PyPI.
 
 on:
-  pull_request:
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - ready_for_review
+  # pull_request:
+  #   types:
+  #     - opened
+  #     - reopened
+  #     - synchronize
+  #     - ready_for_review
   push:
     branches:
       - master

--- a/.github/workflows/wheel_noarch.yml
+++ b/.github/workflows/wheel_noarch.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Checkout PennyLane-Lightning
         uses: actions/checkout@v4
         with:        
-          ref: ${{ inputs.branch }}
+          ref: ${{ inputs.branch || github.ref }}
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/wheel_noarch.yml
+++ b/.github/workflows/wheel_noarch.yml
@@ -26,7 +26,7 @@ on:
         default: master        
 
 concurrency:
-  group: wheel_noarch-${{ github.ref }}-${{ inputs.branch }}
+  group: wheel_noarch-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/wheel_noarch.yml
+++ b/.github/workflows/wheel_noarch.yml
@@ -6,12 +6,12 @@ name: Wheel::Any::None
 # **Who does it impact**: Wheels to be uploaded to PyPI.
 
 on:
-  # pull_request:
-  #   types:
-  #     - opened
-  #     - reopened
-  #     - synchronize
-  #     - ready_for_review
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
   push:
     branches:
       - master

--- a/.github/workflows/wheel_win_x86_64.yml
+++ b/.github/workflows/wheel_win_x86_64.yml
@@ -116,6 +116,8 @@ jobs:
 
       - name: Checkout PennyLane-Lightning
         uses: actions/checkout@v4
+        with:        
+          ref: ${{ inputs.branch }}
 
       - name: Copy cached libraries
         if: steps.kokkos-cache.outputs.cache-hit == 'true'

--- a/.github/workflows/wheel_win_x86_64.yml
+++ b/.github/workflows/wheel_win_x86_64.yml
@@ -18,6 +18,12 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      branch:
+        required: false
+        type: string  
+        default: master
 
 env:
   DISTUTILS_USE_SDK: 1

--- a/.github/workflows/wheel_win_x86_64.yml
+++ b/.github/workflows/wheel_win_x86_64.yml
@@ -30,7 +30,7 @@ env:
   MSSdk: 1
 
 concurrency:
-  group: wheel_win_x86_64-${{ github.ref }}
+  group: wheel_win_x86_64-${{ github.ref }}-${{ inputs.branch }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/wheel_win_x86_64.yml
+++ b/.github/workflows/wheel_win_x86_64.yml
@@ -30,7 +30,7 @@ env:
   MSSdk: 1
 
 concurrency:
-  group: wheel_win_x86_64-${{ github.ref }}
+  group: wheel_win_x86_64-${{ inputs.branch || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/wheel_win_x86_64.yml
+++ b/.github/workflows/wheel_win_x86_64.yml
@@ -30,7 +30,7 @@ env:
   MSSdk: 1
 
 concurrency:
-  group: wheel_win_x86_64-${{ inputs.branch || github.ref }}
+  group: wheel_win_x86_64-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/wheel_win_x86_64.yml
+++ b/.github/workflows/wheel_win_x86_64.yml
@@ -120,7 +120,7 @@ jobs:
       - name: Checkout PennyLane-Lightning
         uses: actions/checkout@v4
         with:        
-          ref: ${{ inputs.branch }}
+          ref: ${{ inputs.branch || github.ref }}
 
       - name: Copy cached libraries
         if: steps.kokkos-cache.outputs.cache-hit == 'true'

--- a/.github/workflows/wheel_win_x86_64.yml
+++ b/.github/workflows/wheel_win_x86_64.yml
@@ -37,8 +37,7 @@ jobs:
     if: |
       github.event_name != 'pull_request' ||
       (github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'ci:build_wheels')) ||
-      github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'schedule' 
+      github.event_name == 'workflow_dispatch' 
     name: "Set wheel build matrix"
     uses: ./.github/workflows/set_wheel_build_matrix.yml
     with:

--- a/.github/workflows/wheel_win_x86_64.yml
+++ b/.github/workflows/wheel_win_x86_64.yml
@@ -37,7 +37,8 @@ jobs:
   set_wheel_build_matrix:
     if: |
       github.event_name != 'pull_request' ||
-      (github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'ci:build_wheels'))
+      (github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'ci:build_wheels')) ||
+      github.event_name == 'workflow_dispatch'
     name: "Set wheel build matrix"
     uses: ./.github/workflows/set_wheel_build_matrix.yml
     with:

--- a/.github/workflows/wheel_win_x86_64.yml
+++ b/.github/workflows/wheel_win_x86_64.yml
@@ -23,7 +23,6 @@ on:
       branch:
         required: false
         type: string  
-        default: master
 
 env:
   DISTUTILS_USE_SDK: 1

--- a/.github/workflows/wheel_win_x86_64.yml
+++ b/.github/workflows/wheel_win_x86_64.yml
@@ -43,6 +43,7 @@ jobs:
     uses: ./.github/workflows/set_wheel_build_matrix.yml
     with:
       event_name: ${{ github.event_name }}
+      workflow_name: wheel_win_x86_64
 
   build_dependencies:
     needs: [set_wheel_build_matrix]

--- a/.github/workflows/wheel_win_x86_64.yml
+++ b/.github/workflows/wheel_win_x86_64.yml
@@ -30,7 +30,7 @@ env:
   MSSdk: 1
 
 concurrency:
-  group: wheel_win_x86_64-${{ github.ref }}-${{ inputs.branch }}
+  group: wheel_win_x86_64-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/wheel_win_x86_64.yml
+++ b/.github/workflows/wheel_win_x86_64.yml
@@ -36,8 +36,7 @@ jobs:
   set_wheel_build_matrix:
     if: |
       github.event_name != 'pull_request' ||
-      (github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'ci:build_wheels')) ||
-      github.event_name == 'workflow_dispatch' 
+      (github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'ci:build_wheels')) 
     name: "Set wheel build matrix"
     uses: ./.github/workflows/set_wheel_build_matrix.yml
     with:

--- a/.github/workflows/wheel_win_x86_64.yml
+++ b/.github/workflows/wheel_win_x86_64.yml
@@ -6,12 +6,12 @@ name: Wheel::Windows::x86_64
 # **Who does it impact**: Wheels to be uploaded to PyPI.
 
 on:
-  # pull_request:
-  #   types:
-  #     - opened
-  #     - reopened
-  #     - synchronize
-  #     - ready_for_review
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
   push:
     branches:
       - master

--- a/.github/workflows/wheel_win_x86_64.yml
+++ b/.github/workflows/wheel_win_x86_64.yml
@@ -38,7 +38,8 @@ jobs:
     if: |
       github.event_name != 'pull_request' ||
       (github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'ci:build_wheels')) ||
-      github.event_name == 'workflow_dispatch'
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'schedule' 
     name: "Set wheel build matrix"
     uses: ./.github/workflows/set_wheel_build_matrix.yml
     with:
@@ -216,6 +217,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: |
           github.event_name == 'release' ||
+          github.event_name == 'schedule' ||
           github.event_name == 'workflow_dispatch' ||
           github.ref == 'refs/heads/master' ||
           steps.rc_build.outputs.match != ''
@@ -244,6 +246,7 @@ jobs:
       - uses: actions/download-artifact@v4
         if: |
           github.event_name == 'release' ||
+          github.event_name == 'schedule' ||
           github.ref == 'refs/heads/master' || 
           steps.rc_build.outputs.match != ''
         with:
@@ -254,6 +257,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         if: |
           github.event_name == 'release' ||
+          github.event_name == 'schedule' ||
           github.ref == 'refs/heads/master' || 
           steps.rc_build.outputs.match != ''
         with:

--- a/.github/workflows/wheel_win_x86_64.yml
+++ b/.github/workflows/wheel_win_x86_64.yml
@@ -6,12 +6,12 @@ name: Wheel::Windows::x86_64
 # **Who does it impact**: Wheels to be uploaded to PyPI.
 
 on:
-  pull_request:
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - ready_for_review
+  # pull_request:
+  #   types:
+  #     - opened
+  #     - reopened
+  #     - synchronize
+  #     - ready_for_review
   push:
     branches:
       - master

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.45.0-dev19"
+__version__ = "0.45.0-dev20"

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.45.0-dev21"
+__version__ = "0.45.0-dev22"

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.45.0-dev18"
+__version__ = "0.45.0-dev19"

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.45.0-dev20"
+__version__ = "0.45.0-dev21"

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.45.0-dev22"
+__version__ = "0.45.0-dev23"


### PR DESCRIPTION
**Context:**
This is part of the nightly release automation synchronization with pennylane and catalyst where the uploads to TestPyPI are done in the following order: Lightning —> Catalyst —> Pennylane. A new workflow to upload wheels built from the RC branch will be added and run on a schedule. The workflow will also trigger Catalyst's rc nightly build.

**Description of the Change:**
Added workflow to update the RC version number, build and push nightly builds of the RC branch to TestPyPi, and trigger the nightly build of Catalyst. The build wheel workflows were also updated to run with the nightly builds.

**Benefits:**
RC branch TestPyPI builds are synchronized.

**Possible Drawbacks:**
None

**Related GitHub Issues:**
https://github.com/PennyLaneAI/catalyst/pull/2491
https://github.com/PennyLaneAI/pennylane/pull/9092