### PR TITLE
adding id-token permission

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -172,6 +172,7 @@ Jake Zaia.
 
 - Added permissions to all GitHub Actions workflows.
   [(#1370)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1370)
+  [(#1371)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1371)
 
 - Updated references to Pennylane's `master` to reference `main`.
   [(#1351)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1351)

--- a/.github/workflows/upload-nightly-rc-release.yml
+++ b/.github/workflows/upload-nightly-rc-release.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write 
 
 jobs:
   setup-rc:

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.45.0-dev42"
+__version__ = "0.45.0-dev43"


### PR DESCRIPTION
**Context:**
Fixing missing `id-token` permission on upload-nightly-release.yml which [failed](https://github.com/PennyLaneAI/pennylane-lightning/actions/runs/25207701505) after permissions update [PR](https://github.com/PennyLaneAI/pennylane-lightning/pull/1370).

**Description of the Change:**
Add `id-token: write` 

**Benefits:**
Workflow passes.

**Possible Drawbacks:**
None

**Related GitHub Issues:**
