### PR TITLE
Update lightning_qubit.toml with dynamic qubit allocation capability

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -17,7 +17,7 @@
 - Added `PauliMeasure` to the Lightning devices TOML files.
   [(#1389)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1389)
 
-- Declare dynamic allocation capabilities for lightning.qubit device.
+- Declare dynamic allocation capabilities for `lightning.qubit` device.
   [(#1407)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1407)
 
 <h3>Breaking changes 💔</h3>

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -17,6 +17,9 @@
 - Added `PauliMeasure` to the Lightning devices TOML files.
   [(#1389)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1389)
 
+- Declare dynamic allocation capabilities for lightning.qubit device.
+  [(#1407)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1407)
+
 <h3>Breaking changes 💔</h3>
 
 - Python 3.11 is no longer supported. The minimum required Python version is now 3.12.
@@ -76,6 +79,7 @@ This release contains contributions from (in alphabetical order):
 
 Runor Agbaire,
 Yushao Chen,
+David Ittah,
 Jeffrey Kam,
 Joseph Lee,
 Jake Zaia

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.46.0-dev19"
+__version__ = "0.46.0-dev20"

--- a/pennylane_lightning/lightning_qubit/lightning_qubit.toml
+++ b/pennylane_lightning/lightning_qubit/lightning_qubit.toml
@@ -124,7 +124,7 @@ runtime_code_generation = false
 supported_mcm_methods = [ "device", "one-shot", "tree-traversal" ]
 
 # Whether the device supports dynamic qubit allocation/deallocation.
-dynamic_qubit_management = false
+dynamic_qubit_management = true
 
 # Whether simultaneous measurements of non-commuting observables is supported.
 non_commuting_observables = true


### PR DESCRIPTION
lightning.qubit has dynamic allocation capabilities, yet the toml file incorrectly declared the field as false.

Unblocks https://github.com/PennyLaneAI/catalyst/issues/3056