### PR TITLE
Avoid decomposing unsupported Ops into QubitUnitary when not specified in the device TOML file

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -11,7 +11,7 @@
 <h3>Improvements 🛠</h3>
 
 - Avoid decomposing unsupported gates and templates into `QubitUnitary` when not specified in the device TOML file of Lightning simulators from Catalyst.
-  [(#)](https://github.com/PennyLaneAI/pennylane-lightning/pull/)
+  [(#1348)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1348)
 
 - Added sitemap configuration and SEO improvements to documentation, including noindex meta tags for C++ API reference pages.
   [(#1331)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1331)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -10,6 +10,9 @@
 
 <h3>Improvements 🛠</h3>
 
+- Avoid decomposing unsupported gates and templates into `QubitUnitary` when not specified in the device TOML file of Lightning simulators from Catalyst.
+  [(#)](https://github.com/PennyLaneAI/pennylane-lightning/pull/)
+
 - Added sitemap configuration and SEO improvements to documentation, including noindex meta tags for C++ API reference pages.
   [(#1331)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1331)
 

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.45.0-dev20"
+__version__ = "0.45.0-dev21"

--- a/pennylane_lightning/lightning_gpu/lightning_gpu.py
+++ b/pennylane_lightning/lightning_gpu/lightning_gpu.py
@@ -161,8 +161,14 @@ class LightningGPU(LightningBase):
 
     # TODO: This is to communicate to Catalyst in qjit-compiled workflows that these operations
     #       should be converted to QubitUnitary instead of their original decompositions. Remove
-    #       this when customizable multiple decomposition pathways are implemented
-    _to_matrix_ops = _to_matrix_ops
+    #       this when the legacy decomposition system in Catalyst is integrated with the
+    #       graph-based decomposition system, which will allow for customizable multi-pathway.
+    _to_matrix_ops = (
+        _to_matrix_ops
+        if "QubitUnitary"
+        in qml.devices.capabilities.load_toml_file(config_filepath)["operators"]["gates"]
+        else None
+    )
 
     # This configuration file declares capabilities of the device
     config_filepath = Path(__file__).parent / "lightning_gpu.toml"

--- a/pennylane_lightning/lightning_gpu/lightning_gpu.py
+++ b/pennylane_lightning/lightning_gpu/lightning_gpu.py
@@ -159,6 +159,9 @@ class LightningGPU(LightningBase):
     _CPP_BINARY_AVAILABLE = LGPU_CPP_BINARY_AVAILABLE
     _backend_info = backend_info if LGPU_CPP_BINARY_AVAILABLE else None
 
+    # This configuration file declares capabilities of the device
+    config_filepath = Path(__file__).parent / "lightning_gpu.toml"
+
     # TODO: This is to communicate to Catalyst in qjit-compiled workflows that these operations
     #       should be converted to QubitUnitary instead of their original decompositions. Remove
     #       this when the legacy decomposition system in Catalyst is integrated with the
@@ -169,9 +172,6 @@ class LightningGPU(LightningBase):
         in qml.devices.capabilities.load_toml_file(config_filepath)["operators"]["gates"]
         else None
     )
-
-    # This configuration file declares capabilities of the device
-    config_filepath = Path(__file__).parent / "lightning_gpu.toml"
 
     def __init__(  # pylint: disable=too-many-arguments
         self,

--- a/pennylane_lightning/lightning_kokkos/lightning_kokkos.py
+++ b/pennylane_lightning/lightning_kokkos/lightning_kokkos.py
@@ -136,8 +136,14 @@ class LightningKokkos(LightningBase):
 
     # TODO: This is to communicate to Catalyst in qjit-compiled workflows that these operations
     #       should be converted to QubitUnitary instead of their original decompositions. Remove
-    #       this when customizable multiple decomposition pathways are implemented
-    _to_matrix_ops = _to_matrix_ops
+    #       this when the legacy decomposition system in Catalyst is integrated with the
+    #       graph-based decomposition system, which will allow for customizable multi-pathway.
+    _to_matrix_ops = (
+        _to_matrix_ops
+        if "QubitUnitary"
+        in qml.devices.capabilities.load_toml_file(config_filepath)["operators"]["gates"]
+        else None
+    )
 
     def __init__(  # pylint: disable=too-many-arguments
         self,

--- a/pennylane_lightning/lightning_qubit/lightning_qubit.py
+++ b/pennylane_lightning/lightning_qubit/lightning_qubit.py
@@ -155,8 +155,14 @@ class LightningQubit(LightningBase):
 
     # TODO: This is to communicate to Catalyst in qjit-compiled workflows that these operations
     #       should be converted to QubitUnitary instead of their original decompositions. Remove
-    #       this when customizable multiple decomposition pathways are implemented
-    _to_matrix_ops = _to_matrix_ops
+    #       this when the legacy decomposition system in Catalyst is integrated with the
+    #       graph-based decomposition system, which will allow for customizable multi-pathway.
+    _to_matrix_ops = (
+        _to_matrix_ops
+        if "QubitUnitary"
+        in qml.devices.capabilities.load_toml_file(config_filepath)["operators"]["gates"]
+        else None
+    )
 
     def __init__(  # pylint: disable=too-many-arguments
         self,

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -245,3 +245,14 @@ def test_supported_macos_platform_qubit():
 
     assert dev_name == "LightningSimulator"
     assert "liblightning_qubit_catalyst.dylib" in shared_lib_name
+
+
+@pytest.mark.skipif(
+    (device_name == "lightning.tensor"),
+    reason="Lightning-Tensor is not integrated with Catalyst and doesn't support to_matrix_ops.",
+)
+def test_device_to_matrix_ops():
+    """Test that the device's to_matrix_ops capability is correctly set based on the config file."""
+    dev = qml.device(device_name)
+    to_mat_ops = dev._to_matrix_ops
+    assert to_mat_ops is not None and isinstance(to_mat_ops, dict)


### PR DESCRIPTION
**Context:**
Avoid decomposing unsupported gates and templates into `QubitUnitary` when not specified in the device TOML file of Lightning simulators from Catalyst. re: https://github.com/PennyLaneAI/catalyst/pull/2426 

**Description of the Change:**

- Skip the initialization of `_to_matrix_ops` when `QubitUnitary` is not in the list of supported ops in Lightning 

**Benefits:**
- Enable decomposing to a custom target gateset without `QubitUnitary` when using Lightning simulators with `qml.qjit`.

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-111263]