### PR TITLE
Bump black to 26.3.1

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -35,7 +35,7 @@
 
 <h3>Internal changes ⚙️</h3>
 
-- Bump `black` version to 26.3.1 to eliminate the vulnerability reported by dependabot.
+- Bumped `black` version to 26.3.1 to eliminate a vulnerability reported by dependabot.
   [(#1360)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1360)
 
 - Fixed a security issue in the triggering mechanism of one of the GH Actions scripts.

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -35,6 +35,9 @@
 
 <h3>Internal changes ⚙️</h3>
 
+- Bump `black` version to 26.3.1 to eliminate the vulnerability reported by dependabot.
+  [(#1360)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1360)
+
 - Fixed a security issue in the triggering mechanism of one of the GH Actions scripts.
   [(#1359)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1359)
 
@@ -96,6 +99,7 @@ This release contains contributions from (in alphabetical order):
 Runor Agbaire,
 Ali Asadi,
 Astral Cai,
+Yushao Chen,
 Ashish Kanwar Singh,
 Jeffrey Kam,
 Joseph Lee,

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/psf/black
-    rev: 25.9.0
+    rev: 26.3.1
     hooks:
     - id: black
       args: [--line-length=100]

--- a/mpitests/conftest.py
+++ b/mpitests/conftest.py
@@ -14,6 +14,7 @@
 """
 Pytest configuration file for PennyLane-Lightning MPI test suite.
 """
+
 # pylint: disable=missing-function-docstring,wrong-import-order,unused-import
 
 import itertools

--- a/mpitests/test_adjoint_jacobian.py
+++ b/mpitests/test_adjoint_jacobian.py
@@ -14,6 +14,7 @@
 """
 Unit tests for adjoint Jacobian on :mod:`pennylane_lightning` MPI-enabled devices.
 """
+
 # pylint: disable=protected-access,cell-var-from-loop,c-extension-no-member
 import itertools
 import math

--- a/mpitests/test_apply.py
+++ b/mpitests/test_apply.py
@@ -14,6 +14,7 @@
 """
 Unit tests for apply on :mod:`pennylane_lightning` MPI-enabled devices.
 """
+
 # pylint: disable=protected-access,cell-var-from-loop,c-extension-no-member,too-many-positional-arguments
 import itertools
 from functools import partial

--- a/mpitests/test_device.py
+++ b/mpitests/test_device.py
@@ -14,6 +14,7 @@
 """
 Unit tests for device creation on :mod:`pennylane_lightning` MPI-enabled devices.
 """
+
 # pylint: disable=protected-access,unused-variable,missing-function-docstring,c-extension-no-member
 
 import pennylane as qml

--- a/mpitests/test_expval.py
+++ b/mpitests/test_expval.py
@@ -14,6 +14,7 @@
 """
 Unit tests for expval on :mod:`pennylane_lightning` MPI-enabled devices.
 """
+
 # pylint: disable=protected-access,too-few-public-methods,unused-import,missing-function-docstring,too-many-arguments,too-many-positional-arguments,c-extension-no-member
 
 import numpy as np

--- a/mpitests/test_measurements_sparse.py
+++ b/mpitests/test_measurements_sparse.py
@@ -14,6 +14,7 @@
 """
 Unit tests for sparse measurements on :mod:`pennylane_lightning` MPI-enabled devices.
 """
+
 # pylint: disable=protected-access,too-few-public-methods,unused-import,missing-function-docstring,too-many-arguments,too-many-positional-arguments
 
 import numpy as np

--- a/mpitests/test_native_mcm.py
+++ b/mpitests/test_native_mcm.py
@@ -14,6 +14,7 @@
 """
 Unit tests for native mid-circuit measurements on :mod:`pennylane_lightning` MPI-enabled devices.
 """
+
 from functools import partial
 
 import numpy as np

--- a/mpitests/test_probs.py
+++ b/mpitests/test_probs.py
@@ -12,6 +12,7 @@
 """
 Unit tests for probs on :mod:`pennylane_lightning` MPI-enabled devices.
 """
+
 import numpy as np
 import pennylane as qml
 import pytest

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.45.0-dev30"
+__version__ = "0.45.0-dev31"

--- a/pennylane_lightning/lightning_base/_serialize.py
+++ b/pennylane_lightning/lightning_base/_serialize.py
@@ -14,6 +14,7 @@
 r"""
 Helper functions for serializing quantum tapes.
 """
+
 from typing import List, Sequence, Tuple
 
 import numpy as np

--- a/pennylane_lightning/lightning_gpu/_state_vector.py
+++ b/pennylane_lightning/lightning_gpu/_state_vector.py
@@ -14,6 +14,7 @@
 """
 Class implementation for lightning_gpu state-vector manipulation.
 """
+
 from warnings import warn
 
 try:

--- a/pennylane_lightning/lightning_kokkos/_state_vector.py
+++ b/pennylane_lightning/lightning_kokkos/_state_vector.py
@@ -14,6 +14,7 @@
 """
 Class implementation for lightning_kokkos state-vector manipulation.
 """
+
 from warnings import warn
 
 try:

--- a/pennylane_lightning/lightning_qubit/_adjoint_jacobian.py
+++ b/pennylane_lightning/lightning_qubit/_adjoint_jacobian.py
@@ -14,6 +14,7 @@
 r"""
 Internal methods for adjoint Jacobian differentiation method.
 """
+
 from __future__ import annotations
 
 from warnings import warn

--- a/pennylane_lightning/lightning_qubit/_state_vector.py
+++ b/pennylane_lightning/lightning_qubit/_state_vector.py
@@ -14,6 +14,7 @@
 """
 Class implementation for lightning_qubit state-vector manipulation.
 """
+
 from warnings import warn
 
 try:

--- a/pennylane_lightning/lightning_tensor/lightning_tensor.py
+++ b/pennylane_lightning/lightning_tensor/lightning_tensor.py
@@ -15,6 +15,7 @@
 This module contains the LightningTensor class that inherits from the new device interface.
 It is a device to perform tensor network simulations of quantum circuits using `cutensornet`.
 """
+
 from dataclasses import replace
 from numbers import Number
 from typing import Callable, Optional, Sequence, Tuple

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ base = [
     "pytest-xdist>=2.5.0",
     "flaky>=3.7.0", # For pl-device-test
     "pennylane>=0.44",
-    "black==25.9.0",
+    "black==26.3.1",
     "clang-tidy~=20.1",
     "clang-format~=20.1",
     "isort~=7.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dev = [
     "pytest-split",
     "flaky>=3.7.0", # For pl-device-test
     "pre-commit>=2.19.0",
-    "black==25.9.0",
+    "black==26.3.1",
     "clang-tidy~=20.1",
     "clang-format~=20.1",
     "isort~=7.0.0",

--- a/scripts/backend_support.py
+++ b/scripts/backend_support.py
@@ -14,6 +14,7 @@
 r"""
 Internal logic to check and set backend variables.
 """
+
 import os
 
 default_backend = "lightning_qubit"

--- a/scripts/configure_pyproject_toml.py
+++ b/scripts/configure_pyproject_toml.py
@@ -14,6 +14,7 @@
 r"""
 Project configuration script.
 """
+
 import argparse
 import os
 from importlib import import_module

--- a/scripts/cuda_version.py
+++ b/scripts/cuda_version.py
@@ -22,6 +22,7 @@ The CUDA version can be set in multiple ways, with the following priority:
 
 The allowed CUDA major versions are "12" and "13".
 """
+
 import os
 import re
 import shutil

--- a/scripts/validate_attrs.py
+++ b/scripts/validate_attrs.py
@@ -14,6 +14,7 @@
 r"""
 Internal logic to validate Lightning packages.
 """
+
 import pprint
 import re
 from pathlib import Path

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,7 @@
 """
 Pytest configuration file for PennyLane-Lightning test suite.
 """
+
 import configparser
 import hashlib
 import os

--- a/tests/lightning_base/test_adjoint_jacobian_class.py
+++ b/tests/lightning_base/test_adjoint_jacobian_class.py
@@ -14,6 +14,7 @@
 """
 Unit tests for the adjoint Jacobian and VJP methods.
 """
+
 import math
 
 import pennylane as qml

--- a/tests/lightning_base/test_expval.py
+++ b/tests/lightning_base/test_expval.py
@@ -14,6 +14,7 @@
 """
 Tests for process and execute (expval calculation).
 """
+
 import itertools
 
 # pylint: disable=too-many-arguments, redefined-outer-name

--- a/tests/lightning_base/test_measurements_samples_MCMC.py
+++ b/tests/lightning_base/test_measurements_samples_MCMC.py
@@ -14,6 +14,7 @@
 """
 Unit tests for MCMC sampling in lightning.qubit.
 """
+
 import numpy as np
 import pennylane as qml
 import pytest

--- a/tests/lightning_base/test_no_binaries.py
+++ b/tests/lightning_base/test_no_binaries.py
@@ -14,6 +14,7 @@
 """
 Unit tests for checking binaries.
 """
+
 import pytest
 from conftest import LightningDevice
 

--- a/tests/lightning_base/test_var.py
+++ b/tests/lightning_base/test_var.py
@@ -14,6 +14,7 @@
 """
 Tests for process and execute (variance calculation).
 """
+
 import numpy as np
 import pennylane as qml
 

--- a/tests/lightning_tensor/test_measurements_class.py
+++ b/tests/lightning_tensor/test_measurements_class.py
@@ -14,6 +14,7 @@
 """
 Unit tests for measurements class.
 """
+
 import numpy as np
 import pennylane as qml
 import pytest

--- a/tests/lightning_tensor/test_serialize_chunk_obs_tensor.py
+++ b/tests/lightning_tensor/test_serialize_chunk_obs_tensor.py
@@ -14,6 +14,7 @@
 """
 Unit tests for the serialization helper functions.
 """
+
 import pennylane as qml
 import pytest
 from conftest import LightningDevice as ld

--- a/tests/lightning_tensor/test_serialize_tensor.py
+++ b/tests/lightning_tensor/test_serialize_tensor.py
@@ -14,6 +14,7 @@
 """
 Unit tests for the serialization helper functions.
 """
+
 import numpy as np
 import pennylane as qml
 import pytest

--- a/tests/lightning_tensor/test_tensornet_class.py
+++ b/tests/lightning_tensor/test_tensornet_class.py
@@ -14,6 +14,7 @@
 """
 Unit tests for the tensornet functions.
 """
+
 import numpy as np
 import pennylane as qml
 import pytest

--- a/tests/test_adjoint_jacobian.py
+++ b/tests/test_adjoint_jacobian.py
@@ -14,6 +14,7 @@
 """
 Tests for ``adjoint_jacobian`` method on Lightning devices.
 """
+
 import itertools
 import math
 

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -14,6 +14,7 @@
 """
 Unit tests for Lightning devices.
 """
+
 import math
 from functools import partial
 

--- a/tests/test_arrays.py
+++ b/tests/test_arrays.py
@@ -14,6 +14,7 @@
 """
 Array tests for Lightning devices.
 """
+
 import numpy as np
 import pytest
 from conftest import LightningDevice as ld

--- a/tests/test_binary_info.py
+++ b/tests/test_binary_info.py
@@ -14,6 +14,7 @@
 """
 Test binary information of Lightning devices.
 """
+
 import platform
 
 import pytest

--- a/tests/test_comparison.py
+++ b/tests/test_comparison.py
@@ -15,6 +15,7 @@
 Integration tests that compare the output states of the
 compiled Lightning device with the ``default.qubit``.
 """
+
 import itertools
 import os
 

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -14,6 +14,7 @@
 """
 Unit tests for Lightning devices creation.
 """
+
 import pickle as pkl
 import sys
 

--- a/tests/test_eval_jaxpr.py
+++ b/tests/test_eval_jaxpr.py
@@ -14,6 +14,7 @@
 """
 This module tests the eval_jaxpr method.
 """
+
 from functools import partial
 
 import pennylane as qml

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -14,6 +14,7 @@
 """
 Integration tests for the ``execute`` method of Lightning devices.
 """
+
 import functools
 
 import pennylane as qml

--- a/tests/test_expval.py
+++ b/tests/test_expval.py
@@ -14,6 +14,7 @@
 """
 Unit tests for the expval method of Lightning devices.
 """
+
 import itertools
 
 import numpy as np

--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -14,6 +14,7 @@
 """
 Unit tests for the correct application of gates with a Lightning device.
 """
+
 import copy
 import itertools
 import sys

--- a/tests/test_jaxpr_jvp.py
+++ b/tests/test_jaxpr_jvp.py
@@ -14,6 +14,7 @@
 """
 This module tests the ``jaxpr_jvp`` method.
 """
+
 from functools import partial
 
 import pennylane as qml

--- a/tests/test_measurements.py
+++ b/tests/test_measurements.py
@@ -14,6 +14,7 @@
 """
 Unit tests for Measurements in Lightning devices.
 """
+
 import itertools
 import math
 from typing import Sequence

--- a/tests/test_measurements_sparse.py
+++ b/tests/test_measurements_sparse.py
@@ -14,6 +14,7 @@
 """
 Unit tests for Sparse Measurements Lightning devices.
 """
+
 import numpy as np
 import pennylane as qml
 import pytest

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -14,6 +14,7 @@
 """
 Unit tests for the serialization helper functions.
 """
+
 import numpy as np
 import pennylane as qml
 import pytest

--- a/tests/test_serialize_chunk_obs.py
+++ b/tests/test_serialize_chunk_obs.py
@@ -14,6 +14,7 @@
 """
 Unit tests for the serialization helper functions.
 """
+
 import pennylane as qml
 import pytest
 from conftest import LightningDevice as ld

--- a/tests/test_serialize_no_binaries.py
+++ b/tests/test_serialize_no_binaries.py
@@ -14,6 +14,7 @@
 """
 Unit tests for the serialization helper functions.
 """
+
 import pytest
 from conftest import LightningDevice, device_name
 

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -14,6 +14,7 @@
 """
 Test the correctness of templates with Lightning devices.
 """
+
 import functools
 
 import pennylane as qml

--- a/tests/test_var.py
+++ b/tests/test_var.py
@@ -14,6 +14,7 @@
 """
 Unit tests for the var method of the :mod:`pennylane_lightning.LightningQubit` device.
 """
+
 import numpy as np
 import pennylane as qml
 import pytest

--- a/tests/test_vjp.py
+++ b/tests/test_vjp.py
@@ -14,6 +14,7 @@
 """
 Tests for the ``vjp`` method.
 """
+
 import itertools
 import math
 


### PR DESCRIPTION
`black` is ~not a dependency of lightning anymore, seemingly. However,~ pinned in `pyproject.toml`; to keep consistent with [Pennylane](https://github.com/PennyLaneAI/pennylane/commit/cfddf8d1461d342ba244fabd441fc46312cfc365) and [Catalyst](https://github.com/PennyLaneAI/catalyst/pull/2650), we could also bump the version in precommit to 26.3.1!

[sc-115638]