### PR TITLE
Change references of pennylane master to main

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -128,6 +128,9 @@ Jake Zaia.
 
 <h3>Internal changes ⚙️</h3>
 
+- Updated references to Pennylane's `master` to reference `main`.
+  [(#1351)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1351)
+
 - Pinned NumPy to versions preceding 2.4 on CIs as `pyscf` is not compatible with the new version of NumPy yet.
   [(#1315)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1315)
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 Thank you for taking the time to contribute to PennyLane-Lightning!
 :confetti_ball: :tada: :fireworks: :balloon:
 
-For details on how to contribute, please see the [PennyLane contribution guide](https://github.com/PennyLaneAI/pennylane/blob/master/.github/CONTRIBUTING.md).
+For details on how to contribute, please see the [PennyLane contribution guide](https://github.com/PennyLaneAI/pennylane/blob/main/.github/CONTRIBUTING.md).
 
 
 \- The PennyLane team

--- a/.github/workflows/compat-docker-latest.yml
+++ b/.github/workflows/compat-docker-latest.yml
@@ -15,6 +15,6 @@ jobs:
     uses: ./.github/workflows/docker_linux_x86_64.yml
     with:
       lightning-version: master
-      pennylane-version: master
+      pennylane-version: main
       push-to-dockerhub: false
     secrets: inherit # pass all secrets

--- a/.github/workflows/docker_linux_x86_64.yml
+++ b/.github/workflows/docker_linux_x86_64.yml
@@ -14,7 +14,7 @@ on:
       pennylane-version:
         type: string
         required: false
-        default: master
+        default: main
         description: The version of PennyLane to use. This should be a valid git tag, e.g. v0.36.0.
       push-to-dockerhub:
         type: boolean
@@ -29,7 +29,7 @@ on:
       pennylane-version:
         type: string
         required: false
-        default: master
+        default: main
         description: The version of PennyLane to use. This should be a valid git tag, e.g. v0.36.0.
       push-to-dockerhub:
         type: boolean

--- a/.github/workflows/tests_gpu_python.yml
+++ b/.github/workflows/tests_gpu_python.yml
@@ -184,7 +184,7 @@ jobs:
         if: inputs.pennylane-version == 'latest'
         run: |
           cd pennylane
-          git checkout master
+          git checkout main
           python -m pip uninstall -y pennylane && python -m pip install . -vv --no-deps
 
       - name: Switch to release build of PennyLane

--- a/.github/workflows/tests_lgpumpi_python.yml
+++ b/.github/workflows/tests_lgpumpi_python.yml
@@ -157,7 +157,7 @@ jobs:
         if: inputs.pennylane-version == 'latest'
         run: |
           cd pennylane
-          git checkout master
+          git checkout main
           python -m pip uninstall -y pennylane && python -m pip install . -vv --no-deps
 
       - name: Switch to release build of PennyLane

--- a/.github/workflows/tests_lkcpu_python.yml
+++ b/.github/workflows/tests_lkcpu_python.yml
@@ -258,7 +258,7 @@ jobs:
         if: inputs.pennylane-version == 'latest'
         run: |
           cd pennylane
-          git checkout master
+          git checkout main
           python -m pip uninstall -y pennylane && python -m pip install . -vv --no-deps
 
       - name: Switch to release build of PennyLane

--- a/.github/workflows/tests_lkcuda_python.yml
+++ b/.github/workflows/tests_lkcuda_python.yml
@@ -233,7 +233,7 @@ jobs:
         if: inputs.pennylane-version == 'latest'
         run: |
           cd pennylane
-          git checkout master
+          git checkout main
           python -m pip uninstall -y pennylane && python -m pip install . -vv --no-deps
 
       - name: Switch to release build of PennyLane

--- a/.github/workflows/tests_lkmpi_cuda_python.yml
+++ b/.github/workflows/tests_lkmpi_cuda_python.yml
@@ -185,7 +185,7 @@ jobs:
         if: inputs.pennylane-version == 'latest'
         run: |
           cd pennylane
-          git checkout master
+          git checkout main
           python -m pip uninstall -y pennylane && python -m pip install . -vv --no-deps
 
       - name: Switch to release build of PennyLane

--- a/.github/workflows/tests_lqcpu_python.yml
+++ b/.github/workflows/tests_lqcpu_python.yml
@@ -196,7 +196,7 @@ jobs:
         if: inputs.pennylane-version == 'latest'
         run: |
           cd pennylane
-          git checkout master
+          git checkout main
           python -m pip uninstall -y pennylane && python -m pip install . -vv --no-deps
 
       - name: Switch to release build of PennyLane

--- a/.github/workflows/tests_without_binary.yml
+++ b/.github/workflows/tests_without_binary.yml
@@ -91,7 +91,7 @@ jobs:
         if: inputs.pennylane-version == 'latest'
         run: |
           cd pennylane
-          git checkout master
+          git checkout main
           python -m pip uninstall -y pennylane && python -m pip install . -vv --no-deps
 
       - name: Switch to release build of PennyLane

--- a/doc/lightning_amdgpu/installation.rst
+++ b/doc/lightning_amdgpu/installation.rst
@@ -25,7 +25,7 @@ Install Lightning-AMDGPU
     git clone https://github.com/PennyLaneAI/pennylane-lightning.git
     cd pennylane-lightning
     python -m pip install --group base
-    pip install git+https://github.com/PennyLaneAI/pennylane.git@master
+    pip install git+https://github.com/PennyLaneAI/pennylane.git@main
 
     # First Install Lightning-Qubit
     PL_BACKEND="lightning_qubit" python scripts/configure_pyproject_toml.py

--- a/doc/lightning_gpu/installation.rst
+++ b/doc/lightning_gpu/installation.rst
@@ -16,7 +16,7 @@ Since you will be installing PennyLane-Lightning from the master branch, it is r
 
 .. code-block:: bash
 
-    pip install git+https://github.com/PennyLaneAI/pennylane.git@master
+    pip install git+https://github.com/PennyLaneAI/pennylane.git@main
 
 To install Lightning-GPU from the package sources using the direct SDK path first install Lightning-Qubit (compilation is not necessary):
 
@@ -26,7 +26,7 @@ To install Lightning-GPU from the package sources using the direct SDK path firs
     cd pennylane-lightning
     python -m pip install --group base
     pip install custatevec-cu12
-    pip install git+https://github.com/PennyLaneAI/pennylane.git@master
+    pip install git+https://github.com/PennyLaneAI/pennylane.git@main
     PL_BACKEND="lightning_qubit" python scripts/configure_pyproject_toml.py
     SKIP_COMPILATION=True pip install -e . --config-settings editable_mode=compat -vv
 

--- a/doc/lightning_kokkos/installation.rst
+++ b/doc/lightning_kokkos/installation.rst
@@ -73,7 +73,7 @@ The simplest way to install Lightning-Kokkos (OpenMP backend) through ``pip``.
     git clone https://github.com/PennyLaneAI/pennylane-lightning.git
     cd pennylane-lightning
     python -m pip install --group base
-    pip install git+https://github.com/PennyLaneAI/pennylane.git@master
+    pip install git+https://github.com/PennyLaneAI/pennylane.git@main
     
     # Lightning-Qubit needs to be 'installed' by pip before Lightning-Kokkos 
     # (compilation is not necessary)
@@ -128,7 +128,7 @@ Then Lightning-Kokkos with MPI support can be installed in the *editable* mode b
     git clone https://github.com/PennyLaneAI/pennylane-lightning.git
     cd pennylane-lightning
     python -m pip install --group base
-    pip install git+https://github.com/PennyLaneAI/pennylane.git@master
+    pip install git+https://github.com/PennyLaneAI/pennylane.git@main
 
     # Lightning-Qubit needs to be 'installed' by pip before Lightning-Kokkos 
     # (compilation is not necessary)

--- a/doc/lightning_kokkos/installation_hpc.rst
+++ b/doc/lightning_kokkos/installation_hpc.rst
@@ -78,7 +78,7 @@ It can be installed from source as follows:
     git clone https://github.com/PennyLaneAI/pennylane-lightning.git
     cd pennylane-lightning
     python -m pip install --group base
-    pip install git+https://github.com/PennyLaneAI/pennylane.git@master
+    pip install git+https://github.com/PennyLaneAI/pennylane.git@main
     PL_BACKEND="lightning_qubit" python scripts/configure_pyproject_toml.py
     CMAKE_ARGS="-DCMAKE_CXX_COMPILER=CC" pip install .
 
@@ -118,4 +118,3 @@ To submit a job, for example on 2 nodes, the following SLURM script can be used:
     export HSA_ENABLE_PEER_SDMA=0
 
     srun --ntasks=16 --cpus-per-task=7 --gpus-per-task=1 --gpu-bind=closest python pennylane_quantum_script.py
-

--- a/doc/lightning_qubit/installation.rst
+++ b/doc/lightning_qubit/installation.rst
@@ -49,7 +49,7 @@ For development and testing, you can install by cloning the repository:
     cd pennylane-lightning
     
     python -m pip install --group base
-    pip install git+https://github.com/PennyLaneAI/pennylane.git@master
+    pip install git+https://github.com/PennyLaneAI/pennylane.git@main
 
     PL_BACKEND=${PL_BACKEND} python scripts/configure_pyproject_toml.py
     pip install -e . --config-settings editable_mode=compat -vv

--- a/doc/lightning_tensor/installation.rst
+++ b/doc/lightning_tensor/installation.rst
@@ -25,7 +25,7 @@ Lightning-Qubit needs to be 'installed' by ``pip`` before Lightning-Tensor (comp
     cd pennylane-lightning
     python -m pip install --group base
     pip install cutensornet-cu12
-    pip install git+https://github.com/PennyLaneAI/pennylane.git@master
+    pip install git+https://github.com/PennyLaneAI/pennylane.git@main
     PL_BACKEND="lightning_qubit" python scripts/configure_pyproject_toml.py
     SKIP_COMPILATION=True pip install -e . --config-settings editable_mode=compat
 

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -4,7 +4,7 @@ wheel
 tomlkit
 custatevec-cu12; sys_platform == "linux"
 cutensornet-cu12; sys_platform == "linux"
-git+https://github.com/PennyLaneAI/pennylane.git@master
+git+https://github.com/PennyLaneAI/pennylane.git@main
 
 # Documentation / Formatting / Linting Dependencies
 breathe

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.45.0-dev23"
+__version__ = "0.45.0-dev24"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dev = [
     "cmake",
     "custatevec-cu12; sys_platform == 'linux'",
     "cutensornet-cu12; sys_platform == 'linux'",
-    "pennylane @ git+https://github.com/PennyLaneAI/pennylane.git@master",
+    "pennylane @ git+https://github.com/PennyLaneAI/pennylane.git@main",
     "pytest>=8.4.1",
     "pytest-benchmark",
     "pytest-cov>=3.0.0",
@@ -65,7 +65,7 @@ tests = [
     "pytest-xdist>=2.5.0",
     "pytest-split",
     "flaky>=3.7.0", # For pl-device-test
-    "pennylane @ git+https://github.com/PennyLaneAI/pennylane.git@master"
+    "pennylane @ git+https://github.com/PennyLaneAI/pennylane.git@main"
 ]
 base = [
     "ninja",
@@ -88,7 +88,7 @@ docs = [
     "tomlkit",
     "custatevec-cu12; sys_platform == 'linux'",
     "cutensornet-cu12; sys_platform == 'linux'",
-    "pennylane @ git+https://github.com/PennyLaneAI/pennylane.git@master",
+    "pennylane @ git+https://github.com/PennyLaneAI/pennylane.git@main",
     "breathe",
     "docutils==0.21.2",
     "exhale>=0.3.3",

--- a/scripts/create_lightning_rc.sh
+++ b/scripts/create_lightning_rc.sh
@@ -218,7 +218,7 @@ create_release_candidate_branch() {
 
     # Update PennyLane dependency
     pushd $ROOT_DIR
-    sed -i "s|pennylane.git@master|pennylane.git@v${RELEASE_VERSION}-rc0|g" pyproject.toml
+    sed -i "s|pennylane.git@main|pennylane.git@v${RELEASE_VERSION}-rc0|g" pyproject.toml
     git add pyproject.toml
     popd
     git commit -m "Target PennyLane v${RELEASE_VERSION}-rc0 in pyproject.toml."
@@ -580,7 +580,7 @@ create_merge_PR(){
     git checkout -b $(branch_name ${RELEASE_VERSION} "rc_merge")
 
     pushd $ROOT_DIR
-    sed -i "s|pennylane.git@v${RELEASE_VERSION}-rc0|pennylane.git@master|g" pyproject.toml  
+    sed -i "s|pennylane.git@v${RELEASE_VERSION}-rc0|pennylane.git@main|g" pyproject.toml  
     git add pyproject.toml
     popd
     git commit -m "Target PennyLane master in pyproject.toml."


### PR DESCRIPTION
**Context:**
Pennylane changed its default branch from master to main. [Some of the workflows](https://github.com/PennyLaneAI/pennylane-lightning/actions/runs/22735447893/job/65935488882#step:10:16) in lightning have started to fail with their pennylane@master references.

**Description of the Change:**
Change all references of pennylane master to main.

**Benefits:**
Workflows and reference to pennylane will be updated.

**Possible Drawbacks:**
None

**Related GitHub Issues:**
N/A