### PR TITLE
Update tests to account for new QFT subroutine

### DIFF
--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.45.0-dev28"
+__version__ = "0.45.0-dev29"

--- a/tests/lightning_tensor/test_serialize_tensor.py
+++ b/tests/lightning_tensor/test_serialize_tensor.py
@@ -797,7 +797,7 @@ class TestSerializeOps:
                     [],
                     [],
                     qml.matrix(qml.QubitUnitary(np.eye(4, dtype=dtype), wires=[0, 1])),
-                    qml.matrix(qml.templates.QFT(wires=[0, 1, 2])),
+                    qml.matrix(qml.templates.QFT, wire_order=[0, 1, 2])(wires=[0, 1, 2]),
                     [],
                     [],
                     [],

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -932,7 +932,7 @@ class TestSerializeOps:
                     mat,
                     mat,
                     np.array([qml.matrix(qml.QubitUnitary(np.eye(4, dtype=dtype), wires=[0, 1]))]),
-                    np.array([qml.matrix(qml.templates.QFT(wires=[0, 1, 2]))]),
+                    np.array([qml.matrix(qml.templates.QFT, wire_order=[0, 1, 2])([0, 1, 2])]),
                     mat,
                     mat,
                     mat,

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -770,7 +770,7 @@ class TestQFT:
     def test_preprocess_qft_decomposition(self, wires):
         """Test that qml.QFT is always decomposed for any wires."""
         tape = qml.tape.QuantumScript(
-            [qml.QFT(wires=list(range(wires)))], [qml.expval(qml.PauliZ(0))]
+            [qml.QFT.operator(wires=list(range(wires)))], [qml.expval(qml.PauliZ(0))]
         )
         dev = LightningDevice(wires=wires)
 
@@ -779,7 +779,7 @@ class TestQFT:
 
         # assert all(not isinstance(op, qml.QFT) for op in new_tape.operations)
         # else:
-        assert tape.operations == [qml.QFT(wires=list(range(wires)))]
+        assert tape.operations == [qml.QFT.operator(wires=list(range(wires)))]
 
 
 class TestAQFT:


### PR DESCRIPTION
**Context:** Some lightning tests need to be updated to use the new `Subroutine` abstraction properly.

**Description of the Change:** Update the way we get `QFT` operators and matrices.

**Benefits:** Tests all passing.

**Possible Drawbacks:** N/A
