### PR TITLE
Add missing PauliMeasure capability to lightning.qubit

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 <h3>Improvements 🛠</h3>
 
+- Updated missing device capabilities after PauliMeasure kernel was added in
+  [#1327](https://github.com/PennyLaneAI/pennylane-lightning/pull/1327).
+  [(#1389)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1389)
+
 <h3>Breaking changes 💔</h3>
 
 <h3>Deprecations 👋</h3>

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.46.0-dev8"
+__version__ = "0.46.0-dev9"

--- a/pennylane_lightning/lightning_gpu/lightning_gpu.toml
+++ b/pennylane_lightning/lightning_gpu/lightning_gpu.toml
@@ -26,6 +26,7 @@ PauliX                 = { properties = [ "invertible", "controllable", "differe
 PauliY                 = { properties = [ "invertible", "controllable", "differentiable" ] }
 PauliZ                 = { properties = [ "invertible", "controllable", "differentiable" ] }
 PauliRot               = { properties = [ "invertible",                                  ] }
+PauliMeasure           = { properties = [                                                ] }
 Hadamard               = { properties = [ "invertible", "controllable", "differentiable" ] }
 S                      = { properties = [ "invertible", "controllable", "differentiable" ] }
 SX                     = { properties = [ "invertible", "controllable", "differentiable" ] }

--- a/pennylane_lightning/lightning_kokkos/lightning_kokkos.toml
+++ b/pennylane_lightning/lightning_kokkos/lightning_kokkos.toml
@@ -45,6 +45,7 @@ PauliX                 = { properties = [ "invertible", "controllable", "differe
 PauliY                 = { properties = [ "invertible", "controllable", "differentiable" ] }
 PauliZ                 = { properties = [ "invertible", "controllable", "differentiable" ] }
 PauliRot               = { properties = [ "invertible",                                  ] }
+PauliMeasure           = { properties = [                                                ] }
 PhaseShift             = { properties = [ "invertible", "controllable", "differentiable" ] }
 PSWAP                  = { properties = [ "invertible", "controllable", "differentiable" ] }
 QubitUnitary           = { properties = [ "invertible", "controllable"                   ] }

--- a/pennylane_lightning/lightning_qubit/lightning_qubit.toml
+++ b/pennylane_lightning/lightning_qubit/lightning_qubit.toml
@@ -45,6 +45,7 @@ PauliX                 = { properties = [ "invertible", "controllable", "differe
 PauliY                 = { properties = [ "invertible", "controllable", "differentiable" ] }
 PauliZ                 = { properties = [ "invertible", "controllable", "differentiable" ] }
 PauliRot               = { properties = [ "invertible",                                  ] }
+PauliMeasure           = { properties = [                                                ] }
 PhaseShift             = { properties = [ "invertible", "controllable", "differentiable" ] }
 PSWAP                  = { properties = [ "invertible", "controllable", "differentiable" ] }
 QubitUnitary           = { properties = [ "invertible", "controllable",                  ] }


### PR DESCRIPTION
PR https://github.com/PennyLaneAI/pennylane-lightning/pull/1327 added native support for PPM execution to lightning devices, but didn't add this capability to the TOML files.

Related PR in Catalyst to make use of this capability from the frontend: https://github.com/PennyLaneAI/catalyst/pull/2816