### PR TITLE
Lightning Kokkos support >=32 qubits on GPUs

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 <h3>Improvements 🛠</h3>
 
-- Added support for simulating >32 qubits using Lightning-Kokkos on GPU devices.
+- The Lightning-Kokkos simulator now supports simulation of statevectors with 32 or more qubits when using GPU devices.
   [(#1382)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1382)
 
 <h3>Breaking changes 💔</h3>

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 <h3>Improvements 🛠</h3>
 
+- Added support for simulating >32 qubits using Lightning-Kokkos on GPU devices.
+  [(#1382)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1382)
+
 <h3>Breaking changes 💔</h3>
 
 <h3>Deprecations 👋</h3>

--- a/doc/lightning_amdgpu/installation.rst
+++ b/doc/lightning_amdgpu/installation.rst
@@ -10,7 +10,7 @@ The installation instruction here is specifically for AMD MI300 GPU (GFX942); fo
 
 .. note::
 
-    - Lightning-AMDGPU require Kokkos version 5.1.0
+    - Lightning-AMDGPU requires Kokkos version 5.1.0
     - Lightning-AMDGPU is verified to work with ROCm 6.2, 6.4, 7.0, 7.1.
     - ROCm 7.2 is known to cause compilation failure with Lightning-AMDGPU.
 

--- a/doc/lightning_amdgpu/installation.rst
+++ b/doc/lightning_amdgpu/installation.rst
@@ -10,7 +10,9 @@ The installation instruction here is specifically for AMD MI300 GPU (GFX942); fo
 
 .. note::
 
-    Lightning-Kokkos and Lightning-AMDGPU are tested with Kokkos version 5.1.0
+    - Lightning-AMDGPU require Kokkos version 5.1.0
+    - Lightning-AMDGPU is verified to work with ROCm 6.2, 6.4, 7.0, 7.1.
+    - ROCm 7.2 is known to cause compilation failure with Lightning-AMDGPU.
 
 
 Install Lightning-AMDGPU

--- a/doc/lightning_amdgpu/installation.rst
+++ b/doc/lightning_amdgpu/installation.rst
@@ -11,7 +11,7 @@ The installation instruction here is specifically for AMD MI300 GPU (GFX942); fo
 .. note::
 
     - Lightning-AMDGPU requires Kokkos version 5.1.0
-    - Lightning-AMDGPU is verified to work with ROCm 6.2, 6.4, 7.0, 7.1.
+    - Lightning-AMDGPU is verified to work with ROCm versions 6.2 to 7.1.
     - ROCm 7.2 is known to cause compilation failure with Lightning-AMDGPU.
 
 

--- a/doc/lightning_kokkos/installation.rst
+++ b/doc/lightning_kokkos/installation.rst
@@ -19,7 +19,7 @@ Install Kokkos (Optional)
 
 .. note::
 
-    Lightning-Kokkos is tested with Kokkos version 5.1.0
+    Lightning-Kokkos requires Kokkos version 5.1.0
 
 We suggest first installing Kokkos with the wanted configuration following the instructions found in the `Kokkos documentation <https://kokkos.github.io/kokkos-core-wiki/building.html>`_.
 For example, the following will build Kokkos for NVIDIA A100 cards:

--- a/doc/lightning_kokkos/installation_hpc.rst
+++ b/doc/lightning_kokkos/installation_hpc.rst
@@ -28,7 +28,9 @@ Install Kokkos (Recommended)
 
 .. note::
 
-    Lightning-Kokkos requires Kokkos version 5.1.0.
+    - Lightning-Kokkos requires Kokkos version 5.1.0.
+    - Lightning-Kokkos is verified to work with ROCm 6.2, 6.4, 7.0, 7.1.
+    - ROCm 7.2 is known to cause compilation failure with Lightning-Kokkos.
 
 We suggest first installing Kokkos with the desired configuration, following the instructions found in the Kokkos documentation.
 For example, the following instructions demonstrate building Kokkos for AMD MI210/250/250X GPUs:

--- a/doc/lightning_kokkos/installation_hpc.rst
+++ b/doc/lightning_kokkos/installation_hpc.rst
@@ -28,7 +28,7 @@ Install Kokkos (Recommended)
 
 .. note::
 
-    Lightning-Kokkos is tested with Kokkos version 5.1.0
+    Lightning-Kokkos requires Kokkos version 5.1.0.
 
 We suggest first installing Kokkos with the desired configuration, following the instructions found in the Kokkos documentation.
 For example, the following instructions demonstrate building Kokkos for AMD MI210/250/250X GPUs:

--- a/doc/lightning_kokkos/installation_hpc.rst
+++ b/doc/lightning_kokkos/installation_hpc.rst
@@ -29,7 +29,7 @@ Install Kokkos (Recommended)
 .. note::
 
     - Lightning-Kokkos requires Kokkos version 5.1.0.
-    - Lightning-Kokkos is verified to work with ROCm 6.2, 6.4, 7.0, 7.1.
+    - Lightning-Kokkos is verified to work with ROCm versions 6.2 to 7.1.
     - ROCm 7.2 is known to cause compilation failure with Lightning-Kokkos.
 
 We suggest first installing Kokkos with the desired configuration, following the instructions found in the Kokkos documentation.

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.46.0-dev4"
+__version__ = "0.46.0-dev5"

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.46.0-dev10"
+__version__ = "0.46.0-dev11"

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.46.0-dev5"
+__version__ = "0.46.0-dev6"

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.46.0-dev8"
+__version__ = "0.46.0-dev9"

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.46.0-dev7"
+__version__ = "0.46.0-dev8"

--- a/pennylane_lightning/core/simulators/lightning_kokkos/StateVectorKokkos.hpp
+++ b/pennylane_lightning/core/simulators/lightning_kokkos/StateVectorKokkos.hpp
@@ -411,9 +411,8 @@ class StateVectorKokkos final
         KokkosVector matrix_trans("matrix_trans", matrix.size());
 
         if (inverse) {
-            StateVectorMDRangePolicy<2, KokkosExecSpace> policy_2d(
-                {0, 0}, {static_cast<std::int64_t>(dim),
-                         static_cast<std::int64_t>(dim)});
+            StateVectorMDRangePolicy<2, KokkosExecSpace> policy_2d({0, 0},
+                                                                   {dim, dim});
             Kokkos::parallel_for(
                 policy_2d, KOKKOS_LAMBDA(std::size_t i, std::size_t j) {
                     matrix_trans(i + j * dim) =
@@ -532,9 +531,8 @@ class StateVectorKokkos final
         KokkosVector matrix_trans("matrix_trans", matrix.size());
 
         if (inverse) {
-            StateVectorMDRangePolicy<2, KokkosExecSpace> policy_2d(
-                {0, 0}, {static_cast<std::int64_t>(dim),
-                         static_cast<std::int64_t>(dim)});
+            StateVectorMDRangePolicy<2, KokkosExecSpace> policy_2d({0, 0},
+                                                                   {dim, dim});
             Kokkos::parallel_for(
                 policy_2d, KOKKOS_LAMBDA(std::size_t i, std::size_t j) {
                     matrix_trans(i + j * dim) =

--- a/pennylane_lightning/core/simulators/lightning_kokkos/StateVectorKokkos.hpp
+++ b/pennylane_lightning/core/simulators/lightning_kokkos/StateVectorKokkos.hpp
@@ -450,6 +450,13 @@ class StateVectorKokkos final
             // shared memory), or SIMD
             std::size_t scratch_size = ScratchViewComplex::shmem_size(dim) +
                                        ScratchViewSizeT::shmem_size(dim);
+            // Kokkos stores TeamPolicy league_size as a 32-bit int on the
+            // CUDA/HIP backends, so abort rather than silently truncate when
+            // the number of teams would exceed the 2^31 league_size limit.
+            PL_ABORT_IF(
+                two2N >= (std::size_t{1} << 31),
+                "Number of thread teams exceeds the Kokkos TeamPolicy "
+                "league_size limit (2^31) on GPU backends for this gate.");
             Kokkos::parallel_for(
                 "multiQubitOpFunctor",
                 TeamPolicy(two2N, Kokkos::AUTO, dim)
@@ -570,6 +577,13 @@ class StateVectorKokkos final
             const std::size_t scratch_size =
                 ScratchViewComplex::shmem_size(dim) +
                 ScratchViewSizeT::shmem_size(dim);
+            // Kokkos stores TeamPolicy league_size as a 32-bit int on the
+            // CUDA/HIP backends, so abort rather than silently truncate when
+            // the number of teams would exceed the 2^31 league_size limit.
+            PL_ABORT_IF(
+                two2N >= (std::size_t{1} << 31),
+                "Number of thread teams exceeds the Kokkos TeamPolicy "
+                "league_size limit (2^31) on GPU backends for this gate.");
             Kokkos::parallel_for(
                 "multiNCQubitOpFunctor",
                 TeamPolicy(two2N, Kokkos::AUTO, dim)

--- a/pennylane_lightning/core/simulators/lightning_kokkos/StateVectorKokkos.hpp
+++ b/pennylane_lightning/core/simulators/lightning_kokkos/StateVectorKokkos.hpp
@@ -411,8 +411,11 @@ class StateVectorKokkos final
         KokkosVector matrix_trans("matrix_trans", matrix.size());
 
         if (inverse) {
-            StateVectorMDRangePolicy<2, KokkosExecSpace> policy_2d({0, 0},
-                                                                   {dim, dim});
+            // MDRangePolicy bounds are Kokkos::Array<int64_t, rank> regardless
+            // of IndexType, so cast from size_t to silence -Wnarrowing.
+            StateVectorMDRangePolicy<2, KokkosExecSpace> policy_2d(
+                {0, 0}, {static_cast<std::int64_t>(dim),
+                         static_cast<std::int64_t>(dim)});
             Kokkos::parallel_for(
                 policy_2d, KOKKOS_LAMBDA(std::size_t i, std::size_t j) {
                     matrix_trans(i + j * dim) =
@@ -531,8 +534,9 @@ class StateVectorKokkos final
         KokkosVector matrix_trans("matrix_trans", matrix.size());
 
         if (inverse) {
-            StateVectorMDRangePolicy<2, KokkosExecSpace> policy_2d({0, 0},
-                                                                   {dim, dim});
+            StateVectorMDRangePolicy<2, KokkosExecSpace> policy_2d(
+                {0, 0}, {static_cast<std::int64_t>(dim),
+                         static_cast<std::int64_t>(dim)});
             Kokkos::parallel_for(
                 policy_2d, KOKKOS_LAMBDA(std::size_t i, std::size_t j) {
                     matrix_trans(i + j * dim) =

--- a/pennylane_lightning/core/simulators/lightning_kokkos/StateVectorKokkos.hpp
+++ b/pennylane_lightning/core/simulators/lightning_kokkos/StateVectorKokkos.hpp
@@ -98,7 +98,7 @@ class StateVectorKokkos final
     using ScratchViewSizeT =
         Kokkos::View<std::size_t *, KokkosExecSpace::scratch_memory_space,
                      Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
-    using TeamPolicy = Kokkos::TeamPolicy<>;
+    using TeamPolicy = StateVectorTeamPolicy<>;
     using MemoryStorageT = Pennylane::Util::MemoryStorageLocation::Undefined;
 
     StateVectorKokkos() = delete;
@@ -138,7 +138,8 @@ class StateVectorKokkos final
         KokkosVector sv_view =
             getView(); // circumvent error capturing this with KOKKOS_LAMBDA
         Kokkos::parallel_for(
-            sv_view.size(), KOKKOS_LAMBDA(std::size_t i) {
+            StateVectorRangePolicy<KokkosExecSpace>(0, sv_view.size()),
+            KOKKOS_LAMBDA(std::size_t i) {
                 sv_view(i) =
                     (i == index) ? ComplexT{1.0, 0.0} : ComplexT{0.0, 0.0};
             });
@@ -195,7 +196,8 @@ class StateVectorKokkos final
         KokkosVector sv_view =
             getView(); // circumvent error capturing this with KOKKOS_LAMBDA
         Kokkos::parallel_for(
-            indices.size(), KOKKOS_LAMBDA(std::size_t i) {
+            StateVectorRangePolicy<KokkosExecSpace>(0, indices.size()),
+            KOKKOS_LAMBDA(std::size_t i) {
                 sv_view(d_indices[i]) = d_values[i];
             });
     }
@@ -235,7 +237,8 @@ class StateVectorKokkos final
         auto d_wires = vector2view(wires);
         initZeros();
         Kokkos::parallel_for(
-            num_state, KOKKOS_LAMBDA(std::size_t i) {
+            StateVectorRangePolicy<KokkosExecSpace>(0, num_state),
+            KOKKOS_LAMBDA(std::size_t i) {
                 std::size_t index{0U};
                 for (std::size_t w = 0; w < d_wires.size(); w++) {
                     const std::size_t bit = (i & (one << w)) >> w;
@@ -408,7 +411,9 @@ class StateVectorKokkos final
         KokkosVector matrix_trans("matrix_trans", matrix.size());
 
         if (inverse) {
-            Kokkos::MDRangePolicy<DoubleLoopRank> policy_2d({0, 0}, {dim, dim});
+            StateVectorMDRangePolicy<2, KokkosExecSpace> policy_2d(
+                {0, 0}, {static_cast<std::int64_t>(dim),
+                         static_cast<std::int64_t>(dim)});
             Kokkos::parallel_for(
                 policy_2d, KOKKOS_LAMBDA(std::size_t i, std::size_t j) {
                     matrix_trans(i + j * dim) =
@@ -420,23 +425,27 @@ class StateVectorKokkos final
         switch (wires.size()) {
         case 1:
             Kokkos::parallel_for(
-                two2N, apply1QubitOpFunctor<fp_t>(*data_, num_qubits,
-                                                  matrix_trans, wires));
+                StateVectorRangePolicy<KokkosExecSpace>(0, two2N),
+                apply1QubitOpFunctor<fp_t>(*data_, num_qubits, matrix_trans,
+                                           wires));
             break;
         case 2:
             Kokkos::parallel_for(
-                two2N, apply2QubitOpFunctor<fp_t>(*data_, num_qubits,
-                                                  matrix_trans, wires));
+                StateVectorRangePolicy<KokkosExecSpace>(0, two2N),
+                apply2QubitOpFunctor<fp_t>(*data_, num_qubits, matrix_trans,
+                                           wires));
             break;
         case 3:
             Kokkos::parallel_for(
-                two2N, apply3QubitOpFunctor<fp_t>(*data_, num_qubits,
-                                                  matrix_trans, wires));
+                StateVectorRangePolicy<KokkosExecSpace>(0, two2N),
+                apply3QubitOpFunctor<fp_t>(*data_, num_qubits, matrix_trans,
+                                           wires));
             break;
         case 4:
             Kokkos::parallel_for(
-                two2N, apply4QubitOpFunctor<fp_t>(*data_, num_qubits,
-                                                  matrix_trans, wires));
+                StateVectorRangePolicy<KokkosExecSpace>(0, two2N),
+                apply4QubitOpFunctor<fp_t>(*data_, num_qubits, matrix_trans,
+                                           wires));
             break;
         default:
             // TODO: explore runtime determine L0 or L1 scratch level (for GPU
@@ -523,7 +532,9 @@ class StateVectorKokkos final
         KokkosVector matrix_trans("matrix_trans", matrix.size());
 
         if (inverse) {
-            Kokkos::MDRangePolicy<DoubleLoopRank> policy_2d({0, 0}, {dim, dim});
+            StateVectorMDRangePolicy<2, KokkosExecSpace> policy_2d(
+                {0, 0}, {static_cast<std::int64_t>(dim),
+                         static_cast<std::int64_t>(dim)});
             Kokkos::parallel_for(
                 policy_2d, KOKKOS_LAMBDA(std::size_t i, std::size_t j) {
                     matrix_trans(i + j * dim) =
@@ -535,22 +546,25 @@ class StateVectorKokkos final
 
         switch (wires.size()) {
         case 1:
-            Kokkos::parallel_for(two2N, applyNC1QubitOpFunctor<fp_t>(
-                                            *data_, num_qubits, matrix_trans,
-                                            controlled_wires, controlled_values,
-                                            wires));
+            Kokkos::parallel_for(
+                StateVectorRangePolicy<KokkosExecSpace>(0, two2N),
+                applyNC1QubitOpFunctor<fp_t>(*data_, num_qubits, matrix_trans,
+                                             controlled_wires,
+                                             controlled_values, wires));
             break;
         case 2:
-            Kokkos::parallel_for(two2N, applyNC2QubitOpFunctor<fp_t>(
-                                            *data_, num_qubits, matrix_trans,
-                                            controlled_wires, controlled_values,
-                                            wires));
+            Kokkos::parallel_for(
+                StateVectorRangePolicy<KokkosExecSpace>(0, two2N),
+                applyNC2QubitOpFunctor<fp_t>(*data_, num_qubits, matrix_trans,
+                                             controlled_wires,
+                                             controlled_values, wires));
             break;
         case 3:
-            Kokkos::parallel_for(two2N, applyNC3QubitOpFunctor<fp_t>(
-                                            *data_, num_qubits, matrix_trans,
-                                            controlled_wires, controlled_values,
-                                            wires));
+            Kokkos::parallel_for(
+                StateVectorRangePolicy<KokkosExecSpace>(0, two2N),
+                applyNC3QubitOpFunctor<fp_t>(*data_, num_qubits, matrix_trans,
+                                             controlled_wires,
+                                             controlled_values, wires));
             break;
         default:
             // TODO: explore runtime determine L0 or L1 scratch level (for GPU
@@ -797,7 +811,8 @@ class StateVectorKokkos final
     void collapse(std::size_t wire, bool branch) {
         KokkosVector matrix("gate_matrix", 4);
         Kokkos::parallel_for(
-            matrix.size(), KOKKOS_LAMBDA(std::size_t k) {
+            StateVectorRangePolicy<KokkosExecSpace>(0, matrix.size()),
+            KOKKOS_LAMBDA(std::size_t k) {
                 matrix(k) = ((k == 0 && branch == 0) || (k == 3 && branch == 1))
                                 ? ComplexT{1.0, 0.0}
                                 : ComplexT{0.0, 0.0};
@@ -814,7 +829,7 @@ class StateVectorKokkos final
 
         PrecisionT squaredNorm = 0.0;
         Kokkos::parallel_reduce(
-            sv_view.size(),
+            StateVectorRangePolicy<KokkosExecSpace>(0, sv_view.size()),
             KOKKOS_LAMBDA(std::size_t i, PrecisionT &sum) {
                 const PrecisionT norm = Kokkos::abs(sv_view(i));
                 sum += norm * norm;
@@ -828,7 +843,7 @@ class StateVectorKokkos final
         const std::complex<PrecisionT> inv_norm =
             1. / Kokkos::sqrt(squaredNorm);
         Kokkos::parallel_for(
-            sv_view.size(),
+            StateVectorRangePolicy<KokkosExecSpace>(0, sv_view.size()),
             KOKKOS_LAMBDA(std::size_t i) { sv_view(i) *= inv_norm; });
     }
 

--- a/pennylane_lightning/core/simulators/lightning_kokkos/StateVectorKokkos.hpp
+++ b/pennylane_lightning/core/simulators/lightning_kokkos/StateVectorKokkos.hpp
@@ -98,7 +98,7 @@ class StateVectorKokkos final
     using ScratchViewSizeT =
         Kokkos::View<std::size_t *, KokkosExecSpace::scratch_memory_space,
                      Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
-    using TeamPolicy = StateVectorTeamPolicy<>;
+    using TeamPolicy = Util::TeamPolicy<>;
     using MemoryStorageT = Pennylane::Util::MemoryStorageLocation::Undefined;
 
     StateVectorKokkos() = delete;
@@ -138,7 +138,7 @@ class StateVectorKokkos final
         KokkosVector sv_view =
             getView(); // circumvent error capturing this with KOKKOS_LAMBDA
         Kokkos::parallel_for(
-            StateVectorRangePolicy<KokkosExecSpace>(0, sv_view.size()),
+            RangePolicy<KokkosExecSpace>(0, sv_view.size()),
             KOKKOS_LAMBDA(std::size_t i) {
                 sv_view(i) =
                     (i == index) ? ComplexT{1.0, 0.0} : ComplexT{0.0, 0.0};
@@ -196,7 +196,7 @@ class StateVectorKokkos final
         KokkosVector sv_view =
             getView(); // circumvent error capturing this with KOKKOS_LAMBDA
         Kokkos::parallel_for(
-            StateVectorRangePolicy<KokkosExecSpace>(0, indices.size()),
+            RangePolicy<KokkosExecSpace>(0, indices.size()),
             KOKKOS_LAMBDA(std::size_t i) {
                 sv_view(d_indices[i]) = d_values[i];
             });
@@ -237,7 +237,7 @@ class StateVectorKokkos final
         auto d_wires = vector2view(wires);
         initZeros();
         Kokkos::parallel_for(
-            StateVectorRangePolicy<KokkosExecSpace>(0, num_state),
+            RangePolicy<KokkosExecSpace>(0, num_state),
             KOKKOS_LAMBDA(std::size_t i) {
                 std::size_t index{0U};
                 for (std::size_t w = 0; w < d_wires.size(); w++) {
@@ -413,7 +413,7 @@ class StateVectorKokkos final
         if (inverse) {
             // MDRangePolicy bounds are Kokkos::Array<int64_t, rank> regardless
             // of IndexType, so cast from size_t to silence -Wnarrowing.
-            StateVectorMDRangePolicy<2, KokkosExecSpace> policy_2d(
+            MDRangePolicy<2, KokkosExecSpace> policy_2d(
                 {0, 0}, {static_cast<std::int64_t>(dim),
                          static_cast<std::int64_t>(dim)});
             Kokkos::parallel_for(
@@ -426,28 +426,24 @@ class StateVectorKokkos final
         }
         switch (wires.size()) {
         case 1:
-            Kokkos::parallel_for(
-                StateVectorRangePolicy<KokkosExecSpace>(0, two2N),
-                apply1QubitOpFunctor<fp_t>(*data_, num_qubits, matrix_trans,
-                                           wires));
+            Kokkos::parallel_for(RangePolicy<KokkosExecSpace>(0, two2N),
+                                 apply1QubitOpFunctor<fp_t>(
+                                     *data_, num_qubits, matrix_trans, wires));
             break;
         case 2:
-            Kokkos::parallel_for(
-                StateVectorRangePolicy<KokkosExecSpace>(0, two2N),
-                apply2QubitOpFunctor<fp_t>(*data_, num_qubits, matrix_trans,
-                                           wires));
+            Kokkos::parallel_for(RangePolicy<KokkosExecSpace>(0, two2N),
+                                 apply2QubitOpFunctor<fp_t>(
+                                     *data_, num_qubits, matrix_trans, wires));
             break;
         case 3:
-            Kokkos::parallel_for(
-                StateVectorRangePolicy<KokkosExecSpace>(0, two2N),
-                apply3QubitOpFunctor<fp_t>(*data_, num_qubits, matrix_trans,
-                                           wires));
+            Kokkos::parallel_for(RangePolicy<KokkosExecSpace>(0, two2N),
+                                 apply3QubitOpFunctor<fp_t>(
+                                     *data_, num_qubits, matrix_trans, wires));
             break;
         case 4:
-            Kokkos::parallel_for(
-                StateVectorRangePolicy<KokkosExecSpace>(0, two2N),
-                apply4QubitOpFunctor<fp_t>(*data_, num_qubits, matrix_trans,
-                                           wires));
+            Kokkos::parallel_for(RangePolicy<KokkosExecSpace>(0, two2N),
+                                 apply4QubitOpFunctor<fp_t>(
+                                     *data_, num_qubits, matrix_trans, wires));
             break;
         default:
             // TODO: explore runtime determine L0 or L1 scratch level (for GPU
@@ -534,7 +530,7 @@ class StateVectorKokkos final
         KokkosVector matrix_trans("matrix_trans", matrix.size());
 
         if (inverse) {
-            StateVectorMDRangePolicy<2, KokkosExecSpace> policy_2d(
+            MDRangePolicy<2, KokkosExecSpace> policy_2d(
                 {0, 0}, {static_cast<std::int64_t>(dim),
                          static_cast<std::int64_t>(dim)});
             Kokkos::parallel_for(
@@ -549,21 +545,21 @@ class StateVectorKokkos final
         switch (wires.size()) {
         case 1:
             Kokkos::parallel_for(
-                StateVectorRangePolicy<KokkosExecSpace>(0, two2N),
+                RangePolicy<KokkosExecSpace>(0, two2N),
                 applyNC1QubitOpFunctor<fp_t>(*data_, num_qubits, matrix_trans,
                                              controlled_wires,
                                              controlled_values, wires));
             break;
         case 2:
             Kokkos::parallel_for(
-                StateVectorRangePolicy<KokkosExecSpace>(0, two2N),
+                RangePolicy<KokkosExecSpace>(0, two2N),
                 applyNC2QubitOpFunctor<fp_t>(*data_, num_qubits, matrix_trans,
                                              controlled_wires,
                                              controlled_values, wires));
             break;
         case 3:
             Kokkos::parallel_for(
-                StateVectorRangePolicy<KokkosExecSpace>(0, two2N),
+                RangePolicy<KokkosExecSpace>(0, two2N),
                 applyNC3QubitOpFunctor<fp_t>(*data_, num_qubits, matrix_trans,
                                              controlled_wires,
                                              controlled_values, wires));
@@ -813,7 +809,7 @@ class StateVectorKokkos final
     void collapse(std::size_t wire, bool branch) {
         KokkosVector matrix("gate_matrix", 4);
         Kokkos::parallel_for(
-            StateVectorRangePolicy<KokkosExecSpace>(0, matrix.size()),
+            RangePolicy<KokkosExecSpace>(0, matrix.size()),
             KOKKOS_LAMBDA(std::size_t k) {
                 matrix(k) = ((k == 0 && branch == 0) || (k == 3 && branch == 1))
                                 ? ComplexT{1.0, 0.0}
@@ -831,7 +827,7 @@ class StateVectorKokkos final
 
         PrecisionT squaredNorm = 0.0;
         Kokkos::parallel_reduce(
-            StateVectorRangePolicy<KokkosExecSpace>(0, sv_view.size()),
+            RangePolicy<KokkosExecSpace>(0, sv_view.size()),
             KOKKOS_LAMBDA(std::size_t i, PrecisionT &sum) {
                 const PrecisionT norm = Kokkos::abs(sv_view(i));
                 sum += norm * norm;
@@ -845,7 +841,7 @@ class StateVectorKokkos final
         const std::complex<PrecisionT> inv_norm =
             1. / Kokkos::sqrt(squaredNorm);
         Kokkos::parallel_for(
-            StateVectorRangePolicy<KokkosExecSpace>(0, sv_view.size()),
+            RangePolicy<KokkosExecSpace>(0, sv_view.size()),
             KOKKOS_LAMBDA(std::size_t i) { sv_view(i) *= inv_norm; });
     }
 

--- a/pennylane_lightning/core/simulators/lightning_kokkos/StateVectorKokkosMPI.hpp
+++ b/pennylane_lightning/core/simulators/lightning_kokkos/StateVectorKokkosMPI.hpp
@@ -513,7 +513,7 @@ class StateVectorKokkosMPI final
 
         PrecisionT squaredLocalNorm = 0.0;
         Kokkos::parallel_reduce(
-            sv_view.size(),
+            StateVectorRangePolicy<KokkosExecSpace>(0, sv_view.size()),
             KOKKOS_LAMBDA(std::size_t i, PrecisionT &sum) {
                 const PrecisionT norm = Kokkos::abs(sv_view(i));
                 sum += norm * norm;
@@ -529,7 +529,7 @@ class StateVectorKokkosMPI final
         const std::complex<PrecisionT> inv_norm =
             1. / Kokkos::sqrt(squaredNorm);
         Kokkos::parallel_for(
-            sv_view.size(),
+            StateVectorRangePolicy<KokkosExecSpace>(0, sv_view.size()),
             KOKKOS_LAMBDA(std::size_t i) { sv_view(i) *= inv_norm; });
     }
 
@@ -775,7 +775,8 @@ class StateVectorKokkosMPI final
 
             // Copy to send buffer
             Kokkos::parallel_for(
-                "copy_sendbuf", send_size,
+                "copy_sendbuf",
+                StateVectorRangePolicy<KokkosExecSpace>(0, send_size),
                 KOKKOS_LAMBDA(std::size_t buffer_index) {
                     std::size_t SV_index = swap_wire_mask;
                     for (std::size_t i = 0; i < not_swapping_local_wire_size;
@@ -798,7 +799,8 @@ class StateVectorKokkosMPI final
 
             // Copy from recv buffer
             Kokkos::parallel_for(
-                "copy_recvbuf", send_size,
+                "copy_recvbuf",
+                StateVectorRangePolicy<KokkosExecSpace>(0, send_size),
                 KOKKOS_LAMBDA(std::size_t buffer_index) {
                     std::size_t SV_index = swap_wire_mask;
 
@@ -919,7 +921,8 @@ class StateVectorKokkosMPI final
             std::size_t offset = i * send_size;
             // COPY to buffer
             Kokkos::parallel_for(
-                "copy_sendbuf", send_size,
+                "copy_sendbuf",
+                StateVectorRangePolicy<KokkosExecSpace>(0, send_size),
                 KOKKOS_LAMBDA(std::size_t buffer_index) {
                     sendbuf_view(buffer_index) = sv_view(buffer_index + offset);
                 });
@@ -929,7 +932,8 @@ class StateVectorKokkosMPI final
             // COPY FROM BUFFER
 
             Kokkos::parallel_for(
-                "copy_recvbuf", send_size,
+                "copy_recvbuf",
+                StateVectorRangePolicy<KokkosExecSpace>(0, send_size),
                 KOKKOS_LAMBDA(std::size_t buffer_index) {
                     sv_view(buffer_index + offset) = recvbuf_view(buffer_index);
                 });
@@ -1311,7 +1315,8 @@ class StateVectorKokkosMPI final
 
         KokkosVector matrix("gate_matrix", 4);
         Kokkos::parallel_for(
-            matrix.size(), KOKKOS_LAMBDA(std::size_t k) {
+            StateVectorRangePolicy<KokkosExecSpace>(0, matrix.size()),
+            KOKKOS_LAMBDA(std::size_t k) {
                 matrix(k) = ((k == 0 && branch == 0) || (k == 3 && branch == 1))
                                 ? ComplexT{1.0, 0.0}
                                 : ComplexT{0.0, 0.0};

--- a/pennylane_lightning/core/simulators/lightning_kokkos/StateVectorKokkosMPI.hpp
+++ b/pennylane_lightning/core/simulators/lightning_kokkos/StateVectorKokkosMPI.hpp
@@ -994,7 +994,7 @@ class StateVectorKokkosMPI final
             if (opName == "PauliX") {
                 std::size_t rev_distance = getRevGlobalWireIndex(wires[0]);
                 for (auto &global_index : mpi_rank_to_global_index_map_) {
-                    global_index = global_index ^ (1U << rev_distance);
+                    global_index = global_index ^ (one << rev_distance);
                 }
                 return;
             } else if (opName == "PauliY") {
@@ -1006,7 +1006,7 @@ class StateVectorKokkosMPI final
                                  : (-1.0) * M_PI_2;
                 (*sv_).applyOperation("GlobalPhase", {}, false, {phase});
                 for (auto &global_index : mpi_rank_to_global_index_map_) {
-                    global_index = global_index ^ (1U << rev_distance);
+                    global_index = global_index ^ (one << rev_distance);
                 }
 
                 return;
@@ -1023,7 +1023,7 @@ class StateVectorKokkosMPI final
                 std::size_t rev_distance_1 = getRevGlobalWireIndex(wires[1]);
                 for (auto &global_index : mpi_rank_to_global_index_map_) {
                     global_index = ((global_index >> rev_distance_0) & 1)
-                                       ? global_index ^ (1U << rev_distance_1)
+                                       ? global_index ^ (one << rev_distance_1)
                                        : global_index;
                 }
                 return;
@@ -1135,7 +1135,7 @@ class StateVectorKokkosMPI final
                             const std::vector<std::size_t> &wires,
                             bool inverse = false) {
         PL_ABORT_IF(wires.empty(), "Number of wires must be larger than 0");
-        size_t n = static_cast<std::size_t>(1U) << wires.size();
+        size_t n = one << wires.size();
         const std::vector<ComplexT> matrix_(matrix, matrix + n * n);
         applyOperation("Matrix", wires, inverse, {}, matrix_);
     }
@@ -1176,7 +1176,7 @@ class StateVectorKokkosMPI final
                           const std::vector<std::size_t> &wires,
                           bool inverse = false) {
         PL_ABORT_IF(wires.empty(), "Number of wires must be larger than 0");
-        size_t n = static_cast<std::size_t>(1U) << wires.size();
+        size_t n = one << wires.size();
         const std::vector<ComplexT> matrix_(matrix, matrix + n * n);
         applyOperation("Matrix", controlled_wires, controlled_values, wires,
                        inverse, {}, matrix_);

--- a/pennylane_lightning/core/simulators/lightning_kokkos/StateVectorKokkosMPI.hpp
+++ b/pennylane_lightning/core/simulators/lightning_kokkos/StateVectorKokkosMPI.hpp
@@ -513,7 +513,7 @@ class StateVectorKokkosMPI final
 
         PrecisionT squaredLocalNorm = 0.0;
         Kokkos::parallel_reduce(
-            StateVectorRangePolicy<KokkosExecSpace>(0, sv_view.size()),
+            RangePolicy<KokkosExecSpace>(0, sv_view.size()),
             KOKKOS_LAMBDA(std::size_t i, PrecisionT &sum) {
                 const PrecisionT norm = Kokkos::abs(sv_view(i));
                 sum += norm * norm;
@@ -529,7 +529,7 @@ class StateVectorKokkosMPI final
         const std::complex<PrecisionT> inv_norm =
             1. / Kokkos::sqrt(squaredNorm);
         Kokkos::parallel_for(
-            StateVectorRangePolicy<KokkosExecSpace>(0, sv_view.size()),
+            RangePolicy<KokkosExecSpace>(0, sv_view.size()),
             KOKKOS_LAMBDA(std::size_t i) { sv_view(i) *= inv_norm; });
     }
 
@@ -775,8 +775,7 @@ class StateVectorKokkosMPI final
 
             // Copy to send buffer
             Kokkos::parallel_for(
-                "copy_sendbuf",
-                StateVectorRangePolicy<KokkosExecSpace>(0, send_size),
+                "copy_sendbuf", RangePolicy<KokkosExecSpace>(0, send_size),
                 KOKKOS_LAMBDA(std::size_t buffer_index) {
                     std::size_t SV_index = swap_wire_mask;
                     for (std::size_t i = 0; i < not_swapping_local_wire_size;
@@ -799,8 +798,7 @@ class StateVectorKokkosMPI final
 
             // Copy from recv buffer
             Kokkos::parallel_for(
-                "copy_recvbuf",
-                StateVectorRangePolicy<KokkosExecSpace>(0, send_size),
+                "copy_recvbuf", RangePolicy<KokkosExecSpace>(0, send_size),
                 KOKKOS_LAMBDA(std::size_t buffer_index) {
                     std::size_t SV_index = swap_wire_mask;
 
@@ -921,8 +919,7 @@ class StateVectorKokkosMPI final
             std::size_t offset = i * send_size;
             // COPY to buffer
             Kokkos::parallel_for(
-                "copy_sendbuf",
-                StateVectorRangePolicy<KokkosExecSpace>(0, send_size),
+                "copy_sendbuf", RangePolicy<KokkosExecSpace>(0, send_size),
                 KOKKOS_LAMBDA(std::size_t buffer_index) {
                     sendbuf_view(buffer_index) = sv_view(buffer_index + offset);
                 });
@@ -932,8 +929,7 @@ class StateVectorKokkosMPI final
             // COPY FROM BUFFER
 
             Kokkos::parallel_for(
-                "copy_recvbuf",
-                StateVectorRangePolicy<KokkosExecSpace>(0, send_size),
+                "copy_recvbuf", RangePolicy<KokkosExecSpace>(0, send_size),
                 KOKKOS_LAMBDA(std::size_t buffer_index) {
                     sv_view(buffer_index + offset) = recvbuf_view(buffer_index);
                 });
@@ -1315,7 +1311,7 @@ class StateVectorKokkosMPI final
 
         KokkosVector matrix("gate_matrix", 4);
         Kokkos::parallel_for(
-            StateVectorRangePolicy<KokkosExecSpace>(0, matrix.size()),
+            RangePolicy<KokkosExecSpace>(0, matrix.size()),
             KOKKOS_LAMBDA(std::size_t k) {
                 matrix(k) = ((k == 0 && branch == 0) || (k == 3 && branch == 1))
                                 ? ComplexT{1.0, 0.0}

--- a/pennylane_lightning/core/simulators/lightning_kokkos/catalyst/LightningKokkosSimulator.cpp
+++ b/pennylane_lightning/core/simulators/lightning_kokkos/catalyst/LightningKokkosSimulator.cpp
@@ -41,7 +41,7 @@ auto LightningKokkosSimulator::AllocateQubit() -> QubitIdType {
         const auto &original_data = this->device_sv->getDataVector();
 
         const size_t dsize = original_data.size();
-        RT_ASSERT(dsize == 1UL << num_qubits);
+        RT_ASSERT(dsize == std::size_t{1} << num_qubits);
 
         std::vector<Kokkos::complex<double>> new_data(dsize << 1UL);
 
@@ -162,7 +162,7 @@ void LightningKokkosSimulator::reduceStateVector() {
     // Create a new state vector with reduced size
     auto old_data = this->device_sv->getDataVector();
     size_t num_qubits_after = wire_id_pairs.size();
-    size_t new_size = 1UL << num_qubits_after;
+    size_t new_size = std::size_t{1} << num_qubits_after;
 
     std::vector<Kokkos::complex<double>> new_data(new_size);
 
@@ -217,9 +217,9 @@ void LightningKokkosSimulator::reduceStateVector() {
             size_t new_bit_pos = num_qubits_after - 1 - i;
 
             if ((new_idx >> new_bit_pos) & 1) {
-                old_idx |= (1UL << old_bit_pos);
+                old_idx |= (std::size_t{1} << old_bit_pos);
             } else {
-                old_idx &= ~(1UL << old_bit_pos);
+                old_idx &= ~(std::size_t{1} << old_bit_pos);
             }
         }
 
@@ -271,7 +271,7 @@ bool LightningKokkosSimulator::checkSingleQubitDisentangled(size_t wire,
 
     const size_t bit_pos = num_qubits - 1U - wire;
 
-    const size_t lower_mask = (1UL << bit_pos) - 1;
+    const size_t lower_mask = (std::size_t{1} << bit_pos) - 1;
     const size_t upper_mask = sv_size - lower_mask - 1;
 
     // The resulting 2x2 reduced density matrix of the complement system to
@@ -319,8 +319,8 @@ void LightningKokkosSimulator::checkReleasedQubitsDisentangled() {
     //     and Tr(ρ_released^2) = 1 (pure state)
     const auto &state_data = this->device_sv->getDataVector();
     const size_t num_released = free_device_qubits.size();
-    const size_t released_space_size = 1UL << num_released;
-    const size_t active_space_size = 1UL << num_active;
+    const size_t released_space_size = std::size_t{1} << num_released;
+    const size_t active_space_size = std::size_t{1} << num_active;
 
     // Map (released_idx, active_idx) to full state vector index.
     // The state vector uses interleaved indexing where released and active
@@ -337,13 +337,13 @@ void LightningKokkosSimulator::checkReleasedQubitsDisentangled() {
             if (is_released) {
                 const size_t new_bit_pos = num_released - 1 - released_bit;
                 if ((released_idx >> new_bit_pos) & 1) {
-                    idx |= (1UL << bit_pos);
+                    idx |= (std::size_t{1} << bit_pos);
                 }
                 released_bit++;
             } else {
                 const size_t new_bit_pos = num_active - 1 - active_bit;
                 if ((active_idx >> new_bit_pos) & 1) {
-                    idx |= (1UL << bit_pos);
+                    idx |= (std::size_t{1} << bit_pos);
                 }
                 active_bit++;
             }
@@ -722,7 +722,7 @@ void LightningKokkosSimulator::PartialSample(
 void LightningKokkosSimulator::Counts(DataView<double, 1> &eigvals,
                                       DataView<int64_t, 1> &counts) {
     const std::size_t numQubits = this->GetNumQubits();
-    const std::size_t numElements = 1U << numQubits;
+    const std::size_t numElements = std::size_t{1} << numQubits;
 
     RT_FAIL_IF(eigvals.size() != numElements || counts.size() != numElements,
                "Invalid size for the pre-allocated counts");
@@ -755,7 +755,7 @@ void LightningKokkosSimulator::PartialCounts(
     const std::vector<QubitIdType> &wires) {
     const std::size_t numWires = wires.size();
     const std::size_t numQubits = this->GetNumQubits();
-    const std::size_t numElements = 1U << numWires;
+    const std::size_t numElements = std::size_t{1} << numWires;
 
     RT_FAIL_IF(numWires > numQubits, "Invalid number of wires");
     RT_FAIL_IF(!isValidQubits(wires), "Invalid given wires to measure");
@@ -794,7 +794,7 @@ auto LightningKokkosSimulator::Measure(QubitIdType wire,
     // get a measurement
     std::vector<QubitIdType> wires = {reinterpret_cast<QubitIdType>(wire)};
 
-    std::vector<double> probs(1U << wires.size());
+    std::vector<double> probs(std::size_t{1} << wires.size());
     DataView<double, 1> buffer_view(probs);
     auto device_shots = GetDeviceShots();
     SetDeviceShots(0);

--- a/pennylane_lightning/core/simulators/lightning_kokkos/gates/BasicGateFunctors.hpp
+++ b/pennylane_lightning/core/simulators/lightning_kokkos/gates/BasicGateFunctors.hpp
@@ -29,11 +29,12 @@ using Kokkos::kokkos_swap;
 using Pennylane::Gates::GateOperation;
 using Pennylane::LightningKokkos::Util::controlBitPatterns;
 using Pennylane::LightningKokkos::Util::generateBitPatterns;
+using Pennylane::LightningKokkos::Util::MDRangePolicy;
+using Pennylane::LightningKokkos::Util::one;
 using Pennylane::LightningKokkos::Util::parity_2_offset;
+using Pennylane::LightningKokkos::Util::RangePolicy;
 using Pennylane::LightningKokkos::Util::reverseWires;
-using Pennylane::LightningKokkos::Util::StateVectorMDRangePolicy;
-using Pennylane::LightningKokkos::Util::StateVectorRangePolicy;
-using Pennylane::LightningKokkos::Util::StateVectorTeamPolicy;
+using Pennylane::LightningKokkos::Util::TeamPolicy;
 using Pennylane::LightningKokkos::Util::vector2view;
 } // namespace
 /// @endcond
@@ -42,7 +43,7 @@ namespace Pennylane::LightningKokkos::Functors {
 template <class PrecisionT, class FuncT> class applyNCNFunctor {
     using KokkosComplexVector = Kokkos::View<Kokkos::complex<PrecisionT> *>;
     using KokkosIntVector = Kokkos::View<std::size_t *>;
-    using MemberType = StateVectorTeamPolicy<>::member_type;
+    using MemberType = TeamPolicy<>::member_type;
 
     KokkosComplexVector arr;
     const FuncT core_function;
@@ -71,8 +72,7 @@ template <class PrecisionT, class FuncT> class applyNCNFunctor {
         controlBitPatterns(indices_, num_qubits, controlled_wires,
                            controlled_values);
         indices = vector2view(indices_);
-        Kokkos::parallel_for(StateVectorTeamPolicy<>(two2N, Kokkos::AUTO, dim),
-                             *this);
+        Kokkos::parallel_for(TeamPolicy<>(two2N, Kokkos::AUTO, dim), *this);
     }
     // TODO: Runtime selection for copying indices to scratch level 0/shmem
     KOKKOS_FUNCTION void operator()(const MemberType &teamMember) const {
@@ -116,7 +116,7 @@ class applyNC1Functor<PrecisionT, FuncT, true> {
                            controlled_values);
         indices = vector2view(indices_);
         Kokkos::parallel_for(
-            StateVectorRangePolicy<ExecutionSpace>(
+            RangePolicy<ExecutionSpace>(
                 0, Pennylane::Util::exp2(num_qubits - controlled_wires.size() -
                                          wires.size())),
             *this);
@@ -152,7 +152,7 @@ class applyNC1Functor<PrecisionT, FuncT, false> {
           wire_parity(fillTrailingOnes(rev_wire)),
           wire_parity_inv(fillLeadingOnes(rev_wire + 1)) {
         Kokkos::parallel_for(
-            StateVectorRangePolicy<ExecutionSpace>(
+            RangePolicy<ExecutionSpace>(
                 0, num_qubits ? Pennylane::Util::exp2(num_qubits - 1) : 1),
             *this);
     }
@@ -725,7 +725,7 @@ class applyNC2Functor<PrecisionT, FuncT, true> {
                            controlled_values);
         indices = vector2view(indices_);
         Kokkos::parallel_for(
-            StateVectorRangePolicy<ExecutionSpace>(
+            RangePolicy<ExecutionSpace>(
                 0, Pennylane::Util::exp2(num_qubits - controlled_wires.size() -
                                          wires.size())),
             *this);
@@ -774,7 +774,7 @@ class applyNC2Functor<PrecisionT, FuncT, false> {
           parity_high(fillLeadingOnes(rev_wire_max + 1)),
           parity_middle(fillLeadingOnes(rev_wire_min + 1) &
                         fillTrailingOnes(rev_wire_max)) {
-        Kokkos::parallel_for(StateVectorRangePolicy<ExecutionSpace>(
+        Kokkos::parallel_for(RangePolicy<ExecutionSpace>(
                                  0, Pennylane::Util::exp2(num_qubits - 2)),
                              *this);
     }
@@ -1389,7 +1389,7 @@ template <class PrecisionT, class FuncT> class applyNC3Functor {
             fillLeadingOnes(rev_wire_min + 1) & fillTrailingOnes(rev_wire_mid);
         parity_hmiddle =
             fillLeadingOnes(rev_wire_mid + 1) & fillTrailingOnes(rev_wire_max);
-        Kokkos::parallel_for(StateVectorRangePolicy<ExecutionSpace>(
+        Kokkos::parallel_for(RangePolicy<ExecutionSpace>(
                                  0, Pennylane::Util::exp2(num_qubits - 3)),
                              *this);
     }
@@ -1485,7 +1485,7 @@ class applyNC4Functor<PrecisionT, FuncT, true> {
                            controlled_values);
         indices = vector2view(indices_);
         Kokkos::parallel_for(
-            StateVectorRangePolicy<ExecutionSpace>(
+            RangePolicy<ExecutionSpace>(
                 0, Pennylane::Util::exp2(num_qubits - controlled_wires.size() -
                                          wires.size())),
             *this);
@@ -1597,7 +1597,7 @@ class applyNC4Functor<PrecisionT, FuncT, false> {
                          fillTrailingOnes(rev_wire_max);
         parity_middle = fillLeadingOnes(rev_wire_min_mid + 1) &
                         fillTrailingOnes(rev_wire_max_mid);
-        Kokkos::parallel_for(StateVectorRangePolicy<ExecutionSpace>(
+        Kokkos::parallel_for(RangePolicy<ExecutionSpace>(
                                  0, Pennylane::Util::exp2(num_qubits - 4)),
                              *this);
     }
@@ -1813,7 +1813,7 @@ void applyDoubleExcitationPlus(Kokkos::View<Kokkos::complex<PrecisionT> *> arr_,
 template <typename PrecisionT> class applyMultiRZFunctor {
     using KokkosComplexVector = Kokkos::View<Kokkos::complex<PrecisionT> *>;
     using KokkosIntVector = Kokkos::View<std::size_t *>;
-    using MemberType = StateVectorTeamPolicy<>::member_type;
+    using MemberType = TeamPolicy<>::member_type;
 
     KokkosComplexVector arr;
     Kokkos::complex<PrecisionT> shift_0;
@@ -1833,13 +1833,12 @@ template <typename PrecisionT> class applyMultiRZFunctor {
         shift_1 = Kokkos::conj(shift_0);
         wires_parity = 0U;
         for (std::size_t wire : wires) {
-            wires_parity |=
-                (static_cast<std::size_t>(1U) << (num_qubits - wire - 1));
+            wires_parity |= (one << (num_qubits - wire - 1));
         }
 
-        Kokkos::parallel_for(StateVectorRangePolicy<ExecutionSpace>(
-                                 0, Pennylane::Util::exp2(num_qubits)),
-                             *this);
+        Kokkos::parallel_for(
+            RangePolicy<ExecutionSpace>(0, Pennylane::Util::exp2(num_qubits)),
+            *this);
     }
 
     KOKKOS_FUNCTION void operator()(const std::size_t k) const {
@@ -1929,8 +1928,7 @@ void applyPauliRot(Kokkos::View<Kokkos::complex<PrecisionT> *> arr_,
         get_mask([&word](const int a) { return word[a] == 'Z'; });
     const auto count_mask_y = std::popcount(mask_y);
     Kokkos::parallel_for(
-        StateVectorRangePolicy<ExecutionSpace>(
-            0, Pennylane::Util::exp2(num_qubits)),
+        RangePolicy<ExecutionSpace>(0, Pennylane::Util::exp2(num_qubits)),
         KOKKOS_LAMBDA(std::size_t i0) {
             std::size_t i1 = i0 ^ mask_xy;
             if (i0 <= i1) {

--- a/pennylane_lightning/core/simulators/lightning_kokkos/gates/BasicGateFunctors.hpp
+++ b/pennylane_lightning/core/simulators/lightning_kokkos/gates/BasicGateFunctors.hpp
@@ -1929,8 +1929,8 @@ void applyPauliRot(Kokkos::View<Kokkos::complex<PrecisionT> *> arr_,
         get_mask([&word](const int a) { return word[a] == 'Z'; });
     const auto count_mask_y = std::popcount(mask_y);
     Kokkos::parallel_for(
-        StateVectorRangePolicy<ExecutionSpace>(0,
-                                            Pennylane::Util::exp2(num_qubits)),
+        StateVectorRangePolicy<ExecutionSpace>(
+            0, Pennylane::Util::exp2(num_qubits)),
         KOKKOS_LAMBDA(std::size_t i0) {
             std::size_t i1 = i0 ^ mask_xy;
             if (i0 <= i1) {

--- a/pennylane_lightning/core/simulators/lightning_kokkos/gates/BasicGateFunctors.hpp
+++ b/pennylane_lightning/core/simulators/lightning_kokkos/gates/BasicGateFunctors.hpp
@@ -72,6 +72,12 @@ template <class PrecisionT, class FuncT> class applyNCNFunctor {
         controlBitPatterns(indices_, num_qubits, controlled_wires,
                            controlled_values);
         indices = vector2view(indices_);
+        // Kokkos stores TeamPolicy league_size as a 32-bit int on the CUDA/HIP
+        // backends, so abort rather than silently truncate when the number of
+        // teams would exceed the 2^31 league_size limit.
+        PL_ABORT_IF(two2N >= (std::size_t{1} << 31),
+                    "Number of thread teams exceeds the Kokkos TeamPolicy "
+                    "league_size limit (2^31) on GPU backends for this gate.");
         Kokkos::parallel_for(TeamPolicy<>(two2N, Kokkos::AUTO, dim), *this);
     }
     // TODO: Runtime selection for copying indices to scratch level 0/shmem
@@ -148,7 +154,7 @@ class applyNC1Functor<PrecisionT, FuncT, false> {
                     const std::vector<std::size_t> &wires, FuncT core_function_)
         : arr(arr_), core_function(core_function_),
           rev_wire(num_qubits ? num_qubits - wires[0] - 1 : 0),
-          rev_wire_shift((static_cast<std::size_t>(1U) << rev_wire)),
+          rev_wire_shift((one << rev_wire)),
           wire_parity(fillTrailingOnes(rev_wire)),
           wire_parity_inv(fillLeadingOnes(rev_wire + 1)) {
         Kokkos::parallel_for(
@@ -766,8 +772,7 @@ class applyNC2Functor<PrecisionT, FuncT, false> {
         : arr(arr_), core_function(core_function_),
           rev_wire0(num_qubits - wires[1] - 1),
           rev_wire1(num_qubits - wires[0] - 1),
-          rev_wire0_shift(static_cast<std::size_t>(1U) << rev_wire0),
-          rev_wire1_shift(static_cast<std::size_t>(1U) << rev_wire1),
+          rev_wire0_shift(one << rev_wire0), rev_wire1_shift(one << rev_wire1),
           rev_wire_min(std::min(rev_wire0, rev_wire1)),
           rev_wire_max(std::max(rev_wire0, rev_wire1)),
           parity_low(fillTrailingOnes(rev_wire_min)),
@@ -1368,9 +1373,8 @@ template <class PrecisionT, class FuncT> class applyNC3Functor {
           rev_wire0(num_qubits - wires[2] - 1),
           rev_wire1(num_qubits - wires[1] - 1),
           rev_wire2(num_qubits - wires[0] - 1),
-          rev_wire0_shift(static_cast<std::size_t>(1U) << rev_wire0),
-          rev_wire1_shift(static_cast<std::size_t>(1U) << rev_wire1),
-          rev_wire2_shift(static_cast<std::size_t>(1U) << rev_wire2) {
+          rev_wire0_shift(one << rev_wire0), rev_wire1_shift(one << rev_wire1),
+          rev_wire2_shift(one << rev_wire2) {
         std::size_t rev_wire_min = std::min(rev_wire0, rev_wire1);
         std::size_t rev_wire_max = std::max(rev_wire0, rev_wire1);
         std::size_t rev_wire_mid{0U};
@@ -1547,10 +1551,8 @@ class applyNC4Functor<PrecisionT, FuncT, false> {
           rev_wire1(num_qubits - wires[2] - 1),
           rev_wire2(num_qubits - wires[1] - 1),
           rev_wire3(num_qubits - wires[0] - 1),
-          rev_wire0_shift(static_cast<std::size_t>(1U) << rev_wire0),
-          rev_wire1_shift(static_cast<std::size_t>(1U) << rev_wire1),
-          rev_wire2_shift(static_cast<std::size_t>(1U) << rev_wire2),
-          rev_wire3_shift(static_cast<std::size_t>(1U) << rev_wire3) {
+          rev_wire0_shift(one << rev_wire0), rev_wire1_shift(one << rev_wire1),
+          rev_wire2_shift(one << rev_wire2), rev_wire3_shift(one << rev_wire3) {
         std::size_t rev_wire_min = std::min(rev_wire0, rev_wire1);
         std::size_t rev_wire_min_mid = std::max(rev_wire0, rev_wire1);
         std::size_t rev_wire_max_mid = std::min(rev_wire2, rev_wire3);

--- a/pennylane_lightning/core/simulators/lightning_kokkos/gates/BasicGateFunctors.hpp
+++ b/pennylane_lightning/core/simulators/lightning_kokkos/gates/BasicGateFunctors.hpp
@@ -31,6 +31,9 @@ using Pennylane::LightningKokkos::Util::controlBitPatterns;
 using Pennylane::LightningKokkos::Util::generateBitPatterns;
 using Pennylane::LightningKokkos::Util::parity_2_offset;
 using Pennylane::LightningKokkos::Util::reverseWires;
+using Pennylane::LightningKokkos::Util::StateVectorMDRangePolicy;
+using Pennylane::LightningKokkos::Util::StateVectorRangePolicy;
+using Pennylane::LightningKokkos::Util::StateVectorTeamPolicy;
 using Pennylane::LightningKokkos::Util::vector2view;
 } // namespace
 /// @endcond
@@ -39,7 +42,7 @@ namespace Pennylane::LightningKokkos::Functors {
 template <class PrecisionT, class FuncT> class applyNCNFunctor {
     using KokkosComplexVector = Kokkos::View<Kokkos::complex<PrecisionT> *>;
     using KokkosIntVector = Kokkos::View<std::size_t *>;
-    using MemberType = Kokkos::TeamPolicy<>::member_type;
+    using MemberType = StateVectorTeamPolicy<>::member_type;
 
     KokkosComplexVector arr;
     const FuncT core_function;
@@ -68,7 +71,7 @@ template <class PrecisionT, class FuncT> class applyNCNFunctor {
         controlBitPatterns(indices_, num_qubits, controlled_wires,
                            controlled_values);
         indices = vector2view(indices_);
-        Kokkos::parallel_for(Kokkos::TeamPolicy(two2N, Kokkos::AUTO, dim),
+        Kokkos::parallel_for(StateVectorTeamPolicy<>(two2N, Kokkos::AUTO, dim),
                              *this);
     }
     // TODO: Runtime selection for copying indices to scratch level 0/shmem
@@ -113,7 +116,7 @@ class applyNC1Functor<PrecisionT, FuncT, true> {
                            controlled_values);
         indices = vector2view(indices_);
         Kokkos::parallel_for(
-            Kokkos::RangePolicy<ExecutionSpace>(
+            StateVectorRangePolicy<ExecutionSpace>(
                 0, Pennylane::Util::exp2(num_qubits - controlled_wires.size() -
                                          wires.size())),
             *this);
@@ -149,7 +152,7 @@ class applyNC1Functor<PrecisionT, FuncT, false> {
           wire_parity(fillTrailingOnes(rev_wire)),
           wire_parity_inv(fillLeadingOnes(rev_wire + 1)) {
         Kokkos::parallel_for(
-            Kokkos::RangePolicy<ExecutionSpace>(
+            StateVectorRangePolicy<ExecutionSpace>(
                 0, num_qubits ? Pennylane::Util::exp2(num_qubits - 1) : 1),
             *this);
     }
@@ -722,7 +725,7 @@ class applyNC2Functor<PrecisionT, FuncT, true> {
                            controlled_values);
         indices = vector2view(indices_);
         Kokkos::parallel_for(
-            Kokkos::RangePolicy<ExecutionSpace>(
+            StateVectorRangePolicy<ExecutionSpace>(
                 0, Pennylane::Util::exp2(num_qubits - controlled_wires.size() -
                                          wires.size())),
             *this);
@@ -771,7 +774,7 @@ class applyNC2Functor<PrecisionT, FuncT, false> {
           parity_high(fillLeadingOnes(rev_wire_max + 1)),
           parity_middle(fillLeadingOnes(rev_wire_min + 1) &
                         fillTrailingOnes(rev_wire_max)) {
-        Kokkos::parallel_for(Kokkos::RangePolicy<ExecutionSpace>(
+        Kokkos::parallel_for(StateVectorRangePolicy<ExecutionSpace>(
                                  0, Pennylane::Util::exp2(num_qubits - 2)),
                              *this);
     }
@@ -1386,7 +1389,7 @@ template <class PrecisionT, class FuncT> class applyNC3Functor {
             fillLeadingOnes(rev_wire_min + 1) & fillTrailingOnes(rev_wire_mid);
         parity_hmiddle =
             fillLeadingOnes(rev_wire_mid + 1) & fillTrailingOnes(rev_wire_max);
-        Kokkos::parallel_for(Kokkos::RangePolicy<ExecutionSpace>(
+        Kokkos::parallel_for(StateVectorRangePolicy<ExecutionSpace>(
                                  0, Pennylane::Util::exp2(num_qubits - 3)),
                              *this);
     }
@@ -1482,7 +1485,7 @@ class applyNC4Functor<PrecisionT, FuncT, true> {
                            controlled_values);
         indices = vector2view(indices_);
         Kokkos::parallel_for(
-            Kokkos::RangePolicy<ExecutionSpace>(
+            StateVectorRangePolicy<ExecutionSpace>(
                 0, Pennylane::Util::exp2(num_qubits - controlled_wires.size() -
                                          wires.size())),
             *this);
@@ -1594,7 +1597,7 @@ class applyNC4Functor<PrecisionT, FuncT, false> {
                          fillTrailingOnes(rev_wire_max);
         parity_middle = fillLeadingOnes(rev_wire_min_mid + 1) &
                         fillTrailingOnes(rev_wire_max_mid);
-        Kokkos::parallel_for(Kokkos::RangePolicy<ExecutionSpace>(
+        Kokkos::parallel_for(StateVectorRangePolicy<ExecutionSpace>(
                                  0, Pennylane::Util::exp2(num_qubits - 4)),
                              *this);
     }
@@ -1810,7 +1813,7 @@ void applyDoubleExcitationPlus(Kokkos::View<Kokkos::complex<PrecisionT> *> arr_,
 template <typename PrecisionT> class applyMultiRZFunctor {
     using KokkosComplexVector = Kokkos::View<Kokkos::complex<PrecisionT> *>;
     using KokkosIntVector = Kokkos::View<std::size_t *>;
-    using MemberType = Kokkos::TeamPolicy<>::member_type;
+    using MemberType = StateVectorTeamPolicy<>::member_type;
 
     KokkosComplexVector arr;
     Kokkos::complex<PrecisionT> shift_0;
@@ -1834,7 +1837,7 @@ template <typename PrecisionT> class applyMultiRZFunctor {
                 (static_cast<std::size_t>(1U) << (num_qubits - wire - 1));
         }
 
-        Kokkos::parallel_for(Kokkos::RangePolicy<ExecutionSpace>(
+        Kokkos::parallel_for(StateVectorRangePolicy<ExecutionSpace>(
                                  0, Pennylane::Util::exp2(num_qubits)),
                              *this);
     }
@@ -1926,7 +1929,7 @@ void applyPauliRot(Kokkos::View<Kokkos::complex<PrecisionT> *> arr_,
         get_mask([&word](const int a) { return word[a] == 'Z'; });
     const auto count_mask_y = std::popcount(mask_y);
     Kokkos::parallel_for(
-        Kokkos::RangePolicy<ExecutionSpace>(0,
+        StateVectorRangePolicy<ExecutionSpace>(0,
                                             Pennylane::Util::exp2(num_qubits)),
         KOKKOS_LAMBDA(std::size_t i0) {
             std::size_t i1 = i0 ^ mask_xy;

--- a/pennylane_lightning/core/simulators/lightning_kokkos/gates/BasicGeneratorFunctors.hpp
+++ b/pennylane_lightning/core/simulators/lightning_kokkos/gates/BasicGeneratorFunctors.hpp
@@ -366,8 +366,8 @@ void applyGenMultiRZ(Kokkos::View<Kokkos::complex<PrecisionT> *> arr_,
         wires_parity |= Pennylane::Util::exp2(num_qubits - wire - 1);
     }
     Kokkos::parallel_for(
-        StateVectorRangePolicy<ExecutionSpace>(0,
-                                            Pennylane::Util::exp2(num_qubits)),
+        StateVectorRangePolicy<ExecutionSpace>(
+            0, Pennylane::Util::exp2(num_qubits)),
         KOKKOS_LAMBDA(std::size_t k) {
             arr_(k) *= static_cast<PrecisionT>(
                 1 - 2 * int(Kokkos::popcount(k & wires_parity) % 2));
@@ -947,8 +947,8 @@ void applyNCGenMultiRZ(Kokkos::View<Kokkos::complex<PrecisionT> *> arr_,
         });
 
     Kokkos::parallel_for(
-        StateVectorRangePolicy<ExecutionSpace>(0,
-                                            Pennylane::Util::exp2(num_qubits)),
+        StateVectorRangePolicy<ExecutionSpace>(
+            0, Pennylane::Util::exp2(num_qubits)),
         KOKKOS_LAMBDA(std::size_t k) {
             if (ctrls_mask == (ctrls_parity & k)) {
                 arr_(k) *= static_cast<PrecisionT>(

--- a/pennylane_lightning/core/simulators/lightning_kokkos/gates/BasicGeneratorFunctors.hpp
+++ b/pennylane_lightning/core/simulators/lightning_kokkos/gates/BasicGeneratorFunctors.hpp
@@ -25,7 +25,7 @@ namespace {
 using namespace Pennylane::Util;
 using Kokkos::kokkos_swap;
 using Pennylane::Gates::GeneratorOperation;
-using Pennylane::LightningKokkos::Util::StateVectorRangePolicy;
+using Pennylane::LightningKokkos::Util::RangePolicy;
 } // namespace
 /// @endcond
 
@@ -366,8 +366,7 @@ void applyGenMultiRZ(Kokkos::View<Kokkos::complex<PrecisionT> *> arr_,
         wires_parity |= Pennylane::Util::exp2(num_qubits - wire - 1);
     }
     Kokkos::parallel_for(
-        StateVectorRangePolicy<ExecutionSpace>(
-            0, Pennylane::Util::exp2(num_qubits)),
+        RangePolicy<ExecutionSpace>(0, Pennylane::Util::exp2(num_qubits)),
         KOKKOS_LAMBDA(std::size_t k) {
             arr_(k) *= static_cast<PrecisionT>(
                 1 - 2 * int(Kokkos::popcount(k & wires_parity) % 2));
@@ -428,7 +427,7 @@ template <class PrecisionT, class FuncT> class applyNCGenerator1Functor {
         i1 = indices_[(mask << one) | one];
         indices = vector2view(indices_);
         Kokkos::parallel_for(
-            StateVectorRangePolicy<ExecutionSpace>(
+            RangePolicy<ExecutionSpace>(
                 0, Pennylane::Util::exp2(num_qubits - controlled_wires.size() -
                                          wires.size())),
             *this);
@@ -605,7 +604,7 @@ template <class PrecisionT, class FuncT> class applyNCGenerator2Functor {
         i11 = indices_[(mask << two) | two | one];
         indices = vector2view(indices_);
         Kokkos::parallel_for(
-            StateVectorRangePolicy<ExecutionSpace>(
+            RangePolicy<ExecutionSpace>(
                 0, Pennylane::Util::exp2(num_qubits - controlled_wires.size() -
                                          wires.size())),
             *this);
@@ -839,7 +838,7 @@ template <class PrecisionT, class FuncT> class applyNCGenerator4Functor {
         i1100 = indices_[(mask << 4U) + 12U];
         indices = vector2view(indices_);
         Kokkos::parallel_for(
-            StateVectorRangePolicy<ExecutionSpace>(
+            RangePolicy<ExecutionSpace>(
                 0, Pennylane::Util::exp2(num_qubits - controlled_wires.size() -
                                          wires.size())),
             *this);
@@ -947,8 +946,7 @@ void applyNCGenMultiRZ(Kokkos::View<Kokkos::complex<PrecisionT> *> arr_,
         });
 
     Kokkos::parallel_for(
-        StateVectorRangePolicy<ExecutionSpace>(
-            0, Pennylane::Util::exp2(num_qubits)),
+        RangePolicy<ExecutionSpace>(0, Pennylane::Util::exp2(num_qubits)),
         KOKKOS_LAMBDA(std::size_t k) {
             if (ctrls_mask == (ctrls_parity & k)) {
                 arr_(k) *= static_cast<PrecisionT>(

--- a/pennylane_lightning/core/simulators/lightning_kokkos/gates/BasicGeneratorFunctors.hpp
+++ b/pennylane_lightning/core/simulators/lightning_kokkos/gates/BasicGeneratorFunctors.hpp
@@ -25,6 +25,7 @@ namespace {
 using namespace Pennylane::Util;
 using Kokkos::kokkos_swap;
 using Pennylane::Gates::GeneratorOperation;
+using Pennylane::LightningKokkos::Util::StateVectorRangePolicy;
 } // namespace
 /// @endcond
 
@@ -365,7 +366,7 @@ void applyGenMultiRZ(Kokkos::View<Kokkos::complex<PrecisionT> *> arr_,
         wires_parity |= Pennylane::Util::exp2(num_qubits - wire - 1);
     }
     Kokkos::parallel_for(
-        Kokkos::RangePolicy<ExecutionSpace>(0,
+        StateVectorRangePolicy<ExecutionSpace>(0,
                                             Pennylane::Util::exp2(num_qubits)),
         KOKKOS_LAMBDA(std::size_t k) {
             arr_(k) *= static_cast<PrecisionT>(
@@ -427,7 +428,7 @@ template <class PrecisionT, class FuncT> class applyNCGenerator1Functor {
         i1 = indices_[(mask << one) | one];
         indices = vector2view(indices_);
         Kokkos::parallel_for(
-            Kokkos::RangePolicy<ExecutionSpace>(
+            StateVectorRangePolicy<ExecutionSpace>(
                 0, Pennylane::Util::exp2(num_qubits - controlled_wires.size() -
                                          wires.size())),
             *this);
@@ -604,7 +605,7 @@ template <class PrecisionT, class FuncT> class applyNCGenerator2Functor {
         i11 = indices_[(mask << two) | two | one];
         indices = vector2view(indices_);
         Kokkos::parallel_for(
-            Kokkos::RangePolicy<ExecutionSpace>(
+            StateVectorRangePolicy<ExecutionSpace>(
                 0, Pennylane::Util::exp2(num_qubits - controlled_wires.size() -
                                          wires.size())),
             *this);
@@ -838,7 +839,7 @@ template <class PrecisionT, class FuncT> class applyNCGenerator4Functor {
         i1100 = indices_[(mask << 4U) + 12U];
         indices = vector2view(indices_);
         Kokkos::parallel_for(
-            Kokkos::RangePolicy<ExecutionSpace>(
+            StateVectorRangePolicy<ExecutionSpace>(
                 0, Pennylane::Util::exp2(num_qubits - controlled_wires.size() -
                                          wires.size())),
             *this);
@@ -946,7 +947,7 @@ void applyNCGenMultiRZ(Kokkos::View<Kokkos::complex<PrecisionT> *> arr_,
         });
 
     Kokkos::parallel_for(
-        Kokkos::RangePolicy<ExecutionSpace>(0,
+        StateVectorRangePolicy<ExecutionSpace>(0,
                                             Pennylane::Util::exp2(num_qubits)),
         KOKKOS_LAMBDA(std::size_t k) {
             if (ctrls_mask == (ctrls_parity & k)) {

--- a/pennylane_lightning/core/simulators/lightning_kokkos/gates/MatrixGateFunctors.hpp
+++ b/pennylane_lightning/core/simulators/lightning_kokkos/gates/MatrixGateFunctors.hpp
@@ -28,7 +28,7 @@ using Pennylane::LightningKokkos::Util::generateBitPatterns;
 using Pennylane::LightningKokkos::Util::one;
 using Pennylane::LightningKokkos::Util::parity_2_offset;
 using Pennylane::LightningKokkos::Util::reverseWires;
-using Pennylane::LightningKokkos::Util::StateVectorTeamPolicy;
+using Pennylane::LightningKokkos::Util::TeamPolicy;
 using Pennylane::LightningKokkos::Util::vector2view;
 using Pennylane::LightningKokkos::Util::wires2Parity;
 } // namespace
@@ -47,7 +47,7 @@ template <class Precision> struct multiQubitOpFunctor {
         Kokkos::View<std::size_t *,
                      Kokkos::DefaultExecutionSpace::scratch_memory_space,
                      Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
-    using MemberType = StateVectorTeamPolicy<>::member_type;
+    using MemberType = TeamPolicy<>::member_type;
 
     KokkosComplexVector arr;
     KokkosComplexVector matrix;
@@ -122,7 +122,7 @@ template <class Precision> struct NCMultiQubitOpFunctor {
         Kokkos::View<std::size_t *,
                      Kokkos::DefaultExecutionSpace::scratch_memory_space,
                      Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
-    using MemberType = StateVectorTeamPolicy<>::member_type;
+    using MemberType = TeamPolicy<>::member_type;
 
     KokkosComplexVector arr;
     KokkosComplexVector matrix;

--- a/pennylane_lightning/core/simulators/lightning_kokkos/gates/MatrixGateFunctors.hpp
+++ b/pennylane_lightning/core/simulators/lightning_kokkos/gates/MatrixGateFunctors.hpp
@@ -28,6 +28,7 @@ using Pennylane::LightningKokkos::Util::generateBitPatterns;
 using Pennylane::LightningKokkos::Util::one;
 using Pennylane::LightningKokkos::Util::parity_2_offset;
 using Pennylane::LightningKokkos::Util::reverseWires;
+using Pennylane::LightningKokkos::Util::StateVectorTeamPolicy;
 using Pennylane::LightningKokkos::Util::vector2view;
 using Pennylane::LightningKokkos::Util::wires2Parity;
 } // namespace
@@ -46,7 +47,7 @@ template <class Precision> struct multiQubitOpFunctor {
         Kokkos::View<std::size_t *,
                      Kokkos::DefaultExecutionSpace::scratch_memory_space,
                      Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
-    using MemberType = Kokkos::TeamPolicy<>::member_type;
+    using MemberType = StateVectorTeamPolicy<>::member_type;
 
     KokkosComplexVector arr;
     KokkosComplexVector matrix;
@@ -121,7 +122,7 @@ template <class Precision> struct NCMultiQubitOpFunctor {
         Kokkos::View<std::size_t *,
                      Kokkos::DefaultExecutionSpace::scratch_memory_space,
                      Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
-    using MemberType = Kokkos::TeamPolicy<>::member_type;
+    using MemberType = StateVectorTeamPolicy<>::member_type;
 
     KokkosComplexVector arr;
     KokkosComplexVector matrix;

--- a/pennylane_lightning/core/simulators/lightning_kokkos/gates/MatrixGateFunctors.hpp
+++ b/pennylane_lightning/core/simulators/lightning_kokkos/gates/MatrixGateFunctors.hpp
@@ -292,8 +292,8 @@ template <class PrecisionT> struct apply2QubitOpFunctor {
 
         rev_wire0 = num_qubits - wires_[1] - 1;
         rev_wire1 = num_qubits - wires_[0] - 1; // Control qubit
-        rev_wire0_shift = static_cast<std::size_t>(1U) << rev_wire0;
-        rev_wire1_shift = static_cast<std::size_t>(1U) << rev_wire1;
+        rev_wire0_shift = one << rev_wire0;
+        rev_wire1_shift = one << rev_wire1;
         rev_wire_min = std::min(rev_wire0, rev_wire1);
         rev_wire_max = std::max(rev_wire0, rev_wire1);
         parity_low = fillTrailingOnes(rev_wire_min);

--- a/pennylane_lightning/core/simulators/lightning_kokkos/measurements/ExpValFunctors.hpp
+++ b/pennylane_lightning/core/simulators/lightning_kokkos/measurements/ExpValFunctors.hpp
@@ -22,6 +22,7 @@
 namespace {
 using namespace Pennylane::Util;
 using Pennylane::LightningKokkos::Util::one;
+using Pennylane::LightningKokkos::Util::StateVectorTeamPolicy;
 using Pennylane::LightningKokkos::Util::vector2view;
 using Pennylane::LightningKokkos::Util::wires2Parity;
 } // namespace
@@ -217,7 +218,7 @@ template <class PrecisionT> struct getExpValMultiQubitOpFunctor {
         Kokkos::View<ComplexT *,
                      Kokkos::DefaultExecutionSpace::scratch_memory_space,
                      Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
-    using MemberType = Kokkos::TeamPolicy<>::member_type;
+    using MemberType = StateVectorTeamPolicy<>::member_type;
 
     KokkosComplexVector arr;
     KokkosComplexVector matrix;

--- a/pennylane_lightning/core/simulators/lightning_kokkos/measurements/ExpValFunctors.hpp
+++ b/pennylane_lightning/core/simulators/lightning_kokkos/measurements/ExpValFunctors.hpp
@@ -102,7 +102,7 @@ template <class PrecisionT> struct getExpectationValuePauliXFunctor {
         std::size_t num_qubits, const std::vector<std::size_t> &wires) {
         arr = arr_;
         rev_wire = num_qubits - wires[0] - 1;
-        rev_wire_shift = (static_cast<std::size_t>(1U) << rev_wire);
+        rev_wire_shift = (one << rev_wire);
         wire_parity = fillTrailingOnes(rev_wire);
         wire_parity_inv = fillLeadingOnes(rev_wire + 1);
     }
@@ -131,7 +131,7 @@ template <class PrecisionT> struct getExpectationValuePauliYFunctor {
         std::size_t num_qubits, const std::vector<std::size_t> &wires) {
         arr = arr_;
         rev_wire = num_qubits - wires[0] - 1;
-        rev_wire_shift = (static_cast<std::size_t>(1U) << rev_wire);
+        rev_wire_shift = (one << rev_wire);
         wire_parity = fillTrailingOnes(rev_wire);
         wire_parity_inv = fillLeadingOnes(rev_wire + 1);
     }
@@ -164,7 +164,7 @@ template <class PrecisionT> struct getExpectationValuePauliZFunctor {
         std::size_t num_qubits, const std::vector<std::size_t> &wires) {
         arr = arr_;
         rev_wire = num_qubits - wires[0] - 1;
-        rev_wire_shift = (static_cast<std::size_t>(1U) << rev_wire);
+        rev_wire_shift = (one << rev_wire);
         wire_parity = fillTrailingOnes(rev_wire);
         wire_parity_inv = fillLeadingOnes(rev_wire + 1);
     }
@@ -192,7 +192,7 @@ template <class PrecisionT> struct getExpectationValueHadamardFunctor {
         std::size_t num_qubits, const std::vector<std::size_t> &wires) {
         arr = arr_;
         rev_wire = num_qubits - wires[0] - 1;
-        rev_wire_shift = (static_cast<std::size_t>(1U) << rev_wire);
+        rev_wire_shift = (one << rev_wire);
         wire_parity = fillTrailingOnes(rev_wire);
         wire_parity_inv = fillLeadingOnes(rev_wire + 1);
     }
@@ -338,7 +338,7 @@ template <class PrecisionT> struct getExpVal1QubitOpFunctor {
         matrix = matrix_;
         num_qubits = num_qubits_;
         rev_wire = num_qubits - wires_[0] - 1;
-        rev_wire_shift = (static_cast<std::size_t>(1U) << rev_wire);
+        rev_wire_shift = (one << rev_wire);
         wire_parity = fillTrailingOnes(rev_wire);
         wire_parity_inv = fillLeadingOnes(rev_wire + 1);
     }
@@ -396,8 +396,8 @@ template <class PrecisionT> struct getExpVal2QubitOpFunctor {
 
         rev_wire0 = num_qubits - wires_[1] - 1;
         rev_wire1 = num_qubits - wires_[0] - 1;
-        rev_wire0_shift = static_cast<std::size_t>(1U) << rev_wire0;
-        rev_wire1_shift = static_cast<std::size_t>(1U) << rev_wire1;
+        rev_wire0_shift = one << rev_wire0;
+        rev_wire1_shift = one << rev_wire1;
         rev_wire_min = std::min(rev_wire0, rev_wire1);
         rev_wire_max = std::max(rev_wire0, rev_wire1);
         parity_low = fillTrailingOnes(rev_wire_min);

--- a/pennylane_lightning/core/simulators/lightning_kokkos/measurements/ExpValFunctors.hpp
+++ b/pennylane_lightning/core/simulators/lightning_kokkos/measurements/ExpValFunctors.hpp
@@ -22,7 +22,7 @@
 namespace {
 using namespace Pennylane::Util;
 using Pennylane::LightningKokkos::Util::one;
-using Pennylane::LightningKokkos::Util::StateVectorTeamPolicy;
+using Pennylane::LightningKokkos::Util::TeamPolicy;
 using Pennylane::LightningKokkos::Util::vector2view;
 using Pennylane::LightningKokkos::Util::wires2Parity;
 } // namespace
@@ -218,7 +218,7 @@ template <class PrecisionT> struct getExpValMultiQubitOpFunctor {
         Kokkos::View<ComplexT *,
                      Kokkos::DefaultExecutionSpace::scratch_memory_space,
                      Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
-    using MemberType = StateVectorTeamPolicy<>::member_type;
+    using MemberType = TeamPolicy<>::member_type;
 
     KokkosComplexVector arr;
     KokkosComplexVector matrix;

--- a/pennylane_lightning/core/simulators/lightning_kokkos/measurements/MeasurementsKokkos.hpp
+++ b/pennylane_lightning/core/simulators/lightning_kokkos/measurements/MeasurementsKokkos.hpp
@@ -173,6 +173,13 @@ class Measurements final
             break;
         default:
             std::size_t scratch_size = ScratchViewComplex::shmem_size(dim);
+            // Kokkos stores TeamPolicy league_size as a 32-bit int on the
+            // CUDA/HIP backends, so abort rather than silently truncate when
+            // the number of teams would exceed the 2^31 league_size limit.
+            PL_ABORT_IF(two2N >= (std::size_t{1} << 31),
+                        "Number of thread teams exceeds the Kokkos TeamPolicy "
+                        "league_size limit (2^31) on GPU backends for this "
+                        "observable.");
             Kokkos::parallel_reduce(
                 "getExpValMultiQubitOpFunctor",
                 TeamPolicy(two2N, Kokkos::AUTO, dim)

--- a/pennylane_lightning/core/simulators/lightning_kokkos/measurements/MeasurementsKokkos.hpp
+++ b/pennylane_lightning/core/simulators/lightning_kokkos/measurements/MeasurementsKokkos.hpp
@@ -100,10 +100,9 @@ class Measurements final
         const std::size_t num_qubits = this->_statevector.getNumQubits();
         const Kokkos::View<ComplexT *> arr_data = this->_statevector.getView();
         PrecisionT expval = 0.0;
-        Kokkos::parallel_reduce(
-            StateVectorRangePolicy<KokkosExecSpace>(
-                0, exp2(num_qubits - num_wires)),
-            functor_t(arr_data, num_qubits, wires), expval);
+        Kokkos::parallel_reduce(StateVectorRangePolicy<KokkosExecSpace>(
+                                    0, exp2(num_qubits - num_wires)),
+                                functor_t(arr_data, num_qubits, wires), expval);
         return expval;
     }
 
@@ -672,8 +671,7 @@ class Measurements final
                                       Kokkos::Rank<2, Kokkos::Iterate::Left>,
                                       Kokkos::IndexType<std::size_t>>;
             auto md_policy = MDPolicyType_2D(
-                {{0, 0}}, {{static_cast<std::int64_t>(all_indices.size()),
-                            static_cast<std::int64_t>(all_offsets.size())}});
+                {{0, 0}}, {{all_indices.size(), all_offsets.size()}});
             Kokkos::parallel_reduce(
                 md_policy,
                 getProbsFunctor<PrecisionT, KokkosExecSpace>(

--- a/pennylane_lightning/core/simulators/lightning_kokkos/measurements/MeasurementsKokkos.hpp
+++ b/pennylane_lightning/core/simulators/lightning_kokkos/measurements/MeasurementsKokkos.hpp
@@ -35,6 +35,8 @@ using namespace Pennylane::Observables;
 using Pennylane::LightningKokkos::StateVectorKokkos;
 using Pennylane::LightningKokkos::Util::getRealOfComplexInnerProduct;
 using Pennylane::LightningKokkos::Util::SparseMV_Kokkos;
+using Pennylane::LightningKokkos::Util::StateVectorMDRangePolicy;
+using Pennylane::LightningKokkos::Util::StateVectorRangePolicy;
 using Pennylane::LightningKokkos::Util::vector2view;
 using Pennylane::LightningKokkos::Util::view2vector;
 using Pennylane::Util::exp2;
@@ -98,8 +100,10 @@ class Measurements final
         const std::size_t num_qubits = this->_statevector.getNumQubits();
         const Kokkos::View<ComplexT *> arr_data = this->_statevector.getView();
         PrecisionT expval = 0.0;
-        Kokkos::parallel_reduce(exp2(num_qubits - num_wires),
-                                functor_t(arr_data, num_qubits, wires), expval);
+        Kokkos::parallel_reduce(
+            StateVectorRangePolicy<KokkosExecSpace>(
+                0, exp2(num_qubits - num_wires)),
+            functor_t(arr_data, num_qubits, wires), expval);
         return expval;
     }
 
@@ -121,7 +125,8 @@ class Measurements final
         Kokkos::View<ComplexT *> arr_data = this->_statevector.getView();
         PrecisionT expval = 0.0;
         Kokkos::parallel_reduce(
-            exp2(num_qubits - num_wires),
+            StateVectorRangePolicy<KokkosExecSpace>(
+                0, exp2(num_qubits - num_wires)),
             functor_t<PrecisionT>(arr_data, num_qubits, matrix, wires), expval);
         return expval;
     }
@@ -146,28 +151,32 @@ class Measurements final
         PrecisionT expval = 0.0;
         switch (wires.size()) {
         case 1:
-            Kokkos::parallel_reduce(two2N,
-                                    getExpVal1QubitOpFunctor<PrecisionT>(
-                                        arr_data, num_qubits, matrix, wires),
-                                    expval);
+            Kokkos::parallel_reduce(
+                StateVectorRangePolicy<KokkosExecSpace>(0, two2N),
+                getExpVal1QubitOpFunctor<PrecisionT>(arr_data, num_qubits,
+                                                     matrix, wires),
+                expval);
             break;
         case 2:
-            Kokkos::parallel_reduce(two2N,
-                                    getExpVal2QubitOpFunctor<PrecisionT>(
-                                        arr_data, num_qubits, matrix, wires),
-                                    expval);
+            Kokkos::parallel_reduce(
+                StateVectorRangePolicy<KokkosExecSpace>(0, two2N),
+                getExpVal2QubitOpFunctor<PrecisionT>(arr_data, num_qubits,
+                                                     matrix, wires),
+                expval);
             break;
         case 3:
-            Kokkos::parallel_reduce(two2N,
-                                    getExpVal3QubitOpFunctor<PrecisionT>(
-                                        arr_data, num_qubits, matrix, wires),
-                                    expval);
+            Kokkos::parallel_reduce(
+                StateVectorRangePolicy<KokkosExecSpace>(0, two2N),
+                getExpVal3QubitOpFunctor<PrecisionT>(arr_data, num_qubits,
+                                                     matrix, wires),
+                expval);
             break;
         case 4:
-            Kokkos::parallel_reduce(two2N,
-                                    getExpVal4QubitOpFunctor<PrecisionT>(
-                                        arr_data, num_qubits, matrix, wires),
-                                    expval);
+            Kokkos::parallel_reduce(
+                StateVectorRangePolicy<KokkosExecSpace>(0, two2N),
+                getExpVal4QubitOpFunctor<PrecisionT>(arr_data, num_qubits,
+                                                     matrix, wires),
+                expval);
             break;
         default:
             std::size_t scratch_size = ScratchViewComplex::shmem_size(dim);
@@ -305,7 +314,9 @@ class Measurements final
             } else {
                 PrecisionT expval_tmp = 0.0;
                 Kokkos::parallel_reduce(
-                    "getExpValPauliWordFunctor", exp2(num_qubits),
+                    "getExpValPauliWordFunctor",
+                    StateVectorRangePolicy<KokkosExecSpace>(0,
+                                                            exp2(num_qubits)),
                     getExpValPauliWordFunctor<PrecisionT>(
                         arr_data, num_qubits, X_wires, Y_wires, Z_wires),
                     expval_tmp);
@@ -390,7 +401,7 @@ class Measurements final
                                            row_map_ptr, row_map_size));
 
         Kokkos::parallel_reduce(
-            row_map_size - 1,
+            StateVectorRangePolicy<KokkosExecSpace>(0, row_map_size - 1),
             getExpectationValueSparseFunctor<PrecisionT>(
                 arr_data, kok_data, kok_indices, kok_row_map),
             expval);
@@ -549,7 +560,7 @@ class Measurements final
         auto sv = this->_statevector.getView();
         Kokkos::View<PrecisionT *> d_probs("d_probs", N);
         Kokkos::parallel_for(
-            Kokkos::RangePolicy<KokkosExecSpace>(0, N),
+            StateVectorRangePolicy<KokkosExecSpace>(0, N),
             KOKKOS_LAMBDA(const std::size_t k) {
                 const PrecisionT rsv = sv(k).real();
                 const PrecisionT isv = sv(k).imag();
@@ -657,10 +668,12 @@ class Measurements final
 
         if (use_mdrange) {
             using MDPolicyType_2D =
-                Kokkos::MDRangePolicy<Kokkos::Rank<2, Kokkos::Iterate::Left>>;
+                Kokkos::MDRangePolicy<KokkosExecSpace,
+                                      Kokkos::Rank<2, Kokkos::Iterate::Left>,
+                                      Kokkos::IndexType<std::size_t>>;
             auto md_policy = MDPolicyType_2D(
-                {{0, 0}}, {{static_cast<int64_t>(all_indices.size()),
-                            static_cast<int64_t>(all_offsets.size())}});
+                {{0, 0}}, {{static_cast<std::int64_t>(all_indices.size()),
+                            static_cast<std::int64_t>(all_offsets.size())}});
             Kokkos::parallel_reduce(
                 md_policy,
                 getProbsFunctor<PrecisionT, KokkosExecSpace>(
@@ -668,7 +681,8 @@ class Measurements final
                 d_probabilities);
         } else {
             Kokkos::parallel_for(
-                all_indices.size(), KOKKOS_LAMBDA(const std::size_t i) {
+                StateVectorRangePolicy<KokkosExecSpace>(0, all_indices.size()),
+                KOKKOS_LAMBDA(const std::size_t i) {
                     for (std::size_t j = 0; j < d_all_offsets.size(); j++) {
                         const std::size_t index =
                             d_all_indices(i) + d_all_offsets(j);
@@ -748,7 +762,7 @@ class Measurements final
         // Convert probability distribution to cumulative distribution
         auto probability = probs_core();
         Kokkos::parallel_scan(
-            Kokkos::RangePolicy<KokkosExecSpace>(0, N),
+            StateVectorRangePolicy<KokkosExecSpace>(0, N),
             KOKKOS_LAMBDA(const std::size_t k, PrecisionT &update_value,
                           const bool is_final) {
                 const PrecisionT val_k = probability(k);
@@ -767,7 +781,7 @@ class Measurements final
                           .count());
 
         Kokkos::parallel_for(
-            Kokkos::RangePolicy<KokkosExecSpace>(0, num_samples),
+            StateVectorRangePolicy<KokkosExecSpace>(0, num_samples),
             Sampler<PrecisionT, Kokkos::Random_XorShift64_Pool>(
                 samples, probability, rand_pool, num_qubits, N));
 

--- a/pennylane_lightning/core/simulators/lightning_kokkos/measurements/MeasurementsKokkos.hpp
+++ b/pennylane_lightning/core/simulators/lightning_kokkos/measurements/MeasurementsKokkos.hpp
@@ -34,8 +34,8 @@ using namespace Pennylane::Measures;
 using namespace Pennylane::Observables;
 using Pennylane::LightningKokkos::StateVectorKokkos;
 using Pennylane::LightningKokkos::Util::getRealOfComplexInnerProduct;
+using Pennylane::LightningKokkos::Util::RangePolicy;
 using Pennylane::LightningKokkos::Util::SparseMV_Kokkos;
-using Pennylane::LightningKokkos::Util::StateVectorRangePolicy;
 using Pennylane::LightningKokkos::Util::vector2view;
 using Pennylane::LightningKokkos::Util::view2vector;
 using Pennylane::Util::exp2;
@@ -99,9 +99,9 @@ class Measurements final
         const std::size_t num_qubits = this->_statevector.getNumQubits();
         const Kokkos::View<ComplexT *> arr_data = this->_statevector.getView();
         PrecisionT expval = 0.0;
-        Kokkos::parallel_reduce(StateVectorRangePolicy<KokkosExecSpace>(
-                                    0, exp2(num_qubits - num_wires)),
-                                functor_t(arr_data, num_qubits, wires), expval);
+        Kokkos::parallel_reduce(
+            RangePolicy<KokkosExecSpace>(0, exp2(num_qubits - num_wires)),
+            functor_t(arr_data, num_qubits, wires), expval);
         return expval;
     }
 
@@ -123,8 +123,7 @@ class Measurements final
         Kokkos::View<ComplexT *> arr_data = this->_statevector.getView();
         PrecisionT expval = 0.0;
         Kokkos::parallel_reduce(
-            StateVectorRangePolicy<KokkosExecSpace>(
-                0, exp2(num_qubits - num_wires)),
+            RangePolicy<KokkosExecSpace>(0, exp2(num_qubits - num_wires)),
             functor_t<PrecisionT>(arr_data, num_qubits, matrix, wires), expval);
         return expval;
     }
@@ -149,32 +148,28 @@ class Measurements final
         PrecisionT expval = 0.0;
         switch (wires.size()) {
         case 1:
-            Kokkos::parallel_reduce(
-                StateVectorRangePolicy<KokkosExecSpace>(0, two2N),
-                getExpVal1QubitOpFunctor<PrecisionT>(arr_data, num_qubits,
-                                                     matrix, wires),
-                expval);
+            Kokkos::parallel_reduce(RangePolicy<KokkosExecSpace>(0, two2N),
+                                    getExpVal1QubitOpFunctor<PrecisionT>(
+                                        arr_data, num_qubits, matrix, wires),
+                                    expval);
             break;
         case 2:
-            Kokkos::parallel_reduce(
-                StateVectorRangePolicy<KokkosExecSpace>(0, two2N),
-                getExpVal2QubitOpFunctor<PrecisionT>(arr_data, num_qubits,
-                                                     matrix, wires),
-                expval);
+            Kokkos::parallel_reduce(RangePolicy<KokkosExecSpace>(0, two2N),
+                                    getExpVal2QubitOpFunctor<PrecisionT>(
+                                        arr_data, num_qubits, matrix, wires),
+                                    expval);
             break;
         case 3:
-            Kokkos::parallel_reduce(
-                StateVectorRangePolicy<KokkosExecSpace>(0, two2N),
-                getExpVal3QubitOpFunctor<PrecisionT>(arr_data, num_qubits,
-                                                     matrix, wires),
-                expval);
+            Kokkos::parallel_reduce(RangePolicy<KokkosExecSpace>(0, two2N),
+                                    getExpVal3QubitOpFunctor<PrecisionT>(
+                                        arr_data, num_qubits, matrix, wires),
+                                    expval);
             break;
         case 4:
-            Kokkos::parallel_reduce(
-                StateVectorRangePolicy<KokkosExecSpace>(0, two2N),
-                getExpVal4QubitOpFunctor<PrecisionT>(arr_data, num_qubits,
-                                                     matrix, wires),
-                expval);
+            Kokkos::parallel_reduce(RangePolicy<KokkosExecSpace>(0, two2N),
+                                    getExpVal4QubitOpFunctor<PrecisionT>(
+                                        arr_data, num_qubits, matrix, wires),
+                                    expval);
             break;
         default:
             std::size_t scratch_size = ScratchViewComplex::shmem_size(dim);
@@ -313,8 +308,7 @@ class Measurements final
                 PrecisionT expval_tmp = 0.0;
                 Kokkos::parallel_reduce(
                     "getExpValPauliWordFunctor",
-                    StateVectorRangePolicy<KokkosExecSpace>(0,
-                                                            exp2(num_qubits)),
+                    RangePolicy<KokkosExecSpace>(0, exp2(num_qubits)),
                     getExpValPauliWordFunctor<PrecisionT>(
                         arr_data, num_qubits, X_wires, Y_wires, Z_wires),
                     expval_tmp);
@@ -399,7 +393,7 @@ class Measurements final
                                            row_map_ptr, row_map_size));
 
         Kokkos::parallel_reduce(
-            StateVectorRangePolicy<KokkosExecSpace>(0, row_map_size - 1),
+            RangePolicy<KokkosExecSpace>(0, row_map_size - 1),
             getExpectationValueSparseFunctor<PrecisionT>(
                 arr_data, kok_data, kok_indices, kok_row_map),
             expval);
@@ -558,7 +552,7 @@ class Measurements final
         auto sv = this->_statevector.getView();
         Kokkos::View<PrecisionT *> d_probs("d_probs", N);
         Kokkos::parallel_for(
-            StateVectorRangePolicy<KokkosExecSpace>(0, N),
+            RangePolicy<KokkosExecSpace>(0, N),
             KOKKOS_LAMBDA(const std::size_t k) {
                 const PrecisionT rsv = sv(k).real();
                 const PrecisionT isv = sv(k).imag();
@@ -681,7 +675,7 @@ class Measurements final
                 d_probabilities);
         } else {
             Kokkos::parallel_for(
-                StateVectorRangePolicy<KokkosExecSpace>(0, all_indices.size()),
+                RangePolicy<KokkosExecSpace>(0, all_indices.size()),
                 KOKKOS_LAMBDA(const std::size_t i) {
                     for (std::size_t j = 0; j < d_all_offsets.size(); j++) {
                         const std::size_t index =
@@ -762,7 +756,7 @@ class Measurements final
         // Convert probability distribution to cumulative distribution
         auto probability = probs_core();
         Kokkos::parallel_scan(
-            StateVectorRangePolicy<KokkosExecSpace>(0, N),
+            RangePolicy<KokkosExecSpace>(0, N),
             KOKKOS_LAMBDA(const std::size_t k, PrecisionT &update_value,
                           const bool is_final) {
                 const PrecisionT val_k = probability(k);
@@ -781,7 +775,7 @@ class Measurements final
                           .count());
 
         Kokkos::parallel_for(
-            StateVectorRangePolicy<KokkosExecSpace>(0, num_samples),
+            RangePolicy<KokkosExecSpace>(0, num_samples),
             Sampler<PrecisionT, Kokkos::Random_XorShift64_Pool>(
                 samples, probability, rand_pool, num_qubits, N));
 

--- a/pennylane_lightning/core/simulators/lightning_kokkos/measurements/MeasurementsKokkos.hpp
+++ b/pennylane_lightning/core/simulators/lightning_kokkos/measurements/MeasurementsKokkos.hpp
@@ -35,7 +35,6 @@ using namespace Pennylane::Observables;
 using Pennylane::LightningKokkos::StateVectorKokkos;
 using Pennylane::LightningKokkos::Util::getRealOfComplexInnerProduct;
 using Pennylane::LightningKokkos::Util::SparseMV_Kokkos;
-using Pennylane::LightningKokkos::Util::StateVectorMDRangePolicy;
 using Pennylane::LightningKokkos::Util::StateVectorRangePolicy;
 using Pennylane::LightningKokkos::Util::vector2view;
 using Pennylane::LightningKokkos::Util::view2vector;
@@ -670,8 +669,11 @@ class Measurements final
                 Kokkos::MDRangePolicy<KokkosExecSpace,
                                       Kokkos::Rank<2, Kokkos::Iterate::Left>,
                                       Kokkos::IndexType<std::size_t>>;
+            // MDRangePolicy bounds are Kokkos::Array<int64_t, rank> regardless
+            // of IndexType, so cast from size_t to silence -Wnarrowing.
             auto md_policy = MDPolicyType_2D(
-                {{0, 0}}, {{all_indices.size(), all_offsets.size()}});
+                {{0, 0}}, {{static_cast<std::int64_t>(all_indices.size()),
+                            static_cast<std::int64_t>(all_offsets.size())}});
             Kokkos::parallel_reduce(
                 md_policy,
                 getProbsFunctor<PrecisionT, KokkosExecSpace>(

--- a/pennylane_lightning/core/simulators/lightning_kokkos/measurements/MeasurementsKokkosMPI.hpp
+++ b/pennylane_lightning/core/simulators/lightning_kokkos/measurements/MeasurementsKokkosMPI.hpp
@@ -36,6 +36,7 @@ using namespace Pennylane::Observables;
 using Pennylane::LightningKokkos::StateVectorKokkos;
 using Pennylane::LightningKokkos::Util::getRealOfComplexInnerProduct;
 using Pennylane::LightningKokkos::Util::SparseMV_Kokkos;
+using Pennylane::LightningKokkos::Util::StateVectorRangePolicy;
 using Pennylane::LightningKokkos::Util::vector2view;
 using Pennylane::LightningKokkos::Util::view2vector;
 using Pennylane::Util::exp2;
@@ -574,7 +575,7 @@ class MeasurementsMPI final
         // Get local squared norm
         PrecisionT local_squared_norm = 0.0;
         Kokkos::parallel_reduce(
-            local_sv_view.size(),
+            StateVectorRangePolicy<KokkosExecSpace>(0, local_sv_view.size()),
             KOKKOS_LAMBDA(std::size_t i, PrecisionT &sum) {
                 const PrecisionT norm = Kokkos::abs(local_sv_view(i));
                 sum += norm * norm;
@@ -593,7 +594,7 @@ class MeasurementsMPI final
             auto d_local_squared_norm = vector2view(local_norms);
 
             Kokkos::parallel_scan(
-                Kokkos::RangePolicy<KokkosExecSpace>(0, twoN_global_qubits),
+                StateVectorRangePolicy<KokkosExecSpace>(0, twoN_global_qubits),
                 KOKKOS_LAMBDA(const std::size_t k, PrecisionT &update_value,
                               const bool is_final) {
                     const PrecisionT val_k = d_local_squared_norm(k);
@@ -602,7 +603,7 @@ class MeasurementsMPI final
                     update_value += val_k;
                 });
             Kokkos::parallel_for(
-                Kokkos::RangePolicy<KokkosExecSpace>(0, num_samples),
+                StateVectorRangePolicy<KokkosExecSpace>(0, num_samples),
                 Global_Bin_Sampler<PrecisionT, Kokkos::Random_XorShift64_Pool>(
                     global_samples_bin, d_local_squared_norm, rand_pool,
                     num_global_qubits, twoN_global_qubits));
@@ -623,7 +624,7 @@ class MeasurementsMPI final
                 Measurements(this->_statevector.getLocalSV()).probs_core();
             const double inv_norm = 1. / local_squared_norm;
             Kokkos::parallel_for(
-                Kokkos::RangePolicy<KokkosExecSpace>(
+                StateVectorRangePolicy<KokkosExecSpace>(
                     0, local_normalized_probability.size()),
                 KOKKOS_LAMBDA(const std::size_t k) {
                     local_normalized_probability(k) *= inv_norm;
@@ -631,7 +632,7 @@ class MeasurementsMPI final
 
             // Convert probability distribution to cumulative distribution
             Kokkos::parallel_scan(
-                Kokkos::RangePolicy<KokkosExecSpace>(0, exp2(num_local_qubits)),
+                StateVectorRangePolicy<KokkosExecSpace>(0, exp2(num_local_qubits)),
                 KOKKOS_LAMBDA(const std::size_t k, PrecisionT &update_value,
                               const bool is_final) {
                     const PrecisionT val_k = local_normalized_probability(k);
@@ -642,7 +643,7 @@ class MeasurementsMPI final
 
             // Generate local samples using local distribution
             Kokkos::parallel_for(
-                Kokkos::RangePolicy<KokkosExecSpace>(0, local_num_samples),
+                StateVectorRangePolicy<KokkosExecSpace>(0, local_num_samples),
                 Local_Sampler<PrecisionT, Kokkos::Random_XorShift64_Pool>(
                     local_samples, local_normalized_probability, rand_pool,
                     num_local_qubits, num_global_qubits, global_index,

--- a/pennylane_lightning/core/simulators/lightning_kokkos/measurements/MeasurementsKokkosMPI.hpp
+++ b/pennylane_lightning/core/simulators/lightning_kokkos/measurements/MeasurementsKokkosMPI.hpp
@@ -632,7 +632,8 @@ class MeasurementsMPI final
 
             // Convert probability distribution to cumulative distribution
             Kokkos::parallel_scan(
-                StateVectorRangePolicy<KokkosExecSpace>(0, exp2(num_local_qubits)),
+                StateVectorRangePolicy<KokkosExecSpace>(0,
+                                                        exp2(num_local_qubits)),
                 KOKKOS_LAMBDA(const std::size_t k, PrecisionT &update_value,
                               const bool is_final) {
                     const PrecisionT val_k = local_normalized_probability(k);

--- a/pennylane_lightning/core/simulators/lightning_kokkos/measurements/MeasurementsKokkosMPI.hpp
+++ b/pennylane_lightning/core/simulators/lightning_kokkos/measurements/MeasurementsKokkosMPI.hpp
@@ -35,8 +35,8 @@ using namespace Pennylane::Measures;
 using namespace Pennylane::Observables;
 using Pennylane::LightningKokkos::StateVectorKokkos;
 using Pennylane::LightningKokkos::Util::getRealOfComplexInnerProduct;
+using Pennylane::LightningKokkos::Util::RangePolicy;
 using Pennylane::LightningKokkos::Util::SparseMV_Kokkos;
-using Pennylane::LightningKokkos::Util::StateVectorRangePolicy;
 using Pennylane::LightningKokkos::Util::vector2view;
 using Pennylane::LightningKokkos::Util::view2vector;
 using Pennylane::Util::exp2;
@@ -575,7 +575,7 @@ class MeasurementsMPI final
         // Get local squared norm
         PrecisionT local_squared_norm = 0.0;
         Kokkos::parallel_reduce(
-            StateVectorRangePolicy<KokkosExecSpace>(0, local_sv_view.size()),
+            RangePolicy<KokkosExecSpace>(0, local_sv_view.size()),
             KOKKOS_LAMBDA(std::size_t i, PrecisionT &sum) {
                 const PrecisionT norm = Kokkos::abs(local_sv_view(i));
                 sum += norm * norm;
@@ -594,7 +594,7 @@ class MeasurementsMPI final
             auto d_local_squared_norm = vector2view(local_norms);
 
             Kokkos::parallel_scan(
-                StateVectorRangePolicy<KokkosExecSpace>(0, twoN_global_qubits),
+                RangePolicy<KokkosExecSpace>(0, twoN_global_qubits),
                 KOKKOS_LAMBDA(const std::size_t k, PrecisionT &update_value,
                               const bool is_final) {
                     const PrecisionT val_k = d_local_squared_norm(k);
@@ -603,7 +603,7 @@ class MeasurementsMPI final
                     update_value += val_k;
                 });
             Kokkos::parallel_for(
-                StateVectorRangePolicy<KokkosExecSpace>(0, num_samples),
+                RangePolicy<KokkosExecSpace>(0, num_samples),
                 Global_Bin_Sampler<PrecisionT, Kokkos::Random_XorShift64_Pool>(
                     global_samples_bin, d_local_squared_norm, rand_pool,
                     num_global_qubits, twoN_global_qubits));
@@ -624,7 +624,7 @@ class MeasurementsMPI final
                 Measurements(this->_statevector.getLocalSV()).probs_core();
             const double inv_norm = 1. / local_squared_norm;
             Kokkos::parallel_for(
-                StateVectorRangePolicy<KokkosExecSpace>(
+                RangePolicy<KokkosExecSpace>(
                     0, local_normalized_probability.size()),
                 KOKKOS_LAMBDA(const std::size_t k) {
                     local_normalized_probability(k) *= inv_norm;
@@ -632,8 +632,7 @@ class MeasurementsMPI final
 
             // Convert probability distribution to cumulative distribution
             Kokkos::parallel_scan(
-                StateVectorRangePolicy<KokkosExecSpace>(0,
-                                                        exp2(num_local_qubits)),
+                RangePolicy<KokkosExecSpace>(0, exp2(num_local_qubits)),
                 KOKKOS_LAMBDA(const std::size_t k, PrecisionT &update_value,
                               const bool is_final) {
                     const PrecisionT val_k = local_normalized_probability(k);
@@ -644,7 +643,7 @@ class MeasurementsMPI final
 
             // Generate local samples using local distribution
             Kokkos::parallel_for(
-                StateVectorRangePolicy<KokkosExecSpace>(0, local_num_samples),
+                RangePolicy<KokkosExecSpace>(0, local_num_samples),
                 Local_Sampler<PrecisionT, Kokkos::Random_XorShift64_Pool>(
                     local_samples, local_normalized_probability, rand_pool,
                     num_local_qubits, num_global_qubits, global_index,

--- a/pennylane_lightning/core/simulators/lightning_kokkos/measurements/MeasurementsKokkosMPI.hpp
+++ b/pennylane_lightning/core/simulators/lightning_kokkos/measurements/MeasurementsKokkosMPI.hpp
@@ -35,6 +35,7 @@ using namespace Pennylane::Measures;
 using namespace Pennylane::Observables;
 using Pennylane::LightningKokkos::StateVectorKokkos;
 using Pennylane::LightningKokkos::Util::getRealOfComplexInnerProduct;
+using Pennylane::LightningKokkos::Util::one;
 using Pennylane::LightningKokkos::Util::RangePolicy;
 using Pennylane::LightningKokkos::Util::SparseMV_Kokkos;
 using Pennylane::LightningKokkos::Util::vector2view;
@@ -285,8 +286,8 @@ class MeasurementsMPI final
                               this->_statevector.getGlobalWires().end(),
                               global_Z_wires[i]));
                 global_z_mask |=
-                    (1U << (this->_statevector.getNumGlobalWires() - 1 -
-                            distance));
+                    (one << (this->_statevector.getNumGlobalWires() - 1 -
+                             distance));
             }
 
             if (std::popcount(global_index & global_z_mask) % 2 == 1) {
@@ -480,7 +481,7 @@ class MeasurementsMPI final
             mpi_manager_.getRank());
         std::size_t mask = 0;
         for (std::size_t i = 0; i < global_wires.size(); i++) {
-            mask |= (1 << (this->_statevector.getRevGlobalWireIndex(
+            mask |= (one << (this->_statevector.getRevGlobalWireIndex(
                          global_wires[i])));
         }
         std::size_t subCommGroupId = global_index & mask;

--- a/pennylane_lightning/core/simulators/lightning_kokkos/measurements/MeasuresFunctors.hpp
+++ b/pennylane_lightning/core/simulators/lightning_kokkos/measurements/MeasuresFunctors.hpp
@@ -18,6 +18,14 @@
 
 #include "UtilKokkos.hpp"
 
+/// @cond DEV
+namespace {
+using Pennylane::LightningKokkos::Util::StateVectorRangePolicy;
+using Pennylane::LightningKokkos::Util::vector2view;
+using Pennylane::LightningKokkos::Util::view2vector;
+} // namespace
+/// @endcond
+
 namespace Pennylane::LightningKokkos::Functors {
 
 /**
@@ -132,9 +140,8 @@ class getProbsNQubitOpFunctor {
         std::vector<std::size_t> parity_ =
             Pennylane::Util::revWireParity(rev_wires_);
         if constexpr (num_wires == 0) {
-            rev_wires =
-                Pennylane::LightningKokkos::Util::vector2view(rev_wires_);
-            parity = Pennylane::LightningKokkos::Util::vector2view(parity_);
+            rev_wires = vector2view(rev_wires_);
+            parity = vector2view(parity_);
         }
         if constexpr (num_wires > 0) {
             rev_wire_0 = rev_wires_[0];
@@ -406,78 +413,69 @@ auto probs_bitshift_generic(
     switch (n_wires) {
     case 1UL:
         Kokkos::parallel_reduce(
-            Pennylane::LightningKokkos::Util::StateVectorRangePolicy<DeviceType>(
-                0, exp2(num_qubits - n_wires)),
+            StateVectorRangePolicy<DeviceType>(0, exp2(num_qubits - n_wires)),
             getProbsNQubitOpFunctor<PrecisionT, DeviceType, 1>(arr, num_qubits,
                                                                wires),
             d_probabilities);
         break;
     case 2UL:
         Kokkos::parallel_reduce(
-            Pennylane::LightningKokkos::Util::StateVectorRangePolicy<DeviceType>(
-                0, exp2(num_qubits - n_wires)),
+            StateVectorRangePolicy<DeviceType>(0, exp2(num_qubits - n_wires)),
             getProbsNQubitOpFunctor<PrecisionT, DeviceType, 2>(arr, num_qubits,
                                                                wires),
             d_probabilities);
         break;
     case 3UL:
         Kokkos::parallel_reduce(
-            Pennylane::LightningKokkos::Util::StateVectorRangePolicy<DeviceType>(
-                0, exp2(num_qubits - n_wires)),
+            StateVectorRangePolicy<DeviceType>(0, exp2(num_qubits - n_wires)),
             getProbsNQubitOpFunctor<PrecisionT, DeviceType, 3>(arr, num_qubits,
                                                                wires),
             d_probabilities);
         break;
     case 4UL:
         Kokkos::parallel_reduce(
-            Pennylane::LightningKokkos::Util::StateVectorRangePolicy<DeviceType>(
-                0, exp2(num_qubits - n_wires)),
+            StateVectorRangePolicy<DeviceType>(0, exp2(num_qubits - n_wires)),
             getProbsNQubitOpFunctor<PrecisionT, DeviceType, 4>(arr, num_qubits,
                                                                wires),
             d_probabilities);
         break;
     case 5UL:
         Kokkos::parallel_reduce(
-            Pennylane::LightningKokkos::Util::StateVectorRangePolicy<DeviceType>(
-                0, exp2(num_qubits - n_wires)),
+            StateVectorRangePolicy<DeviceType>(0, exp2(num_qubits - n_wires)),
             getProbsNQubitOpFunctor<PrecisionT, DeviceType, 5>(arr, num_qubits,
                                                                wires),
             d_probabilities);
         break;
     case 6UL:
         Kokkos::parallel_reduce(
-            Pennylane::LightningKokkos::Util::StateVectorRangePolicy<DeviceType>(
-                0, exp2(num_qubits - n_wires)),
+            StateVectorRangePolicy<DeviceType>(0, exp2(num_qubits - n_wires)),
             getProbsNQubitOpFunctor<PrecisionT, DeviceType, 6>(arr, num_qubits,
                                                                wires),
             d_probabilities);
         break;
     case 7UL:
         Kokkos::parallel_reduce(
-            Pennylane::LightningKokkos::Util::StateVectorRangePolicy<DeviceType>(
-                0, exp2(num_qubits - n_wires)),
+            StateVectorRangePolicy<DeviceType>(0, exp2(num_qubits - n_wires)),
             getProbsNQubitOpFunctor<PrecisionT, DeviceType, 7>(arr, num_qubits,
                                                                wires),
             d_probabilities);
         break;
     case 8UL:
         Kokkos::parallel_reduce(
-            Pennylane::LightningKokkos::Util::StateVectorRangePolicy<DeviceType>(
-                0, exp2(num_qubits - n_wires)),
+            StateVectorRangePolicy<DeviceType>(0, exp2(num_qubits - n_wires)),
             getProbsNQubitOpFunctor<PrecisionT, DeviceType, 8>(arr, num_qubits,
                                                                wires),
             d_probabilities);
         break;
     default:
         Kokkos::parallel_reduce(
-            Pennylane::LightningKokkos::Util::StateVectorRangePolicy<DeviceType>(
-                0, exp2(num_qubits - n_wires)),
+            StateVectorRangePolicy<DeviceType>(0, exp2(num_qubits - n_wires)),
             getProbsNQubitOpFunctor<PrecisionT, DeviceType, 0>(arr, num_qubits,
                                                                wires),
             d_probabilities);
         break;
     }
-    return Pennylane::LightningKokkos::Util::view2vector(d_probabilities);
+    return view2vector(d_probabilities);
 };
 
 /**

--- a/pennylane_lightning/core/simulators/lightning_kokkos/measurements/MeasuresFunctors.hpp
+++ b/pennylane_lightning/core/simulators/lightning_kokkos/measurements/MeasuresFunctors.hpp
@@ -54,7 +54,7 @@ template <class PrecisionT, class DeviceType> class getProbsFunctor {
                     const std::vector<std::size_t> &wires_,
                     const Kokkos::View<std::size_t *> all_indices_,
                     const Kokkos::View<std::size_t *> all_offsets_)
-        : value_count{1U << wires_.size()}, arr{arr_},
+        : value_count{one << wires_.size()}, arr{arr_},
           all_indices{all_indices_}, all_offsets{all_offsets_} {}
 
     KOKKOS_INLINE_FUNCTION
@@ -131,7 +131,7 @@ class getProbsNQubitOpFunctor {
     getProbsNQubitOpFunctor(const Kokkos::View<ComplexT *> &arr_,
                             const std::size_t num_qubits_,
                             const std::vector<std::size_t> &wires_)
-        : value_count{1U << wires_.size()}, arr{arr_}, n_wires{wires_.size()} {
+        : value_count{one << wires_.size()}, arr{arr_}, n_wires{wires_.size()} {
         PL_ABORT_IF(num_wires != 0 && num_wires != n_wires,
                     "num_wires must be equal to n_wires.");
         std::vector<std::size_t> rev_wires_(n_wires);
@@ -199,7 +199,7 @@ class getProbsNQubitOpFunctor {
     void apply0(const std::size_t i0, const std::size_t rev_wire,
                 const std::size_t offset, PrecisionT dst[]) const {
         std::size_t i1;
-        i1 = i0 | (0U << rev_wire);
+        i1 = i0;
         PrecisionT rsv = real(arr(i1));
         PrecisionT isv = imag(arr(i1));
         dst[offset + 0] += rsv * rsv + isv * isv;
@@ -703,7 +703,7 @@ struct getTransposedIndexFunctor {
     KOKKOS_INLINE_FUNCTION
     void operator()(const std::size_t i, const std::size_t j) const {
         const std::size_t axis = sorted_ind_wires(j);
-        const std::size_t index = i / (1L << (max_index_sorted_ind_wires - j));
+        const std::size_t index = i / (one << (max_index_sorted_ind_wires - j));
         const std::size_t sub_index = (index % 2)
                                       << (max_index_sorted_ind_wires - axis);
         Kokkos::atomic_add(&trans_index(i), sub_index);

--- a/pennylane_lightning/core/simulators/lightning_kokkos/measurements/MeasuresFunctors.hpp
+++ b/pennylane_lightning/core/simulators/lightning_kokkos/measurements/MeasuresFunctors.hpp
@@ -20,7 +20,8 @@
 
 /// @cond DEV
 namespace {
-using Pennylane::LightningKokkos::Util::StateVectorRangePolicy;
+using Pennylane::LightningKokkos::Util::one;
+using Pennylane::LightningKokkos::Util::RangePolicy;
 using Pennylane::LightningKokkos::Util::vector2view;
 using Pennylane::LightningKokkos::Util::view2vector;
 } // namespace
@@ -202,7 +203,7 @@ class getProbsNQubitOpFunctor {
         PrecisionT rsv = real(arr(i1));
         PrecisionT isv = imag(arr(i1));
         dst[offset + 0] += rsv * rsv + isv * isv;
-        i1 = i0 | (1U << rev_wire);
+        i1 = i0 | (one << rev_wire);
         rsv = real(arr(i1));
         isv = imag(arr(i1));
         dst[offset + 1] += rsv * rsv + isv * isv;
@@ -213,7 +214,7 @@ class getProbsNQubitOpFunctor {
                 const std::size_t rev_wire_1, const std::size_t offset,
                 PrecisionT dst[]) const {
         apply0(i0, rev_wire_0, 0 + offset, dst);
-        apply0(i0 | (1U << rev_wire_1), rev_wire_0, 2 + offset, dst);
+        apply0(i0 | (one << rev_wire_1), rev_wire_0, 2 + offset, dst);
     }
 
     KOKKOS_INLINE_FUNCTION
@@ -221,7 +222,7 @@ class getProbsNQubitOpFunctor {
                 const std::size_t rev_wire_1, const std::size_t rev_wire_2,
                 const std::size_t offset, PrecisionT dst[]) const {
         apply1(i0, rev_wire_0, rev_wire_1, 0 + offset, dst);
-        apply1(i0 | (1U << rev_wire_2), rev_wire_0, rev_wire_1, 4 + offset,
+        apply1(i0 | (one << rev_wire_2), rev_wire_0, rev_wire_1, 4 + offset,
                dst);
     }
 
@@ -231,7 +232,7 @@ class getProbsNQubitOpFunctor {
                 const std::size_t rev_wire_3, const std::size_t offset,
                 PrecisionT dst[]) const {
         apply2(i0, rev_wire_0, rev_wire_1, rev_wire_2, 0 + offset, dst);
-        apply2(i0 | (1U << rev_wire_3), rev_wire_0, rev_wire_1, rev_wire_2,
+        apply2(i0 | (one << rev_wire_3), rev_wire_0, rev_wire_1, rev_wire_2,
                8 + offset, dst);
     }
 
@@ -242,7 +243,7 @@ class getProbsNQubitOpFunctor {
                 const std::size_t offset, PrecisionT dst[]) const {
         apply3(i0, rev_wire_0, rev_wire_1, rev_wire_2, rev_wire_3, 0 + offset,
                dst);
-        apply3(i0 | (1U << rev_wire_4), rev_wire_0, rev_wire_1, rev_wire_2,
+        apply3(i0 | (one << rev_wire_4), rev_wire_0, rev_wire_1, rev_wire_2,
                rev_wire_3, 16 + offset, dst);
     }
 
@@ -254,7 +255,7 @@ class getProbsNQubitOpFunctor {
                 PrecisionT dst[]) const {
         apply4(i0, rev_wire_0, rev_wire_1, rev_wire_2, rev_wire_3, rev_wire_4,
                0 + offset, dst);
-        apply4(i0 | (1U << rev_wire_5), rev_wire_0, rev_wire_1, rev_wire_2,
+        apply4(i0 | (one << rev_wire_5), rev_wire_0, rev_wire_1, rev_wire_2,
                rev_wire_3, rev_wire_4, 32 + offset, dst);
     }
 
@@ -266,7 +267,7 @@ class getProbsNQubitOpFunctor {
                 const std::size_t offset, PrecisionT dst[]) const {
         apply5(i0, rev_wire_0, rev_wire_1, rev_wire_2, rev_wire_3, rev_wire_4,
                rev_wire_5, 0 + offset, dst);
-        apply5(i0 | (1U << rev_wire_6), rev_wire_0, rev_wire_1, rev_wire_2,
+        apply5(i0 | (one << rev_wire_6), rev_wire_0, rev_wire_1, rev_wire_2,
                rev_wire_3, rev_wire_4, rev_wire_5, 64 + offset, dst);
     }
 
@@ -279,7 +280,7 @@ class getProbsNQubitOpFunctor {
                 PrecisionT dst[]) const {
         apply6(i0, rev_wire_0, rev_wire_1, rev_wire_2, rev_wire_3, rev_wire_4,
                rev_wire_5, rev_wire_6, 0 + offset, dst);
-        apply6(i0 | (1U << rev_wire_7), rev_wire_0, rev_wire_1, rev_wire_2,
+        apply6(i0 | (one << rev_wire_7), rev_wire_0, rev_wire_1, rev_wire_2,
                rev_wire_3, rev_wire_4, rev_wire_5, rev_wire_6, 128 + offset,
                dst);
     }
@@ -293,7 +294,7 @@ class getProbsNQubitOpFunctor {
                 const std::size_t offset, PrecisionT dst[]) const {
         apply7(i0, rev_wire_0, rev_wire_1, rev_wire_2, rev_wire_3, rev_wire_4,
                rev_wire_5, rev_wire_6, rev_wire_7, 0 + offset, dst);
-        apply7(i0 | (1U << rev_wire_8), rev_wire_0, rev_wire_1, rev_wire_2,
+        apply7(i0 | (one << rev_wire_8), rev_wire_0, rev_wire_1, rev_wire_2,
                rev_wire_3, rev_wire_4, rev_wire_5, rev_wire_6, rev_wire_7,
                256 + offset, dst);
     }
@@ -413,63 +414,63 @@ auto probs_bitshift_generic(
     switch (n_wires) {
     case 1UL:
         Kokkos::parallel_reduce(
-            StateVectorRangePolicy<DeviceType>(0, exp2(num_qubits - n_wires)),
+            RangePolicy<DeviceType>(0, exp2(num_qubits - n_wires)),
             getProbsNQubitOpFunctor<PrecisionT, DeviceType, 1>(arr, num_qubits,
                                                                wires),
             d_probabilities);
         break;
     case 2UL:
         Kokkos::parallel_reduce(
-            StateVectorRangePolicy<DeviceType>(0, exp2(num_qubits - n_wires)),
+            RangePolicy<DeviceType>(0, exp2(num_qubits - n_wires)),
             getProbsNQubitOpFunctor<PrecisionT, DeviceType, 2>(arr, num_qubits,
                                                                wires),
             d_probabilities);
         break;
     case 3UL:
         Kokkos::parallel_reduce(
-            StateVectorRangePolicy<DeviceType>(0, exp2(num_qubits - n_wires)),
+            RangePolicy<DeviceType>(0, exp2(num_qubits - n_wires)),
             getProbsNQubitOpFunctor<PrecisionT, DeviceType, 3>(arr, num_qubits,
                                                                wires),
             d_probabilities);
         break;
     case 4UL:
         Kokkos::parallel_reduce(
-            StateVectorRangePolicy<DeviceType>(0, exp2(num_qubits - n_wires)),
+            RangePolicy<DeviceType>(0, exp2(num_qubits - n_wires)),
             getProbsNQubitOpFunctor<PrecisionT, DeviceType, 4>(arr, num_qubits,
                                                                wires),
             d_probabilities);
         break;
     case 5UL:
         Kokkos::parallel_reduce(
-            StateVectorRangePolicy<DeviceType>(0, exp2(num_qubits - n_wires)),
+            RangePolicy<DeviceType>(0, exp2(num_qubits - n_wires)),
             getProbsNQubitOpFunctor<PrecisionT, DeviceType, 5>(arr, num_qubits,
                                                                wires),
             d_probabilities);
         break;
     case 6UL:
         Kokkos::parallel_reduce(
-            StateVectorRangePolicy<DeviceType>(0, exp2(num_qubits - n_wires)),
+            RangePolicy<DeviceType>(0, exp2(num_qubits - n_wires)),
             getProbsNQubitOpFunctor<PrecisionT, DeviceType, 6>(arr, num_qubits,
                                                                wires),
             d_probabilities);
         break;
     case 7UL:
         Kokkos::parallel_reduce(
-            StateVectorRangePolicy<DeviceType>(0, exp2(num_qubits - n_wires)),
+            RangePolicy<DeviceType>(0, exp2(num_qubits - n_wires)),
             getProbsNQubitOpFunctor<PrecisionT, DeviceType, 7>(arr, num_qubits,
                                                                wires),
             d_probabilities);
         break;
     case 8UL:
         Kokkos::parallel_reduce(
-            StateVectorRangePolicy<DeviceType>(0, exp2(num_qubits - n_wires)),
+            RangePolicy<DeviceType>(0, exp2(num_qubits - n_wires)),
             getProbsNQubitOpFunctor<PrecisionT, DeviceType, 8>(arr, num_qubits,
                                                                wires),
             d_probabilities);
         break;
     default:
         Kokkos::parallel_reduce(
-            StateVectorRangePolicy<DeviceType>(0, exp2(num_qubits - n_wires)),
+            RangePolicy<DeviceType>(0, exp2(num_qubits - n_wires)),
             getProbsNQubitOpFunctor<PrecisionT, DeviceType, 0>(arr, num_qubits,
                                                                wires),
             d_probabilities);

--- a/pennylane_lightning/core/simulators/lightning_kokkos/measurements/MeasuresFunctors.hpp
+++ b/pennylane_lightning/core/simulators/lightning_kokkos/measurements/MeasuresFunctors.hpp
@@ -406,63 +406,72 @@ auto probs_bitshift_generic(
     switch (n_wires) {
     case 1UL:
         Kokkos::parallel_reduce(
-            exp2(num_qubits - n_wires),
+            Pennylane::LightningKokkos::Util::StateVectorRangePolicy<DeviceType>(
+                0, exp2(num_qubits - n_wires)),
             getProbsNQubitOpFunctor<PrecisionT, DeviceType, 1>(arr, num_qubits,
                                                                wires),
             d_probabilities);
         break;
     case 2UL:
         Kokkos::parallel_reduce(
-            exp2(num_qubits - n_wires),
+            Pennylane::LightningKokkos::Util::StateVectorRangePolicy<DeviceType>(
+                0, exp2(num_qubits - n_wires)),
             getProbsNQubitOpFunctor<PrecisionT, DeviceType, 2>(arr, num_qubits,
                                                                wires),
             d_probabilities);
         break;
     case 3UL:
         Kokkos::parallel_reduce(
-            exp2(num_qubits - n_wires),
+            Pennylane::LightningKokkos::Util::StateVectorRangePolicy<DeviceType>(
+                0, exp2(num_qubits - n_wires)),
             getProbsNQubitOpFunctor<PrecisionT, DeviceType, 3>(arr, num_qubits,
                                                                wires),
             d_probabilities);
         break;
     case 4UL:
         Kokkos::parallel_reduce(
-            exp2(num_qubits - n_wires),
+            Pennylane::LightningKokkos::Util::StateVectorRangePolicy<DeviceType>(
+                0, exp2(num_qubits - n_wires)),
             getProbsNQubitOpFunctor<PrecisionT, DeviceType, 4>(arr, num_qubits,
                                                                wires),
             d_probabilities);
         break;
     case 5UL:
         Kokkos::parallel_reduce(
-            exp2(num_qubits - n_wires),
+            Pennylane::LightningKokkos::Util::StateVectorRangePolicy<DeviceType>(
+                0, exp2(num_qubits - n_wires)),
             getProbsNQubitOpFunctor<PrecisionT, DeviceType, 5>(arr, num_qubits,
                                                                wires),
             d_probabilities);
         break;
     case 6UL:
         Kokkos::parallel_reduce(
-            exp2(num_qubits - n_wires),
+            Pennylane::LightningKokkos::Util::StateVectorRangePolicy<DeviceType>(
+                0, exp2(num_qubits - n_wires)),
             getProbsNQubitOpFunctor<PrecisionT, DeviceType, 6>(arr, num_qubits,
                                                                wires),
             d_probabilities);
         break;
     case 7UL:
         Kokkos::parallel_reduce(
-            exp2(num_qubits - n_wires),
+            Pennylane::LightningKokkos::Util::StateVectorRangePolicy<DeviceType>(
+                0, exp2(num_qubits - n_wires)),
             getProbsNQubitOpFunctor<PrecisionT, DeviceType, 7>(arr, num_qubits,
                                                                wires),
             d_probabilities);
         break;
     case 8UL:
         Kokkos::parallel_reduce(
-            exp2(num_qubits - n_wires),
+            Pennylane::LightningKokkos::Util::StateVectorRangePolicy<DeviceType>(
+                0, exp2(num_qubits - n_wires)),
             getProbsNQubitOpFunctor<PrecisionT, DeviceType, 8>(arr, num_qubits,
                                                                wires),
             d_probabilities);
         break;
     default:
         Kokkos::parallel_reduce(
-            exp2(num_qubits - n_wires),
+            Pennylane::LightningKokkos::Util::StateVectorRangePolicy<DeviceType>(
+                0, exp2(num_qubits - n_wires)),
             getProbsNQubitOpFunctor<PrecisionT, DeviceType, 0>(arr, num_qubits,
                                                                wires),
             d_probabilities);

--- a/pennylane_lightning/core/simulators/lightning_kokkos/measurements/tests/Test_StateVectorKokkos_Measure.cpp
+++ b/pennylane_lightning/core/simulators/lightning_kokkos/measurements/tests/Test_StateVectorKokkos_Measure.cpp
@@ -31,7 +31,7 @@
 /// @cond DEV
 namespace {
 using namespace Pennylane::LightningKokkos::Measures;
-using Pennylane::LightningKokkos::Util::StateVectorRangePolicy;
+using Pennylane::LightningKokkos::Util::RangePolicy;
 using Pennylane::Util::createNonTrivialState;
 using Pennylane::Util::INVSQRT2;
 }; // namespace
@@ -859,8 +859,7 @@ TEST_CASE("Test tensor transposition", "[Measure]") {
                 getTransposedIndexFunctor(d_wires, d_trans_index, num_wires));
 
             Kokkos::parallel_for(
-                "Transpose",
-                StateVectorRangePolicy<KokkosExecSpace>(0, indices.size()),
+                "Transpose", RangePolicy<KokkosExecSpace>(0, indices.size()),
                 getTransposedFunctor<std::size_t>(d_results, d_indices,
                                                   d_trans_index));
 

--- a/pennylane_lightning/core/simulators/lightning_kokkos/measurements/tests/Test_StateVectorKokkos_Measure.cpp
+++ b/pennylane_lightning/core/simulators/lightning_kokkos/measurements/tests/Test_StateVectorKokkos_Measure.cpp
@@ -31,6 +31,7 @@
 /// @cond DEV
 namespace {
 using namespace Pennylane::LightningKokkos::Measures;
+using Pennylane::LightningKokkos::Util::StateVectorRangePolicy;
 using Pennylane::Util::createNonTrivialState;
 using Pennylane::Util::INVSQRT2;
 }; // namespace
@@ -842,11 +843,14 @@ TEST_CASE("Test tensor transposition", "[Measure]") {
                 UnmanagedSizeTHostView(term.first.data(), term.first.size()));
 
             using MDPolicyType_2D =
-                Kokkos::MDRangePolicy<Kokkos::Rank<2, Kokkos::Iterate::Left>>;
+                Kokkos::MDRangePolicy<Kokkos::Rank<2, Kokkos::Iterate::Left>,
+                                      Kokkos::IndexType<std::size_t>>;
 
+            // MDRangePolicy bounds are Kokkos::Array<int64_t, rank> regardless
+            // of IndexType, so cast from size_t to silence -Wnarrowing.
             MDPolicyType_2D mdpolicy_2d1(
-                {{0, 0}}, {{static_cast<int>(indices.size()),
-                            static_cast<int>(term.first.size())}});
+                {{0, 0}}, {{static_cast<std::int64_t>(indices.size()),
+                            static_cast<std::int64_t>(term.first.size())}});
 
             const int num_wires = term.first.size();
 
@@ -856,7 +860,7 @@ TEST_CASE("Test tensor transposition", "[Measure]") {
 
             Kokkos::parallel_for(
                 "Transpose",
-                Kokkos::RangePolicy<KokkosExecSpace>(0, indices.size()),
+                StateVectorRangePolicy<KokkosExecSpace>(0, indices.size()),
                 getTransposedFunctor<std::size_t>(d_results, d_indices,
                                                   d_trans_index));
 

--- a/pennylane_lightning/core/simulators/lightning_kokkos/utils/LinearAlgebraKokkos.hpp
+++ b/pennylane_lightning/core/simulators/lightning_kokkos/utils/LinearAlgebraKokkos.hpp
@@ -59,7 +59,7 @@ inline auto axpy_Kokkos(Kokkos::complex<PrecisionT> alpha,
                         Kokkos::View<Kokkos::complex<PrecisionT> *> x,
                         Kokkos::View<Kokkos::complex<PrecisionT> *> y,
                         std::size_t length) {
-    Kokkos::parallel_for(StateVectorRangePolicy<>(0, length),
+    Kokkos::parallel_for(RangePolicy<>(0, length),
                          axpy_KokkosFunctor<PrecisionT>(alpha, x, y));
 }
 
@@ -139,7 +139,7 @@ void SparseMV_Kokkos(Kokkos::View<ComplexT *> x, Kokkos::View<ComplexT *> y,
                       ConstSizeTHostView(column_idx_ptr, numNNZ));
     Kokkos::deep_copy(kok_row_map, ConstSizeTHostView(row_map, row_map_size));
 
-    Kokkos::parallel_for(StateVectorRangePolicy<>(0, row_map_size - 1),
+    Kokkos::parallel_for(RangePolicy<>(0, row_map_size - 1),
                          SparseMV_KokkosFunctor<PrecisionT>(
                              x, y, kok_data, kok_column_idx_ptr, kok_row_map));
 }
@@ -182,7 +182,7 @@ getRealOfComplexInnerProduct(Kokkos::View<Kokkos::complex<PrecisionT> *> x,
     PL_ASSERT(x.size() == y.size());
     PrecisionT inner = 0;
     Kokkos::parallel_reduce(
-        StateVectorRangePolicy<>(0, x.size()),
+        RangePolicy<>(0, x.size()),
         getRealOfComplexInnerProductFunctor<PrecisionT>(x, y), inner);
     return inner;
 }
@@ -225,7 +225,7 @@ getImagOfComplexInnerProduct(Kokkos::View<Kokkos::complex<PrecisionT> *> x,
     PL_ASSERT(x.size() == y.size());
     PrecisionT inner = 0;
     Kokkos::parallel_reduce(
-        StateVectorRangePolicy<>(0, x.size()),
+        RangePolicy<>(0, x.size()),
         getImagOfComplexInnerProductFunctor<PrecisionT>(x, y), inner);
     return inner;
 }

--- a/pennylane_lightning/core/simulators/lightning_kokkos/utils/LinearAlgebraKokkos.hpp
+++ b/pennylane_lightning/core/simulators/lightning_kokkos/utils/LinearAlgebraKokkos.hpp
@@ -21,6 +21,7 @@
 #include <Kokkos_Core.hpp>
 
 #include "Error.hpp"
+#include "UtilKokkos.hpp"
 
 namespace Pennylane::LightningKokkos::Util {
 /**
@@ -58,7 +59,8 @@ inline auto axpy_Kokkos(Kokkos::complex<PrecisionT> alpha,
                         Kokkos::View<Kokkos::complex<PrecisionT> *> x,
                         Kokkos::View<Kokkos::complex<PrecisionT> *> y,
                         std::size_t length) {
-    Kokkos::parallel_for(length, axpy_KokkosFunctor<PrecisionT>(alpha, x, y));
+    Kokkos::parallel_for(StateVectorRangePolicy<>(0, length),
+                         axpy_KokkosFunctor<PrecisionT>(alpha, x, y));
 }
 
 /**
@@ -137,7 +139,7 @@ void SparseMV_Kokkos(Kokkos::View<ComplexT *> x, Kokkos::View<ComplexT *> y,
                       ConstSizeTHostView(column_idx_ptr, numNNZ));
     Kokkos::deep_copy(kok_row_map, ConstSizeTHostView(row_map, row_map_size));
 
-    Kokkos::parallel_for(row_map_size - 1,
+    Kokkos::parallel_for(StateVectorRangePolicy<>(0, row_map_size - 1),
                          SparseMV_KokkosFunctor<PrecisionT>(
                              x, y, kok_data, kok_column_idx_ptr, kok_row_map));
 }
@@ -180,7 +182,8 @@ getRealOfComplexInnerProduct(Kokkos::View<Kokkos::complex<PrecisionT> *> x,
     PL_ASSERT(x.size() == y.size());
     PrecisionT inner = 0;
     Kokkos::parallel_reduce(
-        x.size(), getRealOfComplexInnerProductFunctor<PrecisionT>(x, y), inner);
+        StateVectorRangePolicy<>(0, x.size()),
+        getRealOfComplexInnerProductFunctor<PrecisionT>(x, y), inner);
     return inner;
 }
 
@@ -222,7 +225,8 @@ getImagOfComplexInnerProduct(Kokkos::View<Kokkos::complex<PrecisionT> *> x,
     PL_ASSERT(x.size() == y.size());
     PrecisionT inner = 0;
     Kokkos::parallel_reduce(
-        x.size(), getImagOfComplexInnerProductFunctor<PrecisionT>(x, y), inner);
+        StateVectorRangePolicy<>(0, x.size()),
+        getImagOfComplexInnerProductFunctor<PrecisionT>(x, y), inner);
     return inner;
 }
 

--- a/pennylane_lightning/core/simulators/lightning_kokkos/utils/UtilKokkos.hpp
+++ b/pennylane_lightning/core/simulators/lightning_kokkos/utils/UtilKokkos.hpp
@@ -34,6 +34,32 @@ constexpr std::size_t one{1};
 /// @endcond
 
 /**
+ * @brief Project-wide RangePolicy / MDRangePolicy / TeamPolicy aliases that
+ * pin the `index_type` to `std::size_t`.
+ *
+ * Why: a default `Kokkos::RangePolicy<ExecutionSpace>` inherits its
+ * `index_type` from `ExecutionSpace::size_type`, which on the HIP backend is
+ * `unsigned int` (32 bits). For >= 32 qubits, kernels iterate over
+ * `exp2(num_qubits) >= 2^32`, and Kokkos' bound-safety check aborts with
+ * "Kokkos::RangePolicy bound type error: an unsafe implicit conversion is
+ * performed on a bound (4294967296)". Pinning the index type to `std::size_t`
+ * lifts that ceiling on every backend and matches the type used for indices
+ * throughout the rest of the codebase.
+ */
+template <class ExecSpace = Kokkos::DefaultExecutionSpace>
+using StateVectorRangePolicy =
+    Kokkos::RangePolicy<ExecSpace, Kokkos::IndexType<std::size_t>>;
+
+template <int Rank, class ExecSpace = Kokkos::DefaultExecutionSpace>
+using StateVectorMDRangePolicy =
+    Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<Rank>,
+                          Kokkos::IndexType<std::size_t>>;
+
+template <class ExecSpace = Kokkos::DefaultExecutionSpace>
+using StateVectorTeamPolicy =
+    Kokkos::TeamPolicy<ExecSpace, Kokkos::IndexType<std::size_t>>;
+
+/**
  * @brief Copy the content of a Kokkos view to an `std::vector`.
  *
  * @tparam T View data type.

--- a/pennylane_lightning/core/simulators/lightning_kokkos/utils/UtilKokkos.hpp
+++ b/pennylane_lightning/core/simulators/lightning_kokkos/utils/UtilKokkos.hpp
@@ -46,16 +46,15 @@ constexpr std::size_t one{1};
  * lifts that ceiling on every backend.
  */
 template <class ExecSpace = Kokkos::DefaultExecutionSpace>
-using StateVectorRangePolicy =
+using RangePolicy =
     Kokkos::RangePolicy<ExecSpace, Kokkos::IndexType<std::size_t>>;
 
 template <int Rank, class ExecSpace = Kokkos::DefaultExecutionSpace>
-using StateVectorMDRangePolicy =
-    Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<Rank>,
-                          Kokkos::IndexType<std::size_t>>;
+using MDRangePolicy = Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<Rank>,
+                                            Kokkos::IndexType<std::size_t>>;
 
 template <class ExecSpace = Kokkos::DefaultExecutionSpace>
-using StateVectorTeamPolicy =
+using TeamPolicy =
     Kokkos::TeamPolicy<ExecSpace, Kokkos::IndexType<std::size_t>>;
 
 /**

--- a/pennylane_lightning/core/simulators/lightning_kokkos/utils/UtilKokkos.hpp
+++ b/pennylane_lightning/core/simulators/lightning_kokkos/utils/UtilKokkos.hpp
@@ -38,13 +38,12 @@ constexpr std::size_t one{1};
  * pin the `index_type` to `std::size_t`.
  *
  * Why: a default `Kokkos::RangePolicy<ExecutionSpace>` inherits its
- * `index_type` from `ExecutionSpace::size_type`, which on the HIP backend is
- * `unsigned int` (32 bits). For >= 32 qubits, kernels iterate over
- * `exp2(num_qubits) >= 2^32`, and Kokkos' bound-safety check aborts with
- * "Kokkos::RangePolicy bound type error: an unsafe implicit conversion is
+ * `index_type` from `ExecutionSpace::size_type`, which on the HIP/CUDA
+ * backend is `unsigned int` (32 bits). For >= 32 qubits, kernels iterate
+ * over `exp2(num_qubits) >= 2^32`, and Kokkos' bound-safety check aborts
+ * with "Kokkos::RangePolicy bound type error: an unsafe implicit conversion is
  * performed on a bound (4294967296)". Pinning the index type to `std::size_t`
- * lifts that ceiling on every backend and matches the type used for indices
- * throughout the rest of the codebase.
+ * lifts that ceiling on every backend.
  */
 template <class ExecSpace = Kokkos::DefaultExecutionSpace>
 using StateVectorRangePolicy =


### PR DESCRIPTION
**Context:**
Kokkos on CUDA/HIP devices by default uses 32 bit indices, which means that simulation fails for >=32 qubits. We face this problem on newer GPUs with larger memory e.g. MI300X, where circuits will have an error:
```
Kokkos::RangePolicy bound type error: an unsafe implicit conversion is performed on a bound (4294967296), which may not preserve its original value.

```

**Description of the Change:**
Use `std::size_t` for Kokkos indices, which will allow simulation up to 64 qubits. 

**Benefits:**
Be able to simulate  >=32 qubits on GPU with LK.

**Possible Drawbacks:**
Slight performance difference - negligible except for very small system with just measurement without any real workload.

On MI300X, we obtain the following measurements (gates looped over all wires multiple times):
```
=== paulix ===
qubits   baseline (ms)         pr (ms)    delta (ms)    overhead
    20          10.800          10.868        +0.068      +0.63%
    22          27.092          27.454        +0.362      +1.34%
    24          94.421          94.916        +0.495      +0.52%
    26         293.314         293.738        +0.424      +0.14%
    28        1230.227        1229.562        -0.665      -0.05%
    30        5278.789        5277.817        -0.972      -0.02%

=== cnot ===
qubits   baseline (ms)         pr (ms)    delta (ms)    overhead
    20          14.068          13.366        -0.702      -4.99%
    22          22.558          23.893        +1.334      +5.92%
    24          57.296          57.529        +0.233      +0.41%
    26         173.862         175.070        +1.209      +0.70%
    28         672.001         673.227        +1.226      +0.18%
    30        2790.078        2791.488        +1.410      +0.05%

=== rx ===
qubits   baseline (ms)         pr (ms)    delta (ms)    overhead
    20          10.718          10.760        +0.042      +0.39%
    22          33.851          33.540        -0.312      -0.92%
    24         120.239         120.153        -0.086      -0.07%
    26         318.608         318.227        -0.381      -0.12%
    28        1325.579        1332.019        +6.441      +0.49%
    30        5663.157        5714.734       +51.578      +0.91%

=== expval ===
qubits   baseline (ms)         pr (ms)    delta (ms)    overhead
    20           2.765           3.114        +0.349     +12.61%
    22           6.070           6.410        +0.340      +5.60%
    24          13.073          13.453        +0.380      +2.91%
    26          35.489          37.736        +2.247      +6.33%
    28         131.773         132.790        +1.017      +0.77%
    30         542.221         543.234        +1.013      +0.19%
```

We expect very little difference for MI300 (CDNA 3) for a few reasons, including native 64-bit ALU and large register file/low register pressure, and these workloads are memory bound.

**Related GitHub Issues:**
https://github.com/PennyLaneAI/pennylane-lightning/issues/1338

[sc-109851]