### PR TITLE
Bump min Python from 3.11 to 3.12

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -60,6 +60,7 @@
 This release contains contributions from (in alphabetical order):
 
 Runor Agbaire,
+Yushao Chen,
 Jeffrey Kam,
 Joseph Lee,
 Jake Zaia

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -16,6 +16,9 @@
 
 <h3>Breaking changes 💔</h3>
 
+- Python 3.11 is no longer supported. The minimum required Python version is now 3.12.
+  [(#1395)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1395)
+
 <h3>Deprecations 👋</h3>
 
 <h3>Documentation 📝</h3>

--- a/.github/workflows/set_wheel_build_matrix.yml
+++ b/.github/workflows/set_wheel_build_matrix.yml
@@ -4,7 +4,7 @@ permissions:
   contents: read
 
 env:
-  PYTHON3_MIN_VERSION: "11"
+  PYTHON3_MIN_VERSION: "12"
   PYTHON3_MAX_VERSION: "14"
 
 on:

--- a/.github/workflows/upload-nightly-rc-release.yml
+++ b/.github/workflows/upload-nightly-rc-release.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.11"
+        python-version: "3.12"
         
     # Ensure setuptools is up-to-date for pyproject.toml processing
     - name: Install latest setuptools 

--- a/.github/workflows/wheel_linux_aarch64.yml
+++ b/.github/workflows/wheel_linux_aarch64.yml
@@ -1,7 +1,7 @@
 name: Wheel::Linux::ARM
 
 # **What it does**: Builds python wheels for Linux (ubuntu-24.04) architecture ARM 64 and store it as artifacts.
-#                   Python versions: 3.11, 3.12, 3.13, 3.14.
+#                   Python versions: 3.12, 3.13, 3.14.
 # **Why we have it**: To build wheels for pennylane-lightning installation.
 # **Who does it impact**: Wheels to be uploaded to PyPI.
 
@@ -118,7 +118,7 @@ jobs:
         kokkos_version: ${{ fromJson(needs.set_wheel_build_matrix.outputs.kokkos_version) }}
         container_img: ["quay.io/pypa/manylinux_2_28_aarch64"]
     timeout-minutes: 45
-    name: ${{ matrix.os }}::${{ matrix.arch }} - ${{ matrix.pl_backend }} (Python ${{ fromJson('{ "cp311-*":"3.11", "cp312-*":"3.12", "cp313-*":"3.13", "cp314-*":"3.14" }')[matrix.cibw_build] }})
+    name: ${{ matrix.os }}::${{ matrix.arch }} - ${{ matrix.pl_backend }} (Python ${{ fromJson('{ "cp312-*":"3.12", "cp313-*":"3.13", "cp314-*":"3.14" }')[matrix.cibw_build] }})
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -214,7 +214,7 @@ jobs:
           github.ref == 'refs/heads/main' ||
           steps.rc_build.outputs.match != ''
         with:
-          name: ${{ runner.os }}-wheels-${{ matrix.pl_backend }}-${{ fromJson('{ "cp311-*":"py311","cp312-*":"py312", "cp313-*":"py313", "cp314-*":"py314" }')[matrix.cibw_build] }}-${{ matrix.arch }}.zip
+          name: ${{ runner.os }}-wheels-${{ matrix.pl_backend }}-${{ fromJson('{ "cp312-*":"py312", "cp313-*":"py313", "cp314-*":"py314" }')[matrix.cibw_build] }}-${{ matrix.arch }}.zip
           path: ./wheelhouse/*.whl
           retention-days: 1
           include-hidden-files: true
@@ -245,7 +245,7 @@ jobs:
           github.ref == 'refs/heads/main' ||
           steps.rc_build.outputs.match != ''
         with:
-          name: ${{ runner.os }}-wheels-${{ matrix.pl_backend }}-${{ fromJson('{ "cp311-*":"py311","cp312-*":"py312", "cp313-*":"py313", "cp314-*":"py314" }')[matrix.cibw_build] }}-${{ matrix.arch }}.zip
+          name: ${{ runner.os }}-wheels-${{ matrix.pl_backend }}-${{ fromJson('{ "cp312-*":"py312", "cp313-*":"py313", "cp314-*":"py314" }')[matrix.cibw_build] }}-${{ matrix.arch }}.zip
           path: dist
 
       - name: Upload wheels to TestPyPI

--- a/.github/workflows/wheel_linux_aarch64_cuda.yml
+++ b/.github/workflows/wheel_linux_aarch64_cuda.yml
@@ -1,7 +1,7 @@
 name: Wheel::Linux::ARM::CUDA
 
 # **What it does**: Builds python wheels for Linux (ubuntu-24.04) architecture ARM 64 and store it as artifacts.
-#                   Python versions: 3.11, 3.12, 3.13, 3.14.
+#                   Python versions: 3.12, 3.13, 3.14.
 # **Why we have it**: To build wheels for pennylane-lightning installation.
 # **Who does it impact**: Wheels to be uploaded to PyPI.
 
@@ -53,7 +53,7 @@ jobs:
         cibw_build: ${{ fromJson(needs.set_wheel_build_matrix.outputs.python_version_gpu) }}
         container_img: ["quay.io/pypa/manylinux_2_28_aarch64"]
     timeout-minutes: 90 # FIXME: temporarily increased from 60
-    name: ${{ matrix.os }}::${{ matrix.arch }} - ${{ matrix.pl_backend }} (Python ${{ fromJson('{ "cp311-*":"3.11", "cp312-*":"3.12", "cp313-*":"3.13", "cp314-*":"3.14" }')[matrix.cibw_build] }})
+    name: ${{ matrix.os }}::${{ matrix.arch }} - ${{ matrix.pl_backend }} (Python ${{ fromJson('{ "cp312-*":"3.12", "cp313-*":"3.13", "cp314-*":"3.14" }')[matrix.cibw_build] }})
     runs-on: 
       - single-gpu-arm
     steps:
@@ -189,7 +189,7 @@ jobs:
           github.ref == 'refs/heads/main' ||
           steps.rc_build.outputs.match != ''
         with:
-          name: ${{ runner.os }}-wheels-${{ matrix.pl_backend }}-${{ fromJson('{ "cp311-*":"py311","cp312-*":"py312", "cp313-*":"py313", "cp314-*":"py314" }')[matrix.cibw_build] }}-${{ matrix.arch }}-cu${{ matrix.cuda_version }}.zip
+          name: ${{ runner.os }}-wheels-${{ matrix.pl_backend }}-${{ fromJson('{ "cp312-*":"py312", "cp313-*":"py313", "cp314-*":"py314" }')[matrix.cibw_build] }}-${{ matrix.arch }}-cu${{ matrix.cuda_version }}.zip
           path: ./wheelhouse/*.whl
           retention-days: 1
           include-hidden-files: true
@@ -228,7 +228,7 @@ jobs:
           github.ref == 'refs/heads/main' || 
           steps.rc_build.outputs.match != ''
         with:
-          name:  ${{ runner.os }}-wheels-${{ matrix.pl_backend }}-${{ fromJson('{ "cp311-*":"py311","cp312-*":"py312", "cp313-*":"py313", "cp314-*":"py314" }')[matrix.cibw_build] }}-${{ matrix.arch }}-cu${{ matrix.cuda_version }}.zip
+          name:  ${{ runner.os }}-wheels-${{ matrix.pl_backend }}-${{ fromJson('{ "cp312-*":"py312", "cp313-*":"py313", "cp314-*":"py314" }')[matrix.cibw_build] }}-${{ matrix.arch }}-cu${{ matrix.cuda_version }}.zip
           path: dist
 
       - name: Upload wheels to TestPyPI

--- a/.github/workflows/wheel_linux_x86_64.yml
+++ b/.github/workflows/wheel_linux_x86_64.yml
@@ -1,7 +1,7 @@
 name: Wheel::Linux::x86_64
 
 # **What it does**: Builds python wheels for Linux (ubuntu-24.04) architecture x86_64 and store it as artifacts.
-#                   Python versions: 3.11, 3.12, 3.13, 3.14.
+#                   Python versions: 3.12, 3.13, 3.14.
 # **Why we have it**: To build wheels for pennylane-lightning installation.
 # **Who does it impact**: Wheels to be uploaded to PyPI.
 
@@ -118,7 +118,7 @@ jobs:
         kokkos_version: ${{ fromJson(needs.set_wheel_build_matrix.outputs.kokkos_version) }}
         container_img: ["quay.io/pypa/manylinux_2_28_x86_64"]
     timeout-minutes: 30
-    name: Linux::${{ matrix.arch }} - ${{ matrix.pl_backend }} (Python ${{ fromJson('{ "cp311-*":"3.11","cp312-*":"3.12", "cp313-*":"3.13", "cp314-*":"3.14" }')[matrix.cibw_build] }})
+    name: Linux::${{ matrix.arch }} - ${{ matrix.pl_backend }} (Python ${{ fromJson('{ "cp312-*":"3.12", "cp313-*":"3.13", "cp314-*":"3.14" }')[matrix.cibw_build] }})
     runs-on: blacksmith-4vcpu-ubuntu-2404
     container:
       image: ${{ matrix.container_img }}
@@ -213,7 +213,7 @@ jobs:
           github.ref == 'refs/heads/main' ||
           steps.rc_build.outputs.match != ''
         with:
-          name: ${{ runner.os }}-wheels-${{ matrix.pl_backend }}-${{ fromJson('{ "cp311-*":"py311","cp312-*":"py312", "cp313-*":"py313", "cp314-*":"py314" }')[matrix.cibw_build] }}-${{ matrix.arch }}.zip
+          name: ${{ runner.os }}-wheels-${{ matrix.pl_backend }}-${{ fromJson('{ "cp312-*":"py312", "cp313-*":"py313", "cp314-*":"py314" }')[matrix.cibw_build] }}-${{ matrix.arch }}.zip
           path: ./wheelhouse/*.whl
           retention-days: 1
           include-hidden-files: true
@@ -244,7 +244,7 @@ jobs:
           github.ref == 'refs/heads/main' ||
           steps.rc_build.outputs.match != ''
         with:
-          name: ${{ runner.os }}-wheels-${{ matrix.pl_backend }}-${{ fromJson('{ "cp311-*":"py311","cp312-*":"py312", "cp313-*":"py313", "cp314-*":"py314" }')[matrix.cibw_build] }}-${{ matrix.arch }}.zip
+          name: ${{ runner.os }}-wheels-${{ matrix.pl_backend }}-${{ fromJson('{ "cp312-*":"py312", "cp313-*":"py313", "cp314-*":"py314" }')[matrix.cibw_build] }}-${{ matrix.arch }}.zip
           path: dist
 
       - name: Upload wheels to TestPyPI

--- a/.github/workflows/wheel_linux_x86_64_cuda.yml
+++ b/.github/workflows/wheel_linux_x86_64_cuda.yml
@@ -1,7 +1,7 @@
 name: Wheel::Linux::x86_64::CUDA
 
 # **What it does**: Builds python wheels for Linux (ubuntu-24.04) architecture x86_64 and store it as artifacts.
-#                   Python versions: 3.11, 3.12, 3.13, 3.14.
+#                   Python versions: 3.12, 3.13, 3.14.
 # **Why we have it**: To build wheels for pennylane-lightning-gpu installation.
 # **Who does it impact**: Wheels to be uploaded to PyPI.
 on:
@@ -56,7 +56,7 @@ jobs:
         cibw_build: ${{ fromJson(needs.set_wheel_build_matrix.outputs.python_version_gpu) }}
         container_img: ["quay.io/pypa/manylinux_2_28_x86_64"]
     timeout-minutes: 30
-    name: Linux::${{ matrix.arch }} - ${{ matrix.pl_backend }} CUDA ${{ matrix.cuda_version }} (Python ${{ fromJson('{"cp311-*":"3.11","cp312-*":"3.12","cp313-*":"3.13","cp314-*":"3.14"}')[matrix.cibw_build] }})
+    name: Linux::${{ matrix.arch }} - ${{ matrix.pl_backend }} CUDA ${{ matrix.cuda_version }} (Python ${{ fromJson('{"cp312-*":"3.12","cp313-*":"3.13","cp314-*":"3.14"}')[matrix.cibw_build] }})
     runs-on: blacksmith-4vcpu-ubuntu-2404
     container:
       image: ${{ matrix.container_img }}
@@ -132,7 +132,7 @@ jobs:
           github.ref == 'refs/heads/main' ||
           steps.rc_build.outputs.match != ''
         with:
-          name: ${{ runner.os }}-wheels-${{ matrix.pl_backend }}-${{ fromJson('{ "cp311-*":"py311","cp312-*":"py312","cp313-*":"py313","cp314-*":"py314" }')[matrix.cibw_build] }}-${{ matrix.arch }}-cu${{ matrix.cuda_version }}.zip
+          name: ${{ runner.os }}-wheels-${{ matrix.pl_backend }}-${{ fromJson('{ "cp312-*":"py312","cp313-*":"py313","cp314-*":"py314" }')[matrix.cibw_build] }}-${{ matrix.arch }}-cu${{ matrix.cuda_version }}.zip
           path: ./wheelhouse/*.whl
           retention-days: 1
           include-hidden-files: true
@@ -164,7 +164,7 @@ jobs:
           github.ref == 'refs/heads/main' || 
           steps.rc_build.outputs.match != ''
         with:
-          name:  ${{ runner.os }}-wheels-${{ matrix.pl_backend }}-${{ fromJson('{ "cp311-*":"py311","cp312-*":"py312","cp313-*":"py313","cp314-*":"py314" }')[matrix.cibw_build] }}-${{ matrix.arch }}-cu${{ matrix.cuda_version }}.zip
+          name:  ${{ runner.os }}-wheels-${{ matrix.pl_backend }}-${{ fromJson('{ "cp312-*":"py312","cp313-*":"py313","cp314-*":"py314" }')[matrix.cibw_build] }}-${{ matrix.arch }}-cu${{ matrix.cuda_version }}.zip
           path: dist
 
       - name: Upload wheels to TestPyPI

--- a/.github/workflows/wheel_linux_x86_64_rocm.yml
+++ b/.github/workflows/wheel_linux_x86_64_rocm.yml
@@ -1,7 +1,7 @@
 name: Wheel::Linux::x86_64::ROCm
 
 # **What it does**: Builds python wheels for Linux (ubuntu-24.04) architecture x86_64 and store it as artifacts.
-#                   Python versions: 3.11, 3.12, 3.13, 3.14
+#                   Python versions: 3.12, 3.13, 3.14
 # **Why we have it**: To build wheels for pennylane-lightning-amdgpu installation.
 # **Who does it impact**: Wheels to be uploaded to PyPI.
 
@@ -118,7 +118,7 @@ jobs:
         kokkos_version: ${{ fromJson(needs.set_wheel_build_matrix.outputs.kokkos_version) }}
         container_img: ["quay.io/pypa/manylinux_2_28_x86_64"]
     timeout-minutes: 30
-    name: Linux::${{ matrix.arch }} - ${{ matrix.pl_backend }} ROCm ${{ matrix.rocm_version }} (Python ${{ fromJson('{"cp311-*":"3.11","cp312-*":"3.12","cp313-*":"3.13" }')[matrix.cibw_build] }})
+    name: Linux::${{ matrix.arch }} - ${{ matrix.pl_backend }} ROCm ${{ matrix.rocm_version }} (Python ${{ fromJson('{"cp312-*":"3.12","cp313-*":"3.13" }')[matrix.cibw_build] }})
     runs-on: blacksmith-4vcpu-ubuntu-2404
     container:
       image: ${{ matrix.container_img }}
@@ -200,7 +200,7 @@ jobs:
           github.ref == 'refs/heads/main' ||
           steps.rc_build.outputs.match != ''
         with:
-          name: ${{ runner.os }}-wheels-${{ matrix.pl_backend }}-${{ fromJson('{ "cp311-*":"py311","cp312-*":"py312","cp313-*":"py313","cp314-*":"py314" }')[matrix.cibw_build] }}-${{ matrix.arch }}-rocm${{ matrix.rocm_version }}.zip
+          name: ${{ runner.os }}-wheels-${{ matrix.pl_backend }}-${{ fromJson('{ "cp312-*":"py312","cp313-*":"py313","cp314-*":"py314" }')[matrix.cibw_build] }}-${{ matrix.arch }}-rocm${{ matrix.rocm_version }}.zip
           path: ./wheelhouse/*.whl
           retention-days: 1
           include-hidden-files: true
@@ -232,7 +232,7 @@ jobs:
           github.ref == 'refs/heads/main' || 
           steps.rc_build.outputs.match != ''
         with:
-          name:  ${{ runner.os }}-wheels-${{ matrix.pl_backend }}-${{ fromJson('{ "cp311-*":"py311","cp312-*":"py312","cp313-*":"py313","cp314-*":"py314" }')[matrix.cibw_build] }}-${{ matrix.arch }}-rocm${{ matrix.rocm_version }}.zip
+          name:  ${{ runner.os }}-wheels-${{ matrix.pl_backend }}-${{ fromJson('{ "cp312-*":"py312","cp313-*":"py313","cp314-*":"py314" }')[matrix.cibw_build] }}-${{ matrix.arch }}-rocm${{ matrix.rocm_version }}.zip
           path: dist
 
       - name: Upload wheels to TestPyPI

--- a/.github/workflows/wheel_macos_arm64.yml
+++ b/.github/workflows/wheel_macos_arm64.yml
@@ -1,7 +1,7 @@
 name: Wheel::MacOS::ARM
 
 # **What it does**: Builds python wheels for MacOS (11) architecture ARM 64 and store it as artifacts.
-#                   Python versions: 3.11, 3.12, 3.13, 3.14.
+#                   Python versions: 3.12, 3.13, 3.14.
 # **Why we have it**: To build wheels for pennylane-lightning installation.
 # **Who does it impact**: Wheels to be uploaded to PyPI.
 
@@ -59,7 +59,7 @@ jobs:
         pl_backend: ["lightning_kokkos", "lightning_qubit"]
         cibw_build: ${{fromJson(needs.set_wheel_build_matrix.outputs.python_version)}}
     timeout-minutes: 30
-    name: macos-latest::arm64 - ${{ matrix.pl_backend }} (Python ${{ fromJson('{ "cp311-*":"3.11","cp312-*":"3.12", "cp313-*":"3.13", "cp314-*":"3.14" }')[matrix.cibw_build] }})
+    name: macos-latest::arm64 - ${{ matrix.pl_backend }} (Python ${{ fromJson('{ "cp312-*":"3.12", "cp313-*":"3.13", "cp314-*":"3.14" }')[matrix.cibw_build] }})
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -131,7 +131,7 @@ jobs:
           github.ref == 'refs/heads/main' || 
           steps.rc_build.outputs.match != ''
         with:
-          name: ${{ runner.os }}-wheels-${{ matrix.pl_backend }}-${{ fromJson('{ "cp311-*":"py311","cp312-*":"py312", "cp313-*":"py313", "cp314-*":"py314" }')[matrix.cibw_build] }}-${{ matrix.arch }}.zip
+          name: ${{ runner.os }}-wheels-${{ matrix.pl_backend }}-${{ fromJson('{ "cp312-*":"py312", "cp313-*":"py313", "cp314-*":"py314" }')[matrix.cibw_build] }}-${{ matrix.arch }}.zip
           path: ./wheelhouse/*.whl
           retention-days: 1
           include-hidden-files: true
@@ -162,7 +162,7 @@ jobs:
           github.ref == 'refs/heads/main' || 
           steps.rc_build.outputs.match != ''
         with:
-          name: macOS-wheels-${{ matrix.pl_backend }}-${{ fromJson('{ "cp311-*":"py311","cp312-*":"py312", "cp313-*":"py313", "cp314-*":"py314" }')[matrix.cibw_build] }}-${{ matrix.arch }}.zip
+          name: macOS-wheels-${{ matrix.pl_backend }}-${{ fromJson('{ "cp312-*":"py312", "cp313-*":"py313", "cp314-*":"py314" }')[matrix.cibw_build] }}-${{ matrix.arch }}.zip
           path: dist
 
       - name: Upload wheels to TestPyPI

--- a/.github/workflows/wheel_win_x86_64.yml
+++ b/.github/workflows/wheel_win_x86_64.yml
@@ -1,7 +1,7 @@
 name: Wheel::Windows::x86_64
 
 # **What it does**: Builds python wheels for Windows (windows-latest) and store it as artifacts.
-#                   Python versions: 3.11, 3.12, 3.13, 3.14.
+#                   Python versions: 3.12, 3.13, 3.14.
 # **Why we have it**: To build wheels for pennylane-lightning installation.
 # **Who does it impact**: Wheels to be uploaded to PyPI.
 
@@ -110,7 +110,7 @@ jobs:
         exec_model: ["SERIAL"]
         kokkos_version: ${{ fromJson(needs.set_wheel_build_matrix.outputs.kokkos_version) }}
     timeout-minutes: 30
-    name: ${{ matrix.os }} - ${{ matrix.pl_backend }} (Python ${{ fromJson('{ "cp311-*":"3.11","cp312-*":"3.12","cp313-*":"3.13","cp314-*":"3.14" }')[matrix.cibw_build] }})
+    name: ${{ matrix.os }} - ${{ matrix.pl_backend }} (Python ${{ fromJson('{ "cp312-*":"3.12","cp313-*":"3.13","cp314-*":"3.14" }')[matrix.cibw_build] }})
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -226,7 +226,7 @@ jobs:
           github.ref == 'refs/heads/main' ||
           steps.rc_build.outputs.match != ''
         with:
-          name: ${{ runner.os }}-wheels-${{ matrix.pl_backend }}-${{ fromJson('{ "cp311-*":"py311","cp312-*":"py312","cp313-*":"py313","cp314-*":"py314" }')[matrix.cibw_build] }}-${{ matrix.arch }}.zip
+          name: ${{ runner.os }}-wheels-${{ matrix.pl_backend }}-${{ fromJson('{ "cp312-*":"py312","cp313-*":"py313","cp314-*":"py314" }')[matrix.cibw_build] }}-${{ matrix.arch }}.zip
           path: ./wheelhouse/*.whl
           retention-days: 1
           include-hidden-files: true
@@ -255,7 +255,7 @@ jobs:
           github.ref == 'refs/heads/main' || 
           steps.rc_build.outputs.match != ''
         with:
-          name: Windows-wheels-${{ matrix.pl_backend }}-${{ fromJson('{ "cp311-*":"py311","cp312-*":"py312","cp313-*":"py313","cp314-*":"py314" }')[matrix.cibw_build] }}-${{ matrix.arch }}.zip
+          name: Windows-wheels-${{ matrix.pl_backend }}-${{ fromJson('{ "cp312-*":"py312","cp313-*":"py313","cp314-*":"py314" }')[matrix.cibw_build] }}-${{ matrix.arch }}.zip
           path: dist
 
       - name: Upload wheels to PyPI

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The Lightning plugin ecosystem provides fast state-vector and tensor-network sim
 
 [PennyLane](https://docs.pennylane.ai) is a cross-platform Python library for quantum machine
 learning, automatic differentiation, and optimization of hybrid quantum-classical computations.
-PennyLane supports Python 3.11 and above.
+PennyLane supports Python 3.12 and above.
 
 ## Backends
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -12,7 +12,7 @@ The Lightning plugin ecosystem provides fast state-vector and tensor-network sim
 
 `PennyLane <https://docs.pennylane.ai>`_ is a cross-platform Python library for quantum machine
 learning, automatic differentiation, and optimization of hybrid quantum-classical computations.
-PennyLane supports Python 3.11 and above.
+PennyLane supports Python 3.12 and above.
 
 Backends
 ********

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.46.0-dev16"
+__version__ = "0.46.0-dev17"

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.46.0-dev14"
+__version__ = "0.46.0-dev15"

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.46.0-dev15"
+__version__ = "0.46.0-dev16"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "pennylane_lightning"
 description = "PennyLane-Lightning plugin"
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 license = "Apache-2.0"
 classifiers = [
     "Development Status :: 4 - Beta",
@@ -20,7 +20,6 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ if not has_toml:
         "A TOML parser is required to configure 'pyproject.toml'. "
         f"We support any of the following TOML parsers: {toml_libs} "
         "You can install tomlkit via `pip install tomlkit`, or tomli via `pip install tomli`, "
-        "or use Python 3.11 or above which natively offers the tomllib library."
+        "or use Python 3.12 or above which natively offers the tomllib library."
     )
 
 try:


### PR DESCRIPTION
**Context:**
PennyLane is on the way to drop 3.11 (see [this](https://github.com/PennyLaneAI/pennylane/pull/9700#issue-4694793151) and [this](https://github.com/PennyLaneAI/pennylane/pull/9715). Before that happens, Lightning needs to bump to 3.12 first

**Description of the Change:**
- Bump `PYTHON3_MIN_VERSION` from `"11"` to `"12"` in the wheel build matrix.
- Remove all `cp311-*` entries from wheel CI workflows (Linux x86_64, Linux aarch64, Linux x86_64 CUDA, Linux aarch64 CUDA, Linux x86_64 ROCm, macOS arm64, Windows x86_64).
- Update `upload-nightly-rc-release.yml` to use Python 3.12.
- Set `requires-python = ">=3.12"` in `pyproject.toml` and remove the `Programming Language :: Python :: 3.11` classifier.
- Update version references in `setup.py`, `README.md`, and `doc/index.rst`.

**Benefits:**
Keeps PennyLane-Lightning in sync with the PennyLane core Python version policy, reducing CI build time and maintenance surface.

**Possible Drawbacks:**
Users still on Python 3.11 will need to upgrade to 3.12+.

**Related GitHub Issues:**
[sc-123549]