### PR TITLE
Lightning-Kokkos MPI installation doc update

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -40,7 +40,7 @@
 
 - Remove dependency for GCC-11 when building `lightning.amdgpu`.
   [(#1343)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1343)
-  [(#XXXX)](https://github.com/PennyLaneAI/pennylane-lightning/pull/XXXX)
+  [(#1349)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1349)
 
 - Cleaned up the preprocess transforms of the lightning devices, updating the calls to `decompose` with the correct gate set.
   [(#1341)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1341)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -37,6 +37,7 @@
 
 - Remove dependency for GCC-11 when building `lightning.amdgpu`.
   [(#1343)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1343)
+  [(#XXXX)](https://github.com/PennyLaneAI/pennylane-lightning/pull/XXXX)
 
 - Cleaned up the preprocess transforms of the lightning devices, updating the calls to `decompose` with the correct gate set.
   [(#1341)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1341)

--- a/doc/lightning_kokkos/installation_hpc.rst
+++ b/doc/lightning_kokkos/installation_hpc.rst
@@ -15,6 +15,12 @@ We can load the following modules to enable the relevant compilers and Python en
     # Load the required Python and compiler modules
     module load cray-python
     module load PrgEnv-amd
+    module load ninja cmake
+
+    # Create a python environment and upgrade pip
+    python -m venv venv-pennylane
+    source venv-pennylane/bin/activate
+    pip install --upgrade pip
 
 
 Install Kokkos (Recommended)

--- a/doc/lightning_kokkos/installation_hpc.rst
+++ b/doc/lightning_kokkos/installation_hpc.rst
@@ -23,7 +23,7 @@ Install Kokkos (Recommended)
 .. note::
 
     Lightning-Kokkos is tested with Kokkos version 4.5.00
-    
+
 We suggest first installing Kokkos with the desired configuration, following the instructions found in the Kokkos documentation.
 For example, the following instructions demonstrate building Kokkos for AMD MI210/250/250X GPUs:
 
@@ -57,7 +57,7 @@ Build Kokkos for AMD GPU (``GFX90A`` architecture), and append the install locat
         -DKokkos_ENABLE_TESTS:BOOL=OFF \
         -DKokkos_ENABLE_LIBDL:BOOL=OFF
     cmake --build build && cmake --install build
-    export CMAKE_PREFIX_PATH=$KOKKOS_INSTALL_PATH  
+    export CMAKE_PREFIX_PATH=$KOKKOS_INSTALL_PATH
 
 
 Install Lightning-Kokkos
@@ -89,8 +89,7 @@ Then to install Lightning-Kokkos with MPI support:
     export CMAKE_ARGS="-DENABLE_MPI=ON -DCMAKE_CXX_COMPILER=hipcc"
 
     # Extra variables to avoid hipcc linking issues
-    export CMAKE_ARGS="${CMAKE_ARGS} -DCMAKE_CXX_FLAGS='--gcc-install-dir=/opt/cray/pe/gcc/11.2.0/snos/lib/gcc/x86_64-suse-linux/11.2.0/'"
-    export CMAKE_ARGS="${CMAKE_ARGS} -DCMAKE_CXX_COMPILER_CLANG_SCAN_DEPS:FILEPATH=/opt/rocm-6.2.4/lib/llvm/bin/clang-scan-deps" 
+    export CMAKE_ARGS="${CMAKE_ARGS} -DCMAKE_CXX_COMPILER_CLANG_SCAN_DEPS:FILEPATH=/opt/rocm-6.2.4/lib/llvm/bin/clang-scan-deps"
 
     PL_BACKEND="lightning_kokkos" python scripts/configure_pyproject_toml.py
     python -m pip install .
@@ -116,4 +115,4 @@ To submit a job, for example on 2 nodes, the following SLURM script can be used:
     export HSA_ENABLE_PEER_SDMA=0
 
     srun --ntasks=16 --cpus-per-task=7 --gpus-per-task=1 --gpu-bind=closest python pennylane_quantum_script.py
-    
+

--- a/doc/lightning_kokkos/installation_hpc.rst
+++ b/doc/lightning_kokkos/installation_hpc.rst
@@ -88,9 +88,6 @@ Then to install Lightning-Kokkos with MPI support:
     # CMAKE variables for building Lightning-Kokkos with MPI
     export CMAKE_ARGS="-DENABLE_MPI=ON -DCMAKE_CXX_COMPILER=hipcc"
 
-    # Extra variables to avoid hipcc linking issues
-    export CMAKE_ARGS="${CMAKE_ARGS} -DCMAKE_CXX_COMPILER_CLANG_SCAN_DEPS:FILEPATH=/opt/rocm-6.2.4/lib/llvm/bin/clang-scan-deps"
-
     PL_BACKEND="lightning_kokkos" python scripts/configure_pyproject_toml.py
     python -m pip install .
 

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.45.0-dev21"
+__version__ = "0.45.0-dev22"

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.45.0-dev20"
+__version__ = "0.45.0-dev21"


### PR DESCRIPTION
**Context:**
In https://github.com/PennyLaneAI/pennylane-lightning/pull/1343 we removed the dependency for gcc-11 when installing Lightning-Kokkos/Lightning-AMDGPU. Here we update some docs instructions for installing lightning-kokkos with MPI on HPC systems as well

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
