### PR TITLE
Fix Lightning-Qubit state-vector copying

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -41,6 +41,10 @@
 
 <h3>Bug fixes 🐛</h3>
 
+- Added copy and pickle support for Lightning-Qubit state vectors, allowing executed devices
+  and QNodes to be deep-copied while preserving their state.
+  [(Issue #677)](https://github.com/PennyLaneAI/pennylane-lightning/issues/677)
+
 - Restored compatibility with the latest PennyLane operator contract for `qp.PauliRot`,
   `qp.MultiControlledX`, and `qp.DiagonalQubitUnitary`.
   [(#1415)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1415)
@@ -102,6 +106,7 @@ This release contains contributions from (in alphabetical order):
 Runor Agbaire,
 Ali Asadi,
 Yushao Chen,
+Chen Shoval,
 David Ittah,
 Jeffrey Kam,
 Joseph Lee,

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -43,7 +43,7 @@
 
 - Added copy and pickle support for Lightning-Qubit state vectors, allowing executed devices
   and QNodes to be deep-copied while preserving their state.
-  [(Issue #677)](https://github.com/PennyLaneAI/pennylane-lightning/issues/677)
+  [(#1421)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1421)
 
 - Restored compatibility with the latest PennyLane operator contract for `qp.PauliRot`,
   `qp.MultiControlledX`, and `qp.DiagonalQubitUnitary`.

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.46.0-dev27"
+__version__ = "0.46.0-dev28"

--- a/pennylane_lightning/core/simulators/lightning_qubit/bindings/LQubitBindings.hpp
+++ b/pennylane_lightning/core/simulators/lightning_qubit/bindings/LQubitBindings.hpp
@@ -21,6 +21,7 @@
 #pragma once
 #include <complex>
 #include <memory>
+#include <new>
 #include <string>
 #include <vector>
 
@@ -191,6 +192,20 @@ void registerBackendSpecificStateVectorMethods(PyClass &pyclass) {
     registerSparseMatrixOperators<StateVectorT>(pyclass);
 
     pyclass.def(nb::init<std::size_t>(), "Initialize with number of qubits");
+
+    pyclass.def("__copy__",
+                [](const StateVectorT &sv) { return StateVectorT{sv}; });
+    pyclass.def("__deepcopy__", [](const StateVectorT &sv, nb::dict) {
+        return StateVectorT{sv};
+    });
+    pyclass.def("__getstate__", [](const StateVectorT &sv) {
+        return std::vector<ComplexT>{sv.getData(),
+                                     sv.getData() + sv.getLength()};
+    });
+    pyclass.def("__setstate__",
+                [](StateVectorT &sv, const std::vector<ComplexT> &state) {
+                    new (&sv) StateVectorT{state};
+                });
 
     // Add updateData method for LQubit
     pyclass.def(

--- a/tests/bindings/test_statevector_nb.py
+++ b/tests/bindings/test_statevector_nb.py
@@ -13,6 +13,9 @@
 # limitations under the License.
 """Tests for StateVector classes in nanobind-based modules."""
 
+import copy
+import pickle
+
 import numpy as np
 import pytest
 from conftest import device_name, supported_devices
@@ -68,6 +71,42 @@ class TestStateVectorNB:
         expected[0] = 1.0
 
         np.testing.assert_allclose(result, expected)
+
+    @pytest.mark.skipif(
+        device_name != "lightning.qubit",
+        reason="Native state-vector copying is only implemented for lightning.qubit.",
+    )
+    @pytest.mark.parametrize("copy_fn", [copy.copy, copy.deepcopy])
+    def test_statevector_copy(self, get_statevector_class_and_precision, copy_fn):
+        """Test that copied state vectors preserve state and own independent memory."""
+        StateVectorClass, dtype = get_statevector_class_and_precision
+        state = np.array([0.0, 1.0], dtype=dtype)
+        statevector = StateVectorClass(1)
+        statevector.updateData(state)
+
+        copied_statevector = copy_fn(statevector)
+        statevector.resetStateVector()
+
+        result = np.zeros_like(state)
+        copied_statevector.getState(result)
+        np.testing.assert_allclose(result, state)
+
+    @pytest.mark.skipif(
+        device_name != "lightning.qubit",
+        reason="Native state-vector pickling is only implemented for lightning.qubit.",
+    )
+    def test_statevector_pickle(self, get_statevector_class_and_precision):
+        """Test that pickled state vectors preserve their state."""
+        StateVectorClass, dtype = get_statevector_class_and_precision
+        state = np.array([0.0, 1.0], dtype=dtype)
+        statevector = StateVectorClass(1)
+        statevector.updateData(state)
+
+        restored_statevector = pickle.loads(pickle.dumps(statevector))
+
+        result = np.zeros_like(state)
+        restored_statevector.getState(result)
+        np.testing.assert_allclose(result, state)
 
     def test_statevector_gate_operations(self, get_statevector_class_and_precision):
         """Test gate operations on StateVectorC64/128 classes."""

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -15,6 +15,7 @@
 Unit tests for Lightning devices creation.
 """
 
+import copy
 import pickle as pkl
 import sys
 
@@ -98,6 +99,28 @@ def test_devpool_is_pickleable():
 
     except TypeError:
         pytest.fail("DevPool should be Pickleable")
+
+
+@pytest.mark.skipif(
+    device_name != "lightning.qubit",
+    reason="Native state-vector copying is only implemented for lightning.qubit.",
+)
+@pytest.mark.parametrize("c_dtype", [np.complex64, np.complex128])
+def test_qnode_is_deepcopyable_after_execution(c_dtype):
+    """Test that an executed QNode and its native state can be deep-copied."""
+    dev = qp.device(device_name, wires=2, c_dtype=c_dtype)
+
+    @qp.qnode(dev)
+    def circuit(theta):
+        qp.RX(theta, 0)
+        qp.CNOT(wires=[0, 1])
+        return qp.expval(qp.Z(1))
+
+    expected = circuit(0.37)
+    copied_circuit = copy.deepcopy(circuit)
+
+    assert copied_circuit.device is not circuit.device
+    assert np.allclose(copied_circuit(0.37), expected)
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
**Context:**

Fixes #677 for `lightning.qubit`. After a QNode executes, the device owns a native `StateVectorC64` or `StateVectorC128`; these nanobind objects did not implement Python's copy or pickle protocols, so `copy.deepcopy()` failed with `TypeError: cannot pickle ... StateVectorC128 object`.

**Description of the Change:**

- Bind `__copy__` and `__deepcopy__` to the existing managed state-vector copy constructor.
- Bind nanobind `__getstate__`/`__setstate__` methods that serialize amplitudes and reconstruct independent native storage.
- Cover both `complex64` and `complex128`, state preservation, independent memory, pickle round trips, and post-execution QNode deepcopy.

**Benefits:**

Executed Lightning-Qubit devices and QNodes can now be copied or pickled while preserving their native state, enabling workflows such as deep-copying models that contain PennyLane QNodes.

**Possible Drawbacks:**

Copying or pickling a state vector necessarily copies all `2**n` complex amplitudes, so its time and memory cost scale with the state-vector size.

**Validation:**

- `PL_DEVICE=lightning.qubit python -m pytest tests/bindings tests/test_device.py -q`
  - `132 passed, 27 skipped`
- `./bin/format --check pennylane_lightning/core`
  - `0 files would be re-formatted; 370 left unchanged`
- `black --check` and `isort --check-only` passed for the touched Python tests.

A complete local `tests` run was also attempted, but this main checkout currently has thousands of unrelated failures with both PennyLane development and 0.45.1 APIs (`qp.core`, `Operator2`, `compilable_args`, and `pauli_word` mismatches). The binding/device slices affected by this PR pass completely.

**Related GitHub Issues:**

- #677

**AI assistance:**

GitHub Copilot assisted with repository exploration, implementation, and test drafting. I reviewed the changes and am responsible for the contribution.