### PR TITLE
Read version from file in rc branch check

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -15,7 +15,7 @@
 <h3>Internal changes ⚙️</h3>
 
 - Bumped the version.
-    [(#1374)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1374)
+  [(#1374)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1374)
 
 - Update nightly builds of the RC branch to always trigger Catalyst's nightly RC builds.
   [(#1376)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1376)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -17,6 +17,9 @@
 - Bumped the version.
     [(#1374)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1374)
 
+- Update nightly builds of the RC branch to always trigger Catalyst's nightly RC builds.
+  [(#1376)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1376)
+
 <h3>Contributors ✍️</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -81,6 +81,7 @@
 
 - Added workflow to create and upload nightly builds of the RC branch and trigger Catalyst's nightly RC builds.
   [(#1344)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1344)
+  [(#1376)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1376)
 
 - Updated Github docker build action to use relevant lightning branch.
   [(#1346)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1346)

--- a/.github/workflows/upload-nightly-rc-release.yml
+++ b/.github/workflows/upload-nightly-rc-release.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Check for rc branch
       id: check_rc
       run: |
-        VERSION=$(python setup.py --version)
+        VERSION=$(sed -n 's/^__version__ = "\(.*\)"/\1/p' pennylane_lightning/core/_version.py)
         IFS=. read MAJ MIN PAT <<< "${VERSION%-dev[0-9]*}"
         RC_BRANCH="v${MAJ}.$((MIN-1)).${PAT}_rc"
         if git ls-remote --exit-code origin "refs/heads/$RC_BRANCH"; then

--- a/.github/workflows/upload-nightly-rc-release.yml
+++ b/.github/workflows/upload-nightly-rc-release.yml
@@ -125,6 +125,7 @@ jobs:
 
   trigger-catalyst-rc:
     needs: [build-linux-aarch64-cuda, build-linux-x86_64, build-linux-x86_64-cuda, build-linux-aarch64, build-macos-arm64, build-windows-x86_64, build-linux-x86_64_rocm, build-noarch]
+    if: ${{ always() && !cancelled() }}
     name: Trigger Catalyst RC workflow
     runs-on: ubuntu-24.04
     

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.45.0-dev44"
+__version__ = "0.45.0-dev45"

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.45.0-dev45"
+__version__ = "0.46.0-dev1"


### PR DESCRIPTION
**Context:**
Lightning's rc branch check VERSION=$(python setup.py --version) normalizes the version name causing it to miss the rc branch.

`/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/setuptools/dist.py:332: InformationOnly: Normalizing '0.45.0-dev44' to '0.45.0.dev44' [](https://github.com/PennyLaneAI/pennylane-lightning/actions/runs/25365290303/job/74374475382#step:5:22) self.metadata.version = self._normalize_version(self.metadata.version)`

**Description of the Change:**
Change rc_branch check to read from version file.

**Benefits:**
RC branch check works

**Possible Drawbacks:**
None.

**Related GitHub Issues:**
