### PR TITLE
Add tomlkit to pyproject.toml

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -41,10 +41,6 @@
 
 <h3>Bug fixes 🐛</h3>
 
-- Added `tomlkit` to the `dev`, `tests` and `base` dependency groups. It was previously
-  pulled in transitively through PennyLane, which no longer depends on it.
-  [(#1422)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1422)
-
 - Restored compatibility with the latest PennyLane operator contract for `qp.PauliRot`,
   `qp.MultiControlledX`, and `qp.DiagonalQubitUnitary`.
   [(#1415)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1415)
@@ -62,6 +58,10 @@
   [(#1390)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1390)
 
 <h3>Internal changes ⚙️</h3>
+
+- Added `tomlkit` to the `dev`, `tests` and `base` dependency groups. It was previously
+  pulled in transitively through PennyLane, which no longer depends on it.
+  [(#1422)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1422)
 
 - Changed Lightning-Qubit and Lightning-GPU to read the `qp.PCPhase` dimension from its
   Operator2 `compilable_args` dictionary.

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -43,7 +43,7 @@
 
 - Added `tomlkit` to the `dev`, `tests` and `base` dependency groups. It was previously
   pulled in transitively through PennyLane, which no longer depends on it.
-  [(#XXXX)](https://github.com/PennyLaneAI/pennylane-lightning/pull/XXXX)
+  [(#1422)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1422)
 
 - Restored compatibility with the latest PennyLane operator contract for `qp.PauliRot`,
   `qp.MultiControlledX`, and `qp.DiagonalQubitUnitary`.

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -41,6 +41,10 @@
 
 <h3>Bug fixes 🐛</h3>
 
+- Added `tomlkit` to the `dev`, `tests` and `base` dependency groups. It was previously
+  pulled in transitively through PennyLane, which no longer depends on it.
+  [(#XXXX)](https://github.com/PennyLaneAI/pennylane-lightning/pull/XXXX)
+
 - Restored compatibility with the latest PennyLane operator contract for `qp.PauliRot`,
   `qp.MultiControlledX`, and `qp.DiagonalQubitUnitary`.
   [(#1415)](https://github.com/PennyLaneAI/pennylane-lightning/pull/1415)

--- a/pennylane_lightning/core/_version.py
+++ b/pennylane_lightning/core/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.46.0-dev27"
+__version__ = "0.46.0-dev28"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ dev = [
     "click==8.2.1"
 ]
 tests = [
+    "ninja",
     "tomlkit",
     "pytest>=8.4.1",
     "pytest-benchmark",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dev = [
     "build",
     "ninja",
     "cmake",
+    "tomlkit",
     "custatevec-cu12; sys_platform == 'linux'",
     "cutensornet-cu12; sys_platform == 'linux'",
     "pennylane @ git+https://github.com/PennyLaneAI/pennylane.git@main",
@@ -56,6 +57,7 @@ dev = [
     "click==8.2.1"
 ]
 tests = [
+    "tomlkit",
     "pytest>=8.4.1",
     "pytest-benchmark",
     "pytest-cov>=3.0.0",
@@ -68,6 +70,7 @@ tests = [
 ]
 base = [
     "ninja",
+    "tomlkit",
     "pytest>=8.4.1",
     "pytest-cov>=3.0.0",
     "pytest-mock>=3.7.0",


### PR DESCRIPTION
**Context:**
Pennylane removed tomlkit from their dependencies, which we depend on, and was previously pulling in transitively.

**Description of the Change:**
Add tomlkit to our dependency.

updated L/L run https://github.com/PennyLaneAI/pennylane-lightning/actions/runs/32867166464