### PR TITLE
Upgrade macos to macos-15

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -27,6 +27,9 @@
 
 <h3>Internal changes ⚙️</h3>
 
+- Upgrade Mac runner to macos-15.
+  [(#1394)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1394)
+
 - Updated Sphinx to version 9.0.
   [(#1393)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1393)
 

--- a/.github/workflows/wheel_macos_arm64.yml
+++ b/.github/workflows/wheel_macos_arm64.yml
@@ -54,7 +54,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-14]
+        os: [macos-15]
         arch: [arm64]
         pl_backend: ["lightning_kokkos", "lightning_qubit"]
         cibw_build: ${{fromJson(needs.set_wheel_build_matrix.outputs.python_version)}}

--- a/.github/workflows/wheel_macos_arm64.yml
+++ b/.github/workflows/wheel_macos_arm64.yml
@@ -29,7 +29,7 @@ on:
         default: false
 
 env:
-  MACOSX_DEPLOYMENT_TARGET: 13.0
+  MACOSX_DEPLOYMENT_TARGET: 15.0
 
 concurrency:
   group: wheel_macos_arm64-${{ github.ref }}

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.46.0-dev14"
+__version__ = "0.46.0-dev15"


### PR DESCRIPTION
**Context:**
Macos-14 github runners will be deprecated on July 6th and will no longer be available after November 2nd 2026. See [statement](https://github.com/actions/runner-images/issues/13518)

**Description of the Change:**
Upgrade mac runners from macos-14 to macos-15

**Benefits:**
Mac runner stays up do date and available.

**Possible Drawbacks:**
None

**Related GitHub Issues:**
