### PR TITLE
Correct kernel tuning documentation LQ_ENABLE_KERNEL_OMP flag

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -29,6 +29,10 @@
 
 <h3>Documentation 📝</h3>
 
+- Corrected the kernel tuning documentation to clarify that `LQ_ENABLE_KERNEL_OMP` is a
+  compile-time CMake flag rather than a runtime environment variable.
+  [(#XXXX)](https://github.com/PennyLaneAI/pennylane-lightning/pull/XXXX)
+
 <h3>Bug fixes 🐛</h3>
 
 - Fixed controlled-gate execution in Lightning devices when `control_values` is passed

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -31,7 +31,7 @@
 
 - Corrected the kernel tuning documentation to clarify that `LQ_ENABLE_KERNEL_OMP` is a
   compile-time CMake flag rather than a runtime environment variable.
-  [(#XXXX)](https://github.com/PennyLaneAI/pennylane-lightning/pull/XXXX)
+  [(#1409)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1409)
 
 <h3>Bug fixes 🐛</h3>
 

--- a/doc/lightning_qubit/development/kernel_tuning.rst
+++ b/doc/lightning_qubit/development/kernel_tuning.rst
@@ -7,11 +7,10 @@ OpenMP threaded kernels
 OpenMP acceleration of gate kernels across all kernel types (LM, AVX2, and AVX512) is enabled
 by default on Linux and MacOS wheels in Lightning-Qubit.
 
-On other operating systems, OpenMP support can be enabled by setting the environment variable
-``LQ_ENABLE_KERNEL_OMP=ON`` before starting your Python session, or if already running, before
-simulating your PennyLane programs.
-You can also control the number of threads used by setting the ``OMP_NUM_THREADS``
-environment variable.
+If building from source, OpenMP support can be enabled by compiling with the CMake
+flag ``-DLQ_ENABLE_KERNEL_OMP=ON``. Once enabled, you can control the number of threads used
+at runtime by setting the ``OMP_NUM_THREADS`` environment variable before starting your
+Python session, or if already running, before simulating your PennyLane programs.
 
 For workloads that involve gradient computations with many observable measurements,
 OpenMP acceleration may reduce performance due to oversubscription of threads to CPU cores.

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.46.0-dev21"
+__version__ = "0.46.0-dev22"


### PR DESCRIPTION
**Context:**
Currently the kernel tuning docs mention `LQ_ENABLE_KERNEL_OMP` as a runtime flag, but it is actually a compile time cmake flag. This PR fixes it.
 
