### PR TITLE
Add additional id-token write

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -14,6 +14,9 @@
 
 <h3>Internal changes ⚙️</h3>
 
+- Add `id-token: write` permissions for wheel build workflows.
+  [(#1377)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1377)
+
 - Bumped the version.
   [(#1374)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1374)
 

--- a/.github/workflows/wheel_linux_aarch64.yml
+++ b/.github/workflows/wheel_linux_aarch64.yml
@@ -33,6 +33,7 @@ env:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   set_wheel_build_matrix:

--- a/.github/workflows/wheel_linux_aarch64_cuda.yml
+++ b/.github/workflows/wheel_linux_aarch64_cuda.yml
@@ -25,6 +25,7 @@ concurrency:
 
 permissions:
   contents: read
+  id-token: write  
 
 jobs:
   set_wheel_build_matrix:

--- a/.github/workflows/wheel_linux_x86_64.yml
+++ b/.github/workflows/wheel_linux_x86_64.yml
@@ -33,6 +33,7 @@ concurrency:
 
 permissions:
   contents: read
+  id-token: write  
 
 jobs:
   set_wheel_build_matrix:

--- a/.github/workflows/wheel_linux_x86_64_cuda.yml
+++ b/.github/workflows/wheel_linux_x86_64_cuda.yml
@@ -29,7 +29,8 @@ concurrency:
 
 permissions:
   contents: read
-
+  id-token: write
+  
 jobs:
   set_wheel_build_matrix:
     if: |

--- a/.github/workflows/wheel_linux_x86_64_rocm.yml
+++ b/.github/workflows/wheel_linux_x86_64_rocm.yml
@@ -30,6 +30,7 @@ concurrency:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   set_wheel_build_matrix:

--- a/.github/workflows/wheel_macos_arm64.yml
+++ b/.github/workflows/wheel_macos_arm64.yml
@@ -33,6 +33,7 @@ concurrency:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   set_wheel_build_matrix:

--- a/.github/workflows/wheel_noarch.yml
+++ b/.github/workflows/wheel_noarch.yml
@@ -30,6 +30,7 @@ concurrency:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   build-pure-python-wheel:

--- a/.github/workflows/wheel_win_x86_64.yml
+++ b/.github/workflows/wheel_win_x86_64.yml
@@ -34,6 +34,7 @@ concurrency:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   set_wheel_build_matrix:

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.46.0-dev1"
+__version__ = "0.46.0-dev2"


### PR DESCRIPTION
**Context:**
The upload testpypi workflow is missing `id-token: write` permissions at the workflow level causing[ upload failures.](https://github.com/PennyLaneAI/pennylane-lightning/actions/runs/25404626822/job/74513520881#step:4:135)

**Description of the Change:**
Add `id-token: write`

**Benefits:**
Uploads work correctly.

**Possible Drawbacks:**
None

**Related GitHub Issues:**
https://github.com/PennyLaneAI/pennylane-lightning/pull/1370