### PR TITLE
Upload to testpypi from 1 source

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -14,8 +14,9 @@
 
 <h3>Internal changes ⚙️</h3>
 
-- Add `id-token: write` permissions for wheel build workflows.
+- Update nightly RC builds to upload to testpypi from a single workflow; removed global id-token permission.
   [(#1377)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1377)
+  [(#1379)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1379)
 
 - Bumped the version.
   [(#1374)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1374)

--- a/.github/workflows/upload-nightly-rc-release.yml
+++ b/.github/workflows/upload-nightly-rc-release.yml
@@ -145,12 +145,12 @@ jobs:
           echo "=== All wheels ==="
           find dist/ -name "*.whl" | sort
 
-      # - name: Upload to TestPyPI
-      #   uses: pypa/gh-action-pypi-publish@release/v1
-      #   with:
-      #     repository-url: https://test.pypi.org/legacy/
-      #     attestations: false
-      #     skip-existing: true
+      - name: Upload to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          attestations: false
+          skip-existing: true
       
   # trigger-catalyst-rc:
   #   needs: [build-linux-aarch64-cuda, build-linux-x86_64, build-linux-x86_64-cuda, build-linux-aarch64, build-macos-arm64, build-windows-x86_64, build-linux-x86_64_rocm, build-noarch]

--- a/.github/workflows/upload-nightly-rc-release.yml
+++ b/.github/workflows/upload-nightly-rc-release.yml
@@ -56,23 +56,23 @@ jobs:
         ssh-key: ${{ secrets.NIGHTLY_VERSION_UPDATE_DEPLOY_KEY }}
         ref: ${{ steps.check_rc.outputs.rc_branch }}
 
-    # - name: Bump rc version
-    #   if: ${{ steps.check_rc.outputs.branch_exists == 'true' }}
-    #   run: |
-    #     echo "rc_branch is ${{ steps.check_rc.outputs.rc_branch }}"
-    #     python $GITHUB_WORKSPACE/.github/workflows/set_nightly_version_rc.py
-    #     git config --global user.email '${{ secrets.AUTO_UPDATE_VERSION_RINGO_EMAIL }}'
-    #     git config --global user.name "ringo-but-quantum"
-    #     git add $GITHUB_WORKSPACE/pennylane_lightning/core/_version.py
-    #     git commit -m "[no ci] bump nightly version"
-    #     git push
+    - name: Bump rc version
+      if: ${{ steps.check_rc.outputs.branch_exists == 'true' }}
+      run: |
+        echo "rc_branch is ${{ steps.check_rc.outputs.rc_branch }}"
+        python $GITHUB_WORKSPACE/.github/workflows/set_nightly_version_rc.py
+        git config --global user.email '${{ secrets.AUTO_UPDATE_VERSION_RINGO_EMAIL }}'
+        git config --global user.name "ringo-but-quantum"
+        git add $GITHUB_WORKSPACE/pennylane_lightning/core/_version.py
+        git commit -m "[no ci] bump nightly version"
+        git push
 
-  # build-linux-aarch64-cuda:
-  #   needs: setup-rc
-  #   if: ${{ needs.setup-rc.outputs.branch_exists == 'true' }}
-  #   uses: ./.github/workflows/wheel_linux_aarch64_cuda.yml
-  #   with:
-  #     branch: ${{ needs.setup-rc.outputs.rc_branch }}
+  build-linux-aarch64-cuda:
+    needs: setup-rc
+    if: ${{ needs.setup-rc.outputs.branch_exists == 'true' }}
+    uses: ./.github/workflows/wheel_linux_aarch64_cuda.yml
+    with:
+      branch: ${{ needs.setup-rc.outputs.rc_branch }}
 
   build-linux-x86_64:
     needs: setup-rc
@@ -81,12 +81,12 @@ jobs:
     with:
       branch: ${{ needs.setup-rc.outputs.rc_branch }}
 
-  # build-linux-x86_64-cuda:
-  #   needs: setup-rc
-  #   if: ${{ needs.setup-rc.outputs.branch_exists == 'true' }}
-  #   uses: ./.github/workflows/wheel_linux_x86_64_cuda.yml
-  #   with:
-  #     branch: ${{ needs.setup-rc.outputs.rc_branch }}
+  build-linux-x86_64-cuda:
+    needs: setup-rc
+    if: ${{ needs.setup-rc.outputs.branch_exists == 'true' }}
+    uses: ./.github/workflows/wheel_linux_x86_64_cuda.yml
+    with:
+      branch: ${{ needs.setup-rc.outputs.rc_branch }}
 
   build-linux-aarch64:
     needs: setup-rc
@@ -95,12 +95,12 @@ jobs:
     with:
       branch: ${{ needs.setup-rc.outputs.rc_branch }}
 
-  # build-macos-arm64:
-  #   needs: setup-rc
-  #   if: ${{ needs.setup-rc.outputs.branch_exists == 'true' }}
-  #   uses: ./.github/workflows/wheel_macos_arm64.yml
-  #   with:
-  #     branch: ${{ needs.setup-rc.outputs.rc_branch }}
+  build-macos-arm64:
+    needs: setup-rc
+    if: ${{ needs.setup-rc.outputs.branch_exists == 'true' }}
+    uses: ./.github/workflows/wheel_macos_arm64.yml
+    with:
+      branch: ${{ needs.setup-rc.outputs.rc_branch }}
 
   build-windows-x86_64:
     needs: setup-rc
@@ -124,7 +124,7 @@ jobs:
       branch: ${{ needs.setup-rc.outputs.rc_branch }}
 
   upload-to-testpypi:
-    needs: [build-linux-x86_64, build-linux-aarch64, build-windows-x86_64, build-linux-x86_64_rocm, build-noarch]
+    needs: [build-linux-aarch64-cuda, build-linux-x86_64, build-linux-x86_64-cuda, build-linux-aarch64, build-macos-arm64, build-windows-x86_64, build-linux-x86_64_rocm, build-noarch]
     if: ${{ always() && !cancelled() && contains(needs.*.result, 'success') }}
     name: Upload RC wheels to TestPyPI
     runs-on: ubuntu-24.04
@@ -152,23 +152,23 @@ jobs:
           attestations: false
           skip-existing: true
       
-  # trigger-catalyst-rc:
-  #   needs: [build-linux-aarch64-cuda, build-linux-x86_64, build-linux-x86_64-cuda, build-linux-aarch64, build-macos-arm64, build-windows-x86_64, build-linux-x86_64_rocm, build-noarch]
-  #   if: ${{ always() && !cancelled() }}
-  #   name: Trigger Catalyst RC workflow
-  #   runs-on: ubuntu-24.04
+  trigger-catalyst-rc:
+    needs: [build-linux-aarch64-cuda, build-linux-x86_64, build-linux-x86_64-cuda, build-linux-aarch64, build-macos-arm64, build-windows-x86_64, build-linux-x86_64_rocm, build-noarch]
+    if: ${{ always() && !cancelled() }}
+    name: Trigger Catalyst RC workflow
+    runs-on: ubuntu-24.04
     
-  #   steps:
-  #     - name: Checkout Lightning repo
-  #       uses: actions/checkout@v4
-  #       with:
-  #         ref: main
+    steps:
+      - name: Checkout Lightning repo
+        uses: actions/checkout@v4
+        with:
+          ref: main
 
-  #     - name: Trigger Catalyst RC workflow
-  #       env:
-  #         GITHUB_TOKEN: "${{ secrets.PENNYLANE_TRIGGER_RC_WORKFLOW }}"
-  #       run: |
-  #         git config user.name "GitHub Actions Bot"
-  #         git config user.email "<>"         
-  #         gh workflow run build-nightly-release-candidate.yaml --repo PennyLaneAI/catalyst
+      - name: Trigger Catalyst RC workflow
+        env:
+          GITHUB_TOKEN: "${{ secrets.PENNYLANE_TRIGGER_RC_WORKFLOW }}"
+        run: |
+          git config user.name "GitHub Actions Bot"
+          git config user.email "<>"         
+          gh workflow run build-nightly-release-candidate.yaml --repo PennyLaneAI/catalyst
           

--- a/.github/workflows/upload-nightly-rc-release.yml
+++ b/.github/workflows/upload-nightly-rc-release.yml
@@ -56,16 +56,16 @@ jobs:
         ssh-key: ${{ secrets.NIGHTLY_VERSION_UPDATE_DEPLOY_KEY }}
         ref: ${{ steps.check_rc.outputs.rc_branch }}
 
-    - name: Bump rc version
-      if: ${{ steps.check_rc.outputs.branch_exists == 'true' }}
-      run: |
-        echo "rc_branch is ${{ steps.check_rc.outputs.rc_branch }}"
-        python $GITHUB_WORKSPACE/.github/workflows/set_nightly_version_rc.py
-        git config --global user.email '${{ secrets.AUTO_UPDATE_VERSION_RINGO_EMAIL }}'
-        git config --global user.name "ringo-but-quantum"
-        git add $GITHUB_WORKSPACE/pennylane_lightning/core/_version.py
-        git commit -m "[no ci] bump nightly version"
-        git push
+    # - name: Bump rc version
+    #   if: ${{ steps.check_rc.outputs.branch_exists == 'true' }}
+    #   run: |
+    #     echo "rc_branch is ${{ steps.check_rc.outputs.rc_branch }}"
+    #     python $GITHUB_WORKSPACE/.github/workflows/set_nightly_version_rc.py
+    #     git config --global user.email '${{ secrets.AUTO_UPDATE_VERSION_RINGO_EMAIL }}'
+    #     git config --global user.name "ringo-but-quantum"
+    #     git add $GITHUB_WORKSPACE/pennylane_lightning/core/_version.py
+    #     git commit -m "[no ci] bump nightly version"
+    #     git push
 
   build-linux-aarch64-cuda:
     needs: setup-rc
@@ -123,23 +123,52 @@ jobs:
     with:
       branch: ${{ needs.setup-rc.outputs.rc_branch }}
 
-  trigger-catalyst-rc:
+  upload-to-testpypi:
     needs: [build-linux-aarch64-cuda, build-linux-x86_64, build-linux-x86_64-cuda, build-linux-aarch64, build-macos-arm64, build-windows-x86_64, build-linux-x86_64_rocm, build-noarch]
-    if: ${{ always() && !cancelled() }}
-    name: Trigger Catalyst RC workflow
+    if: ${{ always() && !cancelled() && contains(needs.*.result, 'success') }}
+    name: Upload RC wheels to TestPyPI
     runs-on: ubuntu-24.04
-    
-    steps:
-      - name: Checkout Lightning repo
-        uses: actions/checkout@v4
-        with:
-          ref: main
+    environment: testpypi
+    permissions:
+      id-token: write
 
-      - name: Trigger Catalyst RC workflow
-        env:
-          GITHUB_TOKEN: "${{ secrets.PENNYLANE_TRIGGER_RC_WORKFLOW }}"
+    steps:
+      - name: Download all wheel artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: "*-wheels-*"
+          path: dist/
+          merge-multiple: true
+
+      - name: List downloaded wheels
         run: |
-          git config user.name "GitHub Actions Bot"
-          git config user.email "<>"         
-          gh workflow run build-nightly-release-candidate.yaml --repo PennyLaneAI/catalyst
+          echo "=== All wheels ==="
+          find dist/ -name "*.whl" | sort
+
+      - name: Upload to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          attestations: false
+          skip-existing: true
+      
+  # trigger-catalyst-rc:
+  #   needs: [build-linux-aarch64-cuda, build-linux-x86_64, build-linux-x86_64-cuda, build-linux-aarch64, build-macos-arm64, build-windows-x86_64, build-linux-x86_64_rocm, build-noarch]
+  #   if: ${{ always() && !cancelled() }}
+  #   name: Trigger Catalyst RC workflow
+  #   runs-on: ubuntu-24.04
+    
+  #   steps:
+  #     - name: Checkout Lightning repo
+  #       uses: actions/checkout@v4
+  #       with:
+  #         ref: main
+
+  #     - name: Trigger Catalyst RC workflow
+  #       env:
+  #         GITHUB_TOKEN: "${{ secrets.PENNYLANE_TRIGGER_RC_WORKFLOW }}"
+  #       run: |
+  #         git config user.name "GitHub Actions Bot"
+  #         git config user.email "<>"         
+  #         gh workflow run build-nightly-release-candidate.yaml --repo PennyLaneAI/catalyst
           

--- a/.github/workflows/upload-nightly-rc-release.yml
+++ b/.github/workflows/upload-nightly-rc-release.yml
@@ -73,6 +73,7 @@ jobs:
     uses: ./.github/workflows/wheel_linux_aarch64_cuda.yml
     with:
       branch: ${{ needs.setup-rc.outputs.rc_branch }}
+      skip_upload: true
 
   build-linux-x86_64:
     needs: setup-rc
@@ -80,6 +81,7 @@ jobs:
     uses: ./.github/workflows/wheel_linux_x86_64.yml
     with:
       branch: ${{ needs.setup-rc.outputs.rc_branch }}
+      skip_upload: true
 
   build-linux-x86_64-cuda:
     needs: setup-rc
@@ -87,6 +89,7 @@ jobs:
     uses: ./.github/workflows/wheel_linux_x86_64_cuda.yml
     with:
       branch: ${{ needs.setup-rc.outputs.rc_branch }}
+      skip_upload: true
 
   build-linux-aarch64:
     needs: setup-rc
@@ -94,6 +97,7 @@ jobs:
     uses: ./.github/workflows/wheel_linux_aarch64.yml
     with:
       branch: ${{ needs.setup-rc.outputs.rc_branch }}
+      skip_upload: true
 
   build-macos-arm64:
     needs: setup-rc
@@ -101,6 +105,7 @@ jobs:
     uses: ./.github/workflows/wheel_macos_arm64.yml
     with:
       branch: ${{ needs.setup-rc.outputs.rc_branch }}
+      skip_upload: true
 
   build-windows-x86_64:
     needs: setup-rc
@@ -108,6 +113,7 @@ jobs:
     uses: ./.github/workflows/wheel_win_x86_64.yml
     with:
       branch: ${{ needs.setup-rc.outputs.rc_branch }}
+      skip_upload: true
 
   build-linux-x86_64_rocm:
     needs: setup-rc
@@ -115,6 +121,7 @@ jobs:
     uses: ./.github/workflows/wheel_linux_x86_64_rocm.yml
     with:
       branch: ${{ needs.setup-rc.outputs.rc_branch }}
+      skip_upload: true
   
   build-noarch:
     needs: setup-rc
@@ -122,6 +129,7 @@ jobs:
     uses: ./.github/workflows/wheel_noarch.yml
     with:
       branch: ${{ needs.setup-rc.outputs.rc_branch }}
+      skip_upload: true
 
   upload-to-testpypi:
     needs: [build-linux-aarch64-cuda, build-linux-x86_64, build-linux-x86_64-cuda, build-linux-aarch64, build-macos-arm64, build-windows-x86_64, build-linux-x86_64_rocm, build-noarch]

--- a/.github/workflows/upload-nightly-rc-release.yml
+++ b/.github/workflows/upload-nightly-rc-release.yml
@@ -145,12 +145,12 @@ jobs:
           echo "=== All wheels ==="
           find dist/ -name "*.whl" | sort
 
-      - name: Upload to TestPyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          repository-url: https://test.pypi.org/legacy/
-          attestations: false
-          skip-existing: true
+      # - name: Upload to TestPyPI
+      #   uses: pypa/gh-action-pypi-publish@release/v1
+      #   with:
+      #     repository-url: https://test.pypi.org/legacy/
+      #     attestations: false
+      #     skip-existing: true
       
   # trigger-catalyst-rc:
   #   needs: [build-linux-aarch64-cuda, build-linux-x86_64, build-linux-x86_64-cuda, build-linux-aarch64, build-macos-arm64, build-windows-x86_64, build-linux-x86_64_rocm, build-noarch]

--- a/.github/workflows/upload-nightly-rc-release.yml
+++ b/.github/workflows/upload-nightly-rc-release.yml
@@ -67,12 +67,12 @@ jobs:
     #     git commit -m "[no ci] bump nightly version"
     #     git push
 
-  build-linux-aarch64-cuda:
-    needs: setup-rc
-    if: ${{ needs.setup-rc.outputs.branch_exists == 'true' }}
-    uses: ./.github/workflows/wheel_linux_aarch64_cuda.yml
-    with:
-      branch: ${{ needs.setup-rc.outputs.rc_branch }}
+  # build-linux-aarch64-cuda:
+  #   needs: setup-rc
+  #   if: ${{ needs.setup-rc.outputs.branch_exists == 'true' }}
+  #   uses: ./.github/workflows/wheel_linux_aarch64_cuda.yml
+  #   with:
+  #     branch: ${{ needs.setup-rc.outputs.rc_branch }}
 
   build-linux-x86_64:
     needs: setup-rc
@@ -81,12 +81,12 @@ jobs:
     with:
       branch: ${{ needs.setup-rc.outputs.rc_branch }}
 
-  build-linux-x86_64-cuda:
-    needs: setup-rc
-    if: ${{ needs.setup-rc.outputs.branch_exists == 'true' }}
-    uses: ./.github/workflows/wheel_linux_x86_64_cuda.yml
-    with:
-      branch: ${{ needs.setup-rc.outputs.rc_branch }}
+  # build-linux-x86_64-cuda:
+  #   needs: setup-rc
+  #   if: ${{ needs.setup-rc.outputs.branch_exists == 'true' }}
+  #   uses: ./.github/workflows/wheel_linux_x86_64_cuda.yml
+  #   with:
+  #     branch: ${{ needs.setup-rc.outputs.rc_branch }}
 
   build-linux-aarch64:
     needs: setup-rc
@@ -95,12 +95,12 @@ jobs:
     with:
       branch: ${{ needs.setup-rc.outputs.rc_branch }}
 
-  build-macos-arm64:
-    needs: setup-rc
-    if: ${{ needs.setup-rc.outputs.branch_exists == 'true' }}
-    uses: ./.github/workflows/wheel_macos_arm64.yml
-    with:
-      branch: ${{ needs.setup-rc.outputs.rc_branch }}
+  # build-macos-arm64:
+  #   needs: setup-rc
+  #   if: ${{ needs.setup-rc.outputs.branch_exists == 'true' }}
+  #   uses: ./.github/workflows/wheel_macos_arm64.yml
+  #   with:
+  #     branch: ${{ needs.setup-rc.outputs.rc_branch }}
 
   build-windows-x86_64:
     needs: setup-rc
@@ -124,7 +124,7 @@ jobs:
       branch: ${{ needs.setup-rc.outputs.rc_branch }}
 
   upload-to-testpypi:
-    needs: [build-linux-aarch64-cuda, build-linux-x86_64, build-linux-x86_64-cuda, build-linux-aarch64, build-macos-arm64, build-windows-x86_64, build-linux-x86_64_rocm, build-noarch]
+    needs: [build-linux-x86_64, build-linux-aarch64, build-windows-x86_64, build-linux-x86_64_rocm, build-noarch]
     if: ${{ always() && !cancelled() && contains(needs.*.result, 'success') }}
     name: Upload RC wheels to TestPyPI
     runs-on: ubuntu-24.04

--- a/.github/workflows/wheel_linux_aarch64.yml
+++ b/.github/workflows/wheel_linux_aarch64.yml
@@ -23,6 +23,10 @@ on:
       branch:
         required: false
         type: string
+      skip_upload:
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: wheel_linux_aarch64-${{ github.ref }}
@@ -33,7 +37,6 @@ env:
 
 permissions:
   contents: read
-  id-token: write
 
 jobs:
   set_wheel_build_matrix:
@@ -223,6 +226,7 @@ jobs:
 
   upload-pypi:
     needs: [set_wheel_build_matrix, linux-wheels-aarch64]
+    if: ${{ !inputs.skip_upload }}
     strategy:
       matrix:
         arch: [aarch64]

--- a/.github/workflows/wheel_linux_aarch64_cuda.yml
+++ b/.github/workflows/wheel_linux_aarch64_cuda.yml
@@ -18,6 +18,10 @@ on:
       branch:
         required: false
         type: string
+      skip_upload:
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: wheel_linux_aarch64_cu12-${{ github.ref }}
@@ -25,7 +29,6 @@ concurrency:
 
 permissions:
   contents: read
-  id-token: write  
 
 jobs:
   set_wheel_build_matrix:
@@ -200,6 +203,7 @@ jobs:
 
   upload-pypi:
     needs: [set_wheel_build_matrix, linux-wheels-aarch64]
+    if: ${{ !inputs.skip_upload }}
     strategy:
       matrix:
         arch: [aarch64]

--- a/.github/workflows/wheel_linux_x86_64.yml
+++ b/.github/workflows/wheel_linux_x86_64.yml
@@ -26,6 +26,10 @@ on:
       branch:
         required: false
         type: string
+      skip_upload:
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: wheel_linux_x86_64-${{ github.ref }}
@@ -33,7 +37,6 @@ concurrency:
 
 permissions:
   contents: read
-  id-token: write  
 
 jobs:
   set_wheel_build_matrix:
@@ -222,6 +225,7 @@ jobs:
 
   upload-pypi:
     needs: [set_wheel_build_matrix, linux-wheels-x86-64]
+    if: ${{ !inputs.skip_upload }}
     strategy:
       matrix:
         arch: [x86_64]

--- a/.github/workflows/wheel_linux_x86_64_cuda.yml
+++ b/.github/workflows/wheel_linux_x86_64_cuda.yml
@@ -22,6 +22,10 @@ on:
       branch:
         required: false
         type: string  
+      skip_upload:
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: wheel_linux_x86_64_cu12-${{ github.ref }}
@@ -29,7 +33,6 @@ concurrency:
 
 permissions:
   contents: read
-  id-token: write
   
 jobs:
   set_wheel_build_matrix:
@@ -136,6 +139,7 @@ jobs:
 
   upload-pypi:
     needs: [set_wheel_build_matrix, linux-wheels-x86-64]
+    if: ${{ !inputs.skip_upload }}
     strategy:
       matrix:
         arch: [x86_64]

--- a/.github/workflows/wheel_linux_x86_64_rocm.yml
+++ b/.github/workflows/wheel_linux_x86_64_rocm.yml
@@ -23,6 +23,10 @@ on:
       branch:
         required: false
         type: string  
+      skip-upload:
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: wheel_linux_x86_64_rocm-${{ github.ref }}
@@ -30,7 +34,6 @@ concurrency:
 
 permissions:
   contents: read
-  id-token: write
 
 jobs:
   set_wheel_build_matrix:
@@ -204,6 +207,7 @@ jobs:
 
   upload-pypi:
     needs: [set_wheel_build_matrix, linux-wheels-x86-64]
+    if: ${{ !inputs.skip_upload }}
     strategy:
       matrix:
         arch: [x86_64]

--- a/.github/workflows/wheel_macos_arm64.yml
+++ b/.github/workflows/wheel_macos_arm64.yml
@@ -23,6 +23,10 @@ on:
       branch:
         required: false
         type: string  
+      skip_upload:
+        required: false
+        type: boolean
+        default: false
 
 env:
   MACOSX_DEPLOYMENT_TARGET: 13.0
@@ -33,7 +37,6 @@ concurrency:
 
 permissions:
   contents: read
-  id-token: write
 
 jobs:
   set_wheel_build_matrix:
@@ -139,6 +142,7 @@ jobs:
 
   upload-pypi:
     needs: [set_wheel_build_matrix, mac-wheels-arm64]
+    if: ${{ !inputs.skip_upload }}
     strategy:
       matrix:
         arch: [arm64]

--- a/.github/workflows/wheel_noarch.yml
+++ b/.github/workflows/wheel_noarch.yml
@@ -23,6 +23,10 @@ on:
       branch:
         required: false
         type: string  
+      skip_upload:
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: wheel_noarch-${{ github.ref }}
@@ -30,7 +34,6 @@ concurrency:
 
 permissions:
   contents: read
-  id-token: write
 
 jobs:
   build-pure-python-wheel:
@@ -100,6 +103,7 @@ jobs:
 
   upload-pypi:
     needs: build-pure-python-wheel
+    if: ${{ !inputs.skip_upload }}
     strategy:
       matrix:
         pl_backend: ["lightning_qubit"]

--- a/.github/workflows/wheel_win_x86_64.yml
+++ b/.github/workflows/wheel_win_x86_64.yml
@@ -23,6 +23,10 @@ on:
       branch:
         required: false
         type: string  
+      skip_upload:
+        required: false
+        type: boolean
+        default: false
 
 env:
   DISTUTILS_USE_SDK: 1
@@ -34,7 +38,6 @@ concurrency:
 
 permissions:
   contents: read
-  id-token: write
 
 jobs:
   set_wheel_build_matrix:
@@ -230,6 +233,7 @@ jobs:
 
   upload-pypi:
     needs: [set_wheel_build_matrix, win-wheels]
+    if: ${{ !inputs.skip_upload }}
     strategy:
       matrix:
         arch: [AMD64]

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.46.0-dev2"
+__version__ = "0.46.0-dev3"


### PR DESCRIPTION
**Context:**
PyPI doesn't allow trusted publishing from reusable workflows. The current `upload-nightly-rc-release.yml` workflow is configured to upload the wheel from each reusable workflow. The wheels can be downloaded then uploaded from the calling workflow.

**Description of the Change:**
Add download of built wheels and upload them to testpypi from `upload-nightly-rc-release.yml` 

**Benefits:**
Trusted publishing works.

**Possible Drawbacks:**
None.

**Related GitHub Issues:**
https://github.com/PennyLaneAI/pennylane-lightning/pull/1344