### PR TITLE
[fix] Use `base_operation.parameters` for controlled Operators

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -68,6 +68,7 @@
 This release contains contributions from (in alphabetical order):
 
 Runor Agbaire,
+Yushao Chen,
 Jeffrey Kam,
 Joseph Lee,
 Jake Zaia

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -25,6 +25,11 @@
 
 <h3>Bug fixes 🐛</h3>
 
+- Fixed controlled-gate dispatch in Lightning-Kokkos, Lightning-GPU and Lightning-Tensor to read gate
+  parameters from the base operation instead of the `Controlled` wrapper, restoring compatibility with
+  PennyLane where `Controlled.parameters` now includes the control values.
+  [(#1405)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1405)
+
 - Fixed `qp.PauliRot` execution bug when handling identity Pauli word within the compilation pipeline.
   [(#1390)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1390)
 

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.46.0-dev16"
+__version__ = "0.46.0-dev17"

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.46.0-dev17"
+__version__ = "0.46.0-dev18"

--- a/pennylane_lightning/lightning_gpu/_state_vector.py
+++ b/pennylane_lightning/lightning_gpu/_state_vector.py
@@ -275,7 +275,7 @@ class LightningGPUStateVector(LightningBaseStateVector):
         target_wires = list(operation.target_wires)
 
         if method:  # apply n-controlled specialized gate
-            param = operation.parameters
+            param = base_operation.parameters
             if isinstance(base_operation, qp.PCPhase):
                 # PCPhase has hyperparameters for dimension
                 hyper = float(base_operation.hyperparameters["dimension"][0])

--- a/pennylane_lightning/lightning_kokkos/_state_vector.py
+++ b/pennylane_lightning/lightning_kokkos/_state_vector.py
@@ -276,7 +276,7 @@ class LightningKokkosStateVector(LightningBaseStateVector):
         control_values = operation.control_values
         target_wires = list(operation.target_wires)
         if method is not None:  # apply n-controlled specialized gate
-            param = operation.parameters
+            param = base_operation.parameters
             method(control_wires, control_values, target_wires, adjoint, param)
         else:  # apply gate as an n-controlled matrix
             method = getattr(state, "applyControlledMatrix")

--- a/pennylane_lightning/lightning_tensor/_tensornet.py
+++ b/pennylane_lightning/lightning_tensor/_tensornet.py
@@ -676,7 +676,7 @@ class LightningTensorNet:
 
         if method is not None and basename not in ("GlobalPhase", "MultiRZ"):
             inv = False
-            param = operation.parameters
+            param = operation.base.parameters
             method(control_wires, control_values, target_wires, inv, param)
         else:  # apply gate as an n-controlled matrix
             method = getattr(tensornet, "applyControlledMatrix")


### PR DESCRIPTION
**Context:**

The scheduled "Compat Check w/PL — latest/latest" CI run (e.g. [run 29545522067](https://github.com/PennyLaneAI/pennylane-lightning/actions/runs/29545522067)) fails on Lightning-Kokkos and Lightning-GPU with:

```
TypeError: S(): incompatible function arguments.
Invoked with: StateVectorC64, list, list, list, bool, list
```

All 60 failures are in `test_controlled_qubit_gates` / `test_adjoint_controlled_qubit_gates` on controlled S/T/SX gates; other job failures are fail-fast cancellations.

Root cause: PennyLane `master` migrated `S`/`T`/`SX` to the new operator base class (PennyLaneAI/pennylane#9859). `qml.ctrl` on a migrated gate now returns a `ControlledOp2` whose `data`/`parameters` include the control values (e.g. `[[True, False]]`). The controlled-gate dispatch in Lightning-Kokkos, Lightning-GPU, and Lightning-Tensor read `operation.parameters` from the `Controlled` wrapper and passed it as the `params` argument of the C++ binding, which expects `Sequence[float]` — so nanobind rejects the call. Unmigrated gates (`PauliX`, `Hadamard`, …) still return `[]` from the wrapper (and `ctrl(PauliX)` lowers to `MultiControlledX`), which is why only S/T/SX failed.

Lightning-Qubit was already reading `base_operation.parameters` (since #1366) and passed.

**Description of the Change:**

Read gate parameters from the unwrapped base operation instead of the `Controlled` wrapper in `_apply_lightning_controlled`, mirroring Lightning-Qubit:

- `lightning_kokkos/_state_vector.py`: `param = base_operation.parameters`
- `lightning_gpu/_state_vector.py`: `param = base_operation.parameters`
- `lightning_tensor/_tensornet.py`: `param = operation.base.parameters`

`base_operation.parameters` is identical to the previous behavior on released PennyLane (both empty for non-parametric gates, actual gate params for parametric ones) and correct on PennyLane `master`, so this is backward and forward compatible.

**Benefits:**

- Fixes the latest/latest and likely some potential LLL failures.
- Removes a latent inconsistency between Lightning-Qubit and the other backends.

**Possible Drawbacks:**

**Related GitHub Issues:**
https://github.com/PennyLaneAI/pennylane/pull/9818