### PR TITLE
Fix LGPU synchronise before ComputeExpectation

### DIFF
--- a/.github/workflows/tests_lgpumpi_cpp.yml
+++ b/.github/workflows/tests_lgpumpi_cpp.yml
@@ -47,7 +47,7 @@ jobs:
       matrix:
         mpilib: ["openmpi"]
         cuda_version_maj: ["12"]
-        cuda_version_min: ["4"]
+        cuda_version_min: ["9"]
     timeout-minutes: 60
 
     steps:

--- a/.github/workflows/tests_lgpumpi_cpp.yml
+++ b/.github/workflows/tests_lgpumpi_cpp.yml
@@ -170,7 +170,7 @@ jobs:
           mkdir -p ./tests/results
           test_status=0
           for file in *runner ; do ./$file  --reporter junit --out ./tests/results/report_$file.xml && echo "Test $file Success!" || { cat ./tests/results/report_$file.xml; test_status=1; } done;
-          for file in *runner_mpi ; do mpirun --mca opal_cuda_support 0 -np 2 ./$file --order decl --reporter junit --out ./tests/results/report_$file.xml && echo "Test $file Success!" || { cat ./tests/results/report_$file.xml; test_status=1; } done;
+          for file in *runner_mpi ; do mpirun -np 2 ./$file --order decl --reporter junit --out ./tests/results/report_$file.xml && echo "Test $file Success!" || { cat ./tests/results/report_$file.xml; test_status=1; } done;
           if [ $test_status -ne 0 ]; then
             echo "Tests failed. Exiting with error code."
             exit 1

--- a/.github/workflows/tests_lgpumpi_cpp.yml
+++ b/.github/workflows/tests_lgpumpi_cpp.yml
@@ -119,7 +119,7 @@ jobs:
 
       - name: Install required packages
         run: |
-          python -m pip install --upgrade pip        
+          python -m pip install --upgrade pip
           python -m pip install --group tests
           python -m pip install cmake custatevec-cu12 scipy
 
@@ -138,6 +138,9 @@ jobs:
           mpirun --version
           which -a mpicxx
           mpicxx --version
+          ompi_info --parsable --all | grep -i cuda
+          ompi_info --parsable --all | grep mpi_built_with_cuda_support
+          ldd $(which mpirun) | grep -i cuda
           module unload ${{ matrix.mpilib }}
 
       - name: Build and run unit tests
@@ -167,7 +170,7 @@ jobs:
           mkdir -p ./tests/results
           test_status=0
           for file in *runner ; do ./$file  --reporter junit --out ./tests/results/report_$file.xml && echo "Test $file Success!" || { cat ./tests/results/report_$file.xml; test_status=1; } done;
-          for file in *runner_mpi ; do mpirun -np 2 ./$file --order decl --reporter junit --out ./tests/results/report_$file.xml && echo "Test $file Success!" || { cat ./tests/results/report_$file.xml; test_status=1; } done;
+          for file in *runner_mpi ; do mpirun --mca opal_cuda_support 0 -np 2 ./$file --order decl --reporter junit --out ./tests/results/report_$file.xml && echo "Test $file Success!" || { cat ./tests/results/report_$file.xml; test_status=1; } done;
           if [ $test_status -ne 0 ]; then
             echo "Tests failed. Exiting with error code."
             exit 1

--- a/.github/workflows/tests_lgpumpi_cpp.yml
+++ b/.github/workflows/tests_lgpumpi_cpp.yml
@@ -138,9 +138,6 @@ jobs:
           mpirun --version
           which -a mpicxx
           mpicxx --version
-          ompi_info --parsable --all | grep -i cuda
-          ompi_info --parsable --all | grep mpi_built_with_cuda_support
-          ldd $(which mpirun) | grep -i cuda
           module unload ${{ matrix.mpilib }}
 
       - name: Build and run unit tests

--- a/.github/workflows/tests_lgpumpi_python.yml
+++ b/.github/workflows/tests_lgpumpi_python.yml
@@ -49,7 +49,7 @@ jobs:
       matrix:
         mpilib: ["openmpi"]
         cuda_version_maj: ["12"]
