### PR TITLE
fix: forwards MPI kwargs to catalyst properly

### DIFF
--- a/pennylane_lightning/core/simulators/lightning_kokkos/catalyst/LightningKokkosSimulator.cpp
+++ b/pennylane_lightning/core/simulators/lightning_kokkos/catalyst/LightningKokkosSimulator.cpp
@@ -28,7 +28,13 @@ namespace Catalyst::Runtime::Simulator {
 auto LightningKokkosSimulator::AllocateQubit() -> QubitIdType {
     const size_t num_qubits = GetNumQubits();
     if (num_qubits == 0U) {
+#ifdef _ENABLE_PLKOKKOS_MPI
+        this->device_sv = std::make_unique<StateVectorT>(
+            Pennylane::LightningKokkos::Util::MPIManagerKokkos(MPI_COMM_WORLD),
+            1, Kokkos::InitializationSettings{}, comm_buffer_ratio_);
+#else
         this->device_sv = std::make_unique<StateVectorT>(1);
+#endif
         return this->qubit_manager.Allocate(0);
     }
 
@@ -90,7 +96,13 @@ auto LightningKokkosSimulator::AllocateQubits(std::size_t num_qubits)
 
     // at the first call when num_qubits == 0
     if (!this->GetNumQubits()) {
+#ifdef _ENABLE_PLKOKKOS_MPI
+        this->device_sv = std::make_unique<StateVectorT>(
+            Pennylane::LightningKokkos::Util::MPIManagerKokkos(MPI_COMM_WORLD),
+            num_qubits, Kokkos::InitializationSettings{}, comm_buffer_ratio_);
+#else
         this->device_sv = std::make_unique<StateVectorT>(num_qubits);
+#endif
         return this->qubit_manager.AllocateRange(0, num_qubits);
     }
 

--- a/pennylane_lightning/core/simulators/lightning_kokkos/catalyst/LightningKokkosSimulator.hpp
+++ b/pennylane_lightning/core/simulators/lightning_kokkos/catalyst/LightningKokkosSimulator.hpp
@@ -77,6 +77,7 @@ class LightningKokkosSimulator final : public Catalyst::Runtime::QuantumDevice {
     std::size_t device_shots{0};
 
     std::mt19937 *gen{nullptr};
+    std::size_t comm_buffer_ratio_{1};
 
 #ifdef _ENABLE_PLKOKKOS_MPI
     std::unique_ptr<StateVectorT> device_sv = nullptr;
@@ -141,6 +142,15 @@ class LightningKokkosSimulator final : public Catalyst::Runtime::QuantumDevice {
     explicit LightningKokkosSimulator(
         const std::string &kwargs = "{}") noexcept {
         auto &&args = Catalyst::Runtime::parse_kwargs(kwargs);
+        if (args.contains("comm_buffer_ratio")) {
+            try {
+                const auto parsed = std::stoull(args["comm_buffer_ratio"]);
+                if (parsed > 0) {
+                    comm_buffer_ratio_ = parsed;
+                }
+            } catch (...) {
+            }
+        }
     }
     ~LightningKokkosSimulator() noexcept = default;
 

--- a/pennylane_lightning/lightning_kokkos/lightning_kokkos.py
+++ b/pennylane_lightning/lightning_kokkos/lightning_kokkos.py
@@ -200,6 +200,11 @@ class LightningKokkos(LightningBase):
             "comm_buffer_ratio": comm_buffer_ratio,
         }
 
+        # Forward key word arguments to Catalyst
+        self.device_kwargs = {"mpi": mpi}
+        if comm_buffer_ratio is not None:
+            self.device_kwargs["comm_buffer_ratio"] = comm_buffer_ratio
+
     @property
     def name(self):
         """The name of the device."""


### PR DESCRIPTION
The comm_buffer_ratio was ignored so far (and therefore using the default value of 1) which was causing OOM errors. This resolves the issue and properly forwards the arguments. 

### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [ ] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [ ] Ensure that the test suite passes, by running `make test`.

- [ ] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [ ] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
