### PR TITLE
Improve benchmark trigger mechanism

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -27,6 +27,9 @@
 
 <h3>Internal changes ⚙️</h3>
 
+- The `/benchmark` GitHub comment trigger can now accept additional arguments and has been renamed to `!benchmark`.
+  [(#1392)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1392)
+
 - Updated the release script with changes from the v0.45.0 release process.
   [(#1385)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1385)
 

--- a/.github/workflows/trigger_benchmarks.yml
+++ b/.github/workflows/trigger_benchmarks.yml
@@ -95,7 +95,7 @@ jobs:
               "pull_request_number": ${{ env.WEBHOOK_METADATA_PULL_REQUEST_NUMBER }},
               "pull_request_url": "${{ env.WEBHOOK_METADATA_PULL_REQUEST_URL }}",
               "comment_link_api": "${{ env.WEBHOOK_METADATA_COMMENT_LINK_API }}",
-              "comment_link_html": "${{ env.WEBHOOK_METADATA_COMMENT_LINK_HTML }}",
+              "comment_link_html": "${{ env.WEBHOOK_METADATA_COMMENT_LINK_HTML }}"
             }
 
       - name: React to original comment indicating webhook sent

--- a/.github/workflows/trigger_benchmarks.yml
+++ b/.github/workflows/trigger_benchmarks.yml
@@ -25,7 +25,7 @@ jobs:
           COMMENT_BODY: ${{ github.event.comment.body }}
           BENCHMARK_TRIGGER_COMMAND: ${{ env.BENCHMARK_TRIGGER_COMMAND }}
         run: |
-          if [ "$COMMENT_BODY" = "$BENCHMARK_TRIGGER_COMMAND" ]; then
+          if [[ "$COMMENT_BODY" =~ ^[[:space:]]*"$BENCHMARK_TRIGGER_COMMAND" ]]; then
             echo "triggers_benchmark=true" >> $GITHUB_OUTPUT
           else
             echo "triggers_benchmark=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/trigger_benchmarks.yml
+++ b/.github/workflows/trigger_benchmarks.yml
@@ -77,7 +77,8 @@ jobs:
 
           # The username of the person who commented the trigger command on the pull request
           WEBHOOK_METADATA_GITHUB_ACTOR: ${{ github.event.comment.user.login }}
-          WEBHOOK_METADATA_COMMENT_LINK: ${{ github.event.comment.html_url }}
+          WEBHOOK_METADATA_COMMENT_LINK_API: ${{ github.event.comment.url }}
+          WEBHOOK_METADATA_COMMENT_LINK_HTML: ${{ github.event.comment.html_url }}
 
           # Information regarding the pull request
           WEBHOOK_METADATA_PULL_REQUEST_NUMBER: ${{ github.event.issue.number }}
@@ -93,7 +94,8 @@ jobs:
               "github_actor": "${{ env.WEBHOOK_METADATA_GITHUB_ACTOR }}",
               "pull_request_number": ${{ env.WEBHOOK_METADATA_PULL_REQUEST_NUMBER }},
               "pull_request_url": "${{ env.WEBHOOK_METADATA_PULL_REQUEST_URL }}",
-              "comment_link": "${{ env.WEBHOOK_METADATA_COMMENT_LINK }}"
+              "comment_link_api": "${{ env.WEBHOOK_METADATA_COMMENT_LINK_API }}",
+              "comment_link_html": "${{ env.WEBHOOK_METADATA_COMMENT_LINK_HTML }}",
             }
 
       - name: React to original comment indicating webhook sent

--- a/.github/workflows/trigger_benchmarks.yml
+++ b/.github/workflows/trigger_benchmarks.yml
@@ -5,7 +5,7 @@ on:
       - created
 
 env:
-  BENCHMARK_TRIGGER_COMMAND: /benchmark
+  BENCHMARK_TRIGGER_COMMAND: "!benchmark"
 
 permissions:
   contents: read

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.46.0-dev12"
+__version__ = "0.46.0-dev13"


### PR DESCRIPTION
**Context:**
[sc-103160] plans to introduce support for extra arguments to the `/benchmark` trigger. To support this, we will have to change the `/benchmark` triggers in PennyLane, Lightning, and Catalyst to match on the beginning of the comment rather than the full comment.

**Description of the Change:**
Changes the check on the trigger condition for `/benchmark`, renames `/benchmark` to `!benchmark`

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-122206]
https://github.com/PennyLaneAI/pennylane/pull/9676
https://github.com/PennyLaneAI/catalyst/pull/2947