### PR TITLE
Reduce wheel size and include OpenMP flag in LQ wheel

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -14,6 +14,9 @@
 
 <h3>Internal changes ⚙️</h3>
 
+- Reduced Lightning-Qubit and Lightning-Kokkos wheel size by fixing CIBW environment variable.
+  [(#XXXX)](https://github.com/PennyLaneAI/pennylane-lightning/pull/XXXX)
+
 - Update nightly RC builds to upload to testpypi from a single workflow; removed global id-token permission.
   [(#1377)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1377)
   [(#1379)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1379)
@@ -28,6 +31,7 @@
 
 This release contains contributions from (in alphabetical order):
 
+Joseph Lee,
 Jake Zaia
 
 ---

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -15,7 +15,7 @@
 <h3>Internal changes ⚙️</h3>
 
 - Reduced Lightning-Qubit and Lightning-Kokkos wheel size by fixing CIBW environment variable.
-  [(#XXXX)](https://github.com/PennyLaneAI/pennylane-lightning/pull/XXXX)
+  [(#1386)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1386)
 
 - Update nightly RC builds to upload to testpypi from a single workflow; removed global id-token permission.
   [(#1377)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1377)

--- a/.github/workflows/wheel_linux_aarch64.yml
+++ b/.github/workflows/wheel_linux_aarch64.yml
@@ -171,12 +171,7 @@ jobs:
             PATH="/opt/rh/gcc-toolset-13/root/usr/bin:$PATH"
 
           CIBW_ENVIRONMENT: |
-            PATH="/opt/rh/gcc-toolset-13/root/usr/bin:$PATH"
-            CMAKE_ARGS="-DCMAKE_BUILD_TYPE=Release"
-            if ${{ matrix.pl_backend == 'lightning_qubit'}}
-            then
-              CMAKE_ARGS="-DCMAKE_BUILD_TYPE=Release -DLQ_ENABLE_KERNEL_OMP=ON"
-            fi
+            PATH="/opt/rh/gcc-toolset-13/root/usr/bin:$PATH" CMAKE_ARGS="${{ matrix.pl_backend == 'lightning_qubit' && '-DCMAKE_BUILD_TYPE=Release -DLQ_ENABLE_KERNEL_OMP=ON' || '-DCMAKE_BUILD_TYPE=Release' }}"
 
           CIBW_MANYLINUX_AARCH64_IMAGE: manylinux_2_28
 

--- a/.github/workflows/wheel_linux_x86_64.yml
+++ b/.github/workflows/wheel_linux_x86_64.yml
@@ -174,12 +174,7 @@ jobs:
             PATH="/opt/rh/gcc-toolset-13/root/usr/bin:$PATH"
 
           CIBW_ENVIRONMENT: |
-            PATH="/opt/rh/gcc-toolset-13/root/usr/bin:$PATH"
-            CMAKE_ARGS="-DCMAKE_BUILD_TYPE=Release"
-            if ${{ matrix.pl_backend == 'lightning_qubit'}}
-            then
-              CMAKE_ARGS="-DCMAKE_BUILD_TYPE=Release -DLQ_ENABLE_KERNEL_OMP=ON"
-            fi
+            PATH="/opt/rh/gcc-toolset-13/root/usr/bin:$PATH" CMAKE_ARGS="${{ matrix.pl_backend == 'lightning_qubit' && '-DCMAKE_BUILD_TYPE=Release -DLQ_ENABLE_KERNEL_OMP=ON' || '-DCMAKE_BUILD_TYPE=Release' }}"
 
           CIBW_BEFORE_TEST: |
             python -m pip install --group tests

--- a/.github/workflows/wheel_macos_arm64.yml
+++ b/.github/workflows/wheel_macos_arm64.yml
@@ -92,11 +92,7 @@ jobs:
             python -m pip install ninja cmake setuptools
 
           CIBW_ENVIRONMENT: |
-            CMAKE_ARGS="-DCMAKE_CXX_COMPILER_TARGET=arm64-apple-macos11 -DCMAKE_SYSTEM_NAME=Darwin -DCMAKE_SYSTEM_PROCESSOR=ARM64 -DCMAKE_BUILD_TYPE=Release"
-            if ${{ matrix.pl_backend == 'lightning_qubit'}}
-            then
-              CMAKE_ARGS="-DCMAKE_CXX_COMPILER_TARGET=arm64-apple-macos11 -DCMAKE_SYSTEM_NAME=Darwin -DCMAKE_SYSTEM_PROCESSOR=ARM64 -DCMAKE_BUILD_TYPE=Release -DLQ_ENABLE_KERNEL_OMP=ON"
-            fi
+            CMAKE_ARGS="-DCMAKE_CXX_COMPILER_TARGET=arm64-apple-macos11 -DCMAKE_SYSTEM_NAME=Darwin -DCMAKE_SYSTEM_PROCESSOR=ARM64 -DCMAKE_BUILD_TYPE=Release${{ matrix.pl_backend == 'lightning_qubit' && ' -DLQ_ENABLE_KERNEL_OMP=ON' || '' }}"
 
           CIBW_BEFORE_TEST: |
             python -m pip install --group tests

--- a/.github/workflows/wheel_macos_arm64.yml
+++ b/.github/workflows/wheel_macos_arm64.yml
@@ -92,7 +92,7 @@ jobs:
             python -m pip install ninja cmake setuptools
 
           CIBW_ENVIRONMENT: |
-            CMAKE_ARGS="-DCMAKE_CXX_COMPILER_TARGET=arm64-apple-macos11 -DCMAKE_SYSTEM_NAME=Darwin -DCMAKE_SYSTEM_PROCESSOR=ARM64 -DCMAKE_BUILD_TYPE=Release${{ matrix.pl_backend == 'lightning_qubit' && ' -DLQ_ENABLE_KERNEL_OMP=ON' || '' }}"
+            CMAKE_ARGS="${{ matrix.pl_backend == 'lightning_qubit' && '-DCMAKE_CXX_COMPILER_TARGET=arm64-apple-macos11 -DCMAKE_SYSTEM_NAME=Darwin -DCMAKE_SYSTEM_PROCESSOR=ARM64 -DCMAKE_BUILD_TYPE=Release -DLQ_ENABLE_KERNEL_OMP=ON' || '-DCMAKE_CXX_COMPILER_TARGET=arm64-apple-macos11 -DCMAKE_SYSTEM_NAME=Darwin -DCMAKE_SYSTEM_PROCESSOR=ARM64 -DCMAKE_BUILD_TYPE=Release' }}"
 
           CIBW_BEFORE_TEST: |
             python -m pip install --group tests

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.46.0-dev4"
+__version__ = "0.46.0-dev5"

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.46.0-dev5"
+__version__ = "0.46.0-dev6"


### PR DESCRIPTION
**Context:**
CIBW environments are not applied correctly, leading to wrong CMAKE arguments, including RELEASE mode. 
Previously the OpenMP kernel flag also didn't get passed in.

**Description of the Change:**
Fix CIBW environment variables in wheel build actions

**Benefits:**
Reduced wheel sizes.
```
lk arm aarch64 20.4MB -> 4.3 MB
lk x86 21MB -> 4.6MB
lq 25.5MB -> 2.6MB
```

Faster LQ execution for pre-compiled wheels due to inclusion of OpenMP kernel flag.

**Possible Drawbacks:**

**Related GitHub Issues:**

[sc-119470]