### PR TITLE
Capture external dynamic lib in Win builds for LQ

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,7 @@ if(ENABLE_PYTHON)
     endif()
 
     find_package(Python COMPONENTS Interpreter Development.Module REQUIRED)
+    
     message(STATUS "Enabling Nanobind Python bindings")
     message(STATUS "Using Python executable: ${Python_EXECUTABLE}")
     message(STATUS "Python version: ${Python_VERSION}")
@@ -163,6 +164,8 @@ foreach(BACKEND ${PL_BACKEND})
 endforeach()
 
 target_include_directories(pennylane_lightning  INTERFACE "$<INSTALL_INTERFACE:${PROJECT_SOURCE_DIR}/pennylane_lightning/core;include>")
+target_link_options(pennylane_lightning INTERFACE "-Wl,--export-all-symbols")
+set_target_properties(pennylane_lightning PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 
 #####################################################
 if(ENABLE_PYTHON)
@@ -171,6 +174,8 @@ if(ENABLE_PYTHON)
     nanobind_add_module("${PL_BACKEND}_ops"
                         NB_DOMAIN "pennylane_lightning"
                         "pennylane_lightning/core/bindings/Bindings.cpp")
+	target_link_options("${PL_BACKEND}_ops" PUBLIC "-Wl,--export-all-symbols")
+	set_target_properties("${PL_BACKEND}_ops" PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 
     # Remove nanobind's problematic flags that are incompatible with NVCC
     target_compile_options("${PL_BACKEND}_ops" PRIVATE

--- a/cmake/support_catalyst.cmake
+++ b/cmake/support_catalyst.cmake
@@ -25,6 +25,7 @@ macro(FindCatalyst target_name)
         target_include_directories(${target_name} SYSTEM PUBLIC ${LIGHTNING_CATALYST_SRC_PATH}/runtime/include)
 
     else()
+	set(CATALYST_GIT_TAG "mlxd/fwd_it_dataview")
         if(NOT CATALYST_GIT_TAG)
             set(CATALYST_GIT_TAG "main" CACHE STRING "GIT_TAG value to build Catalyst")
         endif()

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.46.0-dev14"
+__version__ = "0.46.0-dev15"

--- a/pennylane_lightning/core/simulators/lightning_qubit/CMakeLists.txt
+++ b/pennylane_lightning/core/simulators/lightning_qubit/CMakeLists.txt
@@ -90,7 +90,7 @@ set(COMPONENT_SUBDIRS   algorithms
                         )
 
 # Do not build the LQ plugin for Windows
-if (NOT WIN32)
+if (1)
     set(COMPONENT_SUBDIRS   ${COMPONENT_SUBDIRS}
                             catalyst
                             )

--- a/pennylane_lightning/core/simulators/lightning_qubit/catalyst/CMakeLists.txt
+++ b/pennylane_lightning/core/simulators/lightning_qubit/catalyst/CMakeLists.txt
@@ -21,6 +21,7 @@ target_link_libraries(lightning_qubit_catalyst PUBLIC  lightning_compile_options
 
 set(CMAKE_BUILD_RPATH_USE_ORIGIN ON)
 set_target_properties(lightning_qubit_catalyst PROPERTIES BUILD_RPATH "${SCIPY_OPENBLAS32_RUNTIME_LIB_PATH}")
+set_target_properties(lightning_qubit_catalyst PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 
 if (BUILD_TESTS)
     enable_testing()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,3 +124,6 @@ exclude_dirs = ["tests"]
 skips = [
     "B101", # We are okay with using asserts in source code as we do not compile optimized bytecode of pennylane
 ]
+[tool.cibuildwheel.windows]
+# Force the linker to find the active pythonXX.lib folder
+environment = { LDFLAGS="/LIBPATH:{python}\\libs", CFLAGS="/I{python}\\include" }

--- a/setup.py
+++ b/setup.py
@@ -98,13 +98,17 @@ class CMakeBuild(build_ext):
             # As Ninja does not support long path for windows yet:
             #  (https://github.com/ninja-build/ninja/pull/2056)
             configure_args += [
-                "-T clangcl",
+                #"-T clangcl",
+                "-DCMAKE_C_COMPILER=clang-cl",
+                "-DCMAKE_CXX_COMPILER=clang-cl",
+                "-DCMAKE_BUILD_TYPE=Release",
+                "-DCMAKE_LINKER=lld-link",
             ]
-        elif ninja_path:
-            configure_args += [
-                "-GNinja",
-                f"-DCMAKE_MAKE_PROGRAM={ninja_path}",
-            ]
+        #elif ninja_path:
+        configure_args += [
+            "-GNinja",
+            f"-DCMAKE_MAKE_PROGRAM={ninja_path}",
+        ]
 
         configure_args += [f"-DPL_BACKEND={backend}"]
         configure_args += self.cmake_defines
@@ -167,6 +171,15 @@ class CMakeBuild(build_ext):
                 source = os.path.join(f"{extdir}", f"lib{lib_name}_catalyst{shared_lib_ext}")
                 destination = os.path.join(os.getcwd(), self.build_temp)
                 shutil.copy(source, destination)
+            elif platform.system() is "Windows":
+                shared_lib_ext = ".dll"
+                lib_name = "lightning_kokkos" if backend == "lightning_amdgpu" else backend
+                # Windows follows diff build rules with locations
+                source = os.path.join(os.getcwd(), self.build_temp, f"{lib_name}_catalyst{shared_lib_ext}")
+                destination = extdir
+                shutil.copy(source, destination)
+            else:
+                raise RuntimeException(f"Unsupported platform {platform.system()} for backend {backend}")
 
 with open(os.path.join("pennylane_lightning", "core", "_version.py"), encoding="utf-8") as f:
     version = f.readlines()[-1].split()[-1].strip("\"'")


### PR DESCRIPTION
**Context:** The Lightning dynamic runtime library for Catalyst currently builds for Linux and MacOS platforms, with all pathways for Windows excluded. This PR opens those pathways to: 1) generate a dynamic library and 2) exposes the symbols using Windows-expected formats.

**Description of the Change:** Create a pathway for building the Catalyst Lightning runtime plugin on Windows systems.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues/PRs:** https://github.com/PennyLaneAI/catalyst/pull/2976
