### PR TITLE
Improve the performance of the PCPhase gate

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Release 0.46.0-dev (development release)
-
 <h3>New features since last release</h3>
 
 <h3>Improvements 🛠</h3>
+
+- Add native CUDA implementation for PCPhase gate
+- Add similar implementation for currently unused general diagonal operator.
+[(#1383)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1384)
 
 <h3>Breaking changes 💔</h3>
 
@@ -28,6 +31,7 @@
 
 This release contains contributions from (in alphabetical order):
 
+Kalman Szenes
 Jake Zaia
 
 ---

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.46.0-dev4"
+__version__ = "0.46.0-dev5"

--- a/pennylane_lightning/core/simulators/lightning_gpu/CMakeLists.txt
+++ b/pennylane_lightning/core/simulators/lightning_gpu/CMakeLists.txt
@@ -20,7 +20,7 @@ if(ENABLE_MPI)
     findMPI_LG(lightning_external_libs)
 endif()
 
-set(LGPU_FILES  StateVectorCudaManaged.cpp initSV.cu
+set(LGPU_FILES  StateVectorCudaManaged.cpp initSV.cu gates/PCPhase.cu
                 CACHE INTERNAL "" FORCE)
 
 if(ENABLE_MPI)

--- a/pennylane_lightning/core/simulators/lightning_gpu/StateVectorCudaManaged.hpp
+++ b/pennylane_lightning/core/simulators/lightning_gpu/StateVectorCudaManaged.hpp
@@ -357,7 +357,8 @@ class StateVectorCudaManaged
 
             applyPCPhase_CUDA(
                 BaseType::getData(), BaseType::getDataBuffer().getLength(),
-                tgtsInt.data(), tgtsInt.size(), dimension, phase, 256,
+                nullptr, nullptr, 0, tgtsInt.data(), tgtsInt.size(), dimension,
+                phase, 256,
                 BaseType::getDataBuffer().getDevTag().getDeviceID(),
                 BaseType::getDataBuffer().getDevTag().getStreamID());
         } else if (native_gates_.find(opName) != native_gates_.end()) {
@@ -495,7 +496,7 @@ class StateVectorCudaManaged
             const PrecisionT phase = adjoint ? -params[0] : params[0];
             const auto dimension = static_cast<std::size_t>(params[1]);
 
-            applyControlledPCPhase_CUDA(
+            applyPCPhase_CUDA(
                 BaseType::getData(), BaseType::getDataBuffer().getLength(),
                 ctrlsInt.data(), ctrls_valuesInt.data(), ctrlsInt.size(),
                 tgtsInt.data(), tgtsInt.size(), dimension, phase, 256,

--- a/pennylane_lightning/core/simulators/lightning_gpu/StateVectorCudaManaged.hpp
+++ b/pennylane_lightning/core/simulators/lightning_gpu/StateVectorCudaManaged.hpp
@@ -355,11 +355,11 @@ class StateVectorCudaManaged
             auto tgtsInt = NormalizeCastIndices<std::size_t, int>(
                 wires, BaseType::getNumQubits());
 
+            const int block_size = 256;
             applyPCPhase_CUDA(
                 BaseType::getData(), BaseType::getDataBuffer().getLength(),
                 nullptr, nullptr, 0, tgtsInt.data(), tgtsInt.size(), dimension,
-                phase, 256,
-                BaseType::getDataBuffer().getDevTag().getDeviceID(),
+                phase, block_size, BaseType::getDataBuffer().getDevTag().getDeviceID(),
                 BaseType::getDataBuffer().getDevTag().getStreamID());
         } else if (native_gates_.find(opName) != native_gates_.end()) {
             applyParametricPauliGate_({opName}, ctrls, tgts, params.front(),

--- a/pennylane_lightning/core/simulators/lightning_gpu/StateVectorCudaManaged.hpp
+++ b/pennylane_lightning/core/simulators/lightning_gpu/StateVectorCudaManaged.hpp
@@ -36,6 +36,7 @@
 #include "cuGateCache.hpp"
 #include "cuGates_host.hpp"
 #include "cuda_helpers.hpp"
+#include "gates/PCPhase.hpp"
 
 #include "CPUMemoryModel.hpp"
 
@@ -349,19 +350,16 @@ class StateVectorCudaManaged
                 BaseType::getDataBuffer().getDevTag().getStreamID(),
                 getCublasCaller());
         } else if (opName == "PCPhase") {
-            const PrecisionT phase = params[0];
+            const PrecisionT phase = adjoint ? -params[0] : params[0];
             const auto dimension = static_cast<std::size_t>(params[1]);
-            const CFP_t upper_complex{std::cos(phase), std::sin(phase)};
-            const CFP_t lower_complex =
-                Pennylane::LightningGPU::Util::Conj(upper_complex);
+            auto tgtsInt = NormalizeCastIndices<std::size_t, int>(
+                wires, BaseType::getNumQubits());
 
-            std::vector<CFP_t> diagonal(Pennylane::Util::exp2(wires.size()),
-                                        lower_complex);
-
-            std::fill(diagonal.begin(), diagonal.begin() + dimension,
-                      upper_complex);
-            applyDevicePermutationGate_({}, diagonal.data(), {}, wires, {},
-                                        adjoint);
+            applyPCPhase_CUDA(
+                BaseType::getData(), BaseType::getDataBuffer().getLength(),
+                tgtsInt.data(), tgtsInt.size(), dimension, phase, 256,
+                BaseType::getDataBuffer().getDevTag().getDeviceID(),
+                BaseType::getDataBuffer().getDevTag().getStreamID());
         } else if (native_gates_.find(opName) != native_gates_.end()) {
             applyParametricPauliGate_({opName}, ctrls, tgts, params.front(),
                                       adjoint);
@@ -494,19 +492,15 @@ class StateVectorCudaManaged
             applyParametricPauliGeneralGate_(names, ctrlsInt, ctrls_valuesInt,
                                              tgtsInt, 2 * params[0], adjoint);
         } else if (opName == "PCPhase") {
-            const PrecisionT phase = params[0];
+            const PrecisionT phase = adjoint ? -params[0] : params[0];
             const auto dimension = static_cast<std::size_t>(params[1]);
-            const CFP_t upper_complex{std::cos(phase), std::sin(phase)};
-            const CFP_t lower_complex{std::cos(phase), -std::sin(phase)};
 
-            std::vector<CFP_t> diagonal(Pennylane::Util::exp2(tgt_wires.size()),
-                                        lower_complex);
-
-            std::fill(diagonal.begin(), diagonal.begin() + dimension,
-                      upper_complex);
-
-            applyDevicePermutationGate_({}, diagonal.data(), controlled_wires,
-                                        tgt_wires, controlled_values, adjoint);
+            applyControlledPCPhase_CUDA(
+                BaseType::getData(), BaseType::getDataBuffer().getLength(),
+                ctrlsInt.data(), ctrls_valuesInt.data(), ctrlsInt.size(),
+                tgtsInt.data(), tgtsInt.size(), dimension, phase, 256,
+                BaseType::getDataBuffer().getDevTag().getDeviceID(),
+                BaseType::getDataBuffer().getDevTag().getStreamID());
         } else if (native_gates_.find(opName) != native_gates_.end()) {
             applyParametricPauliGeneralGate_({opName}, ctrlsInt,
                                              ctrls_valuesInt, tgtsInt,

--- a/pennylane_lightning/core/simulators/lightning_gpu/StateVectorCudaManaged.hpp
+++ b/pennylane_lightning/core/simulators/lightning_gpu/StateVectorCudaManaged.hpp
@@ -355,11 +355,10 @@ class StateVectorCudaManaged
             auto tgtsInt = NormalizeCastIndices<std::size_t, int>(
                 wires, BaseType::getNumQubits());
 
-            const int block_size = 256;
             applyPCPhase_CUDA(
                 BaseType::getData(), BaseType::getDataBuffer().getLength(),
                 nullptr, nullptr, 0, tgtsInt.data(), tgtsInt.size(), dimension,
-                phase, block_size, BaseType::getDataBuffer().getDevTag().getDeviceID(),
+                phase, BaseType::getDataBuffer().getDevTag().getDeviceID(),
                 BaseType::getDataBuffer().getDevTag().getStreamID());
         } else if (native_gates_.find(opName) != native_gates_.end()) {
             applyParametricPauliGate_({opName}, ctrls, tgts, params.front(),
@@ -499,7 +498,7 @@ class StateVectorCudaManaged
             applyPCPhase_CUDA(
                 BaseType::getData(), BaseType::getDataBuffer().getLength(),
                 ctrlsInt.data(), ctrls_valuesInt.data(), ctrlsInt.size(),
-                tgtsInt.data(), tgtsInt.size(), dimension, phase, 256,
+                tgtsInt.data(), tgtsInt.size(), dimension, phase,
                 BaseType::getDataBuffer().getDevTag().getDeviceID(),
                 BaseType::getDataBuffer().getDevTag().getStreamID());
         } else if (native_gates_.find(opName) != native_gates_.end()) {

--- a/pennylane_lightning/core/simulators/lightning_gpu/StateVectorCudaManaged.hpp
+++ b/pennylane_lightning/core/simulators/lightning_gpu/StateVectorCudaManaged.hpp
@@ -356,9 +356,9 @@ class StateVectorCudaManaged
                 wires, BaseType::getNumQubits());
 
             applyPCPhase_CUDA(
-                BaseType::getData(), BaseType::getDataBuffer().getLength(),
-                nullptr, nullptr, 0, tgtsInt.data(), tgtsInt.size(), dimension,
-                phase, BaseType::getDataBuffer().getDevTag().getDeviceID(),
+                BaseType::getData(), BaseType::getDataBuffer().getLength(), {},
+                {}, tgtsInt, dimension, phase,
+                BaseType::getDataBuffer().getDevTag().getDeviceID(),
                 BaseType::getDataBuffer().getDevTag().getStreamID());
         } else if (native_gates_.find(opName) != native_gates_.end()) {
             applyParametricPauliGate_({opName}, ctrls, tgts, params.front(),
@@ -497,8 +497,7 @@ class StateVectorCudaManaged
 
             applyPCPhase_CUDA(
                 BaseType::getData(), BaseType::getDataBuffer().getLength(),
-                ctrlsInt.data(), ctrls_valuesInt.data(), ctrlsInt.size(),
-                tgtsInt.data(), tgtsInt.size(), dimension, phase,
+                ctrlsInt, ctrls_valuesInt, tgtsInt, dimension, phase,
                 BaseType::getDataBuffer().getDevTag().getDeviceID(),
                 BaseType::getDataBuffer().getDevTag().getStreamID());
         } else if (native_gates_.find(opName) != native_gates_.end()) {

--- a/pennylane_lightning/core/simulators/lightning_gpu/gates/PCPhase.cu
+++ b/pennylane_lightning/core/simulators/lightning_gpu/gates/PCPhase.cu
@@ -61,8 +61,8 @@ inline auto makePCPhaseWireList(const int *wires, std::size_t num_wires,
 template <class GPUDataT>
 __global__ void applyPCPhaseKernel(GPUDataT *sv, std::size_t sv_length,
                                    PCPhaseWireList ctrls, PCPhaseWireList tgts,
-                                   std::size_t dimension, GPUDataT upper,
-                                   GPUDataT lower) {
+                                   std::size_t dimension, GPUDataT factor
+                                   ) {
     const std::size_t index =
         static_cast<std::size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
     if (index >= sv_length) {
@@ -91,7 +91,7 @@ __global__ void applyPCPhaseKernel(GPUDataT *sv, std::size_t sv_length,
         target_index |= bit;
     }
 
-    sv[index] = Util::Cmul(sv[index], target_index < dimension ? upper : lower);
+    sv[index] = Util::Cmul(sv[index], target_index < dimension ? factor : Util::Conj(factor));
 }
 
 template <class GPUDataT>
@@ -141,17 +141,15 @@ void applyPCPhase_CUDA_call(GPUDataT *sv, std::size_t sv_length,
     const auto control_list =
         makePCPhaseWireList(ctrls, num_ctrls, ctrl_values);
     const auto target_list = makePCPhaseWireList(tgts, num_tgts);
-    const auto upper =
+    const auto factor =
         makeCudaComplex<GPUDataT>(std::cos(phase), std::sin(phase));
-    const auto lower =
-        makeCudaComplex<GPUDataT>(std::cos(phase), -std::sin(phase));
 
     const std::size_t threads_per_block = 256;
     const std::size_t blocks_per_grid = std::max<std::size_t>(
         (sv_length + threads_per_block - 1) / threads_per_block, 1);
     applyPCPhaseKernel<GPUDataT>
         <<<blocks_per_grid, threads_per_block, 0, stream_id>>>(
-            sv, sv_length, control_list, target_list, dimension, upper, lower);
+            sv, sv_length, control_list, target_list, dimension, factor);
     PL_CUDA_IS_SUCCESS(cudaGetLastError());
     PL_CUDA_IS_SUCCESS(cudaStreamSynchronize(stream_id));
 }

--- a/pennylane_lightning/core/simulators/lightning_gpu/gates/PCPhase.cu
+++ b/pennylane_lightning/core/simulators/lightning_gpu/gates/PCPhase.cu
@@ -15,6 +15,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstddef>
 
 #include "Error.hpp"
 #include "cuError.hpp"
@@ -31,24 +32,39 @@ struct WireValueList {
     int values[maxPCPhaseWires]{};
 };
 
-inline auto makePCPhaseWireList(const int *wires, std::size_t num_wires,
-                                const int *values = nullptr) -> WireValueList {
-    PL_ABORT_IF(num_wires > maxPCPhaseWires,
-                "PCPhase supports at most 64 wires.");
-
-    WireValueList wire_list{};
-    wire_list.size = num_wires;
-    std::copy(wires, wires + num_wires, wire_list.wires);
-    if (values != nullptr) {
-        std::copy(values, values + num_wires, wire_list.values);
+struct WireInfo {
+    std::uint64_t ctrl_mask = 0;
+    std::uint64_t ctrl_vals = 0;
+    std::size_t num_tgts = 0;
+    int tgt_wires[maxPCPhaseWires]{};
+    WireInfo(const std::vector<int> &ctrl_wires,
+             const std::vector<int> &ctrl_vals_vec,
+             const std::vector<int> &tgt_wires_vec) {
+        num_tgts = tgt_wires_vec.size();
+        std::copy(tgt_wires_vec.begin(), tgt_wires_vec.end(), tgt_wires);
+        std::tie(ctrl_mask, ctrl_vals) =
+            makeCtrlMaskValues(ctrl_wires, ctrl_vals_vec);
     }
-    return wire_list;
-}
+    auto makeCtrlMaskValues(const std::vector<int> &wires,
+                            const std::vector<int> &values)
+        -> std::pair<std::uint64_t, std::uint64_t> {
+        std::uint64_t mask = 0;
+        std::uint64_t value = 0;
+        for (std::size_t i = 0; i < wires.size(); ++i) {
+            std::uint64_t bit = 1ULL << static_cast<unsigned>(wires[i]);
+            mask |= bit;
+            if (values[i]) {
+                value |= bit;
+            }
+        }
+        return {mask, value};
+    }
+};
 
 template <class GPUDataT>
 __global__ void applyPCPhaseKernel(GPUDataT *sv, std::size_t sv_length,
-                                   WireValueList ctrls, WireValueList tgts,
-                                   std::size_t dimension, GPUDataT factor) {
+                                   WireInfo params, std::size_t dimension,
+                                   GPUDataT factor) {
     const std::size_t index =
         static_cast<std::size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
     if (index >= sv_length) {
@@ -56,21 +72,16 @@ __global__ void applyPCPhaseKernel(GPUDataT *sv, std::size_t sv_length,
     }
 
     // Check if all control bits are set
-    for (std::size_t i = 0; i < ctrls.size; i++) {
-        const int bit = static_cast<int>(
-            (index >> static_cast<std::size_t>(ctrls.wires[i])) & 1U);
-        // If not exit
-        if (bit != ctrls.values[i]) {
-            return;
-        }
+    if ((index & params.ctrl_mask) != params.ctrl_vals) {
+        return;
     }
 
     // Extract target bits from index
     std::size_t target_index = 0;
-    for (std::size_t i = 0; i < tgts.size; i++) {
+    for (std::size_t i = 0; i < params.num_tgts; i++) {
         // Check if target bit is set
         const std::size_t bit =
-            (index >> static_cast<std::size_t>(tgts.wires[i])) & 1U;
+            (index >> static_cast<std::size_t>(params.tgt_wires[i])) & 1U;
         // Shift target index left and add bit
         target_index <<= 1U;
         // Add bit to target index
@@ -84,8 +95,7 @@ __global__ void applyPCPhaseKernel(GPUDataT *sv, std::size_t sv_length,
 
 template <class GPUDataT>
 __global__ void applyDiagKernel(GPUDataT *sv, std::size_t sv_length,
-                                WireValueList ctrls, WireValueList tgts,
-                                const GPUDataT *diag) {
+                                WireInfo info, const GPUDataT *diag) {
     const std::size_t index =
         static_cast<std::size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
     if (index >= sv_length) {
@@ -93,21 +103,16 @@ __global__ void applyDiagKernel(GPUDataT *sv, std::size_t sv_length,
     }
 
     // Check if all control bits are set
-    for (std::size_t i = 0; i < ctrls.size; i++) {
-        const int bit = static_cast<int>(
-            (index >> static_cast<std::size_t>(ctrls.wires[i])) & 1U);
-        // If not exit
-        if (bit != ctrls.values[i]) {
-            return;
-        }
+    if ((index & info.ctrl_mask) != info.ctrl_vals) {
+        return;
     }
 
     // Extract target bits from index and use as index into diagonal array
     std::size_t target_index = 0;
-    for (std::size_t i = 0; i < tgts.size; i++) {
+    for (std::size_t i = 0; i < info.num_tgts; i++) {
         // Check if target bit is set
         const std::size_t bit =
-            (index >> static_cast<std::size_t>(tgts.wires[i])) & 1U;
+            (index >> static_cast<std::size_t>(info.tgt_wires[i])) & 1U;
         // Shift target index left and add bit
         target_index <<= 1U;
         // Add bit to target index
@@ -120,66 +125,70 @@ __global__ void applyDiagKernel(GPUDataT *sv, std::size_t sv_length,
 } // namespace
 
 template <class GPUDataT, class PrecisionT>
-void applyPCPhase_CUDA(GPUDataT *sv, std::size_t sv_length, const int *ctrls,
-                       const int *ctrl_values, std::size_t num_ctrls,
-                       const int *tgts, std::size_t num_tgts,
+void applyPCPhase_CUDA(GPUDataT *sv, std::size_t sv_length,
+                       const std::vector<int> &ctrl_wires,
+                       const std::vector<int> &ctrl_values,
+                       const std::vector<int> &tgts_wires,
                        std::size_t dimension, PrecisionT phase, int device_id,
                        cudaStream_t stream_id) {
     PL_CUDA_IS_SUCCESS(cudaSetDevice(device_id));
 
-    const auto control_list =
-        makePCPhaseWireList(ctrls, num_ctrls, ctrl_values);
-    const auto target_list = makePCPhaseWireList(tgts, num_tgts);
     const auto factor = Util::complexToCu(
         std::complex<PrecisionT>{std::cos(phase), std::sin(phase)});
+
+    WireInfo wire_info(ctrl_wires, ctrl_values, tgts_wires);
 
     const std::size_t threads_per_block = 256;
     const std::size_t blocks_per_grid = std::max<std::size_t>(
         (sv_length + threads_per_block - 1) / threads_per_block, 1);
     applyPCPhaseKernel<GPUDataT>
         <<<blocks_per_grid, threads_per_block, 0, stream_id>>>(
-            sv, sv_length, control_list, target_list, dimension, factor);
+            sv, sv_length, wire_info, dimension, factor);
     PL_CUDA_IS_SUCCESS(cudaGetLastError());
     PL_CUDA_IS_SUCCESS(cudaStreamSynchronize(stream_id));
 }
 
 template <class GPUDataT>
-void applyDiag_CUDA(GPUDataT *sv, std::size_t sv_length, const int *ctrls,
-                    const int *ctrl_values, std::size_t num_ctrls,
-                    const int *tgts, std::size_t num_tgts, const GPUDataT *diag,
+void applyDiag_CUDA(GPUDataT *sv, std::size_t sv_length,
+                    const std::vector<int> &ctrl_wires,
+                    const std::vector<int> &ctrl_vals,
+                    const std::vector<int> &tgts_wires, const GPUDataT *diag,
                     int device_id, cudaStream_t stream_id) {
     PL_CUDA_IS_SUCCESS(cudaSetDevice(device_id));
 
-    const auto control_list =
-        makePCPhaseWireList(ctrls, num_ctrls, ctrl_values);
-    const auto target_list = makePCPhaseWireList(tgts, num_tgts);
-
+    const WireInfo wire_info(ctrl_wires, ctrl_vals, tgts_wires);
     const std::size_t threads_per_block = 256;
     const std::size_t blocks_per_grid = std::max<std::size_t>(
         (sv_length + threads_per_block - 1) / threads_per_block, 1);
     applyDiagKernel<GPUDataT>
-        <<<blocks_per_grid, threads_per_block, 0, stream_id>>>(
-            sv, sv_length, control_list, target_list, diag);
+        <<<blocks_per_grid, threads_per_block, 0, stream_id>>>(sv, sv_length,
+                                                               wire_info, diag);
     PL_CUDA_IS_SUCCESS(cudaGetLastError());
     PL_CUDA_IS_SUCCESS(cudaStreamSynchronize(stream_id));
 }
 
 // Explicit template instantiations
 template void applyPCPhase_CUDA<cuComplex, float>(cuComplex *, std::size_t,
-                                                  const int *, const int *,
-                                                  std::size_t, const int *,
-                                                  std::size_t, std::size_t,
-                                                  float, int, cudaStream_t);
+                                                  const std::vector<int> &,
+                                                  const std::vector<int> &,
+                                                  const std::vector<int> &,
+                                                  std::size_t, float, int,
+                                                  cudaStream_t);
 template void applyPCPhase_CUDA<cuDoubleComplex, double>(
-    cuDoubleComplex *, std::size_t, const int *, const int *, std::size_t,
-    const int *, std::size_t, std::size_t, double, int, cudaStream_t);
+    cuDoubleComplex *, std::size_t, const std::vector<int> &,
+    const std::vector<int> &, const std::vector<int> &, std::size_t, double,
+    int, cudaStream_t);
 
-template void applyDiag_CUDA<cuComplex>(cuComplex *, std::size_t, const int *,
-                                        const int *, std::size_t, const int *,
-                                        std::size_t, const cuComplex *, int,
-                                        cudaStream_t);
-template void applyDiag_CUDA<cuDoubleComplex>(
-    cuDoubleComplex *, std::size_t, const int *, const int *, std::size_t,
-    const int *, std::size_t, const cuDoubleComplex *, int, cudaStream_t);
+template void applyDiag_CUDA<cuComplex>(cuComplex *, std::size_t,
+                                        const std::vector<int> &,
+                                        const std::vector<int> &,
+                                        const std::vector<int> &,
+                                        const cuComplex *, int, cudaStream_t);
+template void applyDiag_CUDA<cuDoubleComplex>(cuDoubleComplex *, std::size_t,
+                                              const std::vector<int> &,
+                                              const std::vector<int> &,
+                                              const std::vector<int> &,
+                                              const cuDoubleComplex *, int,
+                                              cudaStream_t);
 
 } // namespace Pennylane::LightningGPU

--- a/pennylane_lightning/core/simulators/lightning_gpu/gates/PCPhase.cu
+++ b/pennylane_lightning/core/simulators/lightning_gpu/gates/PCPhase.cu
@@ -73,6 +73,7 @@ __global__ void applyPCPhaseKernel(GPUDataT *sv, std::size_t sv_length,
     for (std::size_t i = 0; i < ctrls.size; i++) {
         const int bit = static_cast<int>(
             (index >> static_cast<std::size_t>(ctrls.wires[i])) & 1U);
+        // If not exit
         if (bit != ctrls.values[i]) {
             return;
         }
@@ -98,8 +99,8 @@ void applyPCPhase_CUDA_call(GPUDataT *sv, std::size_t sv_length,
                             const int *ctrls, const int *ctrl_values,
                             std::size_t num_ctrls, const int *tgts,
                             std::size_t num_tgts, std::size_t dimension,
-                            PrecisionT phase, std::size_t thread_per_block,
-                            int device_id, cudaStream_t stream_id) {
+                            PrecisionT phase, int device_id,
+                            cudaStream_t stream_id) {
     PL_CUDA_IS_SUCCESS(cudaSetDevice(device_id));
 
     const auto control_list =
@@ -110,10 +111,11 @@ void applyPCPhase_CUDA_call(GPUDataT *sv, std::size_t sv_length,
     const auto lower =
         makeCudaComplex<GPUDataT>(std::cos(phase), -std::sin(phase));
 
-    const std::size_t block_per_grid = std::max<std::size_t>(
-        (sv_length + thread_per_block - 1) / thread_per_block, 1);
+    const std::size_t threads_per_block = 256;
+    const std::size_t blocks_per_grid = std::max<std::size_t>(
+        (sv_length + threads_per_block - 1) / threads_per_block, 1);
     applyPCPhaseKernel<GPUDataT>
-        <<<block_per_grid, thread_per_block, 0, stream_id>>>(
+        <<<blocks_per_grid, threads_per_block, 0, stream_id>>>(
             sv, sv_length, control_list, target_list, dimension, upper, lower);
     PL_CUDA_IS_SUCCESS(cudaGetLastError());
     PL_CUDA_IS_SUCCESS(cudaStreamSynchronize(stream_id));
@@ -123,22 +125,18 @@ void applyPCPhase_CUDA_call(GPUDataT *sv, std::size_t sv_length,
 void applyPCPhase_CUDA(cuComplex *sv, std::size_t sv_length, const int *ctrls,
                        const int *ctrl_values, std::size_t num_ctrls,
                        const int *tgts, std::size_t num_tgts,
-                       std::size_t dimension, float phase,
-                       std::size_t thread_per_block, int device_id,
+                       std::size_t dimension, float phase, int device_id,
                        cudaStream_t stream_id) {
     applyPCPhase_CUDA_call(sv, sv_length, ctrls, ctrl_values, num_ctrls, tgts,
-                           num_tgts, dimension, phase, thread_per_block,
-                           device_id, stream_id);
+                           num_tgts, dimension, phase, device_id, stream_id);
 }
 
 void applyPCPhase_CUDA(cuDoubleComplex *sv, std::size_t sv_length,
                        const int *ctrls, const int *ctrl_values,
                        std::size_t num_ctrls, const int *tgts,
                        std::size_t num_tgts, std::size_t dimension,
-                       double phase, std::size_t thread_per_block,
-                       int device_id, cudaStream_t stream_id) {
+                       double phase, int device_id, cudaStream_t stream_id) {
     applyPCPhase_CUDA_call(sv, sv_length, ctrls, ctrl_values, num_ctrls, tgts,
-                           num_tgts, dimension, phase, thread_per_block,
-                           device_id, stream_id);
+                           num_tgts, dimension, phase, device_id, stream_id);
 }
 } // namespace Pennylane::LightningGPU

--- a/pennylane_lightning/core/simulators/lightning_gpu/gates/PCPhase.cu
+++ b/pennylane_lightning/core/simulators/lightning_gpu/gates/PCPhase.cu
@@ -17,7 +17,6 @@
 #include <cmath>
 #include <cstddef>
 
-#include "Error.hpp"
 #include "cuError.hpp"
 #include "cuda_helpers.hpp"
 
@@ -26,12 +25,6 @@ namespace {
 
 // NOTE: structs can be directly passed to kernels, avoids having to H2D memcopy
 constexpr std::size_t maxPCPhaseWires = 64;
-struct WireValueList {
-    std::size_t size = 0;
-    int wires[maxPCPhaseWires]{};
-    int values[maxPCPhaseWires]{};
-};
-
 struct WireInfo {
     std::uint64_t ctrl_mask = 0;
     std::uint64_t ctrl_vals = 0;

--- a/pennylane_lightning/core/simulators/lightning_gpu/gates/PCPhase.cu
+++ b/pennylane_lightning/core/simulators/lightning_gpu/gates/PCPhase.cu
@@ -15,7 +15,6 @@
 
 #include <algorithm>
 #include <cmath>
-#include <type_traits>
 
 #include "Error.hpp"
 #include "cuError.hpp"
@@ -31,17 +30,6 @@ struct PCPhaseWireList {
     int wires[maxPCPhaseWires]{};
     int values[maxPCPhaseWires]{};
 };
-
-template <class GPUDataT, class PrecisionT>
-auto makeCudaComplex(PrecisionT real, PrecisionT imag) -> GPUDataT {
-    if constexpr (std::is_same_v<GPUDataT, cuComplex>) {
-        return make_cuFloatComplex(static_cast<float>(real),
-                                   static_cast<float>(imag));
-    } else {
-        return make_cuDoubleComplex(static_cast<double>(real),
-                                    static_cast<double>(imag));
-    }
-}
 
 inline auto makePCPhaseWireList(const int *wires, std::size_t num_wires,
                                 const int *values = nullptr)
@@ -129,20 +117,22 @@ __global__ void applyDiagKernel(GPUDataT *sv, std::size_t sv_length,
     sv[index] = Util::Cmul(sv[index], diag[target_index]);
 }
 
+} // namespace
+
 template <class GPUDataT, class PrecisionT>
-void applyPCPhase_CUDA_call(GPUDataT *sv, std::size_t sv_length,
-                            const int *ctrls, const int *ctrl_values,
-                            std::size_t num_ctrls, const int *tgts,
-                            std::size_t num_tgts, std::size_t dimension,
-                            PrecisionT phase, int device_id,
-                            cudaStream_t stream_id) {
+void applyPCPhase_CUDA(GPUDataT *sv, std::size_t sv_length,
+                      const int *ctrls, const int *ctrl_values,
+                      std::size_t num_ctrls, const int *tgts,
+                      std::size_t num_tgts, std::size_t dimension,
+                      PrecisionT phase, int device_id,
+                      cudaStream_t stream_id) {
     PL_CUDA_IS_SUCCESS(cudaSetDevice(device_id));
 
     const auto control_list =
         makePCPhaseWireList(ctrls, num_ctrls, ctrl_values);
     const auto target_list = makePCPhaseWireList(tgts, num_tgts);
-    const auto factor =
-        makeCudaComplex<GPUDataT>(std::cos(phase), std::sin(phase));
+    const auto factor = Util::complexToCu(
+        std::complex<PrecisionT>{std::cos(phase), std::sin(phase)});
 
     const std::size_t threads_per_block = 256;
     const std::size_t blocks_per_grid = std::max<std::size_t>(
@@ -155,11 +145,11 @@ void applyPCPhase_CUDA_call(GPUDataT *sv, std::size_t sv_length,
 }
 
 template <class GPUDataT>
-void applyDiag_CUDA_call(GPUDataT *sv, std::size_t sv_length,
-                         const int *ctrls, const int *ctrl_values,
-                         std::size_t num_ctrls, const int *tgts,
-                         std::size_t num_tgts, const GPUDataT *diag,
-                         int device_id, cudaStream_t stream_id) {
+void applyDiag_CUDA(GPUDataT *sv, std::size_t sv_length,
+                   const int *ctrls, const int *ctrl_values,
+                   std::size_t num_ctrls, const int *tgts,
+                   std::size_t num_tgts, const GPUDataT *diag,
+                   int device_id, cudaStream_t stream_id) {
     PL_CUDA_IS_SUCCESS(cudaSetDevice(device_id));
 
     const auto control_list =
@@ -175,41 +165,19 @@ void applyDiag_CUDA_call(GPUDataT *sv, std::size_t sv_length,
     PL_CUDA_IS_SUCCESS(cudaGetLastError());
     PL_CUDA_IS_SUCCESS(cudaStreamSynchronize(stream_id));
 }
-} // namespace
+// Explicit template instantiations
+template void applyPCPhase_CUDA<cuComplex, float>(
+    cuComplex *, std::size_t, const int *, const int *, std::size_t,
+    const int *, std::size_t, std::size_t, float, int, cudaStream_t);
+template void applyPCPhase_CUDA<cuDoubleComplex, double>(
+    cuDoubleComplex *, std::size_t, const int *, const int *, std::size_t,
+    const int *, std::size_t, std::size_t, double, int, cudaStream_t);
 
-void applyPCPhase_CUDA(cuComplex *sv, std::size_t sv_length, const int *ctrls,
-                       const int *ctrl_values, std::size_t num_ctrls,
-                       const int *tgts, std::size_t num_tgts,
-                       std::size_t dimension, float phase, int device_id,
-                       cudaStream_t stream_id) {
-    applyPCPhase_CUDA_call(sv, sv_length, ctrls, ctrl_values, num_ctrls, tgts,
-                           num_tgts, dimension, phase, device_id, stream_id);
-}
+template void applyDiag_CUDA<cuComplex>(
+    cuComplex *, std::size_t, const int *, const int *, std::size_t,
+    const int *, std::size_t, const cuComplex *, int, cudaStream_t);
+template void applyDiag_CUDA<cuDoubleComplex>(
+    cuDoubleComplex *, std::size_t, const int *, const int *, std::size_t,
+    const int *, std::size_t, const cuDoubleComplex *, int, cudaStream_t);
 
-void applyPCPhase_CUDA(cuDoubleComplex *sv, std::size_t sv_length,
-                       const int *ctrls, const int *ctrl_values,
-                       std::size_t num_ctrls, const int *tgts,
-                       std::size_t num_tgts, std::size_t dimension,
-                       double phase, int device_id, cudaStream_t stream_id) {
-    applyPCPhase_CUDA_call(sv, sv_length, ctrls, ctrl_values, num_ctrls, tgts,
-                           num_tgts, dimension, phase, device_id, stream_id);
-}
-
-void applyDiag_CUDA(cuComplex *sv, std::size_t sv_length, const int *ctrls,
-                    const int *ctrl_values, std::size_t num_ctrls,
-                    const int *tgts, std::size_t num_tgts,
-                    const cuComplex *diag, int device_id,
-                    cudaStream_t stream_id) {
-    applyDiag_CUDA_call(sv, sv_length, ctrls, ctrl_values, num_ctrls, tgts,
-                        num_tgts, diag, device_id, stream_id);
-}
-
-void applyDiag_CUDA(cuDoubleComplex *sv, std::size_t sv_length,
-                    const int *ctrls, const int *ctrl_values,
-                    std::size_t num_ctrls, const int *tgts,
-                    std::size_t num_tgts, const cuDoubleComplex *diag,
-                    int device_id, cudaStream_t stream_id) {
-    applyDiag_CUDA_call(sv, sv_length, ctrls, ctrl_values, num_ctrls, tgts,
-                        num_tgts, diag, device_id, stream_id);
-}
 } // namespace Pennylane::LightningGPU

--- a/pennylane_lightning/core/simulators/lightning_gpu/gates/PCPhase.cu
+++ b/pennylane_lightning/core/simulators/lightning_gpu/gates/PCPhase.cu
@@ -130,11 +130,9 @@ void applyPCPhase_CUDA_call(GPUDataT *sv, std::size_t sv_length,
         std::max<std::size_t>((sv_length + thread_per_block - 1) /
                                   thread_per_block,
                               1);
-    dim3 blockSize(thread_per_block, 1, 1);
-    dim3 gridSize(block_per_grid, 1);
-
-    applyPCPhaseKernel<GPUDataT><<<gridSize, blockSize, 0, stream_id>>>(
-        sv, sv_length, target_list, dimension, upper, lower);
+    applyPCPhaseKernel<GPUDataT>
+        <<<block_per_grid, thread_per_block, 0, stream_id>>>(
+            sv, sv_length, target_list, dimension, upper, lower);
     PL_CUDA_IS_SUCCESS(cudaGetLastError());
 }
 
@@ -158,11 +156,8 @@ void applyControlledPCPhase_CUDA_call(
         std::max<std::size_t>((sv_length + thread_per_block - 1) /
                                   thread_per_block,
                               1);
-    dim3 blockSize(thread_per_block, 1, 1);
-    dim3 gridSize(block_per_grid, 1);
-
     applyControlledPCPhaseKernel<GPUDataT>
-        <<<gridSize, blockSize, 0, stream_id>>>(
+        <<<block_per_grid, thread_per_block, 0, stream_id>>>(
             sv, sv_length, control_list, target_list, dimension, upper, lower);
     PL_CUDA_IS_SUCCESS(cudaGetLastError());
 }

--- a/pennylane_lightning/core/simulators/lightning_gpu/gates/PCPhase.cu
+++ b/pennylane_lightning/core/simulators/lightning_gpu/gates/PCPhase.cu
@@ -1,0 +1,215 @@
+// Copyright 2022-2023 Xanadu Quantum Technologies Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+/**
+ * @file PCPhase.cu
+ */
+#include "PCPhase.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <type_traits>
+
+#include "Error.hpp"
+#include "cuError.hpp"
+#include "cuda_helpers.hpp"
+
+namespace Pennylane::LightningGPU {
+namespace {
+constexpr std::size_t maxPCPhaseWires = 64;
+
+struct PCPhaseWireList {
+    std::size_t size = 0;
+    int wires[maxPCPhaseWires]{};
+    int values[maxPCPhaseWires]{};
+};
+
+template <class GPUDataT, class PrecisionT>
+auto makeCudaComplex(PrecisionT real, PrecisionT imag) -> GPUDataT {
+    if constexpr (std::is_same_v<GPUDataT, cuComplex>) {
+        return make_cuFloatComplex(static_cast<float>(real),
+                                   static_cast<float>(imag));
+    } else {
+        return make_cuDoubleComplex(static_cast<double>(real),
+                                    static_cast<double>(imag));
+    }
+}
+
+inline auto makePCPhaseWireList(const int *wires, std::size_t num_wires)
+    -> PCPhaseWireList {
+    PL_ABORT_IF(num_wires > maxPCPhaseWires,
+                "PCPhase supports at most 64 wires.");
+
+    PCPhaseWireList wire_list{};
+    wire_list.size = num_wires;
+    for (std::size_t i = 0; i < num_wires; i++) {
+        wire_list.wires[i] = wires[i];
+    }
+    return wire_list;
+}
+
+inline auto makePCPhaseControlList(const int *ctrls, const int *ctrl_values,
+                                   std::size_t num_ctrls)
+    -> PCPhaseWireList {
+    auto ctrl_list = makePCPhaseWireList(ctrls, num_ctrls);
+    for (std::size_t i = 0; i < num_ctrls; i++) {
+        ctrl_list.values[i] = ctrl_values[i];
+    }
+    return ctrl_list;
+}
+
+template <class GPUDataT>
+__global__ void applyPCPhaseKernel(GPUDataT *sv, std::size_t sv_length,
+                                   PCPhaseWireList tgts,
+                                   std::size_t dimension, GPUDataT upper,
+                                   GPUDataT lower) {
+    const std::size_t index =
+        static_cast<std::size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (index >= sv_length) {
+        return;
+    }
+
+    std::size_t target_index = 0;
+    for (std::size_t i = 0; i < tgts.size; i++) {
+        target_index =
+            (target_index << 1U) |
+            ((index >> static_cast<std::size_t>(tgts.wires[i])) & 1U);
+    }
+
+    sv[index] =
+        Util::Cmul(sv[index], target_index < dimension ? upper : lower);
+}
+
+template <class GPUDataT>
+__global__ void applyControlledPCPhaseKernel(
+    GPUDataT *sv, std::size_t sv_length, PCPhaseWireList ctrls,
+    PCPhaseWireList tgts, std::size_t dimension, GPUDataT upper,
+    GPUDataT lower) {
+    const std::size_t index =
+        static_cast<std::size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (index >= sv_length) {
+        return;
+    }
+
+    for (std::size_t i = 0; i < ctrls.size; i++) {
+        const int bit =
+            static_cast<int>((index >> static_cast<std::size_t>(ctrls.wires[i])) &
+                             1U);
+        if (bit != ctrls.values[i]) {
+            return;
+        }
+    }
+
+    std::size_t target_index = 0;
+    for (std::size_t i = 0; i < tgts.size; i++) {
+        target_index =
+            (target_index << 1U) |
+            ((index >> static_cast<std::size_t>(tgts.wires[i])) & 1U);
+    }
+
+    sv[index] =
+        Util::Cmul(sv[index], target_index < dimension ? upper : lower);
+}
+
+template <class GPUDataT, class PrecisionT>
+void applyPCPhase_CUDA_call(GPUDataT *sv, std::size_t sv_length,
+                            const int *tgts, std::size_t num_tgts,
+                            std::size_t dimension, PrecisionT phase,
+                            std::size_t thread_per_block, int device_id,
+                            cudaStream_t stream_id) {
+    PL_CUDA_IS_SUCCESS(cudaSetDevice(device_id));
+
+    const auto target_list = makePCPhaseWireList(tgts, num_tgts);
+    const auto upper = makeCudaComplex<GPUDataT>(std::cos(phase),
+                                                std::sin(phase));
+    const auto lower = makeCudaComplex<GPUDataT>(std::cos(phase),
+                                                -std::sin(phase));
+
+    const std::size_t block_per_grid =
+        std::max<std::size_t>((sv_length + thread_per_block - 1) /
+                                  thread_per_block,
+                              1);
+    dim3 blockSize(thread_per_block, 1, 1);
+    dim3 gridSize(block_per_grid, 1);
+
+    applyPCPhaseKernel<GPUDataT><<<gridSize, blockSize, 0, stream_id>>>(
+        sv, sv_length, target_list, dimension, upper, lower);
+    PL_CUDA_IS_SUCCESS(cudaGetLastError());
+}
+
+template <class GPUDataT, class PrecisionT>
+void applyControlledPCPhase_CUDA_call(
+    GPUDataT *sv, std::size_t sv_length, const int *ctrls,
+    const int *ctrl_values, std::size_t num_ctrls, const int *tgts,
+    std::size_t num_tgts, std::size_t dimension, PrecisionT phase,
+    std::size_t thread_per_block, int device_id, cudaStream_t stream_id) {
+    PL_CUDA_IS_SUCCESS(cudaSetDevice(device_id));
+
+    const auto control_list = makePCPhaseControlList(ctrls, ctrl_values,
+                                                     num_ctrls);
+    const auto target_list = makePCPhaseWireList(tgts, num_tgts);
+    const auto upper = makeCudaComplex<GPUDataT>(std::cos(phase),
+                                                std::sin(phase));
+    const auto lower = makeCudaComplex<GPUDataT>(std::cos(phase),
+                                                -std::sin(phase));
+
+    const std::size_t block_per_grid =
+        std::max<std::size_t>((sv_length + thread_per_block - 1) /
+                                  thread_per_block,
+                              1);
+    dim3 blockSize(thread_per_block, 1, 1);
+    dim3 gridSize(block_per_grid, 1);
+
+    applyControlledPCPhaseKernel<GPUDataT>
+        <<<gridSize, blockSize, 0, stream_id>>>(
+            sv, sv_length, control_list, target_list, dimension, upper, lower);
+    PL_CUDA_IS_SUCCESS(cudaGetLastError());
+}
+} // namespace
+
+void applyPCPhase_CUDA(cuComplex *sv, std::size_t sv_length, const int *tgts,
+                       std::size_t num_tgts, std::size_t dimension,
+                       float phase, std::size_t thread_per_block,
+                       int device_id, cudaStream_t stream_id) {
+    applyPCPhase_CUDA_call(sv, sv_length, tgts, num_tgts, dimension, phase,
+                           thread_per_block, device_id, stream_id);
+}
+
+void applyPCPhase_CUDA(cuDoubleComplex *sv, std::size_t sv_length,
+                       const int *tgts, std::size_t num_tgts,
+                       std::size_t dimension, double phase,
+                       std::size_t thread_per_block, int device_id,
+                       cudaStream_t stream_id) {
+    applyPCPhase_CUDA_call(sv, sv_length, tgts, num_tgts, dimension, phase,
+                           thread_per_block, device_id, stream_id);
+}
+
+void applyControlledPCPhase_CUDA(cuComplex *sv, std::size_t sv_length,
+                                 const int *ctrls, const int *ctrl_values,
+                                 std::size_t num_ctrls, const int *tgts,
+                                 std::size_t num_tgts, std::size_t dimension,
+                                 float phase, std::size_t thread_per_block,
+                                 int device_id, cudaStream_t stream_id) {
+    applyControlledPCPhase_CUDA_call(
+        sv, sv_length, ctrls, ctrl_values, num_ctrls, tgts, num_tgts,
+        dimension, phase, thread_per_block, device_id, stream_id);
+}
+
+void applyControlledPCPhase_CUDA(cuDoubleComplex *sv, std::size_t sv_length,
+                                 const int *ctrls, const int *ctrl_values,
+                                 std::size_t num_ctrls, const int *tgts,
+                                 std::size_t num_tgts, std::size_t dimension,
+                                 double phase, std::size_t thread_per_block,
+                                 int device_id, cudaStream_t stream_id) {
+    applyControlledPCPhase_CUDA_call(
+        sv, sv_length, ctrls, ctrl_values, num_ctrls, tgts, num_tgts,
+        dimension, phase, thread_per_block, device_id, stream_id);
+}
+} // namespace Pennylane::LightningGPU

--- a/pennylane_lightning/core/simulators/lightning_gpu/gates/PCPhase.cu
+++ b/pennylane_lightning/core/simulators/lightning_gpu/gates/PCPhase.cu
@@ -23,8 +23,9 @@
 
 namespace Pennylane::LightningGPU {
 namespace {
-constexpr std::size_t maxPCPhaseWires = 64;
 
+// NOTE: structs can be directly passed to kernels, avoids having to H2D memcopy
+constexpr std::size_t maxPCPhaseWires = 64;
 struct PCPhaseWireList {
     std::size_t size = 0;
     int wires[maxPCPhaseWires]{};
@@ -61,31 +62,10 @@ inline auto makePCPhaseWireList(const int *wires, std::size_t num_wires,
 
 template <class GPUDataT>
 __global__ void applyPCPhaseKernel(GPUDataT *sv, std::size_t sv_length,
+                                   PCPhaseWireList ctrls,
                                    PCPhaseWireList tgts,
                                    std::size_t dimension, GPUDataT upper,
                                    GPUDataT lower) {
-    const std::size_t index =
-        static_cast<std::size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
-    if (index >= sv_length) {
-        return;
-    }
-
-    std::size_t target_index = 0;
-    for (std::size_t i = 0; i < tgts.size; i++) {
-        target_index =
-            (target_index << 1U) |
-            ((index >> static_cast<std::size_t>(tgts.wires[i])) & 1U);
-    }
-
-    sv[index] =
-        Util::Cmul(sv[index], target_index < dimension ? upper : lower);
-}
-
-template <class GPUDataT>
-__global__ void applyControlledPCPhaseKernel(
-    GPUDataT *sv, std::size_t sv_length, PCPhaseWireList ctrls,
-    PCPhaseWireList tgts, std::size_t dimension, GPUDataT upper,
-    GPUDataT lower) {
     const std::size_t index =
         static_cast<std::size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
     if (index >= sv_length) {
@@ -114,35 +94,11 @@ __global__ void applyControlledPCPhaseKernel(
 
 template <class GPUDataT, class PrecisionT>
 void applyPCPhase_CUDA_call(GPUDataT *sv, std::size_t sv_length,
-                            const int *tgts, std::size_t num_tgts,
-                            std::size_t dimension, PrecisionT phase,
-                            std::size_t thread_per_block, int device_id,
-                            cudaStream_t stream_id) {
-    PL_CUDA_IS_SUCCESS(cudaSetDevice(device_id));
-
-    const auto target_list = makePCPhaseWireList(tgts, num_tgts);
-    const auto upper = makeCudaComplex<GPUDataT>(std::cos(phase),
-                                                std::sin(phase));
-    const auto lower = makeCudaComplex<GPUDataT>(std::cos(phase),
-                                                -std::sin(phase));
-
-    const std::size_t block_per_grid =
-        std::max<std::size_t>((sv_length + thread_per_block - 1) /
-                                  thread_per_block,
-                              1);
-    applyPCPhaseKernel<GPUDataT>
-        <<<block_per_grid, thread_per_block, 0, stream_id>>>(
-            sv, sv_length, target_list, dimension, upper, lower);
-    PL_CUDA_IS_SUCCESS(cudaGetLastError());
-    PL_CUDA_IS_SUCCESS(cudaStreamSynchronize(stream_id));
-}
-
-template <class GPUDataT, class PrecisionT>
-void applyControlledPCPhase_CUDA_call(
-    GPUDataT *sv, std::size_t sv_length, const int *ctrls,
-    const int *ctrl_values, std::size_t num_ctrls, const int *tgts,
-    std::size_t num_tgts, std::size_t dimension, PrecisionT phase,
-    std::size_t thread_per_block, int device_id, cudaStream_t stream_id) {
+                            const int *ctrls, const int *ctrl_values,
+                            std::size_t num_ctrls, const int *tgts,
+                            std::size_t num_tgts, std::size_t dimension,
+                            PrecisionT phase, std::size_t thread_per_block,
+                            int device_id, cudaStream_t stream_id) {
     PL_CUDA_IS_SUCCESS(cudaSetDevice(device_id));
 
     const auto control_list = makePCPhaseWireList(ctrls, num_ctrls,
@@ -157,7 +113,7 @@ void applyControlledPCPhase_CUDA_call(
         std::max<std::size_t>((sv_length + thread_per_block - 1) /
                                   thread_per_block,
                               1);
-    applyControlledPCPhaseKernel<GPUDataT>
+    applyPCPhaseKernel<GPUDataT>
         <<<block_per_grid, thread_per_block, 0, stream_id>>>(
             sv, sv_length, control_list, target_list, dimension, upper, lower);
     PL_CUDA_IS_SUCCESS(cudaGetLastError());
@@ -165,42 +121,25 @@ void applyControlledPCPhase_CUDA_call(
 }
 } // namespace
 
-void applyPCPhase_CUDA(cuComplex *sv, std::size_t sv_length, const int *tgts,
+void applyPCPhase_CUDA(cuComplex *sv, std::size_t sv_length,
+                       const int *ctrls, const int *ctrl_values,
+                       std::size_t num_ctrls, const int *tgts,
                        std::size_t num_tgts, std::size_t dimension,
                        float phase, std::size_t thread_per_block,
                        int device_id, cudaStream_t stream_id) {
-    applyPCPhase_CUDA_call(sv, sv_length, tgts, num_tgts, dimension, phase,
-                           thread_per_block, device_id, stream_id);
+    applyPCPhase_CUDA_call(sv, sv_length, ctrls, ctrl_values, num_ctrls, tgts,
+                           num_tgts, dimension, phase, thread_per_block,
+                           device_id, stream_id);
 }
 
 void applyPCPhase_CUDA(cuDoubleComplex *sv, std::size_t sv_length,
-                       const int *tgts, std::size_t num_tgts,
-                       std::size_t dimension, double phase,
-                       std::size_t thread_per_block, int device_id,
-                       cudaStream_t stream_id) {
-    applyPCPhase_CUDA_call(sv, sv_length, tgts, num_tgts, dimension, phase,
-                           thread_per_block, device_id, stream_id);
-}
-
-void applyControlledPCPhase_CUDA(cuComplex *sv, std::size_t sv_length,
-                                 const int *ctrls, const int *ctrl_values,
-                                 std::size_t num_ctrls, const int *tgts,
-                                 std::size_t num_tgts, std::size_t dimension,
-                                 float phase, std::size_t thread_per_block,
-                                 int device_id, cudaStream_t stream_id) {
-    applyControlledPCPhase_CUDA_call(
-        sv, sv_length, ctrls, ctrl_values, num_ctrls, tgts, num_tgts,
-        dimension, phase, thread_per_block, device_id, stream_id);
-}
-
-void applyControlledPCPhase_CUDA(cuDoubleComplex *sv, std::size_t sv_length,
-                                 const int *ctrls, const int *ctrl_values,
-                                 std::size_t num_ctrls, const int *tgts,
-                                 std::size_t num_tgts, std::size_t dimension,
-                                 double phase, std::size_t thread_per_block,
-                                 int device_id, cudaStream_t stream_id) {
-    applyControlledPCPhase_CUDA_call(
-        sv, sv_length, ctrls, ctrl_values, num_ctrls, tgts, num_tgts,
-        dimension, phase, thread_per_block, device_id, stream_id);
+                       const int *ctrls, const int *ctrl_values,
+                       std::size_t num_ctrls, const int *tgts,
+                       std::size_t num_tgts, std::size_t dimension,
+                       double phase, std::size_t thread_per_block,
+                       int device_id, cudaStream_t stream_id) {
+    applyPCPhase_CUDA_call(sv, sv_length, ctrls, ctrl_values, num_ctrls, tgts,
+                           num_tgts, dimension, phase, thread_per_block,
+                           device_id, stream_id);
 }
 } // namespace Pennylane::LightningGPU

--- a/pennylane_lightning/core/simulators/lightning_gpu/gates/PCPhase.cu
+++ b/pennylane_lightning/core/simulators/lightning_gpu/gates/PCPhase.cu
@@ -25,19 +25,18 @@ namespace {
 
 // NOTE: structs can be directly passed to kernels, avoids having to H2D memcopy
 constexpr std::size_t maxPCPhaseWires = 64;
-struct PCPhaseWireList {
+struct WireValueList {
     std::size_t size = 0;
     int wires[maxPCPhaseWires]{};
     int values[maxPCPhaseWires]{};
 };
 
 inline auto makePCPhaseWireList(const int *wires, std::size_t num_wires,
-                                const int *values = nullptr)
-    -> PCPhaseWireList {
+                                const int *values = nullptr) -> WireValueList {
     PL_ABORT_IF(num_wires > maxPCPhaseWires,
                 "PCPhase supports at most 64 wires.");
 
-    PCPhaseWireList wire_list{};
+    WireValueList wire_list{};
     wire_list.size = num_wires;
     std::copy(wires, wires + num_wires, wire_list.wires);
     if (values != nullptr) {
@@ -48,7 +47,7 @@ inline auto makePCPhaseWireList(const int *wires, std::size_t num_wires,
 
 template <class GPUDataT>
 __global__ void applyPCPhaseKernel(GPUDataT *sv, std::size_t sv_length,
-                                   PCPhaseWireList ctrls, PCPhaseWireList tgts,
+                                   WireValueList ctrls, WireValueList tgts,
                                    std::size_t dimension, GPUDataT factor) {
     const std::size_t index =
         static_cast<std::size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
@@ -85,7 +84,7 @@ __global__ void applyPCPhaseKernel(GPUDataT *sv, std::size_t sv_length,
 
 template <class GPUDataT>
 __global__ void applyDiagKernel(GPUDataT *sv, std::size_t sv_length,
-                                PCPhaseWireList ctrls, PCPhaseWireList tgts,
+                                WireValueList ctrls, WireValueList tgts,
                                 const GPUDataT *diag) {
     const std::size_t index =
         static_cast<std::size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
@@ -164,6 +163,7 @@ void applyDiag_CUDA(GPUDataT *sv, std::size_t sv_length, const int *ctrls,
     PL_CUDA_IS_SUCCESS(cudaGetLastError());
     PL_CUDA_IS_SUCCESS(cudaStreamSynchronize(stream_id));
 }
+
 // Explicit template instantiations
 template void applyPCPhase_CUDA<cuComplex, float>(cuComplex *, std::size_t,
                                                   const int *, const int *,

--- a/pennylane_lightning/core/simulators/lightning_gpu/gates/PCPhase.cu
+++ b/pennylane_lightning/core/simulators/lightning_gpu/gates/PCPhase.cu
@@ -94,6 +94,41 @@ __global__ void applyPCPhaseKernel(GPUDataT *sv, std::size_t sv_length,
     sv[index] = Util::Cmul(sv[index], target_index < dimension ? upper : lower);
 }
 
+template <class GPUDataT>
+__global__ void applyDiagKernel(GPUDataT *sv, std::size_t sv_length,
+                                PCPhaseWireList ctrls, PCPhaseWireList tgts,
+                                const GPUDataT *diag) {
+    const std::size_t index =
+        static_cast<std::size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (index >= sv_length) {
+        return;
+    }
+
+    // Check if all control bits are set
+    for (std::size_t i = 0; i < ctrls.size; i++) {
+        const int bit = static_cast<int>(
+            (index >> static_cast<std::size_t>(ctrls.wires[i])) & 1U);
+        // If not exit
+        if (bit != ctrls.values[i]) {
+            return;
+        }
+    }
+
+    // Extract target bits from index and use as index into diagonal array
+    std::size_t target_index = 0;
+    for (std::size_t i = 0; i < tgts.size; i++) {
+        // Check if target bit is set
+        const std::size_t bit =
+            (index >> static_cast<std::size_t>(tgts.wires[i])) & 1U;
+        // Shift target index left and add bit
+        target_index <<= 1U;
+        // Add bit to target index
+        target_index |= bit;
+    }
+
+    sv[index] = Util::Cmul(sv[index], diag[target_index]);
+}
+
 template <class GPUDataT, class PrecisionT>
 void applyPCPhase_CUDA_call(GPUDataT *sv, std::size_t sv_length,
                             const int *ctrls, const int *ctrl_values,
@@ -120,6 +155,28 @@ void applyPCPhase_CUDA_call(GPUDataT *sv, std::size_t sv_length,
     PL_CUDA_IS_SUCCESS(cudaGetLastError());
     PL_CUDA_IS_SUCCESS(cudaStreamSynchronize(stream_id));
 }
+
+template <class GPUDataT>
+void applyDiag_CUDA_call(GPUDataT *sv, std::size_t sv_length,
+                         const int *ctrls, const int *ctrl_values,
+                         std::size_t num_ctrls, const int *tgts,
+                         std::size_t num_tgts, const GPUDataT *diag,
+                         int device_id, cudaStream_t stream_id) {
+    PL_CUDA_IS_SUCCESS(cudaSetDevice(device_id));
+
+    const auto control_list =
+        makePCPhaseWireList(ctrls, num_ctrls, ctrl_values);
+    const auto target_list = makePCPhaseWireList(tgts, num_tgts);
+
+    const std::size_t threads_per_block = 256;
+    const std::size_t blocks_per_grid = std::max<std::size_t>(
+        (sv_length + threads_per_block - 1) / threads_per_block, 1);
+    applyDiagKernel<GPUDataT>
+        <<<blocks_per_grid, threads_per_block, 0, stream_id>>>(
+            sv, sv_length, control_list, target_list, diag);
+    PL_CUDA_IS_SUCCESS(cudaGetLastError());
+    PL_CUDA_IS_SUCCESS(cudaStreamSynchronize(stream_id));
+}
 } // namespace
 
 void applyPCPhase_CUDA(cuComplex *sv, std::size_t sv_length, const int *ctrls,
@@ -138,5 +195,23 @@ void applyPCPhase_CUDA(cuDoubleComplex *sv, std::size_t sv_length,
                        double phase, int device_id, cudaStream_t stream_id) {
     applyPCPhase_CUDA_call(sv, sv_length, ctrls, ctrl_values, num_ctrls, tgts,
                            num_tgts, dimension, phase, device_id, stream_id);
+}
+
+void applyDiag_CUDA(cuComplex *sv, std::size_t sv_length, const int *ctrls,
+                    const int *ctrl_values, std::size_t num_ctrls,
+                    const int *tgts, std::size_t num_tgts,
+                    const cuComplex *diag, int device_id,
+                    cudaStream_t stream_id) {
+    applyDiag_CUDA_call(sv, sv_length, ctrls, ctrl_values, num_ctrls, tgts,
+                        num_tgts, diag, device_id, stream_id);
+}
+
+void applyDiag_CUDA(cuDoubleComplex *sv, std::size_t sv_length,
+                    const int *ctrls, const int *ctrl_values,
+                    std::size_t num_ctrls, const int *tgts,
+                    std::size_t num_tgts, const cuDoubleComplex *diag,
+                    int device_id, cudaStream_t stream_id) {
+    applyDiag_CUDA_call(sv, sv_length, ctrls, ctrl_values, num_ctrls, tgts,
+                        num_tgts, diag, device_id, stream_id);
 }
 } // namespace Pennylane::LightningGPU

--- a/pennylane_lightning/core/simulators/lightning_gpu/gates/PCPhase.cu
+++ b/pennylane_lightning/core/simulators/lightning_gpu/gates/PCPhase.cu
@@ -42,7 +42,8 @@ auto makeCudaComplex(PrecisionT real, PrecisionT imag) -> GPUDataT {
     }
 }
 
-inline auto makePCPhaseWireList(const int *wires, std::size_t num_wires)
+inline auto makePCPhaseWireList(const int *wires, std::size_t num_wires,
+                                const int *values = nullptr)
     -> PCPhaseWireList {
     PL_ABORT_IF(num_wires > maxPCPhaseWires,
                 "PCPhase supports at most 64 wires.");
@@ -51,18 +52,11 @@ inline auto makePCPhaseWireList(const int *wires, std::size_t num_wires)
     wire_list.size = num_wires;
     for (std::size_t i = 0; i < num_wires; i++) {
         wire_list.wires[i] = wires[i];
+        if (values != nullptr) {
+            wire_list.values[i] = values[i];
+        }
     }
     return wire_list;
-}
-
-inline auto makePCPhaseControlList(const int *ctrls, const int *ctrl_values,
-                                   std::size_t num_ctrls)
-    -> PCPhaseWireList {
-    auto ctrl_list = makePCPhaseWireList(ctrls, num_ctrls);
-    for (std::size_t i = 0; i < num_ctrls; i++) {
-        ctrl_list.values[i] = ctrl_values[i];
-    }
-    return ctrl_list;
 }
 
 template <class GPUDataT>
@@ -152,8 +146,8 @@ void applyControlledPCPhase_CUDA_call(
     std::size_t thread_per_block, int device_id, cudaStream_t stream_id) {
     PL_CUDA_IS_SUCCESS(cudaSetDevice(device_id));
 
-    const auto control_list = makePCPhaseControlList(ctrls, ctrl_values,
-                                                     num_ctrls);
+    const auto control_list = makePCPhaseWireList(ctrls, num_ctrls,
+                                                  ctrl_values);
     const auto target_list = makePCPhaseWireList(tgts, num_tgts);
     const auto upper = makeCudaComplex<GPUDataT>(std::cos(phase),
                                                 std::sin(phase));

--- a/pennylane_lightning/core/simulators/lightning_gpu/gates/PCPhase.cu
+++ b/pennylane_lightning/core/simulators/lightning_gpu/gates/PCPhase.cu
@@ -134,6 +134,7 @@ void applyPCPhase_CUDA_call(GPUDataT *sv, std::size_t sv_length,
         <<<block_per_grid, thread_per_block, 0, stream_id>>>(
             sv, sv_length, target_list, dimension, upper, lower);
     PL_CUDA_IS_SUCCESS(cudaGetLastError());
+    PL_CUDA_IS_SUCCESS(cudaStreamSynchronize(stream_id));
 }
 
 template <class GPUDataT, class PrecisionT>
@@ -160,6 +161,7 @@ void applyControlledPCPhase_CUDA_call(
         <<<block_per_grid, thread_per_block, 0, stream_id>>>(
             sv, sv_length, control_list, target_list, dimension, upper, lower);
     PL_CUDA_IS_SUCCESS(cudaGetLastError());
+    PL_CUDA_IS_SUCCESS(cudaStreamSynchronize(stream_id));
 }
 } // namespace
 

--- a/pennylane_lightning/core/simulators/lightning_gpu/gates/PCPhase.cu
+++ b/pennylane_lightning/core/simulators/lightning_gpu/gates/PCPhase.cu
@@ -49,8 +49,7 @@ inline auto makePCPhaseWireList(const int *wires, std::size_t num_wires,
 template <class GPUDataT>
 __global__ void applyPCPhaseKernel(GPUDataT *sv, std::size_t sv_length,
                                    PCPhaseWireList ctrls, PCPhaseWireList tgts,
-                                   std::size_t dimension, GPUDataT factor
-                                   ) {
+                                   std::size_t dimension, GPUDataT factor) {
     const std::size_t index =
         static_cast<std::size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
     if (index >= sv_length) {
@@ -78,8 +77,10 @@ __global__ void applyPCPhaseKernel(GPUDataT *sv, std::size_t sv_length,
         // Add bit to target index
         target_index |= bit;
     }
-
-    sv[index] = Util::Cmul(sv[index], target_index < dimension ? factor : Util::Conj(factor));
+    using RealT = decltype(factor.x);
+    RealT phase_sign = (target_index < dimension) ? RealT{1.0} : RealT{-1.0};
+    GPUDataT mult_factor{factor.x, phase_sign * factor.y};
+    sv[index] = Util::Cmul(sv[index], mult_factor);
 }
 
 template <class GPUDataT>
@@ -120,12 +121,11 @@ __global__ void applyDiagKernel(GPUDataT *sv, std::size_t sv_length,
 } // namespace
 
 template <class GPUDataT, class PrecisionT>
-void applyPCPhase_CUDA(GPUDataT *sv, std::size_t sv_length,
-                      const int *ctrls, const int *ctrl_values,
-                      std::size_t num_ctrls, const int *tgts,
-                      std::size_t num_tgts, std::size_t dimension,
-                      PrecisionT phase, int device_id,
-                      cudaStream_t stream_id) {
+void applyPCPhase_CUDA(GPUDataT *sv, std::size_t sv_length, const int *ctrls,
+                       const int *ctrl_values, std::size_t num_ctrls,
+                       const int *tgts, std::size_t num_tgts,
+                       std::size_t dimension, PrecisionT phase, int device_id,
+                       cudaStream_t stream_id) {
     PL_CUDA_IS_SUCCESS(cudaSetDevice(device_id));
 
     const auto control_list =
@@ -145,11 +145,10 @@ void applyPCPhase_CUDA(GPUDataT *sv, std::size_t sv_length,
 }
 
 template <class GPUDataT>
-void applyDiag_CUDA(GPUDataT *sv, std::size_t sv_length,
-                   const int *ctrls, const int *ctrl_values,
-                   std::size_t num_ctrls, const int *tgts,
-                   std::size_t num_tgts, const GPUDataT *diag,
-                   int device_id, cudaStream_t stream_id) {
+void applyDiag_CUDA(GPUDataT *sv, std::size_t sv_length, const int *ctrls,
+                    const int *ctrl_values, std::size_t num_ctrls,
+                    const int *tgts, std::size_t num_tgts, const GPUDataT *diag,
+                    int device_id, cudaStream_t stream_id) {
     PL_CUDA_IS_SUCCESS(cudaSetDevice(device_id));
 
     const auto control_list =
@@ -166,16 +165,19 @@ void applyDiag_CUDA(GPUDataT *sv, std::size_t sv_length,
     PL_CUDA_IS_SUCCESS(cudaStreamSynchronize(stream_id));
 }
 // Explicit template instantiations
-template void applyPCPhase_CUDA<cuComplex, float>(
-    cuComplex *, std::size_t, const int *, const int *, std::size_t,
-    const int *, std::size_t, std::size_t, float, int, cudaStream_t);
+template void applyPCPhase_CUDA<cuComplex, float>(cuComplex *, std::size_t,
+                                                  const int *, const int *,
+                                                  std::size_t, const int *,
+                                                  std::size_t, std::size_t,
+                                                  float, int, cudaStream_t);
 template void applyPCPhase_CUDA<cuDoubleComplex, double>(
     cuDoubleComplex *, std::size_t, const int *, const int *, std::size_t,
     const int *, std::size_t, std::size_t, double, int, cudaStream_t);
 
-template void applyDiag_CUDA<cuComplex>(
-    cuComplex *, std::size_t, const int *, const int *, std::size_t,
-    const int *, std::size_t, const cuComplex *, int, cudaStream_t);
+template void applyDiag_CUDA<cuComplex>(cuComplex *, std::size_t, const int *,
+                                        const int *, std::size_t, const int *,
+                                        std::size_t, const cuComplex *, int,
+                                        cudaStream_t);
 template void applyDiag_CUDA<cuDoubleComplex>(
     cuDoubleComplex *, std::size_t, const int *, const int *, std::size_t,
     const int *, std::size_t, const cuDoubleComplex *, int, cudaStream_t);

--- a/pennylane_lightning/core/simulators/lightning_gpu/gates/PCPhase.cu
+++ b/pennylane_lightning/core/simulators/lightning_gpu/gates/PCPhase.cu
@@ -51,19 +51,16 @@ inline auto makePCPhaseWireList(const int *wires, std::size_t num_wires,
 
     PCPhaseWireList wire_list{};
     wire_list.size = num_wires;
-    for (std::size_t i = 0; i < num_wires; i++) {
-        wire_list.wires[i] = wires[i];
-        if (values != nullptr) {
-            wire_list.values[i] = values[i];
-        }
+    std::copy(wires, wires + num_wires, wire_list.wires);
+    if (values != nullptr) {
+        std::copy(values, values + num_wires, wire_list.values);
     }
     return wire_list;
 }
 
 template <class GPUDataT>
 __global__ void applyPCPhaseKernel(GPUDataT *sv, std::size_t sv_length,
-                                   PCPhaseWireList ctrls,
-                                   PCPhaseWireList tgts,
+                                   PCPhaseWireList ctrls, PCPhaseWireList tgts,
                                    std::size_t dimension, GPUDataT upper,
                                    GPUDataT lower) {
     const std::size_t index =
@@ -72,24 +69,28 @@ __global__ void applyPCPhaseKernel(GPUDataT *sv, std::size_t sv_length,
         return;
     }
 
+    // Check if all control bits are set
     for (std::size_t i = 0; i < ctrls.size; i++) {
-        const int bit =
-            static_cast<int>((index >> static_cast<std::size_t>(ctrls.wires[i])) &
-                             1U);
+        const int bit = static_cast<int>(
+            (index >> static_cast<std::size_t>(ctrls.wires[i])) & 1U);
         if (bit != ctrls.values[i]) {
             return;
         }
     }
 
+    // Extract target bits from index
     std::size_t target_index = 0;
     for (std::size_t i = 0; i < tgts.size; i++) {
-        target_index =
-            (target_index << 1U) |
-            ((index >> static_cast<std::size_t>(tgts.wires[i])) & 1U);
+        // Check if target bit is set
+        const std::size_t bit =
+            (index >> static_cast<std::size_t>(tgts.wires[i])) & 1U;
+        // Shift target index left and add bit
+        target_index <<= 1U;
+        // Add bit to target index
+        target_index |= bit;
     }
 
-    sv[index] =
-        Util::Cmul(sv[index], target_index < dimension ? upper : lower);
+    sv[index] = Util::Cmul(sv[index], target_index < dimension ? upper : lower);
 }
 
 template <class GPUDataT, class PrecisionT>
@@ -101,18 +102,16 @@ void applyPCPhase_CUDA_call(GPUDataT *sv, std::size_t sv_length,
                             int device_id, cudaStream_t stream_id) {
     PL_CUDA_IS_SUCCESS(cudaSetDevice(device_id));
 
-    const auto control_list = makePCPhaseWireList(ctrls, num_ctrls,
-                                                  ctrl_values);
+    const auto control_list =
+        makePCPhaseWireList(ctrls, num_ctrls, ctrl_values);
     const auto target_list = makePCPhaseWireList(tgts, num_tgts);
-    const auto upper = makeCudaComplex<GPUDataT>(std::cos(phase),
-                                                std::sin(phase));
-    const auto lower = makeCudaComplex<GPUDataT>(std::cos(phase),
-                                                -std::sin(phase));
+    const auto upper =
+        makeCudaComplex<GPUDataT>(std::cos(phase), std::sin(phase));
+    const auto lower =
+        makeCudaComplex<GPUDataT>(std::cos(phase), -std::sin(phase));
 
-    const std::size_t block_per_grid =
-        std::max<std::size_t>((sv_length + thread_per_block - 1) /
-                                  thread_per_block,
-                              1);
+    const std::size_t block_per_grid = std::max<std::size_t>(
+        (sv_length + thread_per_block - 1) / thread_per_block, 1);
     applyPCPhaseKernel<GPUDataT>
         <<<block_per_grid, thread_per_block, 0, stream_id>>>(
             sv, sv_length, control_list, target_list, dimension, upper, lower);
@@ -121,12 +120,12 @@ void applyPCPhase_CUDA_call(GPUDataT *sv, std::size_t sv_length,
 }
 } // namespace
 
-void applyPCPhase_CUDA(cuComplex *sv, std::size_t sv_length,
-                       const int *ctrls, const int *ctrl_values,
-                       std::size_t num_ctrls, const int *tgts,
-                       std::size_t num_tgts, std::size_t dimension,
-                       float phase, std::size_t thread_per_block,
-                       int device_id, cudaStream_t stream_id) {
+void applyPCPhase_CUDA(cuComplex *sv, std::size_t sv_length, const int *ctrls,
+                       const int *ctrl_values, std::size_t num_ctrls,
+                       const int *tgts, std::size_t num_tgts,
+                       std::size_t dimension, float phase,
+                       std::size_t thread_per_block, int device_id,
+                       cudaStream_t stream_id) {
     applyPCPhase_CUDA_call(sv, sv_length, ctrls, ctrl_values, num_ctrls, tgts,
                            num_tgts, dimension, phase, thread_per_block,
                            device_id, stream_id);

--- a/pennylane_lightning/core/simulators/lightning_gpu/gates/PCPhase.hpp
+++ b/pennylane_lightning/core/simulators/lightning_gpu/gates/PCPhase.hpp
@@ -20,27 +20,17 @@
 
 namespace Pennylane::LightningGPU {
 
-void applyPCPhase_CUDA(cuComplex *sv, std::size_t sv_length, const int *tgts,
+void applyPCPhase_CUDA(cuComplex *sv, std::size_t sv_length,
+                       const int *ctrls, const int *ctrl_values,
+                       std::size_t num_ctrls, const int *tgts,
                        std::size_t num_tgts, std::size_t dimension,
                        float phase, std::size_t thread_per_block,
                        int device_id, cudaStream_t stream_id);
 void applyPCPhase_CUDA(cuDoubleComplex *sv, std::size_t sv_length,
-                       const int *tgts, std::size_t num_tgts,
-                       std::size_t dimension, double phase,
-                       std::size_t thread_per_block, int device_id,
-                       cudaStream_t stream_id);
-
-void applyControlledPCPhase_CUDA(cuComplex *sv, std::size_t sv_length,
-                                 const int *ctrls, const int *ctrl_values,
-                                 std::size_t num_ctrls, const int *tgts,
-                                 std::size_t num_tgts, std::size_t dimension,
-                                 float phase, std::size_t thread_per_block,
-                                 int device_id, cudaStream_t stream_id);
-void applyControlledPCPhase_CUDA(cuDoubleComplex *sv, std::size_t sv_length,
-                                 const int *ctrls, const int *ctrl_values,
-                                 std::size_t num_ctrls, const int *tgts,
-                                 std::size_t num_tgts, std::size_t dimension,
-                                 double phase, std::size_t thread_per_block,
-                                 int device_id, cudaStream_t stream_id);
+                       const int *ctrls, const int *ctrl_values,
+                       std::size_t num_ctrls, const int *tgts,
+                       std::size_t num_tgts, std::size_t dimension,
+                       double phase, std::size_t thread_per_block,
+                       int device_id, cudaStream_t stream_id);
 
 } // namespace Pennylane::LightningGPU

--- a/pennylane_lightning/core/simulators/lightning_gpu/gates/PCPhase.hpp
+++ b/pennylane_lightning/core/simulators/lightning_gpu/gates/PCPhase.hpp
@@ -20,12 +20,12 @@
 
 namespace Pennylane::LightningGPU {
 
-void applyPCPhase_CUDA(cuComplex *sv, std::size_t sv_length,
-                       const int *ctrls, const int *ctrl_values,
-                       std::size_t num_ctrls, const int *tgts,
-                       std::size_t num_tgts, std::size_t dimension,
-                       float phase, std::size_t thread_per_block,
-                       int device_id, cudaStream_t stream_id);
+void applyPCPhase_CUDA(cuComplex *sv, std::size_t sv_length, const int *ctrls,
+                       const int *ctrl_values, std::size_t num_ctrls,
+                       const int *tgts, std::size_t num_tgts,
+                       std::size_t dimension, float phase,
+                       std::size_t thread_per_block, int device_id,
+                       cudaStream_t stream_id);
 void applyPCPhase_CUDA(cuDoubleComplex *sv, std::size_t sv_length,
                        const int *ctrls, const int *ctrl_values,
                        std::size_t num_ctrls, const int *tgts,

--- a/pennylane_lightning/core/simulators/lightning_gpu/gates/PCPhase.hpp
+++ b/pennylane_lightning/core/simulators/lightning_gpu/gates/PCPhase.hpp
@@ -14,6 +14,8 @@
 #pragma once
 
 #include <cstddef>
+#include <driver_types.h>
+#include <vector>
 
 #include <cuComplex.h>
 #include <cuda.h>
@@ -21,32 +23,35 @@
 namespace Pennylane::LightningGPU {
 
 template <class GPUDataT, class PrecisionT>
-void applyPCPhase_CUDA(GPUDataT *sv, std::size_t sv_length, const int *ctrls,
-                       const int *ctrl_values, std::size_t num_ctrls,
-                       const int *tgts, std::size_t num_tgts,
-                       std::size_t dimension, PrecisionT phase, int device_id,
-                       cudaStream_t stream_id);
+void applyPCPhase_CUDA(GPUDataT *sv, std::size_t sv_length,
+                       const std::vector<int> &ctrl_wires,
+                       const std::vector<int> &ctrl_values,
+                       const std::vector<int> &tgt_wires, std::size_t dimension,
+                       PrecisionT phase, int device_id, cudaStream_t stream_id);
 
 extern template void applyPCPhase_CUDA<cuComplex, float>(
-    cuComplex *, std::size_t, const int *, const int *, std::size_t,
-    const int *, std::size_t, std::size_t, float, int, cudaStream_t);
-extern template void applyPCPhase_CUDA<cuDoubleComplex, double>(
-    cuDoubleComplex *, std::size_t, const int *, const int *, std::size_t,
-    const int *, std::size_t, std::size_t, double, int, cudaStream_t);
+    cuComplex *, std::size_t, const std::vector<int> &,
+    const std::vector<int> &, const std::vector<int> &, std::size_t, float, int,
+    cudaStream_t);
+extern template void applyPCPhase_CUDA<cuDoubleComplex, float>(
+    cuDoubleComplex *, std::size_t, const std::vector<int> &,
+    const std::vector<int> &, const std::vector<int> &, std::size_t, float, int,
+    cudaStream_t);
 
 template <class GPUDataT>
-void applyDiag_CUDA(GPUDataT *sv, std::size_t sv_length, const int *ctrls,
-                    const int *ctrl_values, std::size_t num_ctrls,
-                    const int *tgts, std::size_t num_tgts, const GPUDataT *diag,
+void applyDiag_CUDA(GPUDataT *sv, std::size_t sv_length,
+                    const std::vector<int> &ctrl_wires,
+                    const std::vector<int> &ctrl_vals,
+                    const std::vector<int> &tgt_wires, const GPUDataT *diag,
                     int device_id, cudaStream_t stream_id);
 
-extern template void applyDiag_CUDA<cuComplex>(cuComplex *, std::size_t,
-                                               const int *, const int *,
-                                               std::size_t, const int *,
-                                               std::size_t, const cuComplex *,
-                                               int, cudaStream_t);
+extern template void
+applyDiag_CUDA<cuComplex>(cuComplex *, std::size_t, const std::vector<int> &,
+                          const std::vector<int> &, const std::vector<int> &,
+                          const cuComplex *, int, cudaStream_t);
 extern template void applyDiag_CUDA<cuDoubleComplex>(
-    cuDoubleComplex *, std::size_t, const int *, const int *, std::size_t,
-    const int *, std::size_t, const cuDoubleComplex *, int, cudaStream_t);
+    cuDoubleComplex *, std::size_t, const std::vector<int> &,
+    const std::vector<int> &, const std::vector<int> &, const cuDoubleComplex *,
+    int, cudaStream_t);
 
 } // namespace Pennylane::LightningGPU

--- a/pennylane_lightning/core/simulators/lightning_gpu/gates/PCPhase.hpp
+++ b/pennylane_lightning/core/simulators/lightning_gpu/gates/PCPhase.hpp
@@ -23,14 +23,12 @@ namespace Pennylane::LightningGPU {
 void applyPCPhase_CUDA(cuComplex *sv, std::size_t sv_length, const int *ctrls,
                        const int *ctrl_values, std::size_t num_ctrls,
                        const int *tgts, std::size_t num_tgts,
-                       std::size_t dimension, float phase,
-                       std::size_t thread_per_block, int device_id,
+                       std::size_t dimension, float phase, int device_id,
                        cudaStream_t stream_id);
 void applyPCPhase_CUDA(cuDoubleComplex *sv, std::size_t sv_length,
                        const int *ctrls, const int *ctrl_values,
                        std::size_t num_ctrls, const int *tgts,
                        std::size_t num_tgts, std::size_t dimension,
-                       double phase, std::size_t thread_per_block,
-                       int device_id, cudaStream_t stream_id);
+                       double phase, int device_id, cudaStream_t stream_id);
 
 } // namespace Pennylane::LightningGPU

--- a/pennylane_lightning/core/simulators/lightning_gpu/gates/PCPhase.hpp
+++ b/pennylane_lightning/core/simulators/lightning_gpu/gates/PCPhase.hpp
@@ -1,0 +1,46 @@
+// Copyright 2022-2023 Xanadu Quantum Technologies Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+/**
+ * @file PCPhase.hpp
+ */
+#pragma once
+
+#include <cstddef>
+
+#include <cuComplex.h>
+#include <cuda.h>
+
+namespace Pennylane::LightningGPU {
+
+void applyPCPhase_CUDA(cuComplex *sv, std::size_t sv_length, const int *tgts,
+                       std::size_t num_tgts, std::size_t dimension,
+                       float phase, std::size_t thread_per_block,
+                       int device_id, cudaStream_t stream_id);
+void applyPCPhase_CUDA(cuDoubleComplex *sv, std::size_t sv_length,
+                       const int *tgts, std::size_t num_tgts,
+                       std::size_t dimension, double phase,
+                       std::size_t thread_per_block, int device_id,
+                       cudaStream_t stream_id);
+
+void applyControlledPCPhase_CUDA(cuComplex *sv, std::size_t sv_length,
+                                 const int *ctrls, const int *ctrl_values,
+                                 std::size_t num_ctrls, const int *tgts,
+                                 std::size_t num_tgts, std::size_t dimension,
+                                 float phase, std::size_t thread_per_block,
+                                 int device_id, cudaStream_t stream_id);
+void applyControlledPCPhase_CUDA(cuDoubleComplex *sv, std::size_t sv_length,
+                                 const int *ctrls, const int *ctrl_values,
+                                 std::size_t num_ctrls, const int *tgts,
+                                 std::size_t num_tgts, std::size_t dimension,
+                                 double phase, std::size_t thread_per_block,
+                                 int device_id, cudaStream_t stream_id);
+
+} // namespace Pennylane::LightningGPU

--- a/pennylane_lightning/core/simulators/lightning_gpu/gates/PCPhase.hpp
+++ b/pennylane_lightning/core/simulators/lightning_gpu/gates/PCPhase.hpp
@@ -20,26 +20,32 @@
 
 namespace Pennylane::LightningGPU {
 
-void applyPCPhase_CUDA(cuComplex *sv, std::size_t sv_length, const int *ctrls,
+template <class GPUDataT, class PrecisionT>
+void applyPCPhase_CUDA(GPUDataT *sv, std::size_t sv_length, const int *ctrls,
                        const int *ctrl_values, std::size_t num_ctrls,
                        const int *tgts, std::size_t num_tgts,
-                       std::size_t dimension, float phase, int device_id,
+                       std::size_t dimension, PrecisionT phase, int device_id,
                        cudaStream_t stream_id);
-void applyPCPhase_CUDA(cuDoubleComplex *sv, std::size_t sv_length,
-                       const int *ctrls, const int *ctrl_values,
-                       std::size_t num_ctrls, const int *tgts,
-                       std::size_t num_tgts, std::size_t dimension,
-                       double phase, int device_id, cudaStream_t stream_id);
 
-void applyDiag_CUDA(cuComplex *sv, std::size_t sv_length, const int *ctrls,
+extern template void applyPCPhase_CUDA<cuComplex, float>(
+    cuComplex *, std::size_t, const int *, const int *, std::size_t,
+    const int *, std::size_t, std::size_t, float, int, cudaStream_t);
+extern template void applyPCPhase_CUDA<cuDoubleComplex, double>(
+    cuDoubleComplex *, std::size_t, const int *, const int *, std::size_t,
+    const int *, std::size_t, std::size_t, double, int, cudaStream_t);
+
+template <class GPUDataT>
+void applyDiag_CUDA(GPUDataT *sv, std::size_t sv_length, const int *ctrls,
                     const int *ctrl_values, std::size_t num_ctrls,
                     const int *tgts, std::size_t num_tgts,
-                    const cuComplex *diag, int device_id,
+                    const GPUDataT *diag, int device_id,
                     cudaStream_t stream_id);
-void applyDiag_CUDA(cuDoubleComplex *sv, std::size_t sv_length,
-                    const int *ctrls, const int *ctrl_values,
-                    std::size_t num_ctrls, const int *tgts,
-                    std::size_t num_tgts, const cuDoubleComplex *diag,
-                    int device_id, cudaStream_t stream_id);
+
+extern template void applyDiag_CUDA<cuComplex>(
+    cuComplex *, std::size_t, const int *, const int *, std::size_t,
+    const int *, std::size_t, const cuComplex *, int, cudaStream_t);
+extern template void applyDiag_CUDA<cuDoubleComplex>(
+    cuDoubleComplex *, std::size_t, const int *, const int *, std::size_t,
+    const int *, std::size_t, const cuDoubleComplex *, int, cudaStream_t);
 
 } // namespace Pennylane::LightningGPU

--- a/pennylane_lightning/core/simulators/lightning_gpu/gates/PCPhase.hpp
+++ b/pennylane_lightning/core/simulators/lightning_gpu/gates/PCPhase.hpp
@@ -37,13 +37,14 @@ extern template void applyPCPhase_CUDA<cuDoubleComplex, double>(
 template <class GPUDataT>
 void applyDiag_CUDA(GPUDataT *sv, std::size_t sv_length, const int *ctrls,
                     const int *ctrl_values, std::size_t num_ctrls,
-                    const int *tgts, std::size_t num_tgts,
-                    const GPUDataT *diag, int device_id,
-                    cudaStream_t stream_id);
+                    const int *tgts, std::size_t num_tgts, const GPUDataT *diag,
+                    int device_id, cudaStream_t stream_id);
 
-extern template void applyDiag_CUDA<cuComplex>(
-    cuComplex *, std::size_t, const int *, const int *, std::size_t,
-    const int *, std::size_t, const cuComplex *, int, cudaStream_t);
+extern template void applyDiag_CUDA<cuComplex>(cuComplex *, std::size_t,
+                                               const int *, const int *,
+                                               std::size_t, const int *,
+                                               std::size_t, const cuComplex *,
+                                               int, cudaStream_t);
 extern template void applyDiag_CUDA<cuDoubleComplex>(
     cuDoubleComplex *, std::size_t, const int *, const int *, std::size_t,
     const int *, std::size_t, const cuDoubleComplex *, int, cudaStream_t);

--- a/pennylane_lightning/core/simulators/lightning_gpu/gates/PCPhase.hpp
+++ b/pennylane_lightning/core/simulators/lightning_gpu/gates/PCPhase.hpp
@@ -31,4 +31,15 @@ void applyPCPhase_CUDA(cuDoubleComplex *sv, std::size_t sv_length,
                        std::size_t num_tgts, std::size_t dimension,
                        double phase, int device_id, cudaStream_t stream_id);
 
+void applyDiag_CUDA(cuComplex *sv, std::size_t sv_length, const int *ctrls,
+                    const int *ctrl_values, std::size_t num_ctrls,
+                    const int *tgts, std::size_t num_tgts,
+                    const cuComplex *diag, int device_id,
+                    cudaStream_t stream_id);
+void applyDiag_CUDA(cuDoubleComplex *sv, std::size_t sv_length,
+                    const int *ctrls, const int *ctrl_values,
+                    std::size_t num_ctrls, const int *tgts,
+                    std::size_t num_tgts, const cuDoubleComplex *diag,
+                    int device_id, cudaStream_t stream_id);
+
 } // namespace Pennylane::LightningGPU

--- a/pennylane_lightning/core/simulators/lightning_gpu/gates/tests/Test_StateVectorCudaManaged_Param.cpp
+++ b/pennylane_lightning/core/simulators/lightning_gpu/gates/tests/Test_StateVectorCudaManaged_Param.cpp
@@ -1538,9 +1538,7 @@ TEMPLATE_TEST_CASE("LightningGPU::applyDiag_CUDA", "[LightningGPU_Param]",
         diag_device.CopyHostDataToGpu(diag.data(), diag.size());
 
         applyDiag_CUDA(sv_diag.getData(), sv_diag.getLength(),
-                       ctrlsInt.empty() ? nullptr : ctrlsInt.data(),
-                       ctrl_valuesInt.empty() ? nullptr : ctrl_valuesInt.data(),
-                       ctrlsInt.size(), tgtsInt.data(), tgtsInt.size(),
+                       ctrlsInt, ctrl_valuesInt, tgtsInt,
                        diag_device.getData(),
                        sv_diag.getDataBuffer().getDevTag().getDeviceID(),
                        sv_diag.getDataBuffer().getDevTag().getStreamID());

--- a/pennylane_lightning/core/simulators/lightning_gpu/gates/tests/Test_StateVectorCudaManaged_Param.cpp
+++ b/pennylane_lightning/core/simulators/lightning_gpu/gates/tests/Test_StateVectorCudaManaged_Param.cpp
@@ -27,11 +27,13 @@
 #include "Gates.hpp"
 #include "TestHelpers.hpp"
 
+#include "DataBuffer.hpp"
 #include "LinearAlg.hpp"
 #include "StateVectorCudaManaged.hpp"
 #include "cuGateCache.hpp"
 #include "cuGates_host.hpp"
 #include "cuda_helpers.hpp"
+#include "gates/PCPhase.hpp"
 
 /// @cond DEV
 namespace {
@@ -1489,6 +1491,75 @@ TEMPLATE_TEST_CASE("LightningGPU::applyPCPhase", "[LightningGPU_Param]", float,
 
         CHECK(sv_direct.getDataVector() ==
               Pennylane::Util::approx(expected_results));
+    }
+}
+
+TEMPLATE_TEST_CASE("LightningGPU::applyDiag_CUDA", "[LightningGPU_Param]",
+                   float, double) {
+    using ComplexT = std::complex<TestType>;
+    using CFP_t = StateVectorCudaManaged<TestType>::CFP_t;
+
+    const std::size_t num_qubits = 3;
+    const std::size_t sv_length = Pennylane::Util::exp2(num_qubits);
+
+    auto run_test = [&](const std::vector<std::size_t> &ctrls,
+                        const std::vector<bool> &ctrl_values,
+                        const std::vector<std::size_t> &tgts,
+                        const std::vector<ComplexT> &diag) {
+        std::vector<ComplexT> init(sv_length);
+        for (std::size_t i = 0; i < sv_length; i++) {
+            init[i] = {static_cast<TestType>(i + 1),
+                       static_cast<TestType>(-0.1 * i)};
+        }
+
+        StateVectorCudaManaged<TestType> sv_diag{init.data(), init.size()};
+        StateVectorCudaManaged<TestType> sv_matrix{init.data(), init.size()};
+
+        std::vector<ComplexT> matrix(diag.size() * diag.size(), {0.0, 0.0});
+        for (std::size_t i = 0; i < diag.size(); i++) {
+            matrix[i * (diag.size() + 1)] = diag[i];
+        }
+        sv_matrix.applyControlledMatrix(matrix.data(), ctrls, ctrl_values, tgts,
+                                        false);
+
+        const auto ctrlsInt =
+            Pennylane::LightningGPU::Util::NormalizeCastIndices<std::size_t,
+                                                                int>(
+                ctrls, num_qubits);
+        const auto tgtsInt =
+            Pennylane::LightningGPU::Util::NormalizeCastIndices<std::size_t,
+                                                                int>(
+                tgts, num_qubits);
+        const auto ctrl_valuesInt =
+            Pennylane::Util::cast_vector<bool, int>(ctrl_values);
+
+        DataBuffer<CFP_t> diag_device(diag.size(),
+                                      sv_diag.getDataBuffer().getDevTag());
+        diag_device.CopyHostDataToGpu(diag.data(), diag.size());
+
+        applyDiag_CUDA(sv_diag.getData(), sv_diag.getLength(),
+                       ctrlsInt.empty() ? nullptr : ctrlsInt.data(),
+                       ctrl_valuesInt.empty() ? nullptr : ctrl_valuesInt.data(),
+                       ctrlsInt.size(), tgtsInt.data(), tgtsInt.size(),
+                       diag_device.getData(),
+                       sv_diag.getDataBuffer().getDevTag().getDeviceID(),
+                       sv_diag.getDataBuffer().getDevTag().getStreamID());
+
+        CHECK(sv_diag.getDataVector() ==
+              Pennylane::Util::approx(sv_matrix.getDataVector()));
+    };
+
+    SECTION("uncontrolled two-target diagonal") {
+        run_test({}, {}, {0, 2},
+                 {{1.0, 0.0}, {0.0, 1.0}, {-2.0, 0.0}, {0.5, -0.25}});
+    }
+
+    SECTION("single zero-valued control") {
+        run_test({1}, {false}, {0}, {{0.25, 0.5}, {-1.0, 0.0}});
+    }
+
+    SECTION("mixed control values") {
+        run_test({2, 0}, {true, false}, {1}, {{1.5, 0.0}, {0.0, -1.0}});
     }
 }
 

--- a/pennylane_lightning/core/simulators/lightning_gpu/gates/tests/Test_StateVectorCudaManaged_Param.cpp
+++ b/pennylane_lightning/core/simulators/lightning_gpu/gates/tests/Test_StateVectorCudaManaged_Param.cpp
@@ -1536,9 +1536,8 @@ TEMPLATE_TEST_CASE("LightningGPU::applyDiag_CUDA", "[LightningGPU_Param]",
                                       sv_diag.getDataBuffer().getDevTag());
         diag_device.CopyHostDataToGpu(diag.data(), diag.size());
 
-        applyDiag_CUDA(sv_diag.getData(), sv_diag.getLength(),
-                       ctrlsInt, ctrl_valuesInt, tgtsInt,
-                       diag_device.getData(),
+        applyDiag_CUDA(sv_diag.getData(), sv_diag.getLength(), ctrlsInt,
+                       ctrl_valuesInt, tgtsInt, diag_device.getData(),
                        sv_diag.getDataBuffer().getDevTag().getDeviceID(),
                        sv_diag.getDataBuffer().getDevTag().getStreamID());
 

--- a/pennylane_lightning/core/simulators/lightning_gpu/gates/tests/Test_StateVectorCudaManaged_Param.cpp
+++ b/pennylane_lightning/core/simulators/lightning_gpu/gates/tests/Test_StateVectorCudaManaged_Param.cpp
@@ -27,7 +27,6 @@
 #include "Gates.hpp"
 #include "TestHelpers.hpp"
 
-#include "DataBuffer.hpp"
 #include "LinearAlg.hpp"
 #include "StateVectorCudaManaged.hpp"
 #include "cuGateCache.hpp"


### PR DESCRIPTION
**Context:**

The native PCPhase gate implementation on `lightning.gpu` was underperforming the decomposed version in terms of simpler gates.

**Description of the Change:**

PCPhase was implemented in terms of `custatevecApplyGeneralizedPermutationMatrix`, which seems to be inefficient. This PR implements a hand-written CUDA kernel for this operation as well as one for arbitrary diagonal operators.

**Benefits:**

<img width="1200" height="750" alt="pcphase_comparison" src="https://github.com/user-attachments/assets/12a10c03-f9f2-4657-af18-c0105e7f6eca" />

Approximately 2x faster now compared to the decomposed version and achieves ~82% of peak memory bandwidth on A100 (when no control wires are present).

Speedup for the QSVT workflow with fraction of PCPhase gates in circuit

 | Qubits | Time Score | PCPhase Fraction | PCPhase % |                       
 | :----- | ---------: | ---------------: | --------: |                       
 | 23     |       1.17 |        38/21,128 |    0.180% |                       
 | 24     |       1.17 |        38/39,480 |    0.096% |                       
 | 25     |       1.24 |        38/39,776 |    0.096% |                       
 | 26     |       1.43 |        38/27,122 |    0.140% |                       
 | 27     |       1.31 |        38/50,802 |    0.075% |                       
 | 28     |       1.34 |        38/52,134 |    0.073% |                       
 | 29     |       1.26 |        38/68,932 |    0.055% | 


**Possible Drawbacks:**

Maximum State Vector size (number of wires) assumed to be 64 qubits.

**Related GitHub Issues:**

[sc-114555]