### PR TITLE
Fix docker action branch

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -33,7 +33,7 @@
 <h3>Internal changes ⚙️</h3>
 
 - Updated Github docker build action to use relevant lightning branch.
-  [(#XXXX)](https://github.com/PennyLaneAI/pennylane-lightning/pull/XXXX)
+  [(#1346 )](https://github.com/PennyLaneAI/pennylane-lightning/pull/1346)
 
 - Remove dependency for GCC-11 when building `lightning.amdgpu`.
   [(#1343)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1343)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -32,6 +32,9 @@
 
 <h3>Internal changes ⚙️</h3>
 
+- Updated Github docker build action to use relevant lightning branch.
+  [(#XXXX)](https://github.com/PennyLaneAI/pennylane-lightning/pull/XXXX)
+
 - Remove dependency for GCC-11 when building `lightning.amdgpu`.
   [(#1343)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1343)
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -33,7 +33,7 @@
 <h3>Internal changes ⚙️</h3>
 
 - Updated Github docker build action to use relevant lightning branch.
-  [(#1346 )](https://github.com/PennyLaneAI/pennylane-lightning/pull/1346)
+  [(#1346)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1346)
 
 - Remove dependency for GCC-11 when building `lightning.amdgpu`.
   [(#1343)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1343)

--- a/.github/workflows/docker_linux_x86_64.yml
+++ b/.github/workflows/docker_linux_x86_64.yml
@@ -52,6 +52,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.lightning-version }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.45.0-dev19"
+__version__ = "0.45.0-dev20"


### PR DESCRIPTION
**Context:**
Currently the docker build action always uses the dockerfile from the master branch, regardless of which lightning branch we are testing. When the dockerfile is updated in master, this can cause failure when testing stable docker builds.

**Description of the Change:**
Update docker action to use dockerfile from the same lightning branch as that being tested.

**Benefits:**
Stable docker build works

**Possible Drawbacks:**

**Related GitHub Issues:**


[latest docker build](https://github.com/PennyLaneAI/pennylane-lightning/actions/runs/22314096215)
[stable docker build](https://github.com/PennyLaneAI/pennylane-lightning/actions/runs/22314110578)

[sc-112280]