### PR TITLE
Add .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,11 @@
+# Add commits here that should be ignored in the output of git blame. Include a comment
+# about why the commit is ignored, with a link to the corresponding PR if applicable.
+
+
+# Migrating QML->QP (3 parts)
+# https://github.com/PennyLaneAI/pennylane-lightning/pull/1362
+c645b17213ca6bd031f83b946d425bd3df537e6a
+# https://github.com/PennyLaneAI/pennylane-lightning/pull/1363
+a17a93fca8e489e3555112dc21c0cba8aba4869f
+# https://github.com/PennyLaneAI/pennylane-lightning/pull/1366
+0eb09c94e466f36935022e1ced098d13c47b2233

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.45.0-dev39"
+__version__ = "0.45.0-dev40"


### PR DESCRIPTION
Context:
#1362, #1363, and #1366 updated a number of PennyLane modules to import pennylane as qp and to use qp instead of qml throughout. This mangles the git blame and makes it seem like nearly every line containing `qp.` was last modified by one of these PRs.

Description of the Change:
Adds the commits to `main` from #1362, #1363, and #1366 to a new `.git-blame-ignore-revs` file

Benefits:
Cleaner version history when viewing the "git blame" of files

Possible Drawbacks:

**Related GitHub Issues:**
[sc-117172]