### PR TITLE
Fix the LGPU+MPI CUDA Sync issue in stable/stable (CUDA 12.9)

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -38,6 +38,7 @@
 - Upgrade CIs to use CUDA 12.9.
   [(#1353)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1353)
   [(#1354)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1354)
+  [(#1355)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1355)
 
 - Update Catch2 testing framework to v3.11.
   [(#1350)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1350)

--- a/.github/workflows/tests_lgpumpi_python.yml
+++ b/.github/workflows/tests_lgpumpi_python.yml
@@ -85,6 +85,9 @@ jobs:
         run: |
           git fetch --tags --force
           git checkout latest_release
+          # FIXME: remove after v0.45 release:
+          sed -i "2068i\            PL_CUDA_IS_SUCCESS(cudaDeviceSynchronize());" $PWD/pennylane_lightning/core/simulators/lightning_gpu/StateVectorCudaMPI.hpp
+
 
       - uses: actions/setup-python@v5
         id: setup_python

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.45.0-dev27"
+__version__ = "0.45.0-dev28"


### PR DESCRIPTION
**Context:**
To support GPU runner upgrade to CUDA 12.9, we had to fix a CUDA Sync issue in the LGPU+MPI device. While this fix passes on [latest/latest](https://github.com/PennyLaneAI/pennylane-lightning/actions/runs/23143917247), we are seeing expected failures on [stable/stable](https://github.com/PennyLaneAI/pennylane-lightning/actions/runs/23143878344). 

This PR patches the CUDA Sync fix into the stable branch on CI temporarily. This will pass stable/stable and remove the "expected" failure!

**Description of the Change:**

**Benefits:**
- [stable/stable](https://github.com/PennyLaneAI/pennylane-lightning/actions/runs/23155305723) :green_circle: 

**Possible Drawbacks:**
- This is a temporary fix and should be removed with the next release.

**Related GitHub Issues:**
[sc-112893]