### PR TITLE
Fixed controlled-gate execution in Lightning devices when `control_values` is passed as dynamic arg

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -31,6 +31,9 @@
 
 <h3>Bug fixes 🐛</h3>
 
+- Fixed controlled-gate execution in Lightning devices when `control_values` is passed
+  as dynamic argument.
+
 - Fixed controlled-gate dispatch in Lightning-Kokkos, Lightning-GPU and Lightning-Tensor to read gate
   parameters from the base operation instead of the `Controlled` wrapper, restoring compatibility with
   PennyLane where `Controlled.parameters` now includes the control values.

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -33,6 +33,7 @@
 
 - Fixed controlled-gate execution in Lightning devices when `control_values` is passed
   as dynamic argument.
+  [(#1408)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1408)
 
 - Fixed controlled-gate dispatch in Lightning-Kokkos, Lightning-GPU and Lightning-Tensor to read gate
   parameters from the base operation instead of the `Controlled` wrapper, restoring compatibility with

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.46.0-dev20"
+__version__ = "0.46.0-dev21"

--- a/pennylane_lightning/lightning_base/_serialize.py
+++ b/pennylane_lightning/lightning_base/_serialize.py
@@ -485,7 +485,7 @@ class QuantumScriptSerializer:
             ):
                 wires_list = list(op_base.target_wires)
                 controlled_wires_list = list(op_base.control_wires)
-                control_values_list = op_base.control_values
+                control_values_list = [bool(v) for v in op_base.control_values]
                 # Serialize ctrl(adjoint(op))
                 if isinstance(op_base.base, qp.ops.op_math.Adjoint):
                     ctrl_adjoint = True

--- a/pennylane_lightning/lightning_gpu/_state_vector.py
+++ b/pennylane_lightning/lightning_gpu/_state_vector.py
@@ -271,7 +271,7 @@ class LightningGPUStateVector(LightningBaseStateVector):
         method = getattr(state, f"{base_operation.name}", None)
 
         control_wires = list(operation.control_wires)
-        control_values = operation.control_values
+        control_values = [bool(v) for v in operation.control_values]
         target_wires = list(operation.target_wires)
 
         if method:  # apply n-controlled specialized gate

--- a/pennylane_lightning/lightning_kokkos/_state_vector.py
+++ b/pennylane_lightning/lightning_kokkos/_state_vector.py
@@ -273,7 +273,7 @@ class LightningKokkosStateVector(LightningBaseStateVector):
 
         method = getattr(state, f"{base_operation.name}", None)
         control_wires = list(operation.control_wires)
-        control_values = operation.control_values
+        control_values = [bool(v) for v in operation.control_values]
         target_wires = list(operation.target_wires)
         if method is not None:  # apply n-controlled specialized gate
             param = base_operation.parameters

--- a/pennylane_lightning/lightning_qubit/_state_vector.py
+++ b/pennylane_lightning/lightning_qubit/_state_vector.py
@@ -163,7 +163,7 @@ class LightningStateVector(LightningBaseStateVector):  # pylint: disable=too-few
         method = getattr(state, f"{base_operation.name}", None)
 
         control_wires = list(operation.control_wires)
-        control_values = operation.control_values
+        control_values = [bool(v) for v in operation.control_values]
         target_wires = list(operation.target_wires)
 
         if method is not None:  # apply n-controlled specialized gate
@@ -202,7 +202,7 @@ class LightningStateVector(LightningBaseStateVector):  # pylint: disable=too-few
         CSR_SparseHamiltonian = base_operation.sparse_matrix()
 
         control_wires = list(operation.control_wires)
-        control_values = operation.control_values
+        control_values = [bool(v) for v in operation.control_values]
         target_wires = list(operation.target_wires)
 
         method = getattr(state, "applyControlledSparseMatrix")

--- a/pennylane_lightning/lightning_tensor/_tensornet.py
+++ b/pennylane_lightning/lightning_tensor/_tensornet.py
@@ -671,7 +671,7 @@ class LightningTensorNet:
         basename = operation.base.name
         method = getattr(tensornet, f"{basename}", None)
         control_wires = list(operation.control_wires)
-        control_values = operation.control_values
+        control_values = [bool(v) for v in operation.control_values]
         target_wires = list(operation.target_wires)
 
         if method is not None and basename not in ("GlobalPhase", "MultiRZ"):


### PR DESCRIPTION
The Lightning devices cannot execute controlled operators where `control_values` is an array rather than a builtin Python list. This PR unblocks https://github.com/PennyLaneAI/pennylane/pull/9814

[sc-125581]