### PR TITLE
feat: add MPI comm instrumentation to SV destructor

### DIFF
--- a/pennylane_lightning/core/simulators/lightning_kokkos/StateVectorKokkosMPI.hpp
+++ b/pennylane_lightning/core/simulators/lightning_kokkos/StateVectorKokkosMPI.hpp
@@ -19,6 +19,7 @@
 #pragma once
 #include <complex>
 #include <cstddef>
+#include <cstdio>
 #include <cstdlib>
 #include <string>
 #include <unordered_map>
@@ -110,6 +111,10 @@ class StateVectorKokkosMPI final
     std::vector<std::size_t> global_wires_;
     std::vector<std::size_t> local_wires_;
 
+    std::size_t mpi_rank_ = 0;
+    std::size_t swap_events_ = 0;
+    std::size_t transferred_bytes_ = 0;
+
   public:
     StateVectorKokkosMPI() = delete;
 
@@ -131,6 +136,7 @@ class StateVectorKokkosMPI final
           num_qubits_(num_global_qubits + num_local_qubits),
           numGlobalQubits_(num_global_qubits),
           numLocalQubits_(num_local_qubits) {
+        mpi_rank_ = mpi_manager_.getRank();
         PL_ABORT_IF(comm_buffer_ratio == 0, "comm_buffer_ratio must be >= 1");
         Kokkos::InitializationSettings settings = kokkos_args;
 
@@ -307,7 +313,39 @@ class StateVectorKokkosMPI final
         (*sv_).DeviceToDevice(other.getView());
     }
 
-    ~StateVectorKokkosMPI() = default;
+    ~StateVectorKokkosMPI() {
+        const auto formatCommData = [](std::size_t bytes) -> std::string {
+            constexpr std::size_t kib = 1024ULL;
+            constexpr std::size_t mib = 1024ULL * kib;
+            constexpr std::size_t gib = 1024ULL * mib;
+
+            char buffer[64];
+            if (bytes >= gib) {
+                std::snprintf(buffer, sizeof(buffer), "%.2f GiB (%zu B)",
+                              static_cast<double>(bytes) /
+                                  static_cast<double>(gib),
+                              bytes);
+            } else if (bytes >= mib) {
+                std::snprintf(buffer, sizeof(buffer), "%.2f MiB (%zu B)",
+                              static_cast<double>(bytes) /
+                                  static_cast<double>(mib),
+                              bytes);
+            } else if (bytes >= kib) {
+                std::snprintf(buffer, sizeof(buffer), "%.2f KiB (%zu B)",
+                              static_cast<double>(bytes) /
+                                  static_cast<double>(kib),
+                              bytes);
+            } else {
+                std::snprintf(buffer, sizeof(buffer), "%zu B", bytes);
+            }
+            return std::string(buffer);
+        };
+
+        const std::string transferred = formatCommData(transferred_bytes_);
+        std::fprintf(stderr,
+                     "[lightning.kokkos mpi][rank %zu] swap_events=%zu transferred=%s\n",
+                     mpi_rank_, swap_events_, transferred.c_str());
+    }
 
     SVK &getLocalSV() { return *sv_; }
 
@@ -442,6 +480,7 @@ class StateVectorKokkosMPI final
                          const std::size_t tag) {
         mpi_manager_.Sendrecv(*sendbuf_, send_rank, *recvbuf_, recv_rank, size,
                               tag);
+        transferred_bytes_ += 2 * size * sizeof(ComplexT);
     }
     /********************
     Wires-related methods
@@ -749,6 +788,7 @@ class StateVectorKokkosMPI final
     void
     swapGlobalLocalWires(const std::vector<std::size_t> &global_wires_to_swap,
                          const std::vector<std::size_t> &local_wires_to_swap) {
+        swap_events_ += 1;
         PL_ABORT_IF_NOT(global_wires_to_swap.size() ==
                             local_wires_to_swap.size(),
                         "global_wires_to_swap and local_wires_to_swap must "

--- a/pennylane_lightning/core/simulators/lightning_kokkos/StateVectorKokkosMPI.hpp
+++ b/pennylane_lightning/core/simulators/lightning_kokkos/StateVectorKokkosMPI.hpp
@@ -314,37 +314,28 @@ class StateVectorKokkosMPI final
     }
 
     ~StateVectorKokkosMPI() {
-        const auto formatCommData = [](std::size_t bytes) -> std::string {
-            constexpr std::size_t kib = 1024ULL;
-            constexpr std::size_t mib = 1024ULL * kib;
-            constexpr std::size_t gib = 1024ULL * mib;
+        // Gather all instrumentation data on rank 0 for printing
+        const std::size_t root_rank = 0;
+        std::vector<std::size_t> gathered_swap_events(mpi_manager_.getSize());
+        std::vector<std::size_t> gathered_transferred_bytes(
+            mpi_manager_.getSize());
+        mpi_manager_.Gather(swap_events_, gathered_swap_events, root_rank);
+        mpi_manager_.Gather(transferred_bytes_, gathered_transferred_bytes,
+                            root_rank);
 
-            char buffer[64];
-            if (bytes >= gib) {
-                std::snprintf(buffer, sizeof(buffer), "%.2f GiB (%zu B)",
-                              static_cast<double>(bytes) /
-                                  static_cast<double>(gib),
-                              bytes);
-            } else if (bytes >= mib) {
-                std::snprintf(buffer, sizeof(buffer), "%.2f MiB (%zu B)",
-                              static_cast<double>(bytes) /
-                                  static_cast<double>(mib),
-                              bytes);
-            } else if (bytes >= kib) {
-                std::snprintf(buffer, sizeof(buffer), "%.2f KiB (%zu B)",
-                              static_cast<double>(bytes) /
-                                  static_cast<double>(kib),
-                              bytes);
-            } else {
-                std::snprintf(buffer, sizeof(buffer), "%zu B", bytes);
+        if (mpi_rank_ == root_rank) {
+            for (std::size_t rank = 0; rank < mpi_manager_.getSize(); rank++) {
+                const double transferred_gbytes =
+                    static_cast<double>(gathered_transferred_bytes[rank]) /
+                    (1024.0 * 1024.0 * 1024.0);
+                std::fprintf(stderr,
+                             "[lightning.kokkos mpi][rank %zu] swap_events=%zu "
+                             "transferred=%.2f GiB (%zu B)\n",
+                             rank, gathered_swap_events[rank],
+                             transferred_gbytes,
+                             gathered_transferred_bytes[rank]);
             }
-            return std::string(buffer);
-        };
-
-        const std::string transferred = formatCommData(transferred_bytes_);
-        std::fprintf(stderr,
-                     "[lightning.kokkos mpi][rank %zu] swap_events=%zu transferred=%s\n",
-                     mpi_rank_, swap_events_, transferred.c_str());
+        }
     }
 
     SVK &getLocalSV() { return *sv_; }


### PR DESCRIPTION
Add MPI communication instrumentation and output it on destruction of the StateVector.
This would be helpful to precisely know how much communication occurred during the computation
Example output:
```
[lightning.kokkos mpi][rank 0] swap_events=2 transferred=0.06 GiB (67108864 B)
[lightning.kokkos mpi][rank 1] swap_events=2 transferred=0.06 GiB (67108864 B)
```
[sc116555]

### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      [`tests`](../tests) directory!

- [ ] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [ ] Ensure that the test suite passes, by running `make test`.

- [ ] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [ ] Ensure that code is properly formatted by running `make format`. 

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
