### PR TITLE
Remove tests for `DisplacementEmbedding`

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -38,6 +38,10 @@
 
 <h3>Internal changes ⚙️</h3>
 
+- Removed tests for the continuous-variable templates `qp.DisplacementEmbedding`,
+  `qp.SqueezingEmbedding`, and `qp.CVNeuralNetLayers`, following their removal from PennyLane.
+  [(#1406)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1406)
+
 - Upgrade Mac runner to macos-15.
   [(#1394)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1394)
 

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.46.0-dev18"
+__version__ = "0.46.0-dev19"

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -156,25 +156,6 @@ class TestBasisEmbedding:
         assert np.allclose(res, ref)
 
 
-class TestDisplacementSqueezingEmbedding:
-    """Test the DisplacementEmbedding and SqueezingEmbedding algorithms."""
-
-    @pytest.mark.parametrize("n_qubits", range(2, 20, 2))
-    @pytest.mark.parametrize("template", [qp.DisplacementEmbedding, qp.SqueezingEmbedding])
-    def test_displacementembedding(self, n_qubits, template):
-        dev = qp.device(device_name, wires=n_qubits)
-
-        def circuit(feature_vector):
-            template(features=feature_vector, wires=range(n_qubits))
-            qp.QuadraticPhase(0.1, wires=1)
-            return qp.state()
-
-        X = np.arange(1, n_qubits + 1)
-
-        with pytest.raises(DeviceError, match="not supported"):
-            _ = qp.QNode(circuit, dev, diff_method=None)(X)
-
-
 class TestIQPEmbedding:
     """Test the IQPEmbedding algorithm."""
 

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -21,7 +21,6 @@ import pennylane as qp
 import pytest
 from conftest import LightningDevice, device_name, get_random_normalized_state
 from pennylane import numpy as np
-from pennylane.exceptions import DeviceError
 
 # pylint: disable=missing-function-docstring, too-few-public-methods
 
@@ -200,26 +199,6 @@ class TestQAOAEmbedding:
         ref = qp.QNode(circuit, dq, diff_method=None)(X, weights)
 
         assert np.allclose(res, ref)
-
-
-class TestCVNeuralNetLayers:
-    """Test the CVNeuralNetLayers algorithm."""
-
-    @pytest.mark.local_salt(42)
-    def test_cvneuralnetlayers(self, seed):
-        n_qubits = 2
-        dev = qp.device(device_name, wires=n_qubits)
-
-        def circuit(weights):
-            qp.CVNeuralNetLayers(*weights, wires=[0, 1])
-            return qp.state()
-
-        rng = np.random.default_rng(seed)
-        shapes = qp.CVNeuralNetLayers.shape(n_layers=2, n_wires=n_qubits)
-        weights = [rng.random(size=shape) for shape in shapes]
-
-        with pytest.raises(DeviceError, match="not supported"):
-            _ = qp.QNode(circuit, dev, diff_method=None)(weights)
 
 
 class TestRandomLayers:


### PR DESCRIPTION
`DisplacementEmbedding` was removed from PennyLane main as part of the complete CV-stack removal in [PR #9869](https://github.com/PennyLaneAI/pennylane/pull/9869), merged July 21, 2026 (03e702e).

Fixing [Latest/Latest](https://github.com/PennyLaneAI/pennylane-lightning/actions/runs/29880948042/job/88801997057)