### PR TITLE
Fix typo in RC nightly builds

### DIFF
--- a/.github/workflows/set_nightly_version_rc.py
+++ b/.github/workflows/set_nightly_version_rc.py
@@ -33,14 +33,14 @@ with open(version_file_path, "r+", encoding="UTF-8") as f:
     if match:
         # Case 1: Version has RC suffix
         major, minor, bug, rc = match.groups()
-        replacement = f'__version__ = "{major}.{minor}.{bug}-rc{int(rc)+1}"\n'
+        replacement = f'__version__ = "{major}.{minor}.{bug}_rc{int(rc)+1}"\n'
     else:
         # Case 2: Version has no RC suffix
         base_pattern = r"(\d+)\.(\d+)\.(\d+)"
         base_match = re.search(base_pattern, version_line)
         assert base_match, "Version string must be in format X.Y.Z or X.Y.Z-rcN"
         major, minor, bug = base_match.groups()
-        replacement = f'__version__ = "{major}.{minor}.{bug}-rc0"\n'
+        replacement = f'__version__ = "{major}.{minor}.{bug}_rc0"\n'
 
     lines[-1] = replacement
 

--- a/.github/workflows/set_nightly_version_rc.py
+++ b/.github/workflows/set_nightly_version_rc.py
@@ -33,14 +33,14 @@ with open(version_file_path, "r+", encoding="UTF-8") as f:
     if match:
         # Case 1: Version has RC suffix
         major, minor, bug, rc = match.groups()
-        replacement = f'__version__ = "{major}.{minor}.{bug}_rc{int(rc)+1}"\n'
+        replacement = f'__version__ = "{major}.{minor}.{bug}-rc{int(rc)+1}"\n'
     else:
         # Case 2: Version has no RC suffix
         base_pattern = r"(\d+)\.(\d+)\.(\d+)"
         base_match = re.search(base_pattern, version_line)
         assert base_match, "Version string must be in format X.Y.Z or X.Y.Z-rcN"
         major, minor, bug = base_match.groups()
-        replacement = f'__version__ = "{major}.{minor}.{bug}_rc0"\n'
+        replacement = f'__version__ = "{major}.{minor}.{bug}-rc0"\n'
 
     lines[-1] = replacement
 

--- a/.github/workflows/wheel_linux_x86_64_rocm.yml
+++ b/.github/workflows/wheel_linux_x86_64_rocm.yml
@@ -23,7 +23,7 @@ on:
       branch:
         required: false
         type: string  
-      skip-upload:
+      skip_upload:
         required: false
         type: boolean
         default: false

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.46.0-dev3"
+__version__ = "0.46.0-dev4"


### PR DESCRIPTION
**Context:**
There is a typo in the RC nightly builds that's preventing it from running. 

**Description of the Change:**
- Change `skip-upload` to `skip_upload`.

**Benefits:**
Workflow runs 

**Possible Drawbacks:**
None.

**Related GitHub Issues:**
https://github.com/PennyLaneAI/pennylane-lightning/pull/1379