### PR TITLE
Changing references of lightning master to main

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -35,6 +35,8 @@
 
 <h3>Internal changes ⚙️</h3>
 
+- Change default branch references from `master` to `main`
+
 - Upgrade CIs to use CUDA 12.9.
   [(#1353)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1353)
   [(#1354)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1354)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -35,7 +35,8 @@
 
 <h3>Internal changes ⚙️</h3>
 
-- Change default branch references from `master` to `main`
+- Change default branch references from `master` to `main`.
+  [(#1356)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1356)
 
 - Upgrade CIs to use CUDA 12.9.
   [(#1353)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1353)

--- a/.github/workflows/changelog_reminder.yml
+++ b/.github/workflows/changelog_reminder.yml
@@ -16,7 +16,7 @@ jobs:
         changelog_regex: '.github/CHANGELOG.md'
         customPrMessage: |
           Hello. You may have forgotten to update the changelog!
-          Please edit [.github/CHANGELOG.md](/PennyLaneAI/pennylane-lightning/blob/master/.github/CHANGELOG.md) with:
+          Please edit [.github/CHANGELOG.md](/PennyLaneAI/pennylane-lightning/blob/main/.github/CHANGELOG.md) with:
           * A one-to-two sentence description of the change. You may include a small working example for new features.
           * A link back to this PR.
           * Your name (or GitHub username) in the contributors section.

--- a/.github/workflows/code_security_scan.yml
+++ b/.github/workflows/code_security_scan.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - main
 
 concurrency:
   group: code-security-scan-${{ github.workflow }}-${{ github.ref }}
@@ -25,4 +25,3 @@ jobs:
       semgrep-error-on-impact: HIGH
       semgrep-error-on-severity: ERROR
       bandit-error-on-severity: HIGH
-

--- a/.github/workflows/compat-docker-latest.yml
+++ b/.github/workflows/compat-docker-latest.yml
@@ -14,7 +14,7 @@ jobs:
     name: Docker latest - Linux::x86_64
     uses: ./.github/workflows/docker_linux_x86_64.yml
     with:
-      lightning-version: master
+      lightning-version: main
       pennylane-version: main
       push-to-dockerhub: false
     secrets: inherit # pass all secrets

--- a/.github/workflows/dev_version_script.py
+++ b/.github/workflows/dev_version_script.py
@@ -83,7 +83,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--pr-path", dest="pr", type=Path, required=True, help="Path to the PR dir")
     parser.add_argument(
-        "--master-path", dest="master", type=Path, required=True, help="Path to the master dir"
+        "--master-path", dest="main", type=Path, required=True, help="Path to the main dir"
     )
 
     args = parser.parse_args()
@@ -91,7 +91,7 @@ if __name__ == "__main__":
     pr_version = extract_version(args.pr)
     master_version = extract_version(args.master)
 
-    print("Got Package Version from 'master' ->", str(master_version))
+    print("Got Package Version from 'main' ->", str(master_version))
     print("Got Package Version from 'PR' ->", str(pr_version))
 
     # Only attempt to bump the version if the pull_request is:

--- a/.github/workflows/dev_version_script.py
+++ b/.github/workflows/dev_version_script.py
@@ -83,15 +83,15 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--pr-path", dest="pr", type=Path, required=True, help="Path to the PR dir")
     parser.add_argument(
-        "--master-path", dest="main", type=Path, required=True, help="Path to the main dir"
+        "--main-path", dest="main", type=Path, required=True, help="Path to the main dir"
     )
 
     args = parser.parse_args()
 
     pr_version = extract_version(args.pr)
-    master_version = extract_version(args.master)
+    main_version = extract_version(args.main)
 
-    print("Got Package Version from 'main' ->", str(master_version))
+    print("Got Package Version from 'main' ->", str(main_version))
     print("Got Package Version from 'PR' ->", str(pr_version))
 
     # Only attempt to bump the version if the pull_request is:
@@ -102,7 +102,7 @@ if __name__ == "__main__":
     #  This captures the case during release where we might bump the release version
     #  within a PR and reset tag back to dev0
     if (
-        pr_version > master_version
+        pr_version > main_version
         and pr_version.prerelease
         and pr_version.prerelease == DEV_PRERELEASE_TAG_START
     ):
@@ -111,22 +111,22 @@ if __name__ == "__main__":
         )
         print("If this is happening in error, please report it to the PennyLane team!")
     elif pr_version.prerelease and pr_version.prerelease.startswith(DEV_PRERELEASE_TAG_PREFIX):
-        # If master branch does not have a prerelease (for any reason) OR does not have an ending number
+        # If main branch does not have a prerelease (for any reason) OR does not have an ending number
         # Then default to the starting tag
-        if not master_version.prerelease or master_version.prerelease == DEV_PRERELEASE_TAG_PREFIX:
+        if not main_version.prerelease or main_version.prerelease == DEV_PRERELEASE_TAG_PREFIX:
             next_prerelease_version = DEV_PRERELEASE_TAG_START
         else:
-            # If master branch does not have a prerelease (for any reason) OR does not have an ending number
+            # If main branch does not have a prerelease (for any reason) OR does not have an ending number
             # Then default to the starting tag
             if (
-                not master_version.prerelease
-                or master_version.prerelease == DEV_PRERELEASE_TAG_PREFIX
+                not main_version.prerelease
+                or main_version.prerelease == DEV_PRERELEASE_TAG_PREFIX
             ):
                 next_prerelease_version = DEV_PRERELEASE_TAG_START
             else:
-                # Generate the next prerelease version (eg: dev1 -> dev2). Sourcing from master version.
-                next_prerelease_version = master_version.next_version("prerelease").prerelease
-            new_version = master_version.replace(prerelease=next_prerelease_version)
+                # Generate the next prerelease version (eg: dev1 -> dev2). Sourcing from main version.
+                next_prerelease_version = main_version.next_version("prerelease").prerelease
+            new_version = main_version.replace(prerelease=next_prerelease_version)
             if pr_version != new_version:
                 print(f"Updating PR package version from -> '{pr_version}', to -> {new_version}")
                 update_prerelease_version(args.pr, new_version)

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - main
 
 concurrency:
   group: format-${{ github.ref }}

--- a/.github/workflows/pre_release_version_bump.yml
+++ b/.github/workflows/pre_release_version_bump.yml
@@ -35,4 +35,4 @@ jobs:
           body: updated changelog and _version.py
           branch: pre-release-version-bump
           reviewers: tomlqc, maliasadi
-          base: master
+          base: main

--- a/.github/workflows/sync-main-to-master.yml
+++ b/.github/workflows/sync-main-to-master.yml
@@ -1,0 +1,53 @@
+# This workflow syncs the main branch to master every weekday. It will remain until the master branch is deleted.
+name: Sync main to master
+
+on:
+  # Scheduled trigger every weekday at 2:47am UTC
+  schedule:
+  - cron:  '47 2 * * 1-5'
+  workflow_dispatch:
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: master
+          token: ${{ secrets.PENNYLANE_MASTER_MAIN_WRITE }}
+          fetch-depth: 0 
+
+      - name: Sync main to master
+        run: |
+          git fetch origin 
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"          
+          if git merge --no-commit --ff-only origin/main; then
+            echo "Synching from main to master."
+            echo "merge_conflict=false" >> $GITHUB_ENV
+            git push origin master 
+          else
+            echo "Merge conflict detected. Creating a PR ..."
+            echo "merge_conflict=true" >> $GITHUB_ENV
+            git merge --abort || true 
+          fi   
+
+        # If there are conflicts, create a PR for resolution
+      - name: Create PR for conflict resolution
+        env:
+          GH_TOKEN: ${{ secrets.PENNYLANE_MASTER_MAIN_WRITE }}
+        if: env.merge_conflict == 'true'            
+        run: |
+          git checkout main
+          BRANCH="main_$(date +'%Y-%m-%d-%H-%M-%S')"
+          echo "tmp_branch=$BRANCH" >> $GITHUB_ENV
+          git checkout -b "$BRANCH"
+          git config user.name "GitHub Actions Bot"
+          git config user.email "<>"
+          if ! git diff --quiet origin/master origin/main; then
+            git push --set-upstream origin "$BRANCH"
+            gh pr create --repo PennyLaneAI/pennylane-lightning --title "Daily main sync to master - conflict resolution" --body "" --base master 
+          else
+            echo "No new changes to sync from main to master."
+          fi 
+          exit 1

--- a/.github/workflows/tests_gpu_cpp.yml
+++ b/.github/workflows/tests_gpu_cpp.yml
@@ -5,11 +5,11 @@ on:
       lightning-version:
         type: string
         required: true
-        description: The version of Lightning to use. Valid values are either 'release' (most recent release candidate), 'stable' (most recent git-tag) or 'latest' (most recent commit from master)
+        description: The version of Lightning to use. Valid values are either 'release' (most recent release candidate), 'stable' (most recent git-tag) or 'latest' (most recent commit from main)
       pennylane-version:
         type: string
         required: true
-        description: The version of PennyLane to use. Valid values are either 'release' (most recent release candidate), 'stable' (most recent git-tag) or 'latest' (most recent commit from master)
+        description: The version of PennyLane to use. Valid values are either 'release' (most recent release candidate), 'stable' (most recent git-tag) or 'latest' (most recent commit from main)
   pull_request:
     types:
       - opened
@@ -18,7 +18,7 @@ on:
       - ready_for_review
   push:
     branches:
-      - master
+      - main
 
 env:
   CI_CUDA_ARCH: 86

--- a/.github/workflows/tests_gpu_python.yml
+++ b/.github/workflows/tests_gpu_python.yml
@@ -5,11 +5,11 @@ on:
       lightning-version:
         type: string
         required: true
-        description: The version of Lightning to use. Valid values are either 'release' (most recent release candidate), 'stable' (most recent git-tag) or 'latest' (most recent commit from master)
+        description: The version of Lightning to use. Valid values are either 'release' (most recent release candidate), 'stable' (most recent git-tag) or 'latest' (most recent commit from main)
       pennylane-version:
         type: string
         required: true
-        description: The version of PennyLane to use. Valid values are either 'release' (most recent release candidate), 'stable' (most recent git-tag) or 'latest' (most recent commit from master)
+        description: The version of PennyLane to use. Valid values are either 'release' (most recent release candidate), 'stable' (most recent git-tag) or 'latest' (most recent commit from main)
   pull_request:
     types:
       - opened
@@ -18,7 +18,7 @@ on:
       - ready_for_review
   push:
     branches:
-      - master
+      - main
 
 env:
   CI_CUDA_ARCH: 86

--- a/.github/workflows/tests_lgpumpi_cpp.yml
+++ b/.github/workflows/tests_lgpumpi_cpp.yml
@@ -5,11 +5,11 @@ on:
       lightning-version:
         type: string
         required: true
-        description: The version of lightning to use. Valid values are either 'stable' (most recent git-tag) or 'latest' (most recent commit from master)
+        description: The version of lightning to use. Valid values are either 'stable' (most recent git-tag) or 'latest' (most recent commit from main)
       pennylane-version:
         type: string
         required: true
-        description: The version of PennyLane to use. Valid values are either 'stable' (most recent git-tag) or 'latest' (most recent commit from master)
+        description: The version of PennyLane to use. Valid values are either 'stable' (most recent git-tag) or 'latest' (most recent commit from main)
   push:
     branches:
       - main

--- a/.github/workflows/tests_lgpumpi_python.yml
+++ b/.github/workflows/tests_lgpumpi_python.yml
@@ -5,11 +5,11 @@ on:
       lightning-version:
         type: string
         required: true
-        description: The version of lightning to use. Valid values are either 'stable' (most recent git-tag) or 'latest' (most recent commit from master)
+        description: The version of lightning to use. Valid values are either 'stable' (most recent git-tag) or 'latest' (most recent commit from main)
       pennylane-version:
         type: string
         required: true
-        description: The version of PennyLane to use. Valid values are either 'stable' (most recent git-tag) or 'latest' (most recent commit from master)
+        description: The version of PennyLane to use. Valid values are either 'stable' (most recent git-tag) or 'latest' (most recent commit from main)
   push:
     branches:
       - main

--- a/.github/workflows/tests_linux_cpp.yml
+++ b/.github/workflows/tests_linux_cpp.yml
@@ -5,11 +5,11 @@ on:
       lightning-version:
         type: string
         required: true
-        description: The version of Lightning to use. Valid values are either 'release' (most recent release candidate), 'stable' (most recent git-tag) or 'latest' (most recent commit from master)
+        description: The version of Lightning to use. Valid values are either 'release' (most recent release candidate), 'stable' (most recent git-tag) or 'latest' (most recent commit from main)
       pennylane-version:
         type: string
         required: true
-        description: The version of PennyLane to use. Valid values are either 'release' (most recent release candidate), 'stable' (most recent git-tag) or 'latest' (most recent commit from master)
+        description: The version of PennyLane to use. Valid values are either 'release' (most recent release candidate), 'stable' (most recent git-tag) or 'latest' (most recent commit from main)
   pull_request:
     types:
       - opened
@@ -24,7 +24,7 @@ on:
 
   push:
     branches:
-      - master
+      - main
 
 env:
   COVERAGE_FLAGS: "--cov=pennylane_lightning --cov-report=term-missing -p no:warnings --tb=native"

--- a/.github/workflows/tests_lkcpu_python.yml
+++ b/.github/workflows/tests_lkcpu_python.yml
@@ -5,11 +5,11 @@ on:
       lightning-version:
         type: string
         required: true
-        description: The version of Lightning to use. Valid values are either 'release' (most recent release candidate), 'stable' (most recent git-tag) or 'latest' (most recent commit from master)
+        description: The version of Lightning to use. Valid values are either 'release' (most recent release candidate), 'stable' (most recent git-tag) or 'latest' (most recent commit from main)
       pennylane-version:
         type: string
         required: true
-        description: The version of PennyLane to use. Valid values are either 'release' (most recent release candidate), 'stable' (most recent git-tag) or 'latest' (most recent commit from master)
+        description: The version of PennyLane to use. Valid values are either 'release' (most recent release candidate), 'stable' (most recent git-tag) or 'latest' (most recent commit from main)
   pull_request:
     types:
       - opened
@@ -28,7 +28,7 @@ on:
       - pennylane_lightning/lightning_qubit/**
   push:
     branches:
-      - master
+      - main
 
 env:
   TORCH_VERSION: 2.5.1

--- a/.github/workflows/tests_lkcuda_cpp.yml
+++ b/.github/workflows/tests_lkcuda_cpp.yml
@@ -5,11 +5,11 @@ on:
       lightning-version:
         type: string
         required: true
-        description: The version of Lightning to use. Valid values are either 'release' (most recent release candidate), 'stable' (most recent git-tag) or 'latest' (most recent commit from master)
+        description: The version of Lightning to use. Valid values are either 'release' (most recent release candidate), 'stable' (most recent git-tag) or 'latest' (most recent commit from main)
       pennylane-version:
         type: string
         required: true
-        description: The version of PennyLane to use. Valid values are either 'release' (most recent release candidate), 'stable' (most recent git-tag) or 'latest' (most recent commit from master)
+        description: The version of PennyLane to use. Valid values are either 'release' (most recent release candidate), 'stable' (most recent git-tag) or 'latest' (most recent commit from main)
   pull_request:
     types:
       - opened
@@ -23,7 +23,7 @@ on:
       - '!pennylane_lightning/core/simulators/lightning_tensor/**'
   push:
     branches:
-      - master
+      - main
 
 env:
   CI_CUDA_ARCH: 86

--- a/.github/workflows/tests_lkcuda_python.yml
+++ b/.github/workflows/tests_lkcuda_python.yml
@@ -5,11 +5,11 @@ on:
       lightning-version:
         type: string
         required: true
-        description: The version of Lightning to use. Valid values are either 'release' (most recent release candidate), 'stable' (most recent git-tag) or 'latest' (most recent commit from master)
+        description: The version of Lightning to use. Valid values are either 'release' (most recent release candidate), 'stable' (most recent git-tag) or 'latest' (most recent commit from main)
       pennylane-version:
         type: string
         required: true
-        description: The version of PennyLane to use. Valid values are either 'release' (most recent release candidate), 'stable' (most recent git-tag) or 'latest' (most recent commit from master)
+        description: The version of PennyLane to use. Valid values are either 'release' (most recent release candidate), 'stable' (most recent git-tag) or 'latest' (most recent commit from main)
   pull_request:
     types:
       - opened
@@ -28,7 +28,7 @@ on:
       - pennylane_lightning/lightning_tensor/**
   push:
     branches:
-      - master
+      - main
 
 env:
   GCC_VERSION: 13

--- a/.github/workflows/tests_lkmpi_cuda_cpp.yml
+++ b/.github/workflows/tests_lkmpi_cuda_cpp.yml
@@ -5,14 +5,14 @@ on:
       lightning-version:
         type: string
         required: true
-        description: The version of lightning to use. Valid values are either 'stable' (most recent git-tag) or 'latest' (most recent commit from master)
+        description: The version of lightning to use. Valid values are either 'stable' (most recent git-tag) or 'latest' (most recent commit from main)
       pennylane-version:
         type: string
         required: true
-        description: The version of PennyLane to use. Valid values are either 'stable' (most recent git-tag) or 'latest' (most recent commit from master)
+        description: The version of PennyLane to use. Valid values are either 'stable' (most recent git-tag) or 'latest' (most recent commit from main)
   push:
     branches:
-      - master
+      - main
   pull_request:
     types:
       - opened

--- a/.github/workflows/tests_lkmpi_cuda_python.yml
+++ b/.github/workflows/tests_lkmpi_cuda_python.yml
@@ -5,14 +5,14 @@ on:
       lightning-version:
         type: string
         required: true
-        description: The version of lightning to use. Valid values are either 'stable' (most recent git-tag) or 'latest' (most recent commit from master)
+        description: The version of lightning to use. Valid values are either 'stable' (most recent git-tag) or 'latest' (most recent commit from main)
       pennylane-version:
         type: string
         required: true
-        description: The version of PennyLane to use. Valid values are either 'stable' (most recent git-tag) or 'latest' (most recent commit from master)
+        description: The version of PennyLane to use. Valid values are either 'stable' (most recent git-tag) or 'latest' (most recent commit from main)
   push:
     branches:
-      - master
+      - main
   pull_request:
     types:
       - opened

--- a/.github/workflows/tests_lqcpu_python.yml
+++ b/.github/workflows/tests_lqcpu_python.yml
@@ -5,11 +5,11 @@ on:
       lightning-version:
         type: string
         required: true
-        description: The version of Lightning to use. Valid values are either 'release' (most recent release candidate), 'stable' (most recent git-tag) or 'latest' (most recent commit from master)
+        description: The version of Lightning to use. Valid values are either 'release' (most recent release candidate), 'stable' (most recent git-tag) or 'latest' (most recent commit from main)
       pennylane-version:
         type: string
         required: true
-        description: The version of PennyLane to use. Valid values are either 'release' (most recent release candidate), 'stable' (most recent git-tag) or 'latest' (most recent commit from master)
+        description: The version of PennyLane to use. Valid values are either 'release' (most recent release candidate), 'stable' (most recent git-tag) or 'latest' (most recent commit from main)
   pull_request:
     types:
       - opened
@@ -18,7 +18,7 @@ on:
       - ready_for_review
   push:
     branches:
-      - master
+      - main
 
 env:
   TORCH_VERSION: 2.5.1

--- a/.github/workflows/tests_windows_cpp.yml
+++ b/.github/workflows/tests_windows_cpp.yml
@@ -5,14 +5,14 @@ on:
       lightning-version:
         type: string
         required: true
-        description: The version of Lightning to use. Valid values are either 'release' (most recent release candidate), 'stable' (most recent git-tag) or 'latest' (most recent commit from master)
+        description: The version of Lightning to use. Valid values are either 'release' (most recent release candidate), 'stable' (most recent git-tag) or 'latest' (most recent commit from main)
       pennylane-version:
         type: string
         required: true
-        description: The version of PennyLane to use. Valid values are either 'release' (most recent release candidate), 'stable' (most recent git-tag) or 'latest' (most recent commit from master)
+        description: The version of PennyLane to use. Valid values are either 'release' (most recent release candidate), 'stable' (most recent git-tag) or 'latest' (most recent commit from main)
   push:
     branches:
-      - master
+      - main
   pull_request:
     types:
       - opened

--- a/.github/workflows/tests_without_binary.yml
+++ b/.github/workflows/tests_without_binary.yml
@@ -5,11 +5,11 @@ on:
       lightning-version:
         type: string
         required: true
-        description: The version of Lightning to use. Valid values are either 'release' (most recent release candidate), 'stable' (most recent git-tag) or 'latest' (most recent commit from master)
+        description: The version of Lightning to use. Valid values are either 'release' (most recent release candidate), 'stable' (most recent git-tag) or 'latest' (most recent commit from main)
       pennylane-version:
         type: string
         required: true
-        description: The version of PennyLane to use. Valid values are either 'release' (most recent release candidate), 'stable' (most recent git-tag) or 'latest' (most recent commit from master)
+        description: The version of PennyLane to use. Valid values are either 'release' (most recent release candidate), 'stable' (most recent git-tag) or 'latest' (most recent commit from main)
   pull_request:
     types:
       - opened
@@ -20,7 +20,7 @@ on:
       - pennylane_lightning/core/**
   push:
     branches:
-      - master
+      - main
 
 env:
   COVERAGE_FLAGS: "--cov=pennylane_lightning --cov-report=term-missing --cov-report=xml:./coverage.xml -p no:warnings --tb=native"

--- a/.github/workflows/tidy.yml
+++ b/.github/workflows/tidy.yml
@@ -13,7 +13,7 @@ on:
       - '!pennylane_lightning/core/simulators/lightning_kokkos/**'
   push:
     branches:
-      - master
+      - main
 
 env:
   GCC_VERSION: 13

--- a/.github/workflows/update_dev_version.yml
+++ b/.github/workflows/update_dev_version.yml
@@ -49,7 +49,7 @@ jobs:
           python3 \
            main/.github/workflows/dev_version_script.py \
            --pr-path "${{ github.workspace }}/pr" \
-           --master-path "${{ github.workspace }}/main"
+           --main-path "${{ github.workspace }}/main"
 
       - name: Capture Changed version
         id: new_version

--- a/.github/workflows/update_dev_version.yml
+++ b/.github/workflows/update_dev_version.yml
@@ -2,7 +2,7 @@ name: Update dev version automatically
 on:
   pull_request_target:
     branches:
-      - master
+      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
 
-      - name: Checkout PennyLane-Lightning master
+      - name: Checkout PennyLane-Lightning main
         uses: actions/checkout@v4
         with:
-          ref: master
+          ref: main
           path: main
 
       - name: Checkout PennyLane-Lightning PR

--- a/.github/workflows/upload-nightly-rc-release.yml
+++ b/.github/workflows/upload-nightly-rc-release.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Checkout Lightning repo
       uses: actions/checkout@v4
       with:
-        ref: master
+        ref: main
 
     # Sets up Python environment
     - name: Set up Python
@@ -128,7 +128,7 @@ jobs:
       - name: Checkout Lightning repo
         uses: actions/checkout@v4
         with:
-          ref: master
+          ref: main
 
       - name: Trigger Catalyst RC workflow
         env:

--- a/.github/workflows/wheel_linux_aarch64.yml
+++ b/.github/workflows/wheel_linux_aarch64.yml
@@ -14,7 +14,7 @@ on:
       - ready_for_review
   push:
     branches:
-      - master
+      - main
   release:
     types: [published]
   workflow_dispatch:
@@ -206,7 +206,7 @@ jobs:
           github.event_name == 'release' ||
           github.event_name == 'schedule' ||
           github.event_name == 'workflow_dispatch' ||
-          github.ref == 'refs/heads/master' ||
+          github.ref == 'refs/heads/main' ||
           steps.rc_build.outputs.match != ''
         with:
           name: ${{ runner.os }}-wheels-${{ matrix.pl_backend }}-${{ fromJson('{ "cp311-*":"py311","cp312-*":"py312", "cp313-*":"py313", "cp314-*":"py314" }')[matrix.cibw_build] }}-${{ matrix.arch }}.zip
@@ -236,7 +236,7 @@ jobs:
         if: |
           github.event_name == 'release' ||
           github.event_name == 'schedule' ||
-          github.ref == 'refs/heads/master' || 
+          github.ref == 'refs/heads/main' || 
           steps.rc_build.outputs.match != ''
         with:
           name: ${{ runner.os }}-wheels-${{ matrix.pl_backend }}-${{ fromJson('{ "cp311-*":"py311","cp312-*":"py312", "cp313-*":"py313", "cp314-*":"py314" }')[matrix.cibw_build] }}-${{ matrix.arch }}.zip
@@ -247,7 +247,7 @@ jobs:
         if: |
           github.event_name == 'release' ||
           github.event_name == 'schedule' ||
-          github.ref == 'refs/heads/master' || 
+          github.ref == 'refs/heads/main' || 
           steps.rc_build.outputs.match != ''
         with:
           verbose: true

--- a/.github/workflows/wheel_linux_aarch64_cuda.yml
+++ b/.github/workflows/wheel_linux_aarch64_cuda.yml
@@ -9,7 +9,7 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - main
   release:
     types: [published]
   workflow_dispatch:
@@ -179,7 +179,7 @@ jobs:
           github.event_name == 'release' ||
           github.event_name == 'schedule' ||
           github.event_name == 'workflow_dispatch' ||
-          github.ref == 'refs/heads/master' ||
+          github.ref == 'refs/heads/main' ||
           steps.rc_build.outputs.match != ''
         with:
           name: ${{ runner.os }}-wheels-${{ matrix.pl_backend }}-${{ fromJson('{ "cp311-*":"py311","cp312-*":"py312", "cp313-*":"py313", "cp314-*":"py314" }')[matrix.cibw_build] }}-${{ matrix.arch }}-cu${{ matrix.cuda_version }}.zip
@@ -217,7 +217,7 @@ jobs:
         if: |
           github.event_name == 'release' ||
           github.event_name == 'schedule' ||
-          github.ref == 'refs/heads/master' || 
+          github.ref == 'refs/heads/main' || 
           steps.rc_build.outputs.match != ''
         with:
           name:  ${{ runner.os }}-wheels-${{ matrix.pl_backend }}-${{ fromJson('{ "cp311-*":"py311","cp312-*":"py312", "cp313-*":"py313", "cp314-*":"py314" }')[matrix.cibw_build] }}-${{ matrix.arch }}-cu${{ matrix.cuda_version }}.zip
@@ -227,7 +227,7 @@ jobs:
         if: |
           github.event_name == 'release' ||
           github.event_name == 'schedule' ||
-          github.ref == 'refs/heads/master' || 
+          github.ref == 'refs/heads/main' || 
           steps.rc_build.outputs.match != ''
         uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/.github/workflows/wheel_linux_x86_64.yml
+++ b/.github/workflows/wheel_linux_x86_64.yml
@@ -17,7 +17,7 @@ on:
       - ready_for_review
   push:
     branches:
-      - master
+      - main
   release:
     types: [published]
   workflow_dispatch:
@@ -207,7 +207,7 @@ jobs:
           github.event_name == 'release' ||
           github.event_name == 'schedule' ||
           github.event_name == 'workflow_dispatch' ||
-          github.ref == 'refs/heads/master' ||
+          github.ref == 'refs/heads/main' ||
           steps.rc_build.outputs.match != ''
         with:
           name: ${{ runner.os }}-wheels-${{ matrix.pl_backend }}-${{ fromJson('{ "cp311-*":"py311","cp312-*":"py312", "cp313-*":"py313", "cp314-*":"py314" }')[matrix.cibw_build] }}-${{ matrix.arch }}.zip
@@ -237,7 +237,7 @@ jobs:
         if: |
           github.event_name == 'release' ||
           github.event_name == 'schedule' ||
-          github.ref == 'refs/heads/master' || 
+          github.ref == 'refs/heads/main' || 
           steps.rc_build.outputs.match != ''
         with:
           name: ${{ runner.os }}-wheels-${{ matrix.pl_backend }}-${{ fromJson('{ "cp311-*":"py311","cp312-*":"py312", "cp313-*":"py313", "cp314-*":"py314" }')[matrix.cibw_build] }}-${{ matrix.arch }}.zip
@@ -248,7 +248,7 @@ jobs:
         if: |
           github.event_name == 'release' ||
           github.event_name == 'schedule' ||
-          github.ref == 'refs/heads/master' || 
+          github.ref == 'refs/heads/main' || 
           steps.rc_build.outputs.match != ''
         with:
           verbose: true

--- a/.github/workflows/wheel_linux_x86_64_cuda.yml
+++ b/.github/workflows/wheel_linux_x86_64_cuda.yml
@@ -13,7 +13,7 @@ on:
       - ready_for_review
   push:
     branches:
-      - master
+      - main
   release:
     types: [published]
   workflow_dispatch:
@@ -122,7 +122,7 @@ jobs:
           github.event_name == 'release' ||
           github.event_name == 'schedule' ||
           github.event_name == 'workflow_dispatch' ||
-          github.ref == 'refs/heads/master' ||
+          github.ref == 'refs/heads/main' ||
           steps.rc_build.outputs.match != ''
         with:
           name: ${{ runner.os }}-wheels-${{ matrix.pl_backend }}-${{ fromJson('{ "cp311-*":"py311","cp312-*":"py312","cp313-*":"py313","cp314-*":"py314" }')[matrix.cibw_build] }}-${{ matrix.arch }}-cu${{ matrix.cuda_version }}.zip
@@ -153,7 +153,7 @@ jobs:
         if: |
           github.event_name == 'release' ||
           github.event_name == 'schedule' ||
-          github.ref == 'refs/heads/master' || 
+          github.ref == 'refs/heads/main' || 
           steps.rc_build.outputs.match != ''
         with:
           name:  ${{ runner.os }}-wheels-${{ matrix.pl_backend }}-${{ fromJson('{ "cp311-*":"py311","cp312-*":"py312","cp313-*":"py313","cp314-*":"py314" }')[matrix.cibw_build] }}-${{ matrix.arch }}-cu${{ matrix.cuda_version }}.zip
@@ -164,7 +164,7 @@ jobs:
         if: |
           github.event_name == 'release' ||
           github.event_name == 'schedule' ||
-          github.ref == 'refs/heads/master' || 
+          github.ref == 'refs/heads/main' || 
           steps.rc_build.outputs.match != ''
         with:
           verbose: true

--- a/.github/workflows/wheel_linux_x86_64_rocm.yml
+++ b/.github/workflows/wheel_linux_x86_64_rocm.yml
@@ -16,7 +16,7 @@ on:
       - ready_for_review
   push:
     branches:
-      - master
+      - main
   release:
     types: [published]
   workflow_dispatch:
@@ -192,7 +192,7 @@ jobs:
           github.event_name == 'release' ||
           github.event_name == 'schedule' ||
           github.event_name == 'workflow_dispatch' ||
-          github.ref == 'refs/heads/master' ||
+          github.ref == 'refs/heads/main' ||
           steps.rc_build.outputs.match != ''
         with:
           name: ${{ runner.os }}-wheels-${{ matrix.pl_backend }}-${{ fromJson('{ "cp311-*":"py311","cp312-*":"py312","cp313-*":"py313","cp314-*":"py314" }')[matrix.cibw_build] }}-${{ matrix.arch }}-rocm${{ matrix.rocm_version }}.zip
@@ -223,7 +223,7 @@ jobs:
         if: |
           github.event_name == 'release' ||
           github.event_name == 'schedule' ||
-          github.ref == 'refs/heads/master' || 
+          github.ref == 'refs/heads/main' || 
           steps.rc_build.outputs.match != ''
         with:
           name:  ${{ runner.os }}-wheels-${{ matrix.pl_backend }}-${{ fromJson('{ "cp311-*":"py311","cp312-*":"py312","cp313-*":"py313","cp314-*":"py314" }')[matrix.cibw_build] }}-${{ matrix.arch }}-rocm${{ matrix.rocm_version }}.zip
@@ -234,7 +234,7 @@ jobs:
         if: |
           github.event_name == 'release' ||
           github.event_name == 'schedule' ||
-          github.ref == 'refs/heads/master' || 
+          github.ref == 'refs/heads/main' || 
           steps.rc_build.outputs.match != ''
         with:
           verbose: true

--- a/.github/workflows/wheel_macos_arm64.yml
+++ b/.github/workflows/wheel_macos_arm64.yml
@@ -14,7 +14,7 @@ on:
       - ready_for_review
   push:
     branches:
-      - master
+      - main
   release:
     types: [published]
   workflow_dispatch:
@@ -125,7 +125,7 @@ jobs:
           github.event_name == 'release' ||
           github.event_name == 'schedule' ||
           github.event_name == 'workflow_dispatch' ||
-          github.ref == 'refs/heads/master' || 
+          github.ref == 'refs/heads/main' || 
           steps.rc_build.outputs.match != ''
         with:
           name: ${{ runner.os }}-wheels-${{ matrix.pl_backend }}-${{ fromJson('{ "cp311-*":"py311","cp312-*":"py312", "cp313-*":"py313", "cp314-*":"py314" }')[matrix.cibw_build] }}-${{ matrix.arch }}.zip
@@ -155,7 +155,7 @@ jobs:
         if: |
           github.event_name == 'release' ||
           github.event_name == 'schedule' ||
-          github.ref == 'refs/heads/master' || 
+          github.ref == 'refs/heads/main' || 
           steps.rc_build.outputs.match != ''
         with:
           name: macOS-wheels-${{ matrix.pl_backend }}-${{ fromJson('{ "cp311-*":"py311","cp312-*":"py312", "cp313-*":"py313", "cp314-*":"py314" }')[matrix.cibw_build] }}-${{ matrix.arch }}.zip
@@ -166,7 +166,7 @@ jobs:
         if: |
           github.event_name == 'release' ||
           github.event_name == 'schedule' ||
-          github.ref == 'refs/heads/master' || 
+          github.ref == 'refs/heads/main' || 
           steps.rc_build.outputs.match != ''
         with:
           verbose: true

--- a/.github/workflows/wheel_noarch.yml
+++ b/.github/workflows/wheel_noarch.yml
@@ -14,7 +14,7 @@ on:
       - ready_for_review
   push:
     branches:
-      - master
+      - main
   release:
     types: [published]
   workflow_dispatch:
@@ -86,7 +86,7 @@ jobs:
           github.event_name == 'release' || 
           github.event_name == 'schedule' ||
           github.event_name == 'workflow_dispatch' || 
-          github.ref == 'refs/heads/master' ||
+          github.ref == 'refs/heads/main' ||
           steps.rc_build.outputs.match != ''
         with:
           name: pure-python-wheels-${{ matrix.pl_backend }}.zip

--- a/.github/workflows/wheel_win_x86_64.yml
+++ b/.github/workflows/wheel_win_x86_64.yml
@@ -14,7 +14,7 @@ on:
       - ready_for_review
   push:
     branches:
-      - master
+      - main
   release:
     types: [published]
   workflow_dispatch:
@@ -216,7 +216,7 @@ jobs:
           github.event_name == 'release' ||
           github.event_name == 'schedule' ||
           github.event_name == 'workflow_dispatch' ||
-          github.ref == 'refs/heads/master' ||
+          github.ref == 'refs/heads/main' ||
           steps.rc_build.outputs.match != ''
         with:
           name: ${{ runner.os }}-wheels-${{ matrix.pl_backend }}-${{ fromJson('{ "cp311-*":"py311","cp312-*":"py312","cp313-*":"py313","cp314-*":"py314" }')[matrix.cibw_build] }}-${{ matrix.arch }}.zip
@@ -244,7 +244,7 @@ jobs:
         if: |
           github.event_name == 'release' ||
           github.event_name == 'schedule' ||
-          github.ref == 'refs/heads/master' || 
+          github.ref == 'refs/heads/main' || 
           steps.rc_build.outputs.match != ''
         with:
           name: Windows-wheels-${{ matrix.pl_backend }}-${{ fromJson('{ "cp311-*":"py311","cp312-*":"py312","cp313-*":"py313","cp314-*":"py314" }')[matrix.cibw_build] }}-${{ matrix.arch }}.zip
@@ -255,7 +255,7 @@ jobs:
         if: |
           github.event_name == 'release' ||
           github.event_name == 'schedule' ||
-          github.ref == 'refs/heads/master' || 
+          github.ref == 'refs/heads/main' || 
           steps.rc_build.outputs.match != ''
         with:
           user: __token__

--- a/Makefile
+++ b/Makefile
@@ -222,12 +222,12 @@ endif
 ifdef version
     VERSION := $(version)
 else
-    VERSION := master
+    VERSION := main
 endif
 ifdef pl_version
     PL_VERSION := $(pl_version)
 else
-    PL_VERSION := master
+    PL_VERSION := main
 endif
 
 docker-build:
@@ -267,4 +267,3 @@ test-bindings:
 build-test-bindings:
 	$(MAKE) build-nanobind
 	$(MAKE) test-bindings
-

--- a/README.md
+++ b/README.md
@@ -1,27 +1,27 @@
 <p align="center">
   <!-- 01 - Linux x86_64 L-Qubit Python tests (branch) -->
   <a href="https://github.com/PennyLaneAI/pennylane-lightning/actions/workflows/tests_lqcpu_python.yml">
-    <img src="https://img.shields.io/github/actions/workflow/status/PennyLaneAI/pennylane-lightning/tests_lqcpu_python.yml?branch=master&label=LQubit&style=flat-square" />
+    <img src="https://img.shields.io/github/actions/workflow/status/PennyLaneAI/pennylane-lightning/tests_lqcpu_python.yml?branch=main&label=LQubit&style=flat-square" />
   </a>
   <!-- 02 - Linux x86_64 L-GPU Python tests (branch) -->
   <a href="https://github.com/PennyLaneAI/pennylane-lightning/actions/workflows/tests_gpu_python.yml">
-    <img src="https://img.shields.io/github/actions/workflow/status/PennyLaneAI/pennylane-lightning/tests_gpu_python.yml?branch=master&label=LGPU&style=flat-square" />
+    <img src="https://img.shields.io/github/actions/workflow/status/PennyLaneAI/pennylane-lightning/tests_gpu_python.yml?branch=main&label=LGPU&style=flat-square" />
   </a>
   <!-- 03 - Linux x86_64 L-Kokkos Python tests (branch) -->
   <a href="https://github.com/PennyLaneAI/pennylane-lightning/actions/workflows/tests_lkcpu_python.yml">
-    <img src="https://img.shields.io/github/actions/workflow/status/PennyLaneAI/pennylane-lightning/tests_lkcpu_python.yml?branch=master&label=LKokkos&style=flat-square" />
+    <img src="https://img.shields.io/github/actions/workflow/status/PennyLaneAI/pennylane-lightning/tests_lkcpu_python.yml?branch=main&label=LKokkos&style=flat-square" />
   </a>
   <!-- 04 - Linux x86_64 L-Tensor Python tests (branch) -->
   <a href="https://github.com/PennyLaneAI/pennylane-lightning/actions/workflows/tests_gpu_python.yml">
-    <img src="https://img.shields.io/github/actions/workflow/status/PennyLaneAI/pennylane-lightning/tests_gpu_python.yml?branch=master&label=LTensor&style=flat-square" />
+    <img src="https://img.shields.io/github/actions/workflow/status/PennyLaneAI/pennylane-lightning/tests_gpu_python.yml?branch=main&label=LTensor&style=flat-square" />
   </a>
   <!-- 05 - Codecov coverage -->
   <a href="https://codecov.io/gh/PennyLaneAI/pennylane-lightning">
-    <img src="https://img.shields.io/codecov/c/github/PennyLaneAI/pennylane-lightning/master.svg?logo=codecov&style=flat-square" />
+    <img src="https://img.shields.io/codecov/c/github/PennyLaneAI/pennylane-lightning/main.svg?logo=codecov&style=flat-square" />
   </a>
   <!-- 06 - CodeFactor Grade -->
   <a href="https://www.codefactor.io/repository/github/pennylaneai/pennylane-lightning">
-    <img src="https://img.shields.io/codefactor/grade/github/PennyLaneAI/pennylane-lightning/master?logo=codefactor&style=flat-square" />
+    <img src="https://img.shields.io/codefactor/grade/github/PennyLaneAI/pennylane-lightning/main?logo=codefactor&style=flat-square" />
   </a>
   <!-- 07 - Read the Docs -->
   <a href="https://docs.pennylane.ai/projects/lightning">
@@ -46,7 +46,7 @@
 </p>
 
 <p align="center">
-    <img src="https://raw.githubusercontent.com/PennyLaneAI/pennylane-lightning/master/doc/_static/readme/pl-lightning-logo-lightmode.png#gh-light-mode-only" width="700px">
+    <img src="https://raw.githubusercontent.com/PennyLaneAI/pennylane-lightning/main/doc/_static/readme/pl-lightning-logo-lightmode.png#gh-light-mode-only" width="700px">
     <!--
     Use a relative import for the dark mode image. When loading on PyPI, this
     will fail automatically and show nothing.

--- a/doc/_ext/edit_on_github.py
+++ b/doc/_ext/edit_on_github.py
@@ -41,5 +41,5 @@ def html_page_context(app, pagename, templatename, context, doctree):
 
 def setup(app):
     app.add_config_value("edit_on_github_project", "", True)
-    app.add_config_value("edit_on_github_branch", "master", True)
+    app.add_config_value("edit_on_github_branch", "main", True)
     app.connect("html-page-context", html_page_context)

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -250,7 +250,7 @@ html_theme_options = {
 }
 
 edit_on_github_project = "PennyLaneAI/pennylane-lightning"
-edit_on_github_branch = "master/doc"
+edit_on_github_branch = "main/doc"
 
 # -- Sitemap settings -----------------------------------------------------
 sitemap_url_scheme = "{link}"

--- a/doc/lightning_gpu/installation.rst
+++ b/doc/lightning_gpu/installation.rst
@@ -12,7 +12,7 @@ Install Lightning-GPU from source
 
     The section below contains instructions for installing Lightning-GPU **from source**. For most cases, *this is not required* and one can simply use the installation instructions at `pennylane.ai/install <https://pennylane.ai/install/#high-performance-computing-and-gpus>`__. If those instructions do not work for you, or you have a more complex build environment that requires building from source, then consider reading on.
 
-Since you will be installing PennyLane-Lightning from the master branch, it is recommended to install PennyLane from master:
+Since you will be installing PennyLane-Lightning from the main branch, it is recommended to install PennyLane from main:
 
 .. code-block:: bash
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 # Define global build defaults
-ARG PENNYLANE_VERSION=master
-ARG LIGHTNING_VERSION=master
+ARG PENNYLANE_VERSION=main
+ARG LIGHTNING_VERSION=main
 ARG GCC_VERSION=13
 ARG CUDA_INSTALLER=https://developer.download.nvidia.com/compute/cuda/12.5.1/local_installers/cuda_12.5.1_555.42.06_linux.run
 ARG ROCM_INSTALLER=https://repo.radeon.com/amdgpu-install/7.0.3/ubuntu/jammy/amdgpu-install_7.0.3.70003-1_all.deb

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.45.0-dev28"
+__version__ = "0.45.0-dev29"

--- a/scripts/compare_changelog_commits.sh
+++ b/scripts/compare_changelog_commits.sh
@@ -51,7 +51,7 @@ extract_contributors_from_changelog() {
 
 extract_contributors_from_git() {
     # Extract the list of contributors from Git
-    contribution_list=$(git log master --since=$LAST_RELEASE_DATE --pretty=format:"%an <%ae>")
+    contribution_list=$(git log main --since=$LAST_RELEASE_DATE --pretty=format:"%an <%ae>")
     # Sort, find unique entries, and format the contribution list
     contribution_list=$(echo "$contribution_list" | sort | uniq | sed 's|<.*|| ; s|Author: ||')
     echo "$contribution_list"
@@ -69,8 +69,8 @@ echo "--------------------------------------------------------------------------
 
 # Create the list of merged PR
 list_merged_PRs(){
-    # Get the list of merged PRs to master
-    list_PRs=$(gh pr list --state merged --base master --search "merged:>=$LAST_RELEASE_DATE" -L 1000 )
+    # Get the list of merged PRs to main
+    list_PRs=$(gh pr list --state merged --base main --search "merged:>=$LAST_RELEASE_DATE" -L 1000 )
     # Extract the PR number and title, format it, and sort it
     list_PRs=$(echo "$list_PRs" | awk -F 'MERGED' '{print $1}' | sort -h)
     echo "$list_PRs" > release_list_merged_PR.txt

--- a/scripts/create_lightning_rc.sh
+++ b/scripts/create_lightning_rc.sh
@@ -6,13 +6,13 @@ set -e
 # This script automates the creation of a release candidate branch for PennyLane-Lightning.
 #
 # Prerequisites:
-# - Be on the latest master branch in the root directory of pennylane-lightning/
+# - Be on the latest main branch in the root directory of pennylane-lightning/
 # - Have 'gh' CLI installed and authenticated with GitHub
 # - Have 'jq' installed for JSON processing
 #
 # Usage Instructions:
 # The script supports different phases of the release process. The script should run on the root
-# directory of the pennylane-lightning repository and in master branch.
+# directory of the pennylane-lightning repository and in main branch.
 # Run them in sequence:
 #
 # 1. Create Release Candidate (creates branches and PRs):

--- a/scripts/create_lightning_rc.sh
+++ b/scripts/create_lightning_rc.sh
@@ -188,10 +188,10 @@ sed -i "/<h3>Internal changes ⚙️<\/h3>/a \\
 create_release_candidate_branch() {
     # Create a new branch for the release candidate
 
-    # Clean up and checkout master
+    # Clean up and checkout main
     git reset --hard
-    git checkout master
-    git pull origin master
+    git checkout main
+    git pull origin main
 
     # Create branches
     for branch in base docs rc; do
@@ -206,7 +206,7 @@ create_release_candidate_branch() {
     # Update lightning version
     sed -i "/__version__/d" $PL_VERSION_FILE
     if [ "$IS_TEST" == "true" ]; then
-        dev_number=$(git show master:$PL_VERSION_FILE | grep "version" | grep -oP 'dev\K[0-9]+')
+        dev_number=$(git show main:$PL_VERSION_FILE | grep "version" | grep -oP 'dev\K[0-9]+')
         echo '__version__ = "'${RELEASE_VERSION}'-rc0-dev'${dev_number}'"' >> $PL_VERSION_FILE
     else
         echo '__version__ = "'${RELEASE_VERSION}'-rc0"' >> $PL_VERSION_FILE
@@ -275,8 +275,8 @@ create_docs_review_PR(){
 create_docker_PR(){
     # Create a PR for the Docker test in PTM
 
-    git checkout master
-    git pull origin master
+    git checkout main
+    git pull origin main
     git checkout -b $(branch_name ${RELEASE_VERSION} docker)
 
     sed -i "s|v${STABLE_VERSION}|v${RELEASE_VERSION}|g" ${ROOT_DIR}/.github/workflows/compat-docker-release.yml
@@ -295,7 +295,7 @@ create_docker_PR(){
         --title "Docker test for v${RELEASE_VERSION} RC branch" \
         --body "Docker test for v${RELEASE_VERSION} RC branch. This PR was created by an automated script." \
         --head $(branch_name ${RELEASE_VERSION} docker) \
-        --base master \
+        --base main \
         --label 'urgent'
     fi
 }
@@ -342,8 +342,8 @@ echo "$new_changelog_text"
 create_version_bump_PR(){
     # Create a PR for the new version
 
-    git checkout master
-    git pull origin master
+    git checkout main
+    git pull origin main
     git checkout -b $(branch_name ${RELEASE_VERSION} bump)
 
     # Update lightning version
@@ -364,7 +364,7 @@ create_version_bump_PR(){
         --title "Bump version to v${NEXT_VERSION}-dev" \
         --body "Bump version to v${NEXT_VERSION}-dev. This PR was created by an automated script." \
         --head $(branch_name ${RELEASE_VERSION} bump) \
-        --base master \
+        --base main \
         --label 'ci:build_wheels','ci:use-multi-gpu-runner','ci:use-gpu-runner','urgent'
     fi
 
@@ -573,7 +573,7 @@ upload_release_assets_gh(){
 }
 
 create_merge_PR(){
-    # Create the merge branch to merge the RC into master and bump the version with NEXT_VERSION-dev
+    # Create the merge branch to merge the RC into main and bump the version with NEXT_VERSION-dev
 
     git checkout $(branch_name ${RELEASE_VERSION} "release")
     git pull
@@ -583,7 +583,7 @@ create_merge_PR(){
     sed -i "s|pennylane.git@v${RELEASE_VERSION}-rc0|pennylane.git@main|g" pyproject.toml  
     git add pyproject.toml
     popd
-    git commit -m "Target PennyLane master in pyproject.toml."
+    git commit -m "Target PennyLane main in pyproject.toml."
 
     sed -i "/__version__/d" $PL_VERSION_FILE
     if [ "$IS_TEST" == "true" ]; then
@@ -613,7 +613,7 @@ create_merge_PR(){
 
     git commit -m "Update minimum PennyLane version to ${RELEASE_VERSION%??}"
 
-    # Create a PR to merge the RC into master
+    # Create a PR to merge the RC into main
     if [ "$LOCAL_TEST" == "true" ]; then
         PR_number="0000"
     else
@@ -624,13 +624,13 @@ create_merge_PR(){
         --title "Merge RC v${RELEASE_VERSION}_rc to v${NEXT_VERSION}-dev" \
         --body "v${RELEASE_VERSION} RC merge branch. This PR was created by an automated script." \
         --head $(branch_name ${RELEASE_VERSION} "rc_merge") \
-        --base master \
+        --base main \
         --label 'ci:build_wheels','ci:use-multi-gpu-runner','ci:use-gpu-runner','urgent'
 
         PR_number=$(gh pr view --json number --jq .number)
     fi
 
-    add_CHANGELOG_entry "Merge RC v${RELEASE_VERSION} rc to master" "${PR_number}"
+    add_CHANGELOG_entry "Merge RC v${RELEASE_VERSION} rc to main" "${PR_number}"
     git add $CHANGELOG_FILE
     git commit -m "Add CHANGELOG entry for RC merge"
 
@@ -727,8 +727,8 @@ if [ "$CREATE_RC" == "true" ]; then
     create_docs_review_PR
     create_docker_PR
     create_version_bump_PR
-    git checkout master
-    git pull origin master
+    git checkout main
+    git pull origin main
 fi
 
 if [ "$LIGHTNING_TEST" == "true" ]; then


### PR DESCRIPTION
**Context:**
The default branch of pennylane-lightning will be changed from `master` to `main`. The references to `master` need to be updated.

**Description of the Change:**
Change references of `master` to `main`

**Benefits:**
The default branch gets updated.

**Possible Drawbacks:**
None

**Related GitHub Issues:**
