### PR TITLE
[Experimental]: MVP support for MPI with Catalyst `qjit`

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 <h3>Improvements 🛠</h3>
 
-- Singleton manages MPI initialization and finalization [(#1397)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1397)
+- A new singleton class manages MPI initialization and finalization.
+  [(#1397)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1397)
 
 - The MPI send and receive buffer sizes for Lightning-Kokkos are now adjustable via the
   `comm_buffer_ratio` keyword argument.

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 <h3>Improvements 🛠</h3>
 
+- Singleton manages MPI initialization and finalization [(#1397)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1397)
+
 - The MPI send and receive buffer sizes for Lightning-Kokkos are now adjustable via the
   `comm_buffer_ratio` keyword argument.
   [(#1391)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1391)

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.46.0-dev14"
+__version__ = "0.46.0-dev15"

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.46.0-dev15"
+__version__ = "0.46.0-dev16"

--- a/pennylane_lightning/core/simulators/lightning_gpu/StateVectorCudaMPI.hpp
+++ b/pennylane_lightning/core/simulators/lightning_gpu/StateVectorCudaMPI.hpp
@@ -106,8 +106,8 @@ class StateVectorCudaMPI final
     StateVectorCudaMPI() = delete;
 
     StateVectorCudaMPI(const MPIManagerGPU &mpi_manager,
-                       const DevTag<int> &dev_tag,
-                       std::size_t mpi_buf_size, std::size_t num_global_qubits,
+                       const DevTag<int> &dev_tag, std::size_t mpi_buf_size,
+                       std::size_t num_global_qubits,
                        std::size_t num_local_qubits)
         : StateVectorCudaBase<Precision, StateVectorCudaMPI<Precision>>(
               num_local_qubits, dev_tag, true),
@@ -229,9 +229,7 @@ class StateVectorCudaMPI final
      * @brief Get MPI manager
      */
     auto getMPIManager() -> MPIManagerGPU & { return mpi_manager_; }
-    auto getMPIManager() const -> const MPIManagerGPU & {
-        return mpi_manager_;
-    }
+    auto getMPIManager() const -> const MPIManagerGPU & { return mpi_manager_; }
 
     /**
      * @brief Get the total number of wires.

--- a/pennylane_lightning/core/simulators/lightning_gpu/StateVectorCudaMPI.hpp
+++ b/pennylane_lightning/core/simulators/lightning_gpu/StateVectorCudaMPI.hpp
@@ -105,7 +105,8 @@ class StateVectorCudaMPI final
 
     StateVectorCudaMPI() = delete;
 
-    StateVectorCudaMPI(MPIManagerGPU mpi_manager, const DevTag<int> &dev_tag,
+    StateVectorCudaMPI(const MPIManagerGPU &mpi_manager,
+                       const DevTag<int> &dev_tag,
                        std::size_t mpi_buf_size, std::size_t num_global_qubits,
                        std::size_t num_local_qubits)
         : StateVectorCudaBase<Precision, StateVectorCudaMPI<Precision>>(
@@ -227,7 +228,10 @@ class StateVectorCudaMPI final
     /**
      * @brief Get MPI manager
      */
-    auto getMPIManager() const { return mpi_manager_; }
+    auto getMPIManager() -> MPIManagerGPU & { return mpi_manager_; }
+    auto getMPIManager() const -> const MPIManagerGPU & {
+        return mpi_manager_;
+    }
 
     /**
      * @brief Get the total number of wires.

--- a/pennylane_lightning/core/simulators/lightning_gpu/algorithms/AdjointJacobianGPUMPI.hpp
+++ b/pennylane_lightning/core/simulators/lightning_gpu/algorithms/AdjointJacobianGPUMPI.hpp
@@ -113,7 +113,6 @@ class AdjointJacobianMPI final
         if (!jd.hasTrainableParams()) {
             return;
         }
-        MPIManagerGPU mpi_manager_(jd.getMPIManager());
         DevTag<int> dt_local(jd.getDevTag());
 
         const OpsData<StateVectorT> &ops = jd.getOperations();

--- a/pennylane_lightning/core/simulators/lightning_gpu/algorithms/JacobianDataMPI.hpp
+++ b/pennylane_lightning/core/simulators/lightning_gpu/algorithms/JacobianDataMPI.hpp
@@ -76,9 +76,7 @@ class JacobianDataMPI final : public JacobianData<StateVectorT> {
      * @brief Get MPI manager
      */
     auto getMPIManager() -> MPIManagerGPU & { return mpi_manager_; }
-    auto getMPIManager() const -> const MPIManagerGPU & {
-        return mpi_manager_;
-    }
+    auto getMPIManager() const -> const MPIManagerGPU & { return mpi_manager_; }
 
     /**
      * @brief Get DevTag manager

--- a/pennylane_lightning/core/simulators/lightning_gpu/algorithms/JacobianDataMPI.hpp
+++ b/pennylane_lightning/core/simulators/lightning_gpu/algorithms/JacobianDataMPI.hpp
@@ -75,7 +75,10 @@ class JacobianDataMPI final : public JacobianData<StateVectorT> {
     /**
      * @brief Get MPI manager
      */
-    auto getMPIManager() const { return mpi_manager_; }
+    auto getMPIManager() -> MPIManagerGPU & { return mpi_manager_; }
+    auto getMPIManager() const -> const MPIManagerGPU & {
+        return mpi_manager_;
+    }
 
     /**
      * @brief Get DevTag manager

--- a/pennylane_lightning/core/simulators/lightning_gpu/observables/ObservablesGPUMPI.hpp
+++ b/pennylane_lightning/core/simulators/lightning_gpu/observables/ObservablesGPUMPI.hpp
@@ -191,7 +191,7 @@ class HamiltonianMPI final : public HamiltonianBase<StateVectorT> {
 
     // to work with
     void applyInPlace(StateVectorT &sv) const override {
-        auto mpi_manager = sv.getMPIManager();
+        auto &mpi_manager = sv.getMPIManager();
         using CFP_t = typename StateVectorT::CFP_t;
         DataBuffer<CFP_t, int> buffer(sv.getDataBuffer().getLength(),
                                       sv.getDataBuffer().getDevTag());
@@ -278,7 +278,7 @@ class SparseHamiltonianMPI final : public SparseHamiltonianBase<StateVectorT> {
      *
      */
     void applyInPlace(StateVectorT &sv) const override {
-        auto mpi_manager = sv.getMPIManager();
+        auto &mpi_manager = sv.getMPIManager();
         if (mpi_manager.getRank() == 0) {
             PL_ABORT_IF_NOT(
                 this->wires_.size() == sv.getTotalNumQubits(),

--- a/pennylane_lightning/core/simulators/lightning_gpu/utils/MPIManagerGPU.hpp
+++ b/pennylane_lightning/core/simulators/lightning_gpu/utils/MPIManagerGPU.hpp
@@ -93,8 +93,6 @@ class MPIManagerGPU final : public MPIManager {
     MPIManagerGPU(MPI_Comm communicator = MPI_COMM_WORLD)
         : MPIManager(communicator) {}
 
-    MPIManagerGPU(int argc, char **argv) : MPIManager(argc, argv) {}
-
     auto get_cpp_mpi_type_map() const
         -> const std::unordered_map<std::string, MPI_Datatype> & override {
         return cpp_mpi_type_map_with_cuda;

--- a/pennylane_lightning/core/simulators/lightning_gpu/utils/MPIManagerGPU.hpp
+++ b/pennylane_lightning/core/simulators/lightning_gpu/utils/MPIManagerGPU.hpp
@@ -90,8 +90,7 @@ class MPIManagerGPU final : public MPIManager {
         {cppTypeToString<cudaIpcEventHandle_t>(), MPI_UINT8_T}};
 
   public:
-    MPIManagerGPU(MPI_Comm communicator = MPI_COMM_WORLD)
-        : MPIManager(communicator) {}
+    using MPIManager::MPIManager;
 
     auto get_cpp_mpi_type_map() const
         -> const std::unordered_map<std::string, MPI_Datatype> & override {

--- a/pennylane_lightning/core/simulators/lightning_gpu/utils/tests/mpi/Test_MPIManagerGPU.cpp
+++ b/pennylane_lightning/core/simulators/lightning_gpu/utils/tests/mpi/Test_MPIManagerGPU.cpp
@@ -39,6 +39,18 @@ TEST_CASE("MPIManagerGPU ctor", "[MPIManagerGPU]") {
     SECTION("MPIManagerGPU {MPIManagerGPU&}") {
         REQUIRE(std::is_copy_constructible_v<MPIManagerGPU>);
     }
+
+    SECTION("MPIManagerGPU = MPIManagerGPU&") {
+        REQUIRE(std::is_copy_assignable_v<MPIManagerGPU>);
+    }
+
+    SECTION("MPIManagerGPU {MPIManagerGPU&&}") {
+        REQUIRE(std::is_move_constructible_v<MPIManagerGPU>);
+    }
+
+    SECTION("MPIManagerGPU = MPIManagerGPU&&") {
+        REQUIRE(std::is_move_assignable_v<MPIManagerGPU>);
+    }
 }
 
 TEST_CASE("MPIManagerGPU::getMPIDatatype", "[MPIManagerGPU]") {

--- a/pennylane_lightning/core/simulators/lightning_gpu/utils/tests/mpi/Test_MPIManagerGPU.cpp
+++ b/pennylane_lightning/core/simulators/lightning_gpu/utils/tests/mpi/Test_MPIManagerGPU.cpp
@@ -36,10 +36,6 @@ TEST_CASE("MPIManagerGPU ctor", "[MPIManagerGPU]") {
         REQUIRE(std::is_constructible_v<MPIManagerGPU, MPI_Comm>);
     }
 
-    SECTION("Construct with args") {
-        REQUIRE(std::is_constructible_v<MPIManagerGPU, int, char **>);
-    }
-
     SECTION("MPIManagerGPU {MPIManagerGPU&}") {
         REQUIRE(std::is_copy_constructible_v<MPIManagerGPU>);
     }

--- a/pennylane_lightning/core/simulators/lightning_kokkos/StateVectorKokkosMPI.hpp
+++ b/pennylane_lightning/core/simulators/lightning_kokkos/StateVectorKokkosMPI.hpp
@@ -119,7 +119,7 @@ class StateVectorKokkosMPI final
      * @param kokkos_args Arguments for Kokkos initialization
      */
     StateVectorKokkosMPI(
-        MPIManagerKokkos mpi_manager, std::size_t num_global_qubits,
+        const MPIManagerKokkos &mpi_manager, std::size_t num_global_qubits,
         std::size_t num_local_qubits,
         const Kokkos::InitializationSettings &kokkos_args = {},
         std::size_t comm_buffer_ratio = DEFAULT_COMM_BUFFER_RATIO)
@@ -152,7 +152,7 @@ class StateVectorKokkosMPI final
      * @param kokkos_args Arguments for Kokkos initialization
      */
     StateVectorKokkosMPI(
-        MPIManagerKokkos mpi_manager, std::size_t total_num_qubits,
+        const MPIManagerKokkos &mpi_manager, std::size_t total_num_qubits,
         const Kokkos::InitializationSettings &kokkos_args = {},
         std::size_t comm_buffer_ratio = DEFAULT_COMM_BUFFER_RATIO)
         : StateVectorKokkosMPI(mpi_manager, log2(mpi_manager.getSize()),
@@ -308,7 +308,10 @@ class StateVectorKokkosMPI final
 
     SVK &getLocalSV() { return *sv_; }
 
-    auto getMPIManager() const { return mpi_manager_; }
+    auto getMPIManager() -> MPIManagerKokkos & { return mpi_manager_; }
+    auto getMPIManager() const -> const MPIManagerKokkos & {
+        return mpi_manager_;
+    }
 
     /**
      * @brief Compute the per-process MPI communication buffer size in elements.

--- a/pennylane_lightning/core/simulators/lightning_kokkos/StateVectorKokkosMPI.hpp
+++ b/pennylane_lightning/core/simulators/lightning_kokkos/StateVectorKokkosMPI.hpp
@@ -89,6 +89,9 @@ class StateVectorKokkosMPI final
     using UnmanagedPrecisionHostView = typename SVK::UnmanagedPrecisionHostView;
     using KokkosExecSpace = typename SVK::KokkosExecSpace;
     using HostExecSpace = typename SVK::HostExecSpace;
+    using ScratchViewComplex = typename SVK::ScratchViewComplex;
+    using TeamPolicy = typename SVK::TeamPolicy;
+    using MemoryStorageT = typename SVK::MemoryStorageT;
 
     using BaseType = StateVectorBase<fp_t, StateVectorKokkosMPI<fp_t>>;
 

--- a/pennylane_lightning/core/simulators/lightning_kokkos/StateVectorKokkosMPI.hpp
+++ b/pennylane_lightning/core/simulators/lightning_kokkos/StateVectorKokkosMPI.hpp
@@ -19,6 +19,7 @@
 #pragma once
 #include <complex>
 #include <cstddef>
+#include <cstdio>
 #include <cstdlib>
 #include <string>
 #include <unordered_map>
@@ -110,6 +111,10 @@ class StateVectorKokkosMPI final
     std::vector<std::size_t> global_wires_;
     std::vector<std::size_t> local_wires_;
 
+    std::size_t mpi_rank_ = 0;
+    std::size_t swap_events_ = 0;
+    std::size_t transferred_bytes_ = 0;
+
   public:
     StateVectorKokkosMPI() = delete;
 
@@ -131,6 +136,7 @@ class StateVectorKokkosMPI final
           num_qubits_(num_global_qubits + num_local_qubits),
           numGlobalQubits_(num_global_qubits),
           numLocalQubits_(num_local_qubits) {
+        mpi_rank_ = mpi_manager_.getRank();
         PL_ABORT_IF(comm_buffer_ratio == 0, "comm_buffer_ratio must be >= 1");
         Kokkos::InitializationSettings settings = kokkos_args;
 
@@ -307,7 +313,30 @@ class StateVectorKokkosMPI final
         (*sv_).DeviceToDevice(other.getView());
     }
 
-    ~StateVectorKokkosMPI() = default;
+    ~StateVectorKokkosMPI() {
+        // Gather all instrumentation data on rank 0 for printing
+        const std::size_t root_rank = 0;
+        std::vector<std::size_t> gathered_swap_events(mpi_manager_.getSize());
+        std::vector<std::size_t> gathered_transferred_bytes(
+            mpi_manager_.getSize());
+        mpi_manager_.Gather(swap_events_, gathered_swap_events, root_rank);
+        mpi_manager_.Gather(transferred_bytes_, gathered_transferred_bytes,
+                            root_rank);
+
+        if (mpi_rank_ == root_rank) {
+            for (std::size_t rank = 0; rank < mpi_manager_.getSize(); rank++) {
+                const double transferred_gbytes =
+                    static_cast<double>(gathered_transferred_bytes[rank]) /
+                    (1024.0 * 1024.0 * 1024.0);
+                std::fprintf(stderr,
+                             "[lightning.kokkos mpi][rank %zu] swap_events=%zu "
+                             "transferred=%.2f GiB (%zu B)\n",
+                             rank, gathered_swap_events[rank],
+                             transferred_gbytes,
+                             gathered_transferred_bytes[rank]);
+            }
+        }
+    }
 
     SVK &getLocalSV() { return *sv_; }
 
@@ -442,6 +471,7 @@ class StateVectorKokkosMPI final
                          const std::size_t tag) {
         mpi_manager_.Sendrecv(*sendbuf_, send_rank, *recvbuf_, recv_rank, size,
                               tag);
+        transferred_bytes_ += 2 * size * sizeof(ComplexT);
     }
     /********************
     Wires-related methods
@@ -749,6 +779,7 @@ class StateVectorKokkosMPI final
     void
     swapGlobalLocalWires(const std::vector<std::size_t> &global_wires_to_swap,
                          const std::vector<std::size_t> &local_wires_to_swap) {
+        swap_events_ += 1;
         PL_ABORT_IF_NOT(global_wires_to_swap.size() ==
                             local_wires_to_swap.size(),
                         "global_wires_to_swap and local_wires_to_swap must "

--- a/pennylane_lightning/core/simulators/lightning_kokkos/catalyst/LightningKokkosObsManager.hpp
+++ b/pennylane_lightning/core/simulators/lightning_kokkos/catalyst/LightningKokkosObsManager.hpp
@@ -23,6 +23,9 @@
 #include "Utils.hpp"
 
 #include "ObservablesKokkos.hpp"
+#ifdef _ENABLE_PLKOKKOS_MPI
+#include "StateVectorKokkosMPI.hpp"
+#endif
 
 namespace Catalyst::Runtime::Simulator {
 
@@ -33,8 +36,13 @@ namespace Catalyst::Runtime::Simulator {
  */
 template <typename PrecisionT> class LightningKokkosObsManager final {
   private:
+#ifdef _ENABLE_PLKOKKOS_MPI
+    using StateVectorT =
+        Pennylane::LightningKokkos::StateVectorKokkosMPI<PrecisionT>;
+#else
     using StateVectorT =
         Pennylane::LightningKokkos::StateVectorKokkos<PrecisionT>;
+#endif
     using ObservableT = Pennylane::Observables::Observable<StateVectorT>;
     using ObservablePairType = std::pair<std::shared_ptr<ObservableT>, ObsType>;
     std::vector<ObservablePairType> observables_{};

--- a/pennylane_lightning/core/simulators/lightning_kokkos/catalyst/LightningKokkosSimulator.cpp
+++ b/pennylane_lightning/core/simulators/lightning_kokkos/catalyst/LightningKokkosSimulator.cpp
@@ -14,6 +14,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <numeric>
 #include <unordered_set>
 
 #include <Kokkos_Complex.hpp>
@@ -30,6 +31,11 @@ auto LightningKokkosSimulator::AllocateQubit() -> QubitIdType {
         this->device_sv = std::make_unique<StateVectorT>(1);
         return this->qubit_manager.Allocate(0);
     }
+
+#ifdef _ENABLE_PLKOKKOS_MPI
+    RT_FAIL("Dynamic qubit allocation is not supported with MPI backend.");
+    return 0;
+#else
 
     // The statevector may contain previously freed qubits,
     // that means we may not need to resize the vector.
@@ -73,6 +79,7 @@ auto LightningKokkosSimulator::AllocateQubit() -> QubitIdType {
     }
 
     return new_program_idx;
+#endif
 }
 
 auto LightningKokkosSimulator::AllocateQubits(std::size_t num_qubits)
@@ -87,6 +94,11 @@ auto LightningKokkosSimulator::AllocateQubits(std::size_t num_qubits)
         return this->qubit_manager.AllocateRange(0, num_qubits);
     }
 
+#ifdef _ENABLE_PLKOKKOS_MPI
+    RT_FAIL("Dynamic qubit allocation is not supported with MPI backend.");
+    return {};
+#endif
+
     std::vector<QubitIdType> result(num_qubits);
     std::generate_n(result.begin(), num_qubits,
                     [this]() { return AllocateQubit(); });
@@ -99,6 +111,14 @@ void LightningKokkosSimulator::ReleaseQubit(QubitIdType q) {
 
     // Mark the qubit as released in the qubit manager
     this->qubit_manager.Release(q);
+
+#ifdef _ENABLE_PLKOKKOS_MPI
+    if (this->qubit_manager.getNumQubits() == 0) {
+        this->device_sv = nullptr;
+        this->needs_reduction = false;
+        return;
+    }
+#endif
 
     // Mark that reduction is needed
     this->needs_reduction = true;
@@ -118,7 +138,11 @@ void LightningKokkosSimulator::ReleaseQubits(
             });
         if (deallocate_all) {
             this->qubit_manager.ReleaseAll();
+#ifdef _ENABLE_PLKOKKOS_MPI
+            this->device_sv = nullptr;
+#else
             this->device_sv = std::make_unique<StateVectorT>(0);
+#endif
             this->needs_reduction = false;
             return;
         }
@@ -133,14 +157,18 @@ auto LightningKokkosSimulator::GetNumQubits() const -> std::size_t {
     return this->qubit_manager.getNumQubits();
 }
 
-auto LightningKokkosSimulator::getMeasurements()
-    -> Pennylane::LightningKokkos::Measures::Measurements<StateVectorT> {
+auto LightningKokkosSimulator::getMeasurements() -> MeasurementsBackendT {
     reduceStateVector();
-    return Pennylane::LightningKokkos::Measures::Measurements<StateVectorT>{
-        *(this->device_sv)};
+    RT_FAIL_IF(this->device_sv == nullptr, "State vector is not allocated");
+    return MeasurementsBackendT{*(this->device_sv)};
 }
 
 void LightningKokkosSimulator::reduceStateVector() {
+#ifdef _ENABLE_PLKOKKOS_MPI
+    RT_FAIL_IF(this->needs_reduction,
+               "Partial qubit release is not supported with MPI backend.");
+    return;
+#else
     if (!this->needs_reduction) {
         return;
     }
@@ -250,6 +278,7 @@ void LightningKokkosSimulator::reduceStateVector() {
     this->qubit_manager.ClearFreeQubits();
 
     this->needs_reduction = false;
+#endif
 }
 
 /**
@@ -501,10 +530,6 @@ void LightningKokkosSimulator::MatrixOperation(
     const std::vector<QubitIdType> &wires, bool inverse,
     const std::vector<QubitIdType> &controlled_wires,
     const std::vector<bool> &controlled_values) {
-    using UnmanagedComplexHostView =
-        Kokkos::View<Kokkos::complex<double> *, Kokkos::HostSpace,
-                     Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
-
     RT_FAIL_IF(controlled_wires.size() != controlled_values.size(),
                "Controlled wires/values size mismatch");
     RT_FAIL_IF(!isValidQubits(wires), "Given wires do not refer to qubits");
@@ -521,18 +546,15 @@ void LightningKokkosSimulator::MatrixOperation(
         matrix.begin(), matrix.end(), matrix_kok.begin(),
         [](auto c) { return static_cast<Kokkos::complex<double>>(c); });
 
-    Kokkos::View<Kokkos::complex<double> *> gate_matrix("gate_matrix",
-                                                        matrix_kok.size());
-    Kokkos::deep_copy(gate_matrix, UnmanagedComplexHostView(matrix_kok.data(),
-                                                            matrix_kok.size()));
-
-    // Update the state-vector
+    // Update the state-vector. Use applyOperation so the MPI state vector can
+    // move global wires local before applying the matrix.
     if (controlled_wires.empty()) {
-        this->device_sv->applyMultiQubitOp(gate_matrix, dev_wires, inverse);
+        this->device_sv->applyOperation("Matrix", dev_wires, inverse, {},
+                                        matrix_kok);
     } else {
-        this->device_sv->applyNCMultiQubitOp(gate_matrix, dev_controlled_wires,
-                                             controlled_values, dev_wires,
-                                             inverse);
+        this->device_sv->applyOperation("Matrix", dev_controlled_wires,
+                                        controlled_values, dev_wires, inverse,
+                                        {}, matrix_kok);
     }
 
     // Update tape caching if required
@@ -583,7 +605,14 @@ auto LightningKokkosSimulator::Expval(ObsIdType obsKey) -> double {
     auto m = getMeasurements();
     m.setSeed(this->generateSeed());
 
+#ifdef _ENABLE_PLKOKKOS_MPI
+    RT_FAIL_IF(
+        device_shots,
+        "Finite-shot expectation values are not supported with MPI backend.");
+    return m.expval(*obs);
+#else
     return device_shots ? m.expval(*obs, device_shots, {}) : m.expval(*obs);
+#endif
 }
 
 auto LightningKokkosSimulator::Var(ObsIdType obsKey) -> double {
@@ -600,10 +629,20 @@ auto LightningKokkosSimulator::Var(ObsIdType obsKey) -> double {
     auto m = getMeasurements();
     m.setSeed(this->generateSeed());
 
+#ifdef _ENABLE_PLKOKKOS_MPI
+    RT_FAIL_IF(device_shots,
+               "Finite-shot variances are not supported with MPI backend.");
+    return m.var(*obs);
+#else
     return device_shots ? m.var(*obs, device_shots) : m.var(*obs);
+#endif
 }
 
 void LightningKokkosSimulator::State(DataView<std::complex<double>, 1> &state) {
+#ifdef _ENABLE_PLKOKKOS_MPI
+    (void)state;
+    RT_FAIL("State measurement is not supported with MPI backend.");
+#else
     reduceStateVector();
 
     using UnmanagedComplexHostView =
@@ -626,13 +665,22 @@ void LightningKokkosSimulator::State(DataView<std::complex<double>, 1> &state) {
 
     // move data to state leveraging MemRefIter
     std::move(buffer.begin(), buffer.end(), state.begin());
+#endif
 }
 
 void LightningKokkosSimulator::Probs(DataView<double, 1> &probs) {
     auto m = getMeasurements();
     m.setSeed(this->generateSeed());
 
+#ifdef _ENABLE_PLKOKKOS_MPI
+    RT_FAIL_IF(device_shots,
+               "Finite-shot probabilities are not supported with MPI backend.");
+    std::vector<std::size_t> dev_wires(this->GetNumQubits());
+    std::iota(dev_wires.begin(), dev_wires.end(), 0);
+    auto &&dv_probs = m.probs_no_reorder(dev_wires);
+#else
     auto &&dv_probs = device_shots ? m.probs(device_shots) : m.probs();
+#endif
 
     RT_FAIL_IF(probs.size() != dv_probs.size(),
                "Invalid size for the pre-allocated probabilities");
@@ -653,8 +701,14 @@ void LightningKokkosSimulator::PartialProbs(
 
     auto dev_wires = getDeviceWires(wires);
 
+#ifdef _ENABLE_PLKOKKOS_MPI
+    RT_FAIL_IF(device_shots,
+               "Finite-shot probabilities are not supported with MPI backend.");
+    auto &&dv_probs = m.probs_no_reorder(dev_wires);
+#else
     auto &&dv_probs =
         device_shots ? m.probs(dev_wires, device_shots) : m.probs(dev_wires);
+#endif
 
     RT_FAIL_IF(probs.size() != dv_probs.size(),
                "Invalid size for the pre-allocated partial-probabilities");
@@ -883,6 +937,11 @@ auto LightningKokkosSimulator::PauliMeasure(
 void LightningKokkosSimulator::Gradient(
     std::vector<DataView<double, 1>> &gradients,
     const std::vector<std::size_t> &trainParams) {
+#ifdef _ENABLE_PLKOKKOS_MPI
+    (void)gradients;
+    (void)trainParams;
+    RT_FAIL("Gradient computation is not supported with MPI backend.");
+#else
     const bool tp_empty = trainParams.empty();
     const std::size_t num_observables = this->cache_manager.getNumObservables();
     const std::size_t num_params = this->cache_manager.getNumParams();
@@ -964,6 +1023,7 @@ void LightningKokkosSimulator::Gradient(
                   gradients[obs_idx].begin());
         begin_loc_iter += num_train_params;
     }
+#endif
 }
 
 } // namespace Catalyst::Runtime::Simulator

--- a/pennylane_lightning/core/simulators/lightning_kokkos/catalyst/LightningKokkosSimulator.cpp
+++ b/pennylane_lightning/core/simulators/lightning_kokkos/catalyst/LightningKokkosSimulator.cpp
@@ -28,7 +28,13 @@ namespace Catalyst::Runtime::Simulator {
 auto LightningKokkosSimulator::AllocateQubit() -> QubitIdType {
     const size_t num_qubits = GetNumQubits();
     if (num_qubits == 0U) {
+#ifdef _ENABLE_PLKOKKOS_MPI
+        this->device_sv = std::make_unique<StateVectorT>(
+            Pennylane::LightningKokkos::Util::MPIManagerKokkos(MPI_COMM_WORLD),
+            1, Kokkos::InitializationSettings{}, comm_buffer_ratio_);
+#else
         this->device_sv = std::make_unique<StateVectorT>(1);
+#endif
         return this->qubit_manager.Allocate(0);
     }
 
@@ -90,7 +96,13 @@ auto LightningKokkosSimulator::AllocateQubits(std::size_t num_qubits)
 
     // at the first call when num_qubits == 0
     if (!this->GetNumQubits()) {
+#ifdef _ENABLE_PLKOKKOS_MPI
+        this->device_sv = std::make_unique<StateVectorT>(
+            Pennylane::LightningKokkos::Util::MPIManagerKokkos(MPI_COMM_WORLD),
+            num_qubits, Kokkos::InitializationSettings{}, comm_buffer_ratio_);
+#else
         this->device_sv = std::make_unique<StateVectorT>(num_qubits);
+#endif
         return this->qubit_manager.AllocateRange(0, num_qubits);
     }
 

--- a/pennylane_lightning/core/simulators/lightning_kokkos/catalyst/LightningKokkosSimulator.hpp
+++ b/pennylane_lightning/core/simulators/lightning_kokkos/catalyst/LightningKokkosSimulator.hpp
@@ -77,6 +77,7 @@ class LightningKokkosSimulator final : public Catalyst::Runtime::QuantumDevice {
     std::size_t device_shots{0};
 
     std::mt19937 *gen{nullptr};
+    std::size_t comm_buffer_ratio_{1};
 
 #ifdef _ENABLE_PLKOKKOS_MPI
     std::unique_ptr<StateVectorT> device_sv = nullptr;
@@ -141,6 +142,15 @@ class LightningKokkosSimulator final : public Catalyst::Runtime::QuantumDevice {
     explicit LightningKokkosSimulator(
         const std::string &kwargs = "{}") noexcept {
         auto &&args = Catalyst::Runtime::parse_kwargs(kwargs);
+        if (args.contains("comm_buffer_ratio")) {
+            try {
+                const auto parsed = std::stoull(args["comm_buffer_ratio"]);
+                if (parsed > 0) {
+                    comm_buffer_ratio_ = parsed;
+                }
+            } catch (...) {
+            }
+        }
     }
     ~LightningKokkosSimulator() noexcept = default;
 

--- a/pennylane_lightning/core/simulators/lightning_kokkos/catalyst/LightningKokkosSimulator.hpp
+++ b/pennylane_lightning/core/simulators/lightning_kokkos/catalyst/LightningKokkosSimulator.hpp
@@ -23,6 +23,7 @@
 #include <cstdint>
 #include <iostream>
 #include <limits>
+#include <memory>
 #include <optional>
 #include <random>
 #include <span>
@@ -32,6 +33,10 @@
 #include "AdjointJacobianKokkos.hpp"
 #include "MeasurementsKokkos.hpp"
 #include "StateVectorKokkos.hpp"
+#ifdef _ENABLE_PLKOKKOS_MPI
+#include "MeasurementsKokkosMPI.hpp"
+#include "StateVectorKokkosMPI.hpp"
+#endif
 
 #include "CacheManager.hpp"
 #include "Exception.hpp"
@@ -49,7 +54,16 @@ namespace Catalyst::Runtime::Simulator {
  */
 class LightningKokkosSimulator final : public Catalyst::Runtime::QuantumDevice {
   private:
+#ifdef _ENABLE_PLKOKKOS_MPI
+    using StateVectorT =
+        Pennylane::LightningKokkos::StateVectorKokkosMPI<double>;
+    using MeasurementsBackendT =
+        Pennylane::LightningKokkos::Measures::MeasurementsMPI<StateVectorT>;
+#else
     using StateVectorT = Pennylane::LightningKokkos::StateVectorKokkos<double>;
+    using MeasurementsBackendT =
+        Pennylane::LightningKokkos::Measures::Measurements<StateVectorT>;
+#endif
 
     // static constants for RESULT values
     static constexpr bool GLOBAL_RESULT_TRUE_CONST = true;
@@ -64,7 +78,11 @@ class LightningKokkosSimulator final : public Catalyst::Runtime::QuantumDevice {
 
     std::mt19937 *gen{nullptr};
 
+#ifdef _ENABLE_PLKOKKOS_MPI
+    std::unique_ptr<StateVectorT> device_sv = nullptr;
+#else
     std::unique_ptr<StateVectorT> device_sv = std::make_unique<StateVectorT>(0);
+#endif
     LightningKokkosObsManager<double> obs_manager{};
 
     // Flag to indicate if state vector needs reduction
@@ -111,8 +129,7 @@ class LightningKokkosSimulator final : public Catalyst::Runtime::QuantumDevice {
     void reduceStateVector();
 
     // Helper to get Measurements object with reduced state vector
-    auto getMeasurements()
-        -> Pennylane::LightningKokkos::Measures::Measurements<StateVectorT>;
+    auto getMeasurements() -> MeasurementsBackendT;
 
     // Check if released qubits are disentangled from active qubits
     void checkReleasedQubitsDisentangled();

--- a/pennylane_lightning/core/simulators/lightning_kokkos/measurements/MeasurementsKokkosMPI.hpp
+++ b/pennylane_lightning/core/simulators/lightning_kokkos/measurements/MeasurementsKokkosMPI.hpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #pragma once
+#include <algorithm>
 #include <chrono>
 #include <cstdint>
 
@@ -456,9 +457,7 @@ class MeasurementsMPI final
      * @return Floating point std::vector with probabilities.
      * The basis columns are rearranged according to wires.
      *
-     * This will return the probability local to the MPI rank/global index.
-     * To obtain the full probability vector, you need to call
-     * MPI GatherV.
+     * This returns the full probability vector on every MPI rank.
      */
     auto
     probs(const std::vector<std::size_t> &wires,
@@ -470,6 +469,25 @@ class MeasurementsMPI final
             "indices with probability calculations");
         this->_statevector.reorderAllWires();
 
+        return probs_no_reorder(wires, device_wires);
+    }
+
+    /**
+     * @brief Probabilities for a subset of the full system without reordering
+     * the state vector.
+     *
+     * This returns the full probability vector on every MPI rank.
+     *
+     * @param wires Wires will restrict probabilities to a subset of the full
+     * system.
+     * @param device_wires Wires on the device.
+     * @return Floating point std::vector with probabilities. The basis columns
+     * are rearranged according to wires.
+     */
+    auto probs_no_reorder(
+        const std::vector<std::size_t> &wires,
+        [[maybe_unused]] const std::vector<std::size_t> &device_wires = {})
+        -> std::vector<PrecisionT> {
         auto global_wires = this->_statevector.findGlobalWires(wires);
         auto local_wires = this->_statevector.findLocalWires(wires);
 
@@ -486,19 +504,59 @@ class MeasurementsMPI final
         }
         std::size_t subCommGroupId = global_index & mask;
 
-        auto sub_mpi_manager =
-            mpi_manager_.split(subCommGroupId, mpi_manager_.getRank());
+        auto sub_mpi_manager = mpi_manager_.split(subCommGroupId, global_index);
 
-        if (sub_mpi_manager.getSize() == 1) {
-            return local_probabilities;
+        std::vector<PrecisionT> subgroup_probabilities(
+            exp2(local_wires.size()));
+        sub_mpi_manager.Allreduce<PrecisionT>(local_probabilities,
+                                              subgroup_probabilities, "sum");
+
+        if (global_wires.empty()) {
+            return subgroup_probabilities;
         }
-        std::vector<PrecisionT> subgroup_probabilities;
-        if (sub_mpi_manager.getRank() == 0) {
-            subgroup_probabilities.resize(exp2(local_wires.size()));
+
+        auto gathering_mpi_manager =
+            mpi_manager_.split(sub_mpi_manager.getRank(), global_index);
+
+        std::vector<PrecisionT> full_probabilities(exp2(wires.size()));
+        gathering_mpi_manager.Allgather<PrecisionT>(subgroup_probabilities,
+                                                    full_probabilities);
+
+        std::vector<std::size_t> current_probs_wire_order;
+        current_probs_wire_order.reserve(wires.size());
+        for (const auto w : this->_statevector.getGlobalWires()) {
+            if (std::find(global_wires.begin(), global_wires.end(), w) !=
+                global_wires.end()) {
+                current_probs_wire_order.push_back(w);
+            }
         }
-        sub_mpi_manager.Reduce<PrecisionT>(local_probabilities,
-                                           subgroup_probabilities, 0, "sum");
-        return subgroup_probabilities;
+        current_probs_wire_order.insert(current_probs_wire_order.end(),
+                                        local_wires.begin(), local_wires.end());
+
+        std::vector<PrecisionT> reordered_full_probabilities(
+            exp2(wires.size()));
+
+        std::vector<std::size_t> mapping_indices;
+        std::size_t wires_size = wires.size();
+        mapping_indices.reserve(wires_size);
+        for (std::size_t i = 0; i < wires_size; i++) {
+            std::size_t alpha = current_probs_wire_order[wires_size - 1 - i];
+            auto it = std::find(wires.begin(), wires.end(), alpha);
+            auto position = std::distance(wires.begin(), it);
+            std::size_t position_inverse = wires_size - 1 - position;
+            mapping_indices.push_back(position_inverse);
+        }
+
+        for (std::size_t i = 0; i < exp2(wires.size()); i++) {
+            std::size_t reordered_index = 0;
+            for (std::size_t j = 0; j < wires.size(); j++) {
+                reordered_index |= ((i >> j) & 1U) << mapping_indices[j];
+            }
+            reordered_full_probabilities[reordered_index] =
+                full_probabilities[i];
+        }
+
+        return reordered_full_probabilities;
     }
 
     /**

--- a/pennylane_lightning/core/simulators/lightning_kokkos/utils/MPIManagerKokkos.hpp
+++ b/pennylane_lightning/core/simulators/lightning_kokkos/utils/MPIManagerKokkos.hpp
@@ -95,9 +95,7 @@ class MPIManagerKokkos final : public MPIManager {
      */
     static constexpr std::size_t MPI_MAX_TRANSFER_COUNT = std::size_t{1} << 30;
 
-    MPIManagerKokkos(MPI_Comm communicator = MPI_COMM_WORLD)
-        : MPIManager(communicator) {}
-
+    using MPIManager::MPIManager;
     using MPIManager::Bcast;
 
     /**

--- a/pennylane_lightning/core/simulators/lightning_kokkos/utils/MPIManagerKokkos.hpp
+++ b/pennylane_lightning/core/simulators/lightning_kokkos/utils/MPIManagerKokkos.hpp
@@ -95,8 +95,8 @@ class MPIManagerKokkos final : public MPIManager {
      */
     static constexpr std::size_t MPI_MAX_TRANSFER_COUNT = std::size_t{1} << 30;
 
-    using MPIManager::MPIManager;
     using MPIManager::Bcast;
+    using MPIManager::MPIManager;
 
     /**
      * @brief MPI_Sendrecv wrapper for Kokkos::Views.

--- a/pennylane_lightning/core/simulators/lightning_kokkos/utils/MPIManagerKokkos.hpp
+++ b/pennylane_lightning/core/simulators/lightning_kokkos/utils/MPIManagerKokkos.hpp
@@ -98,8 +98,6 @@ class MPIManagerKokkos final : public MPIManager {
     MPIManagerKokkos(MPI_Comm communicator = MPI_COMM_WORLD)
         : MPIManager(communicator) {}
 
-    MPIManagerKokkos(int argc, char **argv) : MPIManager(argc, argv) {}
-
     using MPIManager::Bcast;
 
     /**

--- a/pennylane_lightning/core/simulators/lightning_kokkos/utils/TestHelpersStateVectors.hpp
+++ b/pennylane_lightning/core/simulators/lightning_kokkos/utils/TestHelpersStateVectors.hpp
@@ -108,7 +108,7 @@ auto getFullDataVector(StateVectorKokkosMPI<TestType> &sv,
     -> std::vector<Kokkos::complex<TestType>> {
     sv.reorderGlobalLocalWires();
     sv.reorderLocalWires();
-    auto mpi_manager = sv.getMPIManager();
+    auto &mpi_manager = sv.getMPIManager();
     std::vector<Kokkos::complex<TestType>> data(
         (mpi_manager.getRank() == root) ? sv.getLength() : 0);
 

--- a/pennylane_lightning/core/simulators/lightning_kokkos/utils/tests/mpi/Test_MPIManagerKokkos.cpp
+++ b/pennylane_lightning/core/simulators/lightning_kokkos/utils/tests/mpi/Test_MPIManagerKokkos.cpp
@@ -37,10 +37,6 @@ TEST_CASE("MPIManagerKokkos ctor", "[MPIManagerKokkos]") {
         REQUIRE(std::is_constructible_v<MPIManagerKokkos, MPI_Comm>);
     }
 
-    SECTION("Construct with args") {
-        REQUIRE(std::is_constructible_v<MPIManagerKokkos, int, char **>);
-    }
-
     SECTION("MPIManagerKokkos {MPIManagerKokkos&}") {
         REQUIRE(std::is_copy_constructible_v<MPIManagerKokkos>);
     }

--- a/pennylane_lightning/core/simulators/lightning_kokkos/utils/tests/mpi/Test_MPIManagerKokkos.cpp
+++ b/pennylane_lightning/core/simulators/lightning_kokkos/utils/tests/mpi/Test_MPIManagerKokkos.cpp
@@ -40,6 +40,18 @@ TEST_CASE("MPIManagerKokkos ctor", "[MPIManagerKokkos]") {
     SECTION("MPIManagerKokkos {MPIManagerKokkos&}") {
         REQUIRE(std::is_copy_constructible_v<MPIManagerKokkos>);
     }
+
+    SECTION("MPIManagerKokkos = MPIManagerKokkos&") {
+        REQUIRE(std::is_copy_assignable_v<MPIManagerKokkos>);
+    }
+
+    SECTION("MPIManagerKokkos {MPIManagerKokkos&&}") {
+        REQUIRE(std::is_move_constructible_v<MPIManagerKokkos>);
+    }
+
+    SECTION("MPIManagerKokkos = MPIManagerKokkos&&") {
+        REQUIRE(std::is_move_assignable_v<MPIManagerKokkos>);
+    }
 }
 
 TEST_CASE("MPIManagerKokkos::getMPIDatatype", "[MPIManagerKokkos]") {

--- a/pennylane_lightning/core/utils/MPIManager.hpp
+++ b/pennylane_lightning/core/utils/MPIManager.hpp
@@ -198,6 +198,26 @@ class MPIManager {
          MPI_C_LONG_DOUBLE_COMPLEX}};
 
     /**
+     * @brief Free communicator except for MPI_COMM_WORLD. 
+     */
+    static void freeCommunicator(MPI_Comm &communicator) {
+        int initflag = 0;
+        PL_MPI_IS_SUCCESS(MPI_Initialized(&initflag));
+        int finflag = 0;
+        PL_MPI_IS_SUCCESS(MPI_Finalized(&finflag));
+        if (!initflag || finflag || communicator == MPI_COMM_NULL) {
+            return;
+        }
+
+        int compare;
+        PL_MPI_IS_SUCCESS(
+            MPI_Comm_compare(MPI_COMM_WORLD, communicator, &compare));
+        if (compare != MPI_IDENT) {
+            PL_MPI_IS_SUCCESS(MPI_Comm_free(&communicator));
+        }
+    }
+
+    /**
      * @brief Set the MPI vendor.
      */
     void setVendor() {
@@ -238,11 +258,7 @@ class MPIManager {
                                 this->getRank(), MPI_INFO_NULL, &node_comm));
         PL_MPI_IS_SUCCESS(MPI_Comm_size(node_comm, &size_per_node_int));
         size_per_node_ = static_cast<std::size_t>(size_per_node_int);
-        int compare;
-        PL_MPI_IS_SUCCESS(
-            MPI_Comm_compare(MPI_COMM_WORLD, node_comm, &compare));
-        if (compare != MPI_IDENT)
-            PL_MPI_IS_SUCCESS(MPI_Comm_free(&node_comm));
+        freeCommunicator(node_comm);
         this->Barrier();
     }
 
@@ -302,18 +318,7 @@ class MPIManager {
                 MPI_Comm_dup(other.communicator_, &new_communicator));
         }
 
-        int initflag = 0;
-        PL_MPI_IS_SUCCESS(MPI_Initialized(&initflag));
-        int finflag = 0;
-        PL_MPI_IS_SUCCESS(MPI_Finalized(&finflag));
-        if (initflag && !finflag && communicator_ != MPI_COMM_NULL) {
-            int compare;
-            PL_MPI_IS_SUCCESS(
-                MPI_Comm_compare(MPI_COMM_WORLD, communicator_, &compare));
-            if (compare != MPI_IDENT) {
-                PL_MPI_IS_SUCCESS(MPI_Comm_free(&communicator_));
-            }
-        }
+        freeCommunicator(communicator_);
 
         rank_ = other.rank_;
         size_per_node_ = other.size_per_node_;
@@ -343,18 +348,7 @@ class MPIManager {
             return *this;
         }
 
-        int initflag = 0;
-        PL_MPI_IS_SUCCESS(MPI_Initialized(&initflag));
-        int finflag = 0;
-        PL_MPI_IS_SUCCESS(MPI_Finalized(&finflag));
-        if (initflag && !finflag && communicator_ != MPI_COMM_NULL) {
-            int compare;
-            PL_MPI_IS_SUCCESS(
-                MPI_Comm_compare(MPI_COMM_WORLD, communicator_, &compare));
-            if (compare != MPI_IDENT) {
-                PL_MPI_IS_SUCCESS(MPI_Comm_free(&communicator_));
-            }
-        }
+        freeCommunicator(communicator_);
 
         rank_ = other.rank_;
         size_per_node_ = other.size_per_node_;
@@ -374,22 +368,7 @@ class MPIManager {
     }
 
     // LCOV_EXCL_START
-    ~MPIManager() {
-        int initflag = 0;
-        PL_MPI_IS_SUCCESS(MPI_Initialized(&initflag));
-        int finflag = 0;
-        PL_MPI_IS_SUCCESS(MPI_Finalized(&finflag));
-        if (!initflag || finflag || communicator_ == MPI_COMM_NULL) {
-            return;
-        }
-
-        int compare;
-        PL_MPI_IS_SUCCESS(
-            MPI_Comm_compare(MPI_COMM_WORLD, communicator_, &compare));
-        if (compare != MPI_IDENT) {
-            PL_MPI_IS_SUCCESS(MPI_Comm_free(&communicator_));
-        }
-    }
+    ~MPIManager() { freeCommunicator(communicator_); }
     // LCOV_EXCL_STOP
 
     /**

--- a/pennylane_lightning/core/utils/MPIManager.hpp
+++ b/pennylane_lightning/core/utils/MPIManager.hpp
@@ -135,7 +135,6 @@ class MPIRuntime {
             registerFinalizeHookIfNeeded_();
         }
     }
-
 };
 
 /**
@@ -198,7 +197,7 @@ class MPIManager {
          MPI_C_LONG_DOUBLE_COMPLEX}};
 
     /**
-     * @brief Free communicator except for MPI_COMM_WORLD. 
+     * @brief Free communicator except for MPI_COMM_WORLD.
      */
     static void freeCommunicator(MPI_Comm &communicator) {
         int initflag = 0;
@@ -300,8 +299,9 @@ class MPIManager {
           subversion_(other.subversion_) {
         if (other.communicator_ != MPI_COMM_NULL) {
             MPIRuntime::getInstance().ensureInitialized();
-            // Avoid freeing other.communicator_ in ~MPIManager     
-            PL_MPI_IS_SUCCESS(MPI_Comm_dup(other.communicator_, &communicator_)); 
+            // Avoid freeing other.communicator_ in ~MPIManager
+            PL_MPI_IS_SUCCESS(
+                MPI_Comm_dup(other.communicator_, &communicator_));
         }
     }
 
@@ -313,7 +313,7 @@ class MPIManager {
         MPI_Comm new_communicator = MPI_COMM_NULL;
         if (other.communicator_ != MPI_COMM_NULL) {
             MPIRuntime::getInstance().ensureInitialized();
-            // Avoid freeing other.communicator_ in ~MPIManager     
+            // Avoid freeing other.communicator_ in ~MPIManager
             PL_MPI_IS_SUCCESS(
                 MPI_Comm_dup(other.communicator_, &new_communicator));
         }

--- a/pennylane_lightning/core/utils/MPIManager.hpp
+++ b/pennylane_lightning/core/utils/MPIManager.hpp
@@ -66,17 +66,18 @@ template <typename T> auto cppTypeToString() -> const std::string {
  *
  * This class centralizes MPI initialization/finalization ownership inside
  * Lightning while allowing MPIManager to bootstrap the runtime on demand.
+ * It will finalize MPI at exit only if it was initialized within Lightning C++
  */
 class MPIRuntime {
   private:
-    bool owns_mpi_{false};
+    bool mpi_initialized_here_{false};
     bool atexit_registered_{false};
 
     MPIRuntime() = default;
 
     static void finalizeAtExit() noexcept {
         try {
-            MPIRuntime::instance().finalizeIfOwned();
+            MPIRuntime::getInstance().finalizeIfOwned();
         } catch (...) {
             // Avoid throwing during process shutdown.
         }
@@ -89,8 +90,26 @@ class MPIRuntime {
         }
     }
 
+    void finalizeIfOwned() {
+        if (!mpi_initialized_here_) {
+            return;
+        }
+
+        int finflag = 0;
+        PL_MPI_IS_SUCCESS(MPI_Finalized(&finflag));
+        if (finflag) {
+            return;
+        }
+
+        int initflag = 0;
+        PL_MPI_IS_SUCCESS(MPI_Initialized(&initflag));
+        if (initflag) {
+            PL_MPI_IS_SUCCESS(MPI_Finalize());
+        }
+    }
+
   public:
-    static auto instance() -> MPIRuntime & {
+    static auto getInstance() -> MPIRuntime & {
         static MPIRuntime runtime;
         return runtime;
     }
@@ -112,28 +131,11 @@ class MPIRuntime {
 
         if (!initflag) {
             PL_MPI_IS_SUCCESS(MPI_Init(nullptr, nullptr));
-            owns_mpi_ = true;
+            mpi_initialized_here_ = true;
             registerFinalizeHookIfNeeded_();
         }
     }
 
-    void finalizeIfOwned() {
-        if (!owns_mpi_) {
-            return;
-        }
-
-        int finflag = 0;
-        PL_MPI_IS_SUCCESS(MPI_Finalized(&finflag));
-        if (finflag) {
-            return;
-        }
-
-        int initflag = 0;
-        PL_MPI_IS_SUCCESS(MPI_Initialized(&initflag));
-        if (initflag) {
-            PL_MPI_IS_SUCCESS(MPI_Finalize());
-        }
-    }
 };
 
 /**
@@ -260,7 +262,7 @@ class MPIManager {
   public:
     MPIManager(MPI_Comm communicator = MPI_COMM_WORLD)
         : communicator_(communicator) {
-        MPIRuntime::instance().ensureInitialized();
+        MPIRuntime::getInstance().ensureInitialized();
         int rank_int;
         int size_int;
         PL_MPI_IS_SUCCESS(MPI_Comm_rank(communicator_, &rank_int));
@@ -280,13 +282,10 @@ class MPIManager {
           size_(other.size_), communicator_(MPI_COMM_NULL),
           vendor_(other.vendor_), version_(other.version_),
           subversion_(other.subversion_) {
-        MPIRuntime::instance().ensureInitialized();
         if (other.communicator_ != MPI_COMM_NULL) {
-            PL_MPI_IS_SUCCESS(
-                MPI_Comm_dup(other.communicator_,
-                             &communicator_)); // Avoid freeing
-                                               // other.communicator_
-                                               // in ~MPIManager
+            MPIRuntime::getInstance().ensureInitialized();
+            // Avoid freeing other.communicator_ in ~MPIManager     
+            PL_MPI_IS_SUCCESS(MPI_Comm_dup(other.communicator_, &communicator_)); 
         }
     }
 
@@ -297,7 +296,8 @@ class MPIManager {
 
         MPI_Comm new_communicator = MPI_COMM_NULL;
         if (other.communicator_ != MPI_COMM_NULL) {
-            MPIRuntime::instance().ensureInitialized();
+            MPIRuntime::getInstance().ensureInitialized();
+            // Avoid freeing other.communicator_ in ~MPIManager     
             PL_MPI_IS_SUCCESS(
                 MPI_Comm_dup(other.communicator_, &new_communicator));
         }

--- a/pennylane_lightning/core/utils/MPIManager.hpp
+++ b/pennylane_lightning/core/utils/MPIManager.hpp
@@ -103,7 +103,8 @@ class MPIRuntime {
     void ensureInitialized() {
         int finflag = 0;
         PL_MPI_IS_SUCCESS(MPI_Finalized(&finflag));
-        PL_ABORT_IF(finflag, "MPI has already been finalized and cannot be reused.");
+        PL_ABORT_IF(finflag,
+                    "MPI has already been finalized and cannot be reused.");
 
         int initflag = 0;
         PL_MPI_IS_SUCCESS(MPI_Initialized(&initflag));
@@ -113,7 +114,6 @@ class MPIRuntime {
             owns_mpi_ = true;
             registerFinalizeHookIfNeeded_();
         }
-
     }
 
     void finalizeIfOwned() {
@@ -133,7 +133,6 @@ class MPIRuntime {
             PL_MPI_IS_SUCCESS(MPI_Finalize());
         }
     }
-
 };
 
 /**
@@ -279,9 +278,10 @@ class MPIManager {
         : rank_(other.rank_), size_per_node_(other.size_per_node_),
           size_(other.size_) {
         MPIRuntime::instance().ensureInitialized();
-        PL_MPI_IS_SUCCESS(MPI_Comm_dup(
-            other.communicator_,
-            &communicator_)); // Avoid freeing other.communicator_ in ~MPIManager
+        PL_MPI_IS_SUCCESS(
+            MPI_Comm_dup(other.communicator_,
+                         &communicator_)); // Avoid freeing other.communicator_
+                                           // in ~MPIManager
         vendor_ = other.vendor_;
         version_ = other.version_;
         subversion_ = other.subversion_;

--- a/pennylane_lightning/core/utils/MPIManager.hpp
+++ b/pennylane_lightning/core/utils/MPIManager.hpp
@@ -17,6 +17,8 @@
 #include <algorithm>
 #include <bit>
 #include <complex>
+#include <cstdio>
+#include <cstdlib>
 #include <cstring>
 #include <mpi.h>
 #include <stdexcept>
@@ -59,11 +61,86 @@ template <typename T> auto cppTypeToString() -> const std::string {
 }
 
 /**
+ * @brief Process-wide MPI lifecycle manager.
+ *
+ * This class centralizes MPI initialization/finalization ownership inside
+ * Lightning while allowing MPIManager to bootstrap the runtime on demand.
+ */
+class MPIRuntime {
+  private:
+    bool owns_mpi_{false};
+    bool atexit_registered_{false};
+
+    MPIRuntime() = default;
+
+    static void finalizeAtExit() noexcept {
+        try {
+            MPIRuntime::instance().finalizeIfOwned();
+        } catch (...) {
+            // Avoid throwing during process shutdown.
+        }
+    }
+
+    void registerFinalizeHookIfNeeded_() {
+        if (!atexit_registered_) {
+            std::atexit(&MPIRuntime::finalizeAtExit);
+            atexit_registered_ = true;
+        }
+    }
+
+  public:
+    static auto instance() -> MPIRuntime & {
+        static MPIRuntime runtime;
+        return runtime;
+    }
+
+    MPIRuntime(const MPIRuntime &) = delete;
+    auto operator=(const MPIRuntime &) -> MPIRuntime & = delete;
+    MPIRuntime(MPIRuntime &&) = delete;
+    auto operator=(MPIRuntime &&) -> MPIRuntime & = delete;
+    ~MPIRuntime() = default;
+
+    void ensureInitialized() {
+        int finflag = 0;
+        PL_MPI_IS_SUCCESS(MPI_Finalized(&finflag));
+        PL_ABORT_IF(finflag, "MPI has already been finalized and cannot be reused.");
+
+        int initflag = 0;
+        PL_MPI_IS_SUCCESS(MPI_Initialized(&initflag));
+
+        if (!initflag) {
+            PL_MPI_IS_SUCCESS(MPI_Init(nullptr, nullptr));
+            owns_mpi_ = true;
+            registerFinalizeHookIfNeeded_();
+        }
+
+    }
+
+    void finalizeIfOwned() {
+        if (!owns_mpi_) {
+            return;
+        }
+
+        int finflag = 0;
+        PL_MPI_IS_SUCCESS(MPI_Finalized(&finflag));
+        if (finflag) {
+            return;
+        }
+
+        int initflag = 0;
+        PL_MPI_IS_SUCCESS(MPI_Initialized(&initflag));
+        if (initflag) {
+            PL_MPI_IS_SUCCESS(MPI_Finalize());
+        }
+    }
+
+};
+
+/**
  * @brief MPI operation class. Maintains MPI related operations.
  */
 class MPIManager {
   private:
-    bool isExternalComm_;
     std::size_t rank_;
     std::size_t size_per_node_;
     std::size_t size_;
@@ -183,12 +260,7 @@ class MPIManager {
   public:
     MPIManager(MPI_Comm communicator = MPI_COMM_WORLD)
         : communicator_(communicator) {
-        int status = 0;
-        MPI_Initialized(&status);
-        if (!status) {
-            PL_MPI_IS_SUCCESS(MPI_Init(nullptr, nullptr));
-        }
-        isExternalComm_ = true;
+        MPIRuntime::instance().ensureInitialized();
         int rank_int;
         int size_int;
         PL_MPI_IS_SUCCESS(MPI_Comm_rank(communicator_, &rank_int));
@@ -203,62 +275,33 @@ class MPIManager {
         check_mpi_config();
     }
 
-    MPIManager(int argc, char **argv) {
-        int status = 0;
-        MPI_Initialized(&status);
-        if (!status) {
-            PL_MPI_IS_SUCCESS(MPI_Init(&argc, &argv));
-        }
-        isExternalComm_ = false;
-        communicator_ = MPI_COMM_WORLD;
-        int rank_int;
-        int size_int;
-        PL_MPI_IS_SUCCESS(MPI_Comm_rank(communicator_, &rank_int));
-        PL_MPI_IS_SUCCESS(MPI_Comm_size(communicator_, &size_int));
-
-        rank_ = static_cast<std::size_t>(rank_int);
-        size_ = static_cast<std::size_t>(size_int);
-
-        setVendor();
-        setVersion();
-        setNumProcsPerNode();
-        check_mpi_config();
-    }
-
-    MPIManager(const MPIManager &other) {
-        int status = 0;
-        MPI_Initialized(&status);
-        if (!status) {
-            PL_MPI_IS_SUCCESS(MPI_Init(nullptr, nullptr));
-        }
-        isExternalComm_ = true;
-        rank_ = other.rank_;
-        size_ = other.size_;
-        MPI_Comm_dup(
+    MPIManager(const MPIManager &other)
+        : rank_(other.rank_), size_per_node_(other.size_per_node_),
+          size_(other.size_) {
+        MPIRuntime::instance().ensureInitialized();
+        PL_MPI_IS_SUCCESS(MPI_Comm_dup(
             other.communicator_,
-            &communicator_); // Avoid freeing other.communicator_ in ~MPIManager
+            &communicator_)); // Avoid freeing other.communicator_ in ~MPIManager
         vendor_ = other.vendor_;
         version_ = other.version_;
         subversion_ = other.subversion_;
-        size_per_node_ = other.size_per_node_;
     }
 
     // LCOV_EXCL_START
     ~MPIManager() {
-        if (!isExternalComm_) {
-            int initflag;
-            int finflag;
-            PL_MPI_IS_SUCCESS(MPI_Initialized(&initflag));
-            PL_MPI_IS_SUCCESS(MPI_Finalized(&finflag));
-            if (initflag && !finflag) {
-                PL_MPI_IS_SUCCESS(MPI_Finalize());
-            }
-        } else {
-            int compare;
-            PL_MPI_IS_SUCCESS(
-                MPI_Comm_compare(MPI_COMM_WORLD, communicator_, &compare));
-            if (compare != MPI_IDENT)
-                PL_MPI_IS_SUCCESS(MPI_Comm_free(&communicator_));
+        int initflag = 0;
+        PL_MPI_IS_SUCCESS(MPI_Initialized(&initflag));
+        int finflag = 0;
+        PL_MPI_IS_SUCCESS(MPI_Finalized(&finflag));
+        if (!initflag || finflag) {
+            return;
+        }
+
+        int compare;
+        PL_MPI_IS_SUCCESS(
+            MPI_Comm_compare(MPI_COMM_WORLD, communicator_, &compare));
+        if (compare != MPI_IDENT) {
+            PL_MPI_IS_SUCCESS(MPI_Comm_free(&communicator_));
         }
     }
     // LCOV_EXCL_STOP

--- a/pennylane_lightning/core/utils/MPIManager.hpp
+++ b/pennylane_lightning/core/utils/MPIManager.hpp
@@ -26,6 +26,7 @@
 #include <typeindex>
 #include <typeinfo>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 #include "Error.hpp"
@@ -276,15 +277,100 @@ class MPIManager {
 
     MPIManager(const MPIManager &other)
         : rank_(other.rank_), size_per_node_(other.size_per_node_),
-          size_(other.size_) {
+          size_(other.size_), communicator_(MPI_COMM_NULL),
+          vendor_(other.vendor_), version_(other.version_),
+          subversion_(other.subversion_) {
         MPIRuntime::instance().ensureInitialized();
-        PL_MPI_IS_SUCCESS(
-            MPI_Comm_dup(other.communicator_,
-                         &communicator_)); // Avoid freeing other.communicator_
-                                           // in ~MPIManager
+        if (other.communicator_ != MPI_COMM_NULL) {
+            PL_MPI_IS_SUCCESS(
+                MPI_Comm_dup(other.communicator_,
+                             &communicator_)); // Avoid freeing
+                                               // other.communicator_
+                                               // in ~MPIManager
+        }
+    }
+
+    auto operator=(const MPIManager &other) -> MPIManager & {
+        if (this == &other) {
+            return *this;
+        }
+
+        MPI_Comm new_communicator = MPI_COMM_NULL;
+        if (other.communicator_ != MPI_COMM_NULL) {
+            MPIRuntime::instance().ensureInitialized();
+            PL_MPI_IS_SUCCESS(
+                MPI_Comm_dup(other.communicator_, &new_communicator));
+        }
+
+        int initflag = 0;
+        PL_MPI_IS_SUCCESS(MPI_Initialized(&initflag));
+        int finflag = 0;
+        PL_MPI_IS_SUCCESS(MPI_Finalized(&finflag));
+        if (initflag && !finflag && communicator_ != MPI_COMM_NULL) {
+            int compare;
+            PL_MPI_IS_SUCCESS(
+                MPI_Comm_compare(MPI_COMM_WORLD, communicator_, &compare));
+            if (compare != MPI_IDENT) {
+                PL_MPI_IS_SUCCESS(MPI_Comm_free(&communicator_));
+            }
+        }
+
+        rank_ = other.rank_;
+        size_per_node_ = other.size_per_node_;
+        size_ = other.size_;
+        communicator_ = new_communicator;
         vendor_ = other.vendor_;
         version_ = other.version_;
         subversion_ = other.subversion_;
+        return *this;
+    }
+
+    MPIManager(MPIManager &&other) noexcept
+        : rank_(other.rank_), size_per_node_(other.size_per_node_),
+          size_(other.size_), communicator_(other.communicator_),
+          vendor_(std::move(other.vendor_)), version_(other.version_),
+          subversion_(other.subversion_) {
+        other.rank_ = 0;
+        other.size_per_node_ = 0;
+        other.size_ = 0;
+        other.communicator_ = MPI_COMM_NULL;
+        other.version_ = 0;
+        other.subversion_ = 0;
+    }
+
+    auto operator=(MPIManager &&other) noexcept -> MPIManager & {
+        if (this == &other) {
+            return *this;
+        }
+
+        int initflag = 0;
+        PL_MPI_IS_SUCCESS(MPI_Initialized(&initflag));
+        int finflag = 0;
+        PL_MPI_IS_SUCCESS(MPI_Finalized(&finflag));
+        if (initflag && !finflag && communicator_ != MPI_COMM_NULL) {
+            int compare;
+            PL_MPI_IS_SUCCESS(
+                MPI_Comm_compare(MPI_COMM_WORLD, communicator_, &compare));
+            if (compare != MPI_IDENT) {
+                PL_MPI_IS_SUCCESS(MPI_Comm_free(&communicator_));
+            }
+        }
+
+        rank_ = other.rank_;
+        size_per_node_ = other.size_per_node_;
+        size_ = other.size_;
+        communicator_ = other.communicator_;
+        vendor_ = std::move(other.vendor_);
+        version_ = other.version_;
+        subversion_ = other.subversion_;
+
+        other.rank_ = 0;
+        other.size_per_node_ = 0;
+        other.size_ = 0;
+        other.communicator_ = MPI_COMM_NULL;
+        other.version_ = 0;
+        other.subversion_ = 0;
+        return *this;
     }
 
     // LCOV_EXCL_START
@@ -293,7 +379,7 @@ class MPIManager {
         PL_MPI_IS_SUCCESS(MPI_Initialized(&initflag));
         int finflag = 0;
         PL_MPI_IS_SUCCESS(MPI_Finalized(&finflag));
-        if (!initflag || finflag) {
+        if (!initflag || finflag || communicator_ == MPI_COMM_NULL) {
             return;
         }
 

--- a/pennylane_lightning/core/utils/tests/mpi/Test_MPIManager.cpp
+++ b/pennylane_lightning/core/utils/tests/mpi/Test_MPIManager.cpp
@@ -19,6 +19,8 @@
 #include <utility>
 #include <vector>
 
+#include <mpi.h>
+
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>
 
@@ -38,6 +40,75 @@ TEST_CASE("MPIManager ctor", "[MPIManager]") {
 
     SECTION("MPIManager {MPIManager&}") {
         REQUIRE(std::is_copy_constructible_v<MPIManager>);
+    }
+
+    SECTION("MPIManager = MPIManager&") {
+        REQUIRE(std::is_copy_assignable_v<MPIManager>);
+    }
+
+    SECTION("MPIManager {MPIManager&&}") {
+        REQUIRE(std::is_move_constructible_v<MPIManager>);
+    }
+
+    SECTION("MPIManager = MPIManager&&") {
+        REQUIRE(std::is_move_assignable_v<MPIManager>);
+    }
+}
+
+TEST_CASE("MPIManager special member functions", "[MPIManager]") {
+    MPIManager mpi_manager(MPI_COMM_WORLD);
+    REQUIRE(mpi_manager.getSize() == 2);
+
+    SECTION("Copy assignment duplicates communicator ownership") {
+        auto owned_comm = mpi_manager.split(0, mpi_manager.getRank());
+        MPIManager assigned_manager(MPI_COMM_WORLD);
+
+        assigned_manager = owned_comm;
+
+        CHECK(assigned_manager.getRank() == owned_comm.getRank());
+        CHECK(assigned_manager.getSize() == owned_comm.getSize());
+        CHECK(assigned_manager.getSizeNode() == owned_comm.getSizeNode());
+
+        int compare = MPI_UNEQUAL;
+        MPI_Comm assigned_comm = assigned_manager.getComm();
+        MPI_Comm source_comm = owned_comm.getComm();
+        PL_MPI_IS_SUCCESS(
+            MPI_Comm_compare(assigned_comm, source_comm, &compare));
+        CHECK(compare == MPI_CONGRUENT);
+    }
+
+    SECTION("Move construction transfers communicator ownership") {
+        auto owned_comm = mpi_manager.split(0, mpi_manager.getRank());
+        MPI_Comm source_comm = owned_comm.getComm();
+
+        MPIManager moved_manager(std::move(owned_comm));
+
+        CHECK(owned_comm.getComm() == MPI_COMM_NULL);
+        CHECK(moved_manager.getRank() == mpi_manager.getRank());
+        CHECK(moved_manager.getSize() == mpi_manager.getSize());
+
+        int compare = MPI_UNEQUAL;
+        MPI_Comm moved_comm = moved_manager.getComm();
+        PL_MPI_IS_SUCCESS(MPI_Comm_compare(moved_comm, source_comm, &compare));
+        CHECK(compare == MPI_IDENT);
+    }
+
+    SECTION("Move assignment transfers communicator ownership") {
+        auto owned_comm = mpi_manager.split(0, mpi_manager.getRank());
+        MPI_Comm source_comm = owned_comm.getComm();
+        MPIManager assigned_manager(MPI_COMM_WORLD);
+
+        assigned_manager = std::move(owned_comm);
+
+        CHECK(owned_comm.getComm() == MPI_COMM_NULL);
+        CHECK(assigned_manager.getRank() == mpi_manager.getRank());
+        CHECK(assigned_manager.getSize() == mpi_manager.getSize());
+
+        int compare = MPI_UNEQUAL;
+        MPI_Comm assigned_comm = assigned_manager.getComm();
+        PL_MPI_IS_SUCCESS(
+            MPI_Comm_compare(assigned_comm, source_comm, &compare));
+        CHECK(compare == MPI_IDENT);
     }
 }
 

--- a/pennylane_lightning/core/utils/tests/mpi/Test_MPIManager.cpp
+++ b/pennylane_lightning/core/utils/tests/mpi/Test_MPIManager.cpp
@@ -36,10 +36,6 @@ TEST_CASE("MPIManager ctor", "[MPIManager]") {
         REQUIRE(std::is_constructible_v<MPIManager, MPI_Comm>);
     }
 
-    SECTION("Construct with args") {
-        REQUIRE(std::is_constructible_v<MPIManager, int, char **>);
-    }
-
     SECTION("MPIManager {MPIManager&}") {
         REQUIRE(std::is_copy_constructible_v<MPIManager>);
     }

--- a/pennylane_lightning/lightning_kokkos/lightning_kokkos.py
+++ b/pennylane_lightning/lightning_kokkos/lightning_kokkos.py
@@ -190,20 +190,15 @@ class LightningKokkos(LightningBase):
                 raise DeviceError("comm_buffer_ratio requires mpi=True")
             if not isinstance(comm_buffer_ratio, int) or comm_buffer_ratio < 1:
                 raise DeviceError("comm_buffer_ratio must be a positive integer (>= 1)")
-        if mpi:
-            if wires is None:
-                raise DeviceError("Lightning-Kokkos-MPI does not support dynamic wires allocation.")
-            self._statevector = self.LightningStateVector(
-                num_wires=len(self.wires),
-                dtype=self.c_dtype,
-                kokkos_args=kokkos_args,
-                mpi=True,
-                rng=self._rng,
-                comm_buffer_ratio=comm_buffer_ratio,
-            )
-        else:
-            self._statevector = None
-            self._sv_init_kwargs = {"kokkos_args": kokkos_args}
+        if mpi and wires is None:
+            raise DeviceError("Lightning-Kokkos-MPI does not support dynamic wires allocation.")
+
+        self._statevector = None
+        self._sv_init_kwargs = {
+            "kokkos_args": kokkos_args,
+            "mpi": mpi,
+            "comm_buffer_ratio": comm_buffer_ratio,
+        }
 
     @property
     def name(self):

--- a/pennylane_lightning/lightning_kokkos/lightning_kokkos.py
+++ b/pennylane_lightning/lightning_kokkos/lightning_kokkos.py
@@ -200,6 +200,11 @@ class LightningKokkos(LightningBase):
             "comm_buffer_ratio": comm_buffer_ratio,
         }
 
+        # Forward key word arguments to Catalyst
+        self.device_kwargs = {"mpi": mpi}
+        if comm_buffer_ratio is not None:
+            self.device_kwargs["comm_buffer_ratio"] = comm_buffer_ratio
+
     @property
     def name(self):
         """The name of the device."""


### PR DESCRIPTION
feat: add minimal MPI support to Catalyst

Supports a subset of the functionality:
- expval
- variance
- full/partial probs

Notably, MPI usage is determined at compile time of lightning and not at runtime.

Can be tested with:

```python
from __future__ import annotations

from itertools import combinations

import numpy as np
import pennylane as qml
from catalyst import qjit
from mpi4py import MPI

comm = MPI.COMM_WORLD
rank = comm.Get_rank()
size = comm.Get_size()

if size < 2:
    raise RuntimeError(
        "Run this smoke test with at least two MPI ranks, e.g. `mpirun -n 2 ...`"
    )


N_WIRES = 10
SINGLE_WIRES = tuple((wire,) for wire in range(N_WIRES))
WIRE_PAIRS = tuple(combinations(range(N_WIRES), 2))

DEV_MPI = qml.device("lightning.kokkos", wires=N_WIRES, mpi=True)
DEV_REF = qml.device("default.qubit", wires=N_WIRES)


def ansatz():
    """A circuit that exercises one- and two-qubit operations on all wires."""
    for wire in range(N_WIRES):
        qml.RX(0.13 * (wire + 1), wires=wire)
        qml.RY(-0.07 * (wire + 1), wires=wire)
        qml.RZ(0.11 * (wire + 1), wires=wire)

    for wire in range(N_WIRES - 1):
        qml.CNOT(wires=[wire, wire + 1])

    for wire in range(0, N_WIRES, 2):
        qml.Hadamard(wires=wire)

    for wire in range(N_WIRES - 1, 0, -1):
        qml.CNOT(wires=[wire, wire - 1])


def circuit():
    """Circuit under test. It is wrapped below with both devices."""
    ansatz()
    full_probs = qml.probs()
    partial_probs = tuple(
        qml.probs(wires=list(wires)) for wires in SINGLE_WIRES + WIRE_PAIRS
    )
    expval = qml.expval(qml.PauliZ(0))
    var = qml.var(qml.PauliZ(1))
    return (
        full_probs,
        *partial_probs,
        expval,
        var,
    )


mpi_circuit = qjit(qml.qnode(DEV_MPI)(circuit))
ref_circuit = qml.qnode(DEV_REF)(circuit)


def assert_close(name: str, got, expected):
    # Check that all ranks got the same
    gathered = comm.allgather(np.asarray(got))
    for other_rank, other in enumerate(gathered):
        if not np.allclose(got, other, atol=1e-7, rtol=1e-7):
            raise AssertionError(
                f"{name} differs across MPI ranks\n"
                f"rank {rank}: {got}\nrank {other_rank}: {other}"
            )

    # Check that matches output of `default.qubit`
    if not np.allclose(got, expected, atol=1e-7, rtol=1e-7):
        raise AssertionError(f"{name} mismatch\nMPI: {got}\nref: {expected}")
    if rank == 0:
        got_array = np.asarray(got)
        print(f"{name}: OK (shape={got_array.shape}, sum={np.sum(got_array):.12g})")


def main():
    mpi_results = mpi_circuit()
    ref_results = ref_circuit()

    assert_close("full probs", np.asarray(mpi_results[0]), np.asarray(ref_results[0]))

    offset = 1
    for idx, wires in enumerate(SINGLE_WIRES):
        assert_close(
            f"partial probs wire {wires[0]}",
            np.asarray(mpi_results[offset + idx]),
            np.asarray(ref_results[offset + idx]),
        )

    offset += len(SINGLE_WIRES)
    for idx, wires in enumerate(WIRE_PAIRS):
        assert_close(
            f"partial probs wires {wires}",
            np.asarray(mpi_results[offset + idx]),
            np.asarray(ref_results[offset + idx]),
        )

    assert_close("expval", float(mpi_results[-2]), float(ref_results[-2]))
    assert_close("var", float(mpi_results[-1]), float(ref_results[-1]))
    if rank == 0:
        print("Catalyst lightning.kokkos MPI smoke test passed.")


if __name__ == "__main__":
    main()
```

[sc116555]

### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [ ] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [ ] Ensure that the test suite passes, by running `make test`.

- [ ] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [ ] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
