### PR TITLE
Remove pass from codecov skips

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -5,7 +5,7 @@ omit =
     tests/*
     mpitests/*
     pennylane_lightning/lightning_amdgpu/*
-    
+
 
 [coverage:run]
 parallel = true
@@ -28,7 +28,6 @@ exclude_lines =
 
     # Don't complain if non-runnable code isn't run:
     if 0:
-    pass
     if __name__ == .__main__.:
     raise NotImplementedError
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -40,6 +40,9 @@
 
 <h3>Internal changes ⚙️</h3>
 
+- Modified the code coverage options to no longer skip lines containing "pass".
+  [(#1369)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1369)
+
 - Removed `lightning_interpreter` from pennylane-lightning.
   [(#1367)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1367)
 

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.45.0-dev40"
+__version__ = "0.45.0-dev41"


### PR DESCRIPTION
**Context:**
The `.coveragerc` file contains a skip on lines containing `pass`, which can inadvertently skip lines which contain "pass" as a substring. 

**Description of the Change:**
Removes this rule from `.coveragerc`

**Benefits:**
Less false negatives about poor coverage

**Possible Drawbacks:**

**Related GitHub Issues:**