-        cuda_version_min: ["2"]
+        cuda_version_min: ["9"]
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/tests_lgpumpi_python.yml
+++ b/.github/workflows/tests_lgpumpi_python.yml
@@ -194,7 +194,7 @@ jobs:
       - name: Run unit tests for MPI-enabled lightning.gpu device
         run: |
           source /etc/profile.d/modules.sh && module use /opt/modules/ && module load ${{ matrix.mpilib }}
-          PL_DEVICE=lightning.gpu mpirun -np 2 \
+          PL_DEVICE=lightning.gpu mpirun --mca opal_cuda_support 0 -np 2 \
           coverage run --rcfile=.coveragerc --source=pennylane_lightning -p -m mpi4py -m pytest ./mpitests -vv --maxfail=5 --tb=native
           coverage combine
           coverage xml -o coverage-${{ github.job }}-lightning_gpu_${{ matrix.mpilib }}_cu${{ matrix.cuda_version_maj }}-main.xml

--- a/.github/workflows/tests_lgpumpi_python.yml
+++ b/.github/workflows/tests_lgpumpi_python.yml
@@ -194,7 +194,7 @@ jobs:
       - name: Run unit tests for MPI-enabled lightning.gpu device
         run: |
           source /etc/profile.d/modules.sh && module use /opt/modules/ && module load ${{ matrix.mpilib }}
-          PL_DEVICE=lightning.gpu mpirun --mca opal_cuda_support 0 -np 2 \
+          PL_DEVICE=lightning.gpu mpirun -np 2 \
           coverage run --rcfile=.coveragerc --source=pennylane_lightning -p -m mpi4py -m pytest ./mpitests -vv --maxfail=5 --tb=native
           coverage combine
           coverage xml -o coverage-${{ github.job }}-lightning_gpu_${{ matrix.mpilib }}_cu${{ matrix.cuda_version_maj }}-main.xml

--- a/pennylane_lightning/core/simulators/lightning_gpu/StateVectorCudaMPI.hpp
+++ b/pennylane_lightning/core/simulators/lightning_gpu/StateVectorCudaMPI.hpp
@@ -2065,6 +2065,7 @@ class StateVectorCudaMPI final
             /* custatevecComputeType_t */ compute_type,
             /* void* */ extraWorkspace,
             /* std::size_t */ extraWorkspaceSizeInBytes));
+            PL_CUDA_IS_SUCCESS(cudaDeviceSynchronize());
         // LCOV_EXCL_START
         if (extraWorkspaceSizeInBytes) {
             PL_CUDA_IS_SUCCESS(cudaFree(extraWorkspace));

--- a/pennylane_lightning/core/simulators/lightning_gpu/StateVectorCudaMPI.hpp
+++ b/pennylane_lightning/core/simulators/lightning_gpu/StateVectorCudaMPI.hpp
@@ -2065,7 +2065,7 @@ class StateVectorCudaMPI final
             /* custatevecComputeType_t */ compute_type,
             /* void* */ extraWorkspace,
             /* std::size_t */ extraWorkspaceSizeInBytes));
-            PL_CUDA_IS_SUCCESS(cudaDeviceSynchronize());
+        PL_CUDA_IS_SUCCESS(cudaDeviceSynchronize());
         // LCOV_EXCL_START
         if (extraWorkspaceSizeInBytes) {
             PL_CUDA_IS_SUCCESS(cudaFree(extraWorkspace));


### PR DESCRIPTION
**Context:**
Upgrading to CUDA 12.9 uncovered an error (e.g. [here](https://github.com/PennyLaneAI/pennylane-lightning/actions/runs/23126420272/job/67170365591?pr=1353)) when performing some expectation value computation for LGPU with MPI, where the result read by the host if 0.

The issue comes from the fact that `custatevecComputeExpectation` is potentially asynchronous, as noted in their [documentation](https://docs.nvidia.com/cuda/cuquantum/25.03.0/custatevec/api/functions.html#custateveccomputeexpectation):

> This function might be asynchronous with respect to host depending on the arguments. Please use cudaStreamSynchronize (for synchronization) or cudaStreamWaitEvent (for establishing the stream order) with the stream set to the handle of the current device before using the results stored in expectationValue.

**Description of the Change:**
By applying a cuda sync between the ComputeExpectation call and the host read call, we prevent the error observed where we read a value of 0.

**Benefits:**
Fix bug and we can upgrade to CUDA 12.9

**Possible Drawbacks:**

**Related GitHub Issues:**

[sc-112893]