### PR TITLE
fix PauliRot op2 API

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -35,6 +35,10 @@
 
 <h3>Bug fixes 🐛</h3>
 
+- Restored compatibility with the latest PennyLane operator contract for `qp.PauliRot`,
+  `qp.MultiControlledX`, and `qp.DiagonalQubitUnitary`.
+  [(#1415)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1415)
+
 - Fixed controlled-gate execution in Lightning devices when `control_values` is passed
   as dynamic argument.
   [(#1408)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1408)

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.46.0-dev22"
+__version__ = "0.46.0-dev23"

--- a/pennylane_lightning/lightning_base/_adjoint_jacobian.py
+++ b/pennylane_lightning/lightning_base/_adjoint_jacobian.py
@@ -125,14 +125,25 @@ class LightningBaseAdjointJacobian(ABC):
         record_tp_rows = []
         all_params = 0
 
+        # MultiControlledX has no native gate parameters, so exclude its control
+        # metadata from the tape's flat parameter indices.
+        mcx_param_indices = []
+        param_idx = 0
+        for operation in tape.operations:
+            if isinstance(operation, qp.MultiControlledX):
+                mcx_param_indices.extend(range(param_idx, param_idx + len(operation.data)))
+            param_idx += len(operation.data)
+
         for op_idx, trainable_param in enumerate(trainable_params):
             # get op_idx-th operator among differentiable operators
             operation, _, _ = tape.get_operation(op_idx)
             if isinstance(operation, Operation) and not isinstance(
-                operation, (BasisState, StatePrep)
+                operation, (BasisState, StatePrep, qp.MultiControlledX)
             ):
-                # We now just ignore non-op or state preps
-                tp_shift.append(trainable_param)
+                # Ignore non-operations, state preparation, and MCX control metadata.
+                tp_shift.append(
+                    trainable_param - sum(i < trainable_param for i in mcx_param_indices)
+                )
                 record_tp_rows.append(all_params)
             all_params += 1
 

--- a/pennylane_lightning/lightning_base/_adjoint_jacobian.py
+++ b/pennylane_lightning/lightning_base/_adjoint_jacobian.py
@@ -29,6 +29,13 @@ from pennylane.tape import QuantumTape
 from pennylane_lightning.lightning_base._serialize import QuantumScriptSerializer
 
 
+def _is_mcx(operation: Operation) -> bool:
+    """Return whether an operation is a MultiControlledX, possibly wrapped in adjoints."""
+    while isinstance(operation, qp.ops.op_math.Adjoint):
+        operation = operation.base
+    return isinstance(operation, qp.MultiControlledX)
+
+
 class LightningBaseAdjointJacobian(ABC):
     """Lightning [Device] Adjoint Jacobian class
 
@@ -130,15 +137,17 @@ class LightningBaseAdjointJacobian(ABC):
         mcx_param_indices = []
         param_idx = 0
         for operation in tape.operations:
-            if isinstance(operation, qp.MultiControlledX):
+            if _is_mcx(operation):
                 mcx_param_indices.extend(range(param_idx, param_idx + len(operation.data)))
             param_idx += len(operation.data)
 
         for op_idx, trainable_param in enumerate(trainable_params):
             # get op_idx-th operator among differentiable operators
             operation, _, _ = tape.get_operation(op_idx)
-            if isinstance(operation, Operation) and not isinstance(
-                operation, (BasisState, StatePrep, qp.MultiControlledX)
+            if (
+                isinstance(operation, Operation)
+                and not isinstance(operation, (BasisState, StatePrep))
+                and not _is_mcx(operation)
             ):
                 # Ignore non-operations, state preparation, and MCX control metadata.
                 tp_shift.append(

--- a/pennylane_lightning/lightning_base/_serialize.py
+++ b/pennylane_lightning/lightning_base/_serialize.py
@@ -489,10 +489,11 @@ class QuantumScriptSerializer:
                 # Serialize ctrl(adjoint(op))
                 if isinstance(op_base.base, qp.ops.op_math.Adjoint):
                     ctrl_adjoint = True
-                    name = op_base.base.base.name
+                    controlled_base = op_base.base.base
                 else:
                     ctrl_adjoint = False
-                    name = op_base.base.name
+                    controlled_base = op_base.base
+                name = controlled_base.name
 
                 # Inside the controlled operation, if the base operation (of the adjoint)
                 # is supported natively, we apply the the base operation and invert the
@@ -504,6 +505,7 @@ class QuantumScriptSerializer:
                     )
                     name = single_op_base.name
                 else:
+                    single_op_base = controlled_base
                     inverse ^= ctrl_adjoint
             else:
                 name = single_op_base.name

--- a/pennylane_lightning/lightning_base/_serialize.py
+++ b/pennylane_lightning/lightning_base/_serialize.py
@@ -489,11 +489,10 @@ class QuantumScriptSerializer:
                 # Serialize ctrl(adjoint(op))
                 if isinstance(op_base.base, qp.ops.op_math.Adjoint):
                     ctrl_adjoint = True
-                    controlled_base = op_base.base.base
+                    name = op_base.base.base.name
                 else:
                     ctrl_adjoint = False
-                    controlled_base = op_base.base
-                name = controlled_base.name
+                    name = op_base.base.name
 
                 # Inside the controlled operation, if the base operation (of the adjoint)
                 # is supported natively, we apply the the base operation and invert the
@@ -505,7 +504,6 @@ class QuantumScriptSerializer:
                     )
                     name = single_op_base.name
                 else:
-                    single_op_base = controlled_base
                     inverse ^= ctrl_adjoint
             else:
                 name = single_op_base.name

--- a/pennylane_lightning/lightning_base/_serialize.py
+++ b/pennylane_lightning/lightning_base/_serialize.py
@@ -539,9 +539,14 @@ class QuantumScriptSerializer:
                 ) = get_wires(operation, single_op)
                 inverses.append(inverse)
                 names.append(name)
+                # MultiControlledX has no kernel parameters; its control values are
+                # serialized separately as control metadata.
+                if isinstance(single_op_base, qp.MultiControlledX):
+                    params.append([])
+                    mats.append(np.array([]))
                 # QubitUnitary is a special case, it has a parameter which is not differentiable.
                 # We thus pass a dummy 0.0 parameter which will not be referenced
-                if isinstance(single_op_base, qp.QubitUnitary):
+                elif isinstance(single_op_base, qp.QubitUnitary):
                     params.append([0.0])
                     mats.append(matrix(single_op_base))
                 else:

--- a/pennylane_lightning/lightning_gpu/_state_vector.py
+++ b/pennylane_lightning/lightning_gpu/_state_vector.py
@@ -343,10 +343,10 @@ class LightningGPUStateVector(LightningBaseStateVector):
                 )
             elif isinstance(operation, qp.PauliRot):
                 method = getattr(state, "applyPauliRot")
-                paulis = operation.hyperparameters["pauli_word"]
+                paulis = operation.pauli_word
                 wires = [w for w, p in zip(wires, paulis) if p != "I"]
                 word = "".join(p for p in paulis if p != "I")
-                method(wires, invert_param, operation.parameters, word)
+                method(wires, invert_param, [operation.theta], word)
             elif method is not None:  # apply specialized gate
                 param = op_adjoint_base.parameters
                 if isinstance(op_adjoint_base, qp.PCPhase):

--- a/pennylane_lightning/lightning_gpu/_state_vector.py
+++ b/pennylane_lightning/lightning_gpu/_state_vector.py
@@ -262,15 +262,11 @@ class LightningGPUStateVector(LightningBaseStateVector):
         """
         state = self.state_vector
 
-        base_operation = (
-            operation.base.base if isinstance(operation.base, Adjoint) else operation.base
-        )
-        if isinstance(base_operation, qp.GlobalPhase) and not operation.target_wires:
-            state.applyMatrix(qp.matrix(operation), list(operation.control_wires), adjoint)
-            return
-
         if isinstance(operation.base, Adjoint):
+            base_operation = operation.base.base
             adjoint = not adjoint
+        else:
+            base_operation = operation.base
 
         method = getattr(state, f"{base_operation.name}", None)
 

--- a/pennylane_lightning/lightning_gpu/_state_vector.py
+++ b/pennylane_lightning/lightning_gpu/_state_vector.py
@@ -274,6 +274,10 @@ class LightningGPUStateVector(LightningBaseStateVector):
         control_values = [bool(v) for v in operation.control_values]
         target_wires = list(operation.target_wires)
 
+        if not target_wires:
+            state.applyMatrix(qp.matrix(operation), control_wires, adjoint)
+            return
+
         if method:  # apply n-controlled specialized gate
             param = base_operation.parameters
             if isinstance(base_operation, qp.PCPhase):

--- a/pennylane_lightning/lightning_gpu/_state_vector.py
+++ b/pennylane_lightning/lightning_gpu/_state_vector.py
@@ -339,14 +339,12 @@ class LightningGPUStateVector(LightningBaseStateVector):
                 )
             elif isinstance(operation, qp.PauliRot):
                 method = getattr(state, "applyPauliRot")
-                paulis = operation._hyperparameters[  # pylint: disable=protected-access
-                    "pauli_word"
-                ]
+                paulis = operation.hyperparameters["pauli_word"]
                 wires = [w for w, p in zip(wires, paulis) if p != "I"]
                 word = "".join(p for p in paulis if p != "I")
                 method(wires, invert_param, operation.parameters, word)
             elif method is not None:  # apply specialized gate
-                param = operation.parameters
+                param = op_adjoint_base.parameters
                 if isinstance(op_adjoint_base, qp.PCPhase):
                     # PCPhase has hyperparameters for dimension
                     hyper = float(op_adjoint_base.hyperparameters["dimension"][0])

--- a/pennylane_lightning/lightning_gpu/_state_vector.py
+++ b/pennylane_lightning/lightning_gpu/_state_vector.py
@@ -262,21 +262,21 @@ class LightningGPUStateVector(LightningBaseStateVector):
         """
         state = self.state_vector
 
+        base_operation = (
+            operation.base.base if isinstance(operation.base, Adjoint) else operation.base
+        )
+        if isinstance(base_operation, qp.GlobalPhase) and not operation.target_wires:
+            state.applyMatrix(qp.matrix(operation), list(operation.control_wires), adjoint)
+            return
+
         if isinstance(operation.base, Adjoint):
-            base_operation = operation.base.base
             adjoint = not adjoint
-        else:
-            base_operation = operation.base
 
         method = getattr(state, f"{base_operation.name}", None)
 
         control_wires = list(operation.control_wires)
         control_values = [bool(v) for v in operation.control_values]
         target_wires = list(operation.target_wires)
-
-        if not target_wires:
-            state.applyMatrix(qp.matrix(operation), control_wires, adjoint)
-            return
 
         if method:  # apply n-controlled specialized gate
             param = base_operation.parameters
@@ -348,7 +348,7 @@ class LightningGPUStateVector(LightningBaseStateVector):
                 word = "".join(p for p in paulis if p != "I")
                 method(wires, invert_param, [operation.theta], word)
             elif method is not None:  # apply specialized gate
-                param = op_adjoint_base.parameters
+                param = operation.parameters
                 if isinstance(op_adjoint_base, qp.PCPhase):
                     # PCPhase has hyperparameters for dimension
                     hyper = float(op_adjoint_base.hyperparameters["dimension"][0])

--- a/pennylane_lightning/lightning_gpu/_state_vector.py
+++ b/pennylane_lightning/lightning_gpu/_state_vector.py
@@ -372,7 +372,7 @@ class LightningGPUStateVector(LightningBaseStateVector):
                     mat = operation.matrix
                 r_dtype = np.float32 if self.dtype == np.complex64 else np.float64
                 param = (
-                    [[r_dtype(operation.hash)]]
+                    [[r_dtype(hash(operation))]]
                     if isinstance(operation, gate_cache_needs_hash)
                     else []
                 )

--- a/pennylane_lightning/lightning_kokkos/_state_vector.py
+++ b/pennylane_lightning/lightning_kokkos/_state_vector.py
@@ -335,10 +335,10 @@ class LightningKokkosStateVector(LightningBaseStateVector):
                 )
             elif isinstance(operation, qp.PauliRot):
                 method = getattr(state, "applyPauliRot")
-                paulis = operation.hyperparameters["pauli_word"]
+                paulis = operation.pauli_word
                 wires = [i for i, w in zip(wires, paulis) if w != "I"]
                 word = "".join(p for p in paulis if p != "I")
-                method(wires, invert_param, operation.parameters, word)
+                method(wires, invert_param, [operation.theta], word)
             elif method is not None:  # apply specialized gate
                 param = op_adjoint_base.parameters
                 method(wires, invert_param, param)

--- a/pennylane_lightning/lightning_kokkos/_state_vector.py
+++ b/pennylane_lightning/lightning_kokkos/_state_vector.py
@@ -332,14 +332,12 @@ class LightningKokkosStateVector(LightningBaseStateVector):
                 )
             elif isinstance(operation, qp.PauliRot):
                 method = getattr(state, "applyPauliRot")
-                paulis = operation._hyperparameters[  # pylint: disable=protected-access
-                    "pauli_word"
-                ]
+                paulis = operation.hyperparameters["pauli_word"]
                 wires = [i for i, w in zip(wires, paulis) if w != "I"]
                 word = "".join(p for p in paulis if p != "I")
                 method(wires, invert_param, operation.parameters, word)
             elif method is not None:  # apply specialized gate
-                param = operation.parameters
+                param = op_adjoint_base.parameters
                 method(wires, invert_param, param)
             elif isinstance(op_adjoint_base, qp.ops.Controlled):  # apply n-controlled gate
                 self._apply_lightning_controlled(op_adjoint_base, invert_param)

--- a/pennylane_lightning/lightning_kokkos/_state_vector.py
+++ b/pennylane_lightning/lightning_kokkos/_state_vector.py
@@ -275,6 +275,9 @@ class LightningKokkosStateVector(LightningBaseStateVector):
         control_wires = list(operation.control_wires)
         control_values = [bool(v) for v in operation.control_values]
         target_wires = list(operation.target_wires)
+        if not target_wires:
+            state.applyMatrix(qp.matrix(operation), control_wires, adjoint)
+            return
         if method is not None:  # apply n-controlled specialized gate
             param = base_operation.parameters
             method(control_wires, control_values, target_wires, adjoint, param)

--- a/pennylane_lightning/lightning_kokkos/_state_vector.py
+++ b/pennylane_lightning/lightning_kokkos/_state_vector.py
@@ -265,19 +265,20 @@ class LightningKokkosStateVector(LightningBaseStateVector):
         """
         state = self.state_vector
 
+        base_operation = (
+            operation.base.base if isinstance(operation.base, Adjoint) else operation.base
+        )
+        if isinstance(base_operation, qp.GlobalPhase) and not operation.target_wires:
+            state.applyMatrix(qp.matrix(operation), list(operation.control_wires), adjoint)
+            return
+
         if isinstance(operation.base, Adjoint):
-            base_operation = operation.base.base
             adjoint = not adjoint
-        else:
-            base_operation = operation.base
 
         method = getattr(state, f"{base_operation.name}", None)
         control_wires = list(operation.control_wires)
         control_values = [bool(v) for v in operation.control_values]
         target_wires = list(operation.target_wires)
-        if not target_wires:
-            state.applyMatrix(qp.matrix(operation), control_wires, adjoint)
-            return
         if method is not None:  # apply n-controlled specialized gate
             param = base_operation.parameters
             method(control_wires, control_values, target_wires, adjoint, param)
@@ -340,7 +341,7 @@ class LightningKokkosStateVector(LightningBaseStateVector):
                 word = "".join(p for p in paulis if p != "I")
                 method(wires, invert_param, [operation.theta], word)
             elif method is not None:  # apply specialized gate
-                param = op_adjoint_base.parameters
+                param = operation.parameters
                 method(wires, invert_param, param)
             elif isinstance(op_adjoint_base, qp.ops.Controlled):  # apply n-controlled gate
                 self._apply_lightning_controlled(op_adjoint_base, invert_param)

--- a/pennylane_lightning/lightning_kokkos/_state_vector.py
+++ b/pennylane_lightning/lightning_kokkos/_state_vector.py
@@ -265,15 +265,11 @@ class LightningKokkosStateVector(LightningBaseStateVector):
         """
         state = self.state_vector
 
-        base_operation = (
-            operation.base.base if isinstance(operation.base, Adjoint) else operation.base
-        )
-        if isinstance(base_operation, qp.GlobalPhase) and not operation.target_wires:
-            state.applyMatrix(qp.matrix(operation), list(operation.control_wires), adjoint)
-            return
-
         if isinstance(operation.base, Adjoint):
+            base_operation = operation.base.base
             adjoint = not adjoint
+        else:
+            base_operation = operation.base
 
         method = getattr(state, f"{base_operation.name}", None)
         control_wires = list(operation.control_wires)

--- a/pennylane_lightning/lightning_kokkos/lightning_kokkos.py
+++ b/pennylane_lightning/lightning_kokkos/lightning_kokkos.py
@@ -80,7 +80,7 @@ def stopping_condition(op: Operator, allow_mcms: bool = True) -> bool:
     """A function that determines whether or not an operation is supported by ``lightning.kokkos``."""
 
     if isinstance(op, qp.PauliRot):
-        word = op._hyperparameters["pauli_word"]  # pylint: disable=protected-access
+        word = op.hyperparameters["pauli_word"]
         # decomposes to IsingXX, etc. for n <= 2
         return reduce(lambda x, y: x + (y != "I"), word, 0) > 2
 

--- a/pennylane_lightning/lightning_kokkos/lightning_kokkos.py
+++ b/pennylane_lightning/lightning_kokkos/lightning_kokkos.py
@@ -80,7 +80,7 @@ def stopping_condition(op: Operator, allow_mcms: bool = True) -> bool:
     """A function that determines whether or not an operation is supported by ``lightning.kokkos``."""
 
     if isinstance(op, qp.PauliRot):
-        word = op.hyperparameters["pauli_word"]
+        word = op.pauli_word
         # decomposes to IsingXX, etc. for n <= 2
         return reduce(lambda x, y: x + (y != "I"), word, 0) > 2
 

--- a/pennylane_lightning/lightning_qubit/_state_vector.py
+++ b/pennylane_lightning/lightning_qubit/_state_vector.py
@@ -166,6 +166,10 @@ class LightningStateVector(LightningBaseStateVector):  # pylint: disable=too-few
         control_values = [bool(v) for v in operation.control_values]
         target_wires = list(operation.target_wires)
 
+        if not target_wires:
+            state.applyMatrix(qp.matrix(operation), control_wires, adjoint)
+            return
+
         if method is not None:  # apply n-controlled specialized gate
             param = base_operation.parameters
 

--- a/pennylane_lightning/lightning_qubit/_state_vector.py
+++ b/pennylane_lightning/lightning_qubit/_state_vector.py
@@ -265,10 +265,10 @@ class LightningStateVector(LightningBaseStateVector):  # pylint: disable=too-few
                 )
             elif isinstance(operation, qp.PauliRot):
                 method = getattr(state, "applyPauliRot")
-                paulis = operation.hyperparameters["pauli_word"]
+                paulis = operation.pauli_word
                 wires = [i for i, w in zip(wires, paulis) if w != "I"]
                 word = "".join(p for p in paulis if p != "I")
-                method(wires, invert_param, operation.parameters, word)
+                method(wires, invert_param, [operation.theta], word)
             elif self._operation_is_sparse(operation):
                 # Inverse can be set to False since operation.sparse_matrix() is already in inverted form
                 if isinstance(op_adjoint_base, qp.ops.Controlled):

--- a/pennylane_lightning/lightning_qubit/_state_vector.py
+++ b/pennylane_lightning/lightning_qubit/_state_vector.py
@@ -154,21 +154,21 @@ class LightningStateVector(LightningBaseStateVector):  # pylint: disable=too-few
         """
         state = self.state_vector
 
+        base_operation = (
+            operation.base.base if isinstance(operation.base, Adjoint) else operation.base
+        )
+        if isinstance(base_operation, qp.GlobalPhase) and not operation.target_wires:
+            state.applyMatrix(qp.matrix(operation), list(operation.control_wires), adjoint)
+            return
+
         if isinstance(operation.base, Adjoint):
-            base_operation = operation.base.base
             adjoint = not adjoint
-        else:
-            base_operation = operation.base
 
         method = getattr(state, f"{base_operation.name}", None)
 
         control_wires = list(operation.control_wires)
         control_values = [bool(v) for v in operation.control_values]
         target_wires = list(operation.target_wires)
-
-        if not target_wires:
-            state.applyMatrix(qp.matrix(operation), control_wires, adjoint)
-            return
 
         if method is not None:  # apply n-controlled specialized gate
             param = base_operation.parameters

--- a/pennylane_lightning/lightning_qubit/_state_vector.py
+++ b/pennylane_lightning/lightning_qubit/_state_vector.py
@@ -154,15 +154,11 @@ class LightningStateVector(LightningBaseStateVector):  # pylint: disable=too-few
         """
         state = self.state_vector
 
-        base_operation = (
-            operation.base.base if isinstance(operation.base, Adjoint) else operation.base
-        )
-        if isinstance(base_operation, qp.GlobalPhase) and not operation.target_wires:
-            state.applyMatrix(qp.matrix(operation), list(operation.control_wires), adjoint)
-            return
-
         if isinstance(operation.base, Adjoint):
+            base_operation = operation.base.base
             adjoint = not adjoint
+        else:
+            base_operation = operation.base
 
         method = getattr(state, f"{base_operation.name}", None)
 

--- a/pennylane_lightning/lightning_qubit/_state_vector.py
+++ b/pennylane_lightning/lightning_qubit/_state_vector.py
@@ -261,9 +261,7 @@ class LightningStateVector(LightningBaseStateVector):  # pylint: disable=too-few
                 )
             elif isinstance(operation, qp.PauliRot):
                 method = getattr(state, "applyPauliRot")
-                paulis = operation._hyperparameters[  # pylint: disable=protected-access
-                    "pauli_word"
-                ]
+                paulis = operation.hyperparameters["pauli_word"]
                 wires = [i for i, w in zip(wires, paulis) if w != "I"]
                 word = "".join(p for p in paulis if p != "I")
                 method(wires, invert_param, operation.parameters, word)

--- a/pennylane_lightning/lightning_qubit/lightning_qubit.py
+++ b/pennylane_lightning/lightning_qubit/lightning_qubit.py
@@ -84,7 +84,7 @@ def stopping_condition(op: Operator, allow_mcms=True) -> bool:
     if isinstance(op, qp.ControlledQubitUnitary):
         return True
     if isinstance(op, qp.PauliRot):
-        word = op._hyperparameters["pauli_word"]  # pylint: disable=protected-access
+        word = op.hyperparameters["pauli_word"]
         # decomposes to IsingXX, etc. for n <= 2
         return reduce(lambda x, y: x + (y != "I"), word, 0) > 2
     if isinstance(op, MidMeasure):

--- a/pennylane_lightning/lightning_qubit/lightning_qubit.py
+++ b/pennylane_lightning/lightning_qubit/lightning_qubit.py
@@ -84,7 +84,7 @@ def stopping_condition(op: Operator, allow_mcms=True) -> bool:
     if isinstance(op, qp.ControlledQubitUnitary):
         return True
     if isinstance(op, qp.PauliRot):
-        word = op.hyperparameters["pauli_word"]
+        word = op.pauli_word
         # decomposes to IsingXX, etc. for n <= 2
         return reduce(lambda x, y: x + (y != "I"), word, 0) > 2
     if isinstance(op, MidMeasure):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,9 +76,10 @@ VARPHI = np.linspace(0.02, 1, 3)
 
 def get_operation_num_wires(operation):
     """Return the minimum wire count needed to instantiate an operation class."""
+    if issubclass(operation, qp.core.Operator2):
+        return operation.wire_sizes[0] or 1
+
     num_wires = getattr(operation, "num_wires", None)
-    if isinstance(num_wires, property):
-        return 1
     return max(num_wires, 1) if num_wires else 1
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -74,6 +74,14 @@ PHI = np.linspace(0.32, 1, 3)
 VARPHI = np.linspace(0.02, 1, 3)
 
 
+def get_operation_num_wires(operation):
+    """Return the minimum wire count needed to instantiate an operation class."""
+    num_wires = getattr(operation, "num_wires", None)
+    if isinstance(num_wires, property):
+        return 1
+    return max(num_wires, 1) if num_wires else 1
+
+
 @pytest.fixture(scope="session")
 def tol():
     """Numerical tolerance for equality tests."""

--- a/tests/lightning_base/test_adjoint_jacobian_class.py
+++ b/tests/lightning_base/test_adjoint_jacobian_class.py
@@ -172,7 +172,10 @@ class TestAdjointJacobian:
 
         with qp.tape.QuantumTape() as tape:
             qp.StatePrep(init_state, wires=range(n_qubits))
-            qp.ctrl(qp.PhaseShift(par, wires=n_qubits - 1), range(0, n_qubits - 1))
+            if n_qubits == 1:
+                qp.PhaseShift(par, wires=0)
+            else:
+                qp.ctrl(qp.PhaseShift(par, wires=n_qubits - 1), range(0, n_qubits - 1))
             qp.expval(qp.PauliY(n_qubits - 1))
 
         tape.trainable_params = {1}

--- a/tests/lightning_base/test_adjoint_jacobian_class.py
+++ b/tests/lightning_base/test_adjoint_jacobian_class.py
@@ -212,6 +212,35 @@ class TestAdjointJacobian:
 
         assert np.allclose(expected, result, atol=tol, rtol=0)
 
+    @pytest.mark.parametrize("use_adjoint", [False, True])
+    @pytest.mark.parametrize(
+        "trainable_params",
+        [{0, 2}, {0, 1, 2}],
+        ids=["circuit-parameters", "all-tape-parameters"],
+    )
+    def test_multicontrolledx_control_values_not_differentiated(
+        self, use_adjoint, trainable_params, tol, lightning_sv
+    ):
+        """Test that MCX control values do not shift native gate parameter indices."""
+        x, y = 0.4, 0.3
+
+        with qp.tape.QuantumTape() as tape:
+            qp.RX(x, wires=0)
+            mcx = qp.MultiControlledX(wires=[0, 1], control_values=[False])
+            if use_adjoint:
+                qp.adjoint(mcx, lazy=True)
+            qp.RY(y, wires=1)
+            qp.expval(qp.PauliZ(1))
+
+        tape.trainable_params = trainable_params
+
+        expected = [np.sin(x) * np.cos(y), np.cos(x) * np.sin(y)]
+        if 1 in trainable_params:
+            expected.insert(1, 0.0)
+        result = self.calculate_jacobian(lightning_sv(num_wires=2), tape)
+
+        assert np.allclose(expected, result, atol=tol, rtol=0)
+
     def test_multiple_rx_gradient_pauliz(self, tol, lightning_sv):
         """Tests that the gradient of multiple RX gates in a circuit yields the correct result."""
         params = np.array([np.pi, np.pi / 2, np.pi / 3])

--- a/tests/lightning_base/test_measurements_class.py
+++ b/tests/lightning_base/test_measurements_class.py
@@ -27,6 +27,7 @@ from conftest import (  # tested device
     LightningStateVector,
     device_name,
     get_hermitian_matrix,
+    get_operation_num_wires,
     get_random_normalized_state,
     get_sparse_hermitian_matrix,
     validate_counts,
@@ -1003,7 +1004,7 @@ class TestControlledOps:
     ):
         """Test that multi-controlled gates are correctly applied to a state"""
         threshold = 250 if device_name != "lightning.tensor" else 5
-        num_wires = max(operation.num_wires, 1) if operation.num_wires else 1
+        num_wires = get_operation_num_wires(operation)
         rng = np.random.default_rng(seed)
 
         if device_name not in ["lightning.qubit", "lightning.gpu"] and operation == qp.PCPhase:
@@ -1131,7 +1132,7 @@ class TestControlledOps:
         """Test that multi-controlled gates are correctly applied to a state"""
         threshold = 250 if device_name != "lightning.tensor" else 5
         operation = qp.GlobalPhase
-        num_wires = max(operation.num_wires, 1) if operation.num_wires else 1
+        num_wires = get_operation_num_wires(operation)
 
         for n_wires in range(num_wires + 1, num_wires + 4):
             wire_lists = list(itertools.permutations(range(0, n_qubits), n_wires))

--- a/tests/test_adjoint_jacobian.py
+++ b/tests/test_adjoint_jacobian.py
@@ -21,7 +21,12 @@ import math
 import pennylane as qp
 import pytest
 from conftest import LightningDevice as ld
-from conftest import device_name, get_random_matrix, get_random_normalized_state
+from conftest import (
+    device_name,
+    get_operation_num_wires,
+    get_random_matrix,
+    get_random_normalized_state,
+)
 from pennylane import QNode
 from pennylane import numpy as np
 from pennylane import qchem, qnode
@@ -641,7 +646,7 @@ class TestAdjointJacobianQNode:
         init_state = get_random_normalized_state(2**n_qubits)
         init_state = np.array(init_state, requires_grad=False)
 
-        num_wires = max(operation.num_wires, 1) if operation.num_wires else 1
+        num_wires = get_operation_num_wires(operation)
         if num_wires > n_qubits:
             return
 
@@ -704,7 +709,7 @@ class TestAdjointJacobianQNode:
         init_state = get_random_normalized_state(2**n_qubits)
         init_state = np.array(init_state, requires_grad=False)
 
-        num_wires = max(operation.num_wires, 1) if operation.num_wires else 1
+        num_wires = get_operation_num_wires(operation)
         if num_wires > n_qubits:
             return
 
@@ -764,7 +769,7 @@ class TestAdjointJacobianQNode:
         dqu = qp.device("default.qubit", wires=n_qubits)
         init_state = get_random_normalized_state(2**n_qubits)
         init_state = np.array(init_state, requires_grad=False)
-        num_wires = max(operation.num_wires, 1) if operation.num_wires else 1
+        num_wires = get_operation_num_wires(operation)
         if num_wires > n_qubits:
             return
 

--- a/tests/test_adjoint_jacobian.py
+++ b/tests/test_adjoint_jacobian.py
@@ -228,7 +228,10 @@ class TestAdjointJacobian:
 
         with qp.tape.QuantumTape() as tape:
             qp.StatePrep(init_state, wires=range(n_qubits))
-            qp.ctrl(qp.PhaseShift(par, wires=n_qubits - 1), range(0, n_qubits - 1))
+            if n_qubits == 1:
+                qp.PhaseShift(par, wires=0)
+            else:
+                qp.ctrl(qp.PhaseShift(par, wires=n_qubits - 1), range(0, n_qubits - 1))
             qp.expval(qp.PauliY(n_qubits - 1))
 
         tape.trainable_params = {1}

--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -24,7 +24,12 @@ import pennylane as qp
 import pytest
 from conftest import PHI, THETA
 from conftest import LightningDevice as ld
-from conftest import device_name, get_random_matrix, get_random_normalized_state
+from conftest import (
+    device_name,
+    get_operation_num_wires,
+    get_random_matrix,
+    get_random_normalized_state,
+)
 from scipy.sparse import csr_matrix
 
 if not ld._CPP_BINARY_AVAILABLE:
@@ -620,7 +625,7 @@ def test_controlled_qubit_gates(operation, n_qubits, control_value, adjoint, tol
     dev_def = qp.device("default.qubit", wires=n_qubits)
     dev = qp.device(device_name, wires=n_qubits)
     threshold = 5 if device_name == "lightning.tensor" else 250
-    num_wires = max(operation.num_wires, 1) if operation.num_wires else 1
+    num_wires = get_operation_num_wires(operation)
     operation = qp.adjoint(operation) if adjoint else operation
 
     if device_name not in ["lightning.qubit", "lightning.gpu"] and op == qp.PCPhase:
@@ -758,7 +763,7 @@ def test_controlled_globalphase(n_qubits, control_value, tol):
     dev = qp.device(device_name, wires=n_qubits)
     threshold = 250
     operation = qp.GlobalPhase
-    num_wires = max(operation.num_wires, 1) if operation.num_wires else 1
+    num_wires = get_operation_num_wires(operation)
     for n_wires in range(num_wires + 1, num_wires + 4):
         wire_lists = list(itertools.permutations(range(0, n_qubits), n_wires))
         n_perms = len(wire_lists) * n_wires
@@ -913,7 +918,7 @@ def test_adjoint_controlled_qubit_gates(operation, n_qubits, control_value, tol,
     dev_def = qp.device("default.qubit", wires=n_qubits)
     dev = qp.device(device_name, wires=n_qubits)
     threshold = 5 if device_name == "lightning.tensor" else 250
-    num_wires = max(operation.num_wires, 1) if operation.num_wires else 1
+    num_wires = get_operation_num_wires(operation)
     operation = qp.adjoint(operation) if adjoint else operation
 
     for n_wires in range(num_wires + 1, num_wires + 4):

--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -22,7 +22,10 @@ import sys
 import numpy as np
 import pennylane as qp
 import pytest
-from conftest import PHI, THETA
+from conftest import (
+    PHI,
+    THETA,
+)
 from conftest import LightningDevice as ld
 from conftest import (
     device_name,

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -144,7 +144,7 @@ class TestBasisEmbedding:
         dq = qp.device("default.qubit")
 
         def circuit(feature_vector):
-            qp.BasisEmbedding(features=feature_vector, wires=range(n_qubits))
+            qp.BasisEmbedding(feature_vector, wires=range(n_qubits))
             return qp.state()
 
         X = np.ones(n_qubits)


### PR DESCRIPTION
# Context

To fix [latest/latest](https://github.com/PennyLaneAI/pennylane-lightning/actions/runs/31445916814), as well as unblock many other works.

# Changes

1. `PauliRot.pauli_words` rather than the legacy `op._hyperparameters["pauli_word"]`
2. `MultiControlledX` has a special branch to avoid being processed by trainable pipeline etc.
3. `

[sc-127403]